### PR TITLE
Harden POS refund cancellation flows

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentController.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentController.kt
@@ -787,11 +787,16 @@ class CardReaderPaymentController(
         }
     }
 
+    @Suppress("TooGenericExceptionCaught")
     fun stop() {
         paymentDataForRetry?.let {
             cardReaderManager.cancelPayment(it)
         }
-        scope.cancel()
+        try {
+            scope.cancel()
+        } catch (e: RuntimeException) {
+            WooLog.e(WooLog.T.CARD_READER, "Failed to stop card reader payment controller", e)
+        }
     }
 
     fun onBackPressed() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentController.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentController.kt
@@ -643,7 +643,8 @@ class CardReaderPaymentController(
         when (val state = _paymentState.value) {
             is CardReaderInteracRefundState.CollectingInteracRefund -> {
                 _paymentState.value = state.copy(
-                    cardReaderHint = cardReaderHint.toHintLabel(true)
+                    cardReaderHint = cardReaderHint.toHintLabel(true),
+                    isDismissBlocked = cardReaderHint == REMOVE_CARD,
                 )
             }
 
@@ -789,13 +790,18 @@ class CardReaderPaymentController(
 
     @Suppress("TooGenericExceptionCaught")
     fun stop() {
-        paymentDataForRetry?.let {
-            cardReaderManager.cancelPayment(it)
-        }
         try {
-            scope.cancel()
-        } catch (e: RuntimeException) {
-            WooLog.e(WooLog.T.CARD_READER, "Failed to stop card reader payment controller", e)
+            paymentDataForRetry?.let {
+                cardReaderManager.cancelPayment(it)
+            }
+        } catch (e: Exception) {
+            WooLog.e(WooLog.T.CARD_READER, "Failed to cancel card reader payment", e)
+        } finally {
+            try {
+                scope.cancel()
+            } catch (e: Exception) {
+                WooLog.e(WooLog.T.CARD_READER, "Failed to stop card reader payment controller", e)
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentController.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentController.kt
@@ -70,8 +70,10 @@ import com.woocommerce.android.util.PrintHtmlHelper.PrintJobResult.CANCELLED
 import com.woocommerce.android.util.PrintHtmlHelper.PrintJobResult.FAILED
 import com.woocommerce.android.util.PrintHtmlHelper.PrintJobResult.STARTED
 import com.woocommerce.android.util.WooLog
+import kotlinx.coroutines.CompletionHandlerException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
@@ -788,18 +790,20 @@ class CardReaderPaymentController(
         }
     }
 
-    @Suppress("TooGenericExceptionCaught")
+    @OptIn(InternalCoroutinesApi::class)
     fun stop() {
         try {
             paymentDataForRetry?.let {
                 cardReaderManager.cancelPayment(it)
             }
-        } catch (e: Exception) {
+        } catch (e: IllegalStateException) {
             WooLog.e(WooLog.T.CARD_READER, "Failed to cancel card reader payment", e)
         } finally {
             try {
+                // Stripe Terminal can throw from a coroutine cancellation handler while it is waiting for
+                // a network response; coroutines wrap that in CompletionHandlerException.
                 scope.cancel()
-            } catch (e: Exception) {
+            } catch (e: CompletionHandlerException) {
                 WooLog.e(WooLog.T.CARD_READER, "Failed to stop card reader payment controller", e)
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentOrRefundState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentOrRefundState.kt
@@ -165,6 +165,7 @@ sealed class CardReaderPaymentOrRefundState {
             val amountWithCurrencyLabel: String,
             val onCancel: () -> Unit,
             @StringRes val cardReaderHint: Int? = null,
+            val isDismissBlocked: Boolean = false,
         ) : CardReaderInteracRefundState()
 
         data class ProcessingInteracRefund(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModel.kt
@@ -234,7 +234,7 @@ class WooPosHomeViewModel @Inject constructor(
                         }
                     }
 
-                    is NavigationEvent -> viewModelScope.launch { _navigationEvent.emit(event) }
+                    is NavigationEvent -> viewModelScope.launch { handleNavigationEvent(event) }
                     is ChildToParentEvent.SearchEvent.QueryChanged -> {
                         sendEventToChildren(ChangedQuery(event.query))
                     }
@@ -315,6 +315,22 @@ class WooPosHomeViewModel @Inject constructor(
         viewModelScope.launch {
             parentToChildrenEventSender.sendToChildren(event)
         }
+    }
+
+    private suspend fun handleNavigationEvent(event: NavigationEvent) {
+        if (event == NavigationEvent.ToOrders) {
+            cancelCheckoutBeforeOpeningOrders()
+        }
+        _navigationEvent.emit(event)
+    }
+
+    private suspend fun cancelCheckoutBeforeOpeningOrders() {
+        if (_state.value.screenPositionState !is ScreenPositionState.Checkout) return
+
+        _state.value = _state.value.copy(
+            screenPositionState = ScreenPositionState.Cart
+        )
+        parentToChildrenEventSender.sendToChildren(ParentToChildrenEvent.BackFromCheckoutToCartClicked)
     }
 
     private fun onOrderSuccessfullyPaid(paymentMethod: PaymentMethod) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosIssueRefundScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosIssueRefundScreen.kt
@@ -148,7 +148,8 @@ private fun WooPosRefundState.hasPendingChanges(): Boolean {
 
 private enum class RefundHeaderNavigationIcon {
     Back,
-    Close
+    Close,
+    None
 }
 
 @Composable
@@ -224,19 +225,49 @@ fun WooPosIssueRefundScreen(
     val modalIsProcessing = modalState.isNonCancelableModal()
     var showCardReaderConnectionDialog by remember { mutableStateOf(false) }
 
-    val handleModalDismiss = {
+    val handleCancelRefundFlow = {
         val currentState = state
         if (currentState is WooPosRefundState.Content && !currentState.step.isNonCancelable()) {
             viewModel.onUIEvent(WooPosRefundUIEvent.CancelRefund)
-            viewModel.onUIEvent(WooPosRefundUIEvent.BackToSelectItemsClicked)
+            handleDismiss()
         } else if (!modalIsProcessing) {
             handleDismiss()
         }
     }
 
+    val handleModalBack = {
+        when (val currentState = state) {
+            is WooPosRefundState.Content -> when (currentState.step) {
+                WooPosRefundState.Content.RefundStep.SelectItems ->
+                    handleDismiss()
+                WooPosRefundState.Content.RefundStep.ReviewRefund ->
+                    viewModel.onUIEvent(WooPosRefundUIEvent.BackToSelectItemsClicked)
+                WooPosRefundState.Content.RefundStep.ConfirmRefund ->
+                    viewModel.onUIEvent(WooPosRefundUIEvent.BackToReviewClicked)
+                WooPosRefundState.Content.RefundStep.PreparingReader,
+                WooPosRefundState.Content.RefundStep.ReaderDisconnected,
+                is WooPosRefundState.Content.RefundStep.ReadyForRefund -> {
+                    if (!currentState.step.isNonCancelable()) {
+                        viewModel.onUIEvent(WooPosRefundUIEvent.CancelRefund)
+                        viewModel.onUIEvent(WooPosRefundUIEvent.BackToConfirmRefundClicked)
+                    }
+                }
+                WooPosRefundState.Content.RefundStep.Processing,
+                WooPosRefundState.Content.RefundStep.ProcessingRefund,
+                WooPosRefundState.Content.RefundStep.NotifyingStore -> Unit
+            }
+            is WooPosRefundState.Error,
+            is WooPosRefundState.RefundSuccess ->
+                handleCancelRefundFlow()
+            is WooPosRefundState.Loading,
+            is WooPosRefundState.NoRefundableItems ->
+                handleDismiss()
+        }
+    }
+
     BackHandler {
         if (modalState != null) {
-            handleModalDismiss()
+            handleModalBack()
         } else {
             handleDismiss()
         }
@@ -263,7 +294,8 @@ fun WooPosIssueRefundScreen(
                 state = modalState,
                 orderId = orderId,
                 onDismiss = handleDismiss,
-                onModalDismiss = handleModalDismiss,
+                onModalBack = handleModalBack,
+                onCancelRefundFlow = handleCancelRefundFlow,
                 closeButtonEnabled = !modalIsProcessing,
                 onEvent = viewModel::onUIEvent,
                 onConnectReaderClicked = {
@@ -283,7 +315,7 @@ fun WooPosIssueRefundScreen(
         Dialog(
             onDismissRequest = {
                 if (!modalIsProcessing) {
-                    handleModalDismiss()
+                    handleModalBack()
                 }
             },
             properties = DialogProperties(
@@ -302,7 +334,8 @@ fun WooPosIssueRefundScreen(
                     state = modalState,
                     orderId = orderId,
                     onDismiss = handleDismiss,
-                    onModalDismiss = handleModalDismiss,
+                    onModalBack = handleModalBack,
+                    onCancelRefundFlow = handleCancelRefundFlow,
                     closeButtonEnabled = !modalIsProcessing,
                     onEvent = viewModel::onUIEvent,
                     onConnectReaderClicked = {
@@ -365,7 +398,7 @@ private fun RefundSelectionLayer(
     ) {
         RefundScreenHeader(
             title = resolveToolbarTitle(state),
-            onCloseClicked = onDismiss,
+            onNavigationIconClicked = onDismiss,
             closeButtonEnabled = true,
             navigationIcon = RefundHeaderNavigationIcon.Back,
         )
@@ -405,7 +438,7 @@ private fun RefundSelectionLayer(
             RefundScreenButtons(
                 state = state,
                 onDismiss = onDismiss,
-                onModalDismiss = onDismiss,
+                onCancelRefundFlow = onDismiss,
                 onEvent = onEvent,
                 onConnectReaderClicked = {},
                 onNavigationEvent = onNavigationEvent,
@@ -420,7 +453,8 @@ private fun RefundModalLayer(
     state: WooPosRefundState,
     orderId: Long,
     onDismiss: () -> Unit,
-    onModalDismiss: () -> Unit,
+    onModalBack: () -> Unit,
+    onCancelRefundFlow: () -> Unit,
     closeButtonEnabled: Boolean,
     onEvent: (WooPosRefundUIEvent) -> Unit,
     onConnectReaderClicked: () -> Unit,
@@ -449,11 +483,16 @@ private fun RefundModalLayer(
             .background(MaterialTheme.colorScheme.surface)
             .then(contentInsetsModifier)
     ) {
+        val navigationIcon = state.modalNavigationIcon()
         RefundScreenHeader(
             title = null,
-            onCloseClicked = onModalDismiss,
+            onNavigationIconClicked = when (navigationIcon) {
+                RefundHeaderNavigationIcon.Back -> onModalBack
+                RefundHeaderNavigationIcon.Close -> onCancelRefundFlow
+                RefundHeaderNavigationIcon.None -> ({})
+            },
             closeButtonEnabled = closeButtonEnabled,
-            navigationIcon = RefundHeaderNavigationIcon.Close,
+            navigationIcon = navigationIcon,
         )
 
         Column(
@@ -490,7 +529,7 @@ private fun RefundModalLayer(
             RefundScreenButtons(
                 state = state,
                 onDismiss = onDismiss,
-                onModalDismiss = onModalDismiss,
+                onCancelRefundFlow = onCancelRefundFlow,
                 onEvent = onEvent,
                 onConnectReaderClicked = onConnectReaderClicked,
                 onNavigationEvent = onNavigationEvent,
@@ -541,10 +580,35 @@ private fun resolveToolbarTitle(state: WooPosRefundState): String? {
     }
 }
 
+private fun WooPosRefundState.modalNavigationIcon(): RefundHeaderNavigationIcon {
+    return when (this) {
+        is WooPosRefundState.Content -> when (step) {
+            WooPosRefundState.Content.RefundStep.ConfirmRefund,
+            WooPosRefundState.Content.RefundStep.PreparingReader,
+            WooPosRefundState.Content.RefundStep.ReaderDisconnected,
+            is WooPosRefundState.Content.RefundStep.ReadyForRefund ->
+                if (step.isNonCancelable()) {
+                    RefundHeaderNavigationIcon.None
+                } else {
+                    RefundHeaderNavigationIcon.Back
+                }
+            WooPosRefundState.Content.RefundStep.SelectItems,
+            WooPosRefundState.Content.RefundStep.ReviewRefund,
+            WooPosRefundState.Content.RefundStep.Processing,
+            WooPosRefundState.Content.RefundStep.ProcessingRefund,
+            WooPosRefundState.Content.RefundStep.NotifyingStore -> RefundHeaderNavigationIcon.None
+        }
+        is WooPosRefundState.Error,
+        is WooPosRefundState.RefundSuccess -> RefundHeaderNavigationIcon.Close
+        is WooPosRefundState.Loading,
+        is WooPosRefundState.NoRefundableItems -> RefundHeaderNavigationIcon.None
+    }
+}
+
 @Composable
 private fun RefundScreenHeader(
     title: String?,
-    onCloseClicked: () -> Unit,
+    onNavigationIconClicked: () -> Unit,
     modifier: Modifier = Modifier,
     closeButtonEnabled: Boolean = true,
     navigationIcon: RefundHeaderNavigationIcon = RefundHeaderNavigationIcon.Close,
@@ -561,7 +625,7 @@ private fun RefundScreenHeader(
             RefundHeaderNavigationIcon.Back -> {
                 WooPosBackButton(
                     contentDescription = backContentDescription,
-                    onClick = onCloseClicked,
+                    onClick = onNavigationIconClicked,
                     modifier = Modifier
                         .align(Alignment.CenterStart)
                         .padding(start = WooPosSpacing.Small.value)
@@ -569,7 +633,7 @@ private fun RefundScreenHeader(
             }
             RefundHeaderNavigationIcon.Close -> {
                 IconButton(
-                    onClick = onCloseClicked,
+                    onClick = onNavigationIconClicked,
                     enabled = closeButtonEnabled,
                     modifier = Modifier
                         .align(Alignment.CenterStart)
@@ -582,6 +646,7 @@ private fun RefundScreenHeader(
                     )
                 }
             }
+            RefundHeaderNavigationIcon.None -> Unit
         }
 
         if (title != null) {
@@ -605,7 +670,7 @@ private fun RefundScreenHeader(
 private fun RefundScreenButtons(
     state: WooPosRefundState,
     onDismiss: () -> Unit,
-    onModalDismiss: () -> Unit,
+    onCancelRefundFlow: () -> Unit,
     onEvent: (WooPosRefundUIEvent) -> Unit,
     onConnectReaderClicked: () -> Unit,
     onNavigationEvent: (WooPosNavigationEvent) -> Unit,
@@ -623,7 +688,7 @@ private fun RefundScreenButtons(
             )
             is WooPosRefundState.Content -> RefundContentStepButtons(
                 state = state,
-                onModalDismiss = onModalDismiss,
+                onCancelRefundFlow = onCancelRefundFlow,
                 onEvent = onEvent,
                 onConnectReaderClicked = onConnectReaderClicked,
                 disablePartialRefund = disablePartialRefund,
@@ -631,7 +696,7 @@ private fun RefundScreenButtons(
             is WooPosRefundState.Error -> RefundErrorButtons(
                 state = state,
                 onDismiss = onDismiss,
-                onModalDismiss = onModalDismiss,
+                onCancelRefundFlow = onCancelRefundFlow,
                 onEvent = onEvent,
             )
             is WooPosRefundState.NoRefundableItems -> {
@@ -653,7 +718,7 @@ private fun RefundScreenButtons(
 @Composable
 private fun RefundContentStepButtons(
     state: WooPosRefundState.Content,
-    onModalDismiss: () -> Unit,
+    onCancelRefundFlow: () -> Unit,
     onEvent: (WooPosRefundUIEvent) -> Unit,
     onConnectReaderClicked: () -> Unit,
     disablePartialRefund: Boolean,
@@ -673,7 +738,7 @@ private fun RefundContentStepButtons(
             )
             if (!disablePartialRefund) {
                 WooPosOutlinedButton(
-                    text = stringResource(R.string.woopos_orders_edit_refund),
+                    text = stringResource(R.string.back),
                     onClick = {
                         onEvent(WooPosRefundUIEvent.BackToSelectItemsClicked)
                     },
@@ -688,10 +753,8 @@ private fun RefundContentStepButtons(
                 modifier = Modifier.fillMaxWidth()
             )
             WooPosOutlinedButton(
-                text = stringResource(R.string.back),
-                onClick = {
-                    onEvent(WooPosRefundUIEvent.BackToReviewClicked)
-                },
+                text = stringResource(R.string.cancel),
+                onClick = onCancelRefundFlow,
                 modifier = Modifier.fillMaxWidth()
             )
         }
@@ -703,7 +766,7 @@ private fun RefundContentStepButtons(
                 modifier = Modifier.fillMaxWidth()
             )
             WooPosOutlinedButton(
-                text = stringResource(R.string.back),
+                text = stringResource(R.string.cancel),
                 onClick = {},
                 state = WooPosButtonState.DISABLED,
                 modifier = Modifier.fillMaxWidth()
@@ -711,11 +774,13 @@ private fun RefundContentStepButtons(
         }
         WooPosRefundState.Content.RefundStep.PreparingReader,
         is WooPosRefundState.Content.RefundStep.ReadyForRefund -> {
-            WooPosOutlinedButton(
-                text = stringResource(R.string.cancel),
-                onClick = onModalDismiss,
-                modifier = Modifier.fillMaxWidth()
-            )
+            if (!state.step.isNonCancelable()) {
+                WooPosOutlinedButton(
+                    text = stringResource(R.string.cancel),
+                    onClick = onCancelRefundFlow,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
         }
         WooPosRefundState.Content.RefundStep.ReaderDisconnected -> {
             WooPosButton(
@@ -725,7 +790,7 @@ private fun RefundContentStepButtons(
             )
             WooPosOutlinedButton(
                 text = stringResource(R.string.cancel),
-                onClick = onModalDismiss,
+                onClick = onCancelRefundFlow,
                 modifier = Modifier.fillMaxWidth()
             )
         }
@@ -750,7 +815,7 @@ private fun RefundContentStepButtons(
 private fun RefundErrorButtons(
     state: WooPosRefundState.Error,
     onDismiss: () -> Unit,
-    onModalDismiss: () -> Unit,
+    onCancelRefundFlow: () -> Unit,
     onEvent: (WooPosRefundUIEvent) -> Unit,
 ) {
     if (state.canRetry) {
@@ -770,7 +835,7 @@ private fun RefundErrorButtons(
         )
         WooPosOutlinedButton(
             text = stringResource(R.string.cancel),
-            onClick = onModalDismiss,
+            onClick = onCancelRefundFlow,
             modifier = Modifier.fillMaxWidth()
         )
     } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundState.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.woopos.orders.details.refund
 
 import androidx.annotation.StringRes
 import androidx.compose.runtime.Immutable
+import com.woocommerce.android.R
 import java.math.BigDecimal
 
 @Immutable
@@ -33,16 +34,16 @@ sealed class WooPosRefundState {
         @Immutable
         sealed class RefundStep {
             fun isNonCancelable(): Boolean {
-                return when (this) {
+                return when (val step = this) {
                     Processing,
                     ProcessingRefund,
                     NotifyingStore -> true
+                    is ReadyForRefund -> step.cardReaderHint == R.string.card_reader_payment_remove_card_prompt
                     SelectItems,
                     ReviewRefund,
                     ConfirmRefund,
                     PreparingReader,
-                    ReaderDisconnected,
-                    is ReadyForRefund -> false
+                    ReaderDisconnected -> false
                 }
             }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundState.kt
@@ -2,7 +2,6 @@ package com.woocommerce.android.ui.woopos.orders.details.refund
 
 import androidx.annotation.StringRes
 import androidx.compose.runtime.Immutable
-import com.woocommerce.android.R
 import java.math.BigDecimal
 
 @Immutable
@@ -38,7 +37,7 @@ sealed class WooPosRefundState {
                     Processing,
                     ProcessingRefund,
                     NotifyingStore -> true
-                    is ReadyForRefund -> step.cardReaderHint == R.string.card_reader_payment_remove_card_prompt
+                    is ReadyForRefund -> step.isDismissBlocked
                     SelectItems,
                     ReviewRefund,
                     ConfirmRefund,
@@ -66,7 +65,10 @@ sealed class WooPosRefundState {
             data object ReaderDisconnected : RefundStep()
 
             @Immutable
-            data class ReadyForRefund(@StringRes val cardReaderHint: Int? = null) : RefundStep()
+            data class ReadyForRefund(
+                @StringRes val cardReaderHint: Int? = null,
+                val isDismissBlocked: Boolean = false,
+            ) : RefundStep()
 
             @Immutable
             data object ProcessingRefund : RefundStep()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSubmissionProcessor.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSubmissionProcessor.kt
@@ -49,7 +49,10 @@ sealed class WooPosRefundSubmissionState {
     data object Processing : WooPosRefundSubmissionState()
     data object PreparingReader : WooPosRefundSubmissionState()
     data object ReaderConnectionRequired : WooPosRefundSubmissionState()
-    data class WaitingForCard(@StringRes val cardReaderHint: Int? = null) : WooPosRefundSubmissionState()
+    data class WaitingForCard(
+        @StringRes val cardReaderHint: Int? = null,
+        val isDismissBlocked: Boolean = false,
+    ) : WooPosRefundSubmissionState()
     data object ProcessingReaderRefund : WooPosRefundSubmissionState()
     data object NotifyingStore : WooPosRefundSubmissionState()
     data object Success : WooPosRefundSubmissionState()
@@ -371,7 +374,12 @@ class WooPosRefundSubmissionProcessorImpl @Inject constructor(
                     "WooPosRefund: reader refund collecting card " +
                         "orderId=${request.orderId}, hint=${state.cardReaderHint}"
                 )
-                trySendState(WooPosRefundSubmissionState.WaitingForCard(state.cardReaderHint))
+                trySendState(
+                    WooPosRefundSubmissionState.WaitingForCard(
+                        cardReaderHint = state.cardReaderHint,
+                        isDismissBlocked = state.isDismissBlocked,
+                    )
+                )
             }
 
             is CardReaderInteracRefundState.ProcessingInteracRefund -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSubmissionProcessor.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSubmissionProcessor.kt
@@ -314,7 +314,13 @@ class WooPosRefundSubmissionProcessorImpl @Inject constructor(
             stateJob.cancel()
             eventJob.cancel()
             refundSessionState.exitFallbackJob?.cancel()
-            controller.stop()
+            runCatching { controller.stop() }.onFailure {
+                WooLog.e(
+                    WooLog.T.POS,
+                    "WooPosRefund: failed to stop Interac reader refund controller orderId=${request.orderId}",
+                    it
+                )
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundUIEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundUIEvent.kt
@@ -8,6 +8,7 @@ sealed class WooPosRefundUIEvent {
     data object BackToSelectItemsClicked : WooPosRefundUIEvent()
     data class OnRefundReasonChanged(val reason: String) : WooPosRefundUIEvent()
     data object ContinueToConfirmRefundClicked : WooPosRefundUIEvent()
+    data object BackToConfirmRefundClicked : WooPosRefundUIEvent()
     data object BackToReviewClicked : WooPosRefundUIEvent()
     data object OnRefundConfirmed : WooPosRefundUIEvent()
     data object RefundFlowDismissed : WooPosRefundUIEvent()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundViewModel.kt
@@ -466,7 +466,8 @@ class WooPosRefundViewModel @AssistedInject constructor(
             is WooPosRefundSubmissionState.WaitingForCard -> {
                 _state.value = contentState.copy(
                     step = WooPosRefundState.Content.RefundStep.ReadyForRefund(
-                        submissionState.cardReaderHint
+                        cardReaderHint = submissionState.cardReaderHint,
+                        isDismissBlocked = submissionState.isDismissBlocked,
                     )
                 )
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundViewModel.kt
@@ -291,6 +291,8 @@ class WooPosRefundViewModel @AssistedInject constructor(
                 _state.value = currentState.copy(refundReason = event.reason)
             WooPosRefundUIEvent.ContinueToConfirmRefundClicked ->
                 _state.value = currentState.copy(step = WooPosRefundState.Content.RefundStep.ConfirmRefund)
+            WooPosRefundUIEvent.BackToConfirmRefundClicked ->
+                _state.value = currentState.copy(step = WooPosRefundState.Content.RefundStep.ConfirmRefund)
             WooPosRefundUIEvent.BackToReviewClicked ->
                 _state.value = currentState.copy(step = WooPosRefundState.Content.RefundStep.ReviewRefund)
             WooPosRefundUIEvent.ConnectReaderClicked -> handleConnectReaderClicked()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentControllerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentControllerTest.kt
@@ -2479,6 +2479,20 @@ class CardReaderPaymentControllerTest : BaseUnitTest() {
         }
 
     @Test
+    fun `given user leaves the screen, when cancel payment throws, then stop does not crash`() =
+        testBlocking {
+            whenever(cardReaderManager.collectPayment(any())).thenAnswer {
+                flow { emit(paymentFailedWithValidDataForRetry) }
+            }
+            whenever(cardReaderManager.cancelPayment(any())).thenThrow(RuntimeException("Cancellation race"))
+            controller.start()
+
+            controller.stop()
+
+            verify(cardReaderManager).cancelPayment(any())
+        }
+
+    @Test
     fun `given user leaves the screen, when payment succeeded on retry, then payment NOT canceled`() =
         testBlocking {
             whenever(errorMapper.mapPaymentErrorToUiError(Generic, false))
@@ -3020,10 +3034,9 @@ class CardReaderPaymentControllerTest : BaseUnitTest() {
 
             controller.start()
 
-            assertThat(
-                (controller.paymentState.value as CardReaderInteracRefundState.CollectingInteracRefund).cardReaderHint
-            )
-                .isEqualTo(R.string.card_reader_payment_remove_card_prompt)
+            val state = controller.paymentState.value as CardReaderInteracRefundState.CollectingInteracRefund
+            assertThat(state.cardReaderHint).isEqualTo(R.string.card_reader_payment_remove_card_prompt)
+            assertThat(state.isDismissBlocked).isTrue()
         }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentControllerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentControllerTest.kt
@@ -80,6 +80,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.test.advanceUntilIdle
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -2484,12 +2485,29 @@ class CardReaderPaymentControllerTest : BaseUnitTest() {
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(paymentFailedWithValidDataForRetry) }
             }
-            whenever(cardReaderManager.cancelPayment(any())).thenThrow(RuntimeException("Cancellation race"))
+            whenever(cardReaderManager.cancelPayment(any())).thenThrow(IllegalStateException("Cancellation race"))
             controller.start()
 
             controller.stop()
 
             verify(cardReaderManager).cancelPayment(any())
+        }
+
+    @Test
+    fun `given user leaves the screen, when scope cancellation handler throws, then stop does not crash`() =
+        testBlocking {
+            whenever(cardReaderManager.collectPayment(any())).thenAnswer {
+                flow<CardPaymentStatus> {
+                    suspendCancellableCoroutine<Unit> { continuation ->
+                        continuation.invokeOnCancellation {
+                            throw IllegalStateException("Cancellation race")
+                        }
+                    }
+                }
+            }
+            controller.start()
+
+            controller.stop()
         }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModelTest.kt
@@ -2,6 +2,8 @@ package com.woocommerce.android.ui.woopos.home
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.viewModelScope
+import app.cash.turbine.test
 import com.woocommerce.android.ui.woopos.common.util.WooPosSoundHelper
 import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent.OrderSuccessfullyPaid.PaymentMethod
 import com.woocommerce.android.ui.woopos.home.WooPosHomeUIEvent.ExitPosClicked
@@ -12,13 +14,16 @@ import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Eve
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.ExitConfirmed
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
 import org.junit.Rule
 import org.mockito.kotlin.argThat
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import kotlin.test.Test
@@ -37,6 +42,13 @@ class WooPosHomeViewModelTest {
     private val parentToChildrenEventSender: WooPosParentToChildrenEventSender = mock()
     private val analyticsTracker: WooPosAnalyticsTracker = mock()
     private val soundHelper: WooPosSoundHelper = mock()
+
+    private var viewModel: WooPosHomeViewModel? = null
+
+    @After
+    fun tearDown() {
+        viewModel?.viewModelScope?.cancel()
+    }
 
     @Test
     fun `when order created, then pass event to cart`() =
@@ -330,6 +342,47 @@ class WooPosHomeViewModelTest {
     }
 
     @Test
+    fun `given home at Checkout, when opening orders, then checkout is cancelled`() = runTest {
+        // GIVEN
+        val events = MutableSharedFlow<ChildToParentEvent>()
+        whenever(childrenToParentEventReceiver.events).thenReturn(events)
+        val viewModel = createViewModel()
+        events.emit(ChildToParentEvent.CheckoutClicked(listOf(ItemClickedData.Product.Simple(1))))
+
+        // WHEN
+        viewModel.navigationEvent.test {
+            events.emit(ChildToParentEvent.NavigationEvent.ToOrders)
+
+            // THEN
+            assertThat(awaitItem()).isEqualTo(ChildToParentEvent.NavigationEvent.ToOrders)
+            verify(parentToChildrenEventSender).sendToChildren(
+                ParentToChildrenEvent.BackFromCheckoutToCartClicked
+            )
+            assertThat(viewModel.state.value.screenPositionState)
+                .isEqualTo(WooPosHomeState.ScreenPositionState.Cart)
+        }
+    }
+
+    @Test
+    fun `given home outside Checkout, when opening orders, then checkout is not cancelled`() = runTest {
+        // GIVEN
+        val events = MutableSharedFlow<ChildToParentEvent>()
+        whenever(childrenToParentEventReceiver.events).thenReturn(events)
+        val viewModel = createViewModel()
+
+        // WHEN
+        viewModel.navigationEvent.test {
+            events.emit(ChildToParentEvent.NavigationEvent.ToOrders)
+
+            // THEN
+            assertThat(awaitItem()).isEqualTo(ChildToParentEvent.NavigationEvent.ToOrders)
+            verify(parentToChildrenEventSender, never()).sendToChildren(
+                ParentToChildrenEvent.BackFromCheckoutToCartClicked
+            )
+        }
+    }
+
+    @Test
     fun `given Cart state with ScanningSetupDialog visible, when SystemBackClicked, then dialog should be dismissed`() = runTest {
         // GIVEN
         val events = MutableSharedFlow<ChildToParentEvent>()
@@ -368,6 +421,6 @@ class WooPosHomeViewModelTest {
             analyticsTracker,
             soundHelper,
             SavedStateHandle()
-        )
+        ).also { viewModel = it }
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSubmissionProcessorTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSubmissionProcessorTest.kt
@@ -645,7 +645,7 @@ class WooPosRefundSubmissionProcessorTest {
                     paymentMethodType = INTERAC_PRESENT
                 )
             )
-            whenever(cardReaderPaymentControllerFactory.createRefund(any(), any(), any(), any(), any()))
+            whenever(cardReaderPaymentControllerFactory.createRefund(any(), any(), any()))
                 .thenReturn(controller)
 
             processor.submit(request).test {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSubmissionProcessorTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSubmissionProcessorTest.kt
@@ -30,6 +30,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -604,6 +605,34 @@ class WooPosRefundSubmissionProcessorTest {
                 assertThat(awaitItem()).isEqualTo(WooPosRefundSubmissionState.ReaderConnectionRequired)
                 awaitComplete()
             }
+        }
+
+    @Test
+    fun `given controller stop fails during cancellation, when collection is cancelled, then it does not crash`() =
+        runTest {
+            val paymentState = MutableStateFlow<CardReaderPaymentOrRefundState>(
+                CardReaderInteracRefundState.LoadingData {}
+            )
+            val controller = mockController(paymentState)
+            doThrow(RuntimeException("Cannot cancel this operation while it is waiting for a network response"))
+                .whenever(controller)
+                .stop()
+            whenever(paymentChargeRepository.fetchCardDataUsedForOrderPayment("ch_123")).thenReturn(
+                PaymentChargeRepository.CardDataUsedForOrderPaymentResult.Success(
+                    cardBrand = "interac",
+                    cardLast4 = "1234",
+                    paymentMethodType = INTERAC_PRESENT
+                )
+            )
+            whenever(cardReaderPaymentControllerFactory.createRefund(any(), any(), any(), any(), any()))
+                .thenReturn(controller)
+
+            processor.submit(request).test {
+                assertThat(awaitItem()).isEqualTo(WooPosRefundSubmissionState.PreparingReader)
+                cancelAndIgnoreRemainingEvents()
+            }
+
+            verify(controller).stop()
         }
 
     private fun mockController(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundViewModelTest.kt
@@ -879,7 +879,8 @@ class WooPosRefundViewModelTest {
             whenever(refundSubmissionProcessor.submit(any())).thenReturn(
                 flowOf(
                     WooPosRefundSubmissionState.WaitingForCard(
-                        R.string.card_reader_payment_remove_card_prompt
+                        cardReaderHint = R.string.card_reader_payment_remove_card_prompt,
+                        isDismissBlocked = true,
                     )
                 )
             )
@@ -894,7 +895,8 @@ class WooPosRefundViewModelTest {
             val state = viewModel.state.value as WooPosRefundState.Content
             assertThat(state.step).isEqualTo(
                 WooPosRefundState.Content.RefundStep.ReadyForRefund(
-                    R.string.card_reader_payment_remove_card_prompt
+                    cardReaderHint = R.string.card_reader_payment_remove_card_prompt,
+                    isDismissBlocked = true,
                 )
             )
             assertThat(viewModel.onDismissRequest()).isFalse()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.woopos.orders.details.refund
 
+import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R
 import com.woocommerce.android.cardreader.connection.CardReaderStatus
 import com.woocommerce.android.model.Address
@@ -17,11 +18,13 @@ import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -137,6 +140,14 @@ class WooPosRefundViewModelTest {
                 WooPosRefundSubmissionState.Success
             )
         )
+    }
+
+    @After
+    fun tearDown() {
+        if (::viewModel.isInitialized) {
+            viewModel.viewModelScope.cancel()
+            coroutineTestRule.testDispatcher.scheduler.advanceUntilIdle()
+        }
     }
 
     private fun createViewModel(): WooPosRefundViewModel {
@@ -805,6 +816,88 @@ class WooPosRefundViewModelTest {
 
             verify(refundSubmissionProcessor, times(2)).submit(any())
             assertThat(viewModel.state.value).isInstanceOf(WooPosRefundState.RefundSuccess::class.java)
+        }
+
+    @Test
+    fun `given interac refund requires reader connection, when returning to confirm, then pending refund is cleared`() =
+        runTest {
+            val refundableItems = listOf(testRefundableItem)
+            val groupedItems = listOf(
+                RefundRequestItem(
+                    itemId = 1L,
+                    quantity = 1,
+                    refundTotal = BigDecimal("20.00"),
+                    refundTax = emptyList()
+                )
+            )
+
+            whenever(ordersDataSource.refreshOrderById(testOrderId)).thenReturn(Result.success(testOrder))
+            whenever(retrieveOrderRefunds.invoke(eq(testOrder), any())).thenReturn(Result.success(emptyList()))
+            whenever(getRefundableItems.invoke(any(), any())).thenReturn(refundableItems)
+            whenever(groupRefundItems.invoke(eq(refundableItems), eq(testOrder), any())).thenReturn(groupedItems)
+            whenever(refundSubmissionProcessor.submit(any())).thenReturn(
+                flowOf(WooPosRefundSubmissionState.ReaderConnectionRequired)
+            )
+
+            viewModel = createViewModel()
+            viewModel.onUIEvent(WooPosRefundUIEvent.RefundFlowOpened)
+            advanceUntilIdle()
+
+            viewModel.onUIEvent(WooPosRefundUIEvent.OnRefundConfirmed)
+            advanceUntilIdle()
+
+            val disconnectedState = viewModel.state.value as WooPosRefundState.Content
+            assertThat(disconnectedState.step).isEqualTo(WooPosRefundState.Content.RefundStep.ReaderDisconnected)
+
+            viewModel.onUIEvent(WooPosRefundUIEvent.CancelRefund)
+            viewModel.onUIEvent(WooPosRefundUIEvent.BackToConfirmRefundClicked)
+            readerStatus.value = CardReaderStatus.Connected(mock())
+            advanceUntilIdle()
+
+            val confirmState = viewModel.state.value as WooPosRefundState.Content
+            assertThat(confirmState.step).isEqualTo(WooPosRefundState.Content.RefundStep.ConfirmRefund)
+            verify(refundSubmissionProcessor, times(1)).submit(any())
+        }
+
+    @Test
+    fun `given reader asks to remove card, when dismiss requested, then dismissal is blocked`() =
+        runTest {
+            val refundableItems = listOf(testRefundableItem)
+            val groupedItems = listOf(
+                RefundRequestItem(
+                    itemId = 1L,
+                    quantity = 1,
+                    refundTotal = BigDecimal("20.00"),
+                    refundTax = emptyList()
+                )
+            )
+
+            whenever(ordersDataSource.refreshOrderById(testOrderId)).thenReturn(Result.success(testOrder))
+            whenever(retrieveOrderRefunds.invoke(eq(testOrder), any())).thenReturn(Result.success(emptyList()))
+            whenever(getRefundableItems.invoke(any(), any())).thenReturn(refundableItems)
+            whenever(groupRefundItems.invoke(eq(refundableItems), eq(testOrder), any())).thenReturn(groupedItems)
+            whenever(refundSubmissionProcessor.submit(any())).thenReturn(
+                flowOf(
+                    WooPosRefundSubmissionState.WaitingForCard(
+                        R.string.card_reader_payment_remove_card_prompt
+                    )
+                )
+            )
+
+            viewModel = createViewModel()
+            viewModel.onUIEvent(WooPosRefundUIEvent.RefundFlowOpened)
+            advanceUntilIdle()
+
+            viewModel.onUIEvent(WooPosRefundUIEvent.OnRefundConfirmed)
+            advanceUntilIdle()
+
+            val state = viewModel.state.value as WooPosRefundState.Content
+            assertThat(state.step).isEqualTo(
+                WooPosRefundState.Content.RefundStep.ReadyForRefund(
+                    R.string.card_reader_payment_remove_card_prompt
+                )
+            )
+            assertThat(viewModel.onDismissRequest()).isFalse()
         }
 
     @Test


### PR DESCRIPTION
Part of: RSM-645

### Description
- Cancel in-flight checkout payment work before opening orders/refunds.
- Align refund back and cancel behavior across selection, review, confirmation, and reader states.
- Avoid crashing or retrying terminal work when cancellation races with Stripe Terminal processing.

### Stack
Previous PR: #15994
Base branch: issue/android-pos-interac-refunds-03-reader-ui
Next branch: issue/android-pos-interac-refunds-05-detail-pane

### Test Steps
- Unit tests pass.
- From the tip of the stack (https://github.com/woocommerce/woocommerce-android/pull/15996), start POS checkout with the reader disconnected, open Orders, start a card-present refund, connect the reader, and verify the old checkout payment flow does not continue or race the refund.
- During an Interac-present refund, verify Back returns to the previous refund step where allowed, Cancel exits the refund flow, and cancellation is blocked once terminal processing is non-cancelable.
- While the card is being tapped/processed, attempt to cancel/back out and verify the app does not crash.

### Images/gif
N/A. This PR hardens flow behavior and is best validated in-device.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
