### PR TITLE
[WOOMOB-3124] Fix USPS customs validation for US territories

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 - [*] Fixed POS Checkout screen clipping content on small phones and in phone landscape [https://github.com/woocommerce/woocommerce-android/pull/15953]
 - [Internal] Added WOO_POS_SCAN_TO_PAY and WOO_POS_MARK_ORDER_AS_COMPLETE feature flags (off in production) for the upcoming Woo POS Scan to Pay and Mark Order as Complete payment methods [https://github.com/woocommerce/woocommerce-android/pull/15928]
 - [**] Contact support now includes troubleshooting and AI help [https://github.com/woocommerce/woocommerce-android/pull/15979]
+- [*] Fixed USPS shipping label customs handling for US territories and added a 30-character limit on customs item descriptions [https://github.com/woocommerce/woocommerce-android/pull/15999]
 
 24.8
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationFragment.kt
@@ -102,6 +102,7 @@ class WooShippingLabelCreationFragment : BaseFragment() {
                 is NavigateToCustomsFormEdit -> {
                     WooShippingLabelCreationFragmentDirections
                         .actionWooShippingLabelCreationFragmentToWooShippingLabelCustomsFormFragment(
+                            originCountryCode = event.originCountryCode,
                             destinationCountryCode = event.destinationCountryCode,
                             customsData = event.customData,
                             storeOptions = event.storeOptions

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -583,9 +583,10 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         ) { addresses, customsData ->
             customsData.mapIndexed { index, currentItemCustomsData ->
                 val selectedAddress = addresses.getOrNull(index)
+                val originCountryCode = selectedAddress?.shipFrom?.country.orEmpty()
                 val destinationCountryCode = selectedAddress?.shipTo?.address?.country?.code.orEmpty()
                 val customsFormValidationResult = currentItemCustomsData?.let {
-                    customsValidator.validate(it, destinationCountryCode)
+                    customsValidator.validate(it, originCountryCode, destinationCountryCode)
                 }
 
                 when (customsFormValidationResult) {
@@ -1187,11 +1188,13 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     }
 
     fun onEditCustomsClick() {
-        val destinationCountryCode = shippingAddresses.value.getOrNull(selectedShipmentIndex)
-            ?.shipTo?.address?.country?.code.orEmpty()
+        val selectedAddress = shippingAddresses.value.getOrNull(selectedShipmentIndex)
+        val originCountryCode = selectedAddress?.shipFrom?.country.orEmpty()
+        val destinationCountryCode = selectedAddress?.shipTo?.address?.country?.code.orEmpty()
 
         launch {
             val event = NavigateToCustomsFormEdit(
+                originCountryCode = originCountryCode,
                 destinationCountryCode = destinationCountryCode,
                 customData = requireNotNull(customsFormDataFlow.value[selectedShipmentIndex]),
                 storeOptions = accountSettings.first()?.storeOptions ?: StoreOptionsModel.EMPTY
@@ -1357,6 +1360,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     ) : Parcelable
 
     data class NavigateToCustomsFormEdit(
+        val originCountryCode: String,
         val destinationCountryCode: String,
         val customData: CustomsData,
         val storeOptions: StoreOptionsModel

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
@@ -35,6 +35,7 @@ class WooShippingCustomsFormViewModel @Inject constructor(
     savedState: SavedStateHandle
 ) : ScopedViewModel(savedState) {
     private val navArgs: WooShippingCustomsFormFragmentArgs by savedState.navArgs()
+    private val originCountryCode = navArgs.originCountryCode
     private val destinationCountryCode = navArgs.destinationCountryCode
     private val storeOptions = navArgs.storeOptions
 
@@ -97,7 +98,9 @@ class WooShippingCustomsFormViewModel @Inject constructor(
                 WooShippingCustomsProductUIModel(
                     productId = item.productID,
                     name = item.description,
-                    description = validateAsInputValue(item.description, customsValidator::validateProductDescription),
+                    description = validateAsInputValue(item.description) {
+                        customsValidator.validateProductDescription(it, originCountryCode, destinationCountryCode)
+                    },
                     tariffNumber = validateAsInputValue(item.hsTariffNumber) {
                         customsValidator.validateHSTariffNumber(it, destinationCountryCode)
                     },
@@ -184,7 +187,11 @@ class WooShippingCustomsFormViewModel @Inject constructor(
 
     fun onShippableProductDescriptionChanged(itemIndex: Int, newValue: String) {
         updateShippingProductsAt(itemIndex) { item ->
-            item.copy(description = validateAsInputValue(newValue, customsValidator::validateProductDescription))
+            item.copy(
+                description = validateAsInputValue(newValue) {
+                    customsValidator.validateProductDescription(it, originCountryCode, destinationCountryCode)
+                }
+            )
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/domain/ShouldRequireCustomsForm.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/domain/ShouldRequireCustomsForm.kt
@@ -23,7 +23,11 @@ class ShouldRequireCustomsForm @Inject constructor() {
     }
 
     private val WooShippingAddresses.isDifferentCountryShipment
-        get() = shipFrom.country != shipTo.address.country.code
+        get() = getEffectiveCustomsCountry(shipFrom.country, shipFrom.state.orEmpty()) !=
+            getEffectiveCustomsCountry(shipTo.address.country.code, shipTo.address.state.codeOrRaw)
+
+    private fun getEffectiveCustomsCountry(country: String, state: String): String =
+        if (country == US_COUNTRY_CODE && state in US_TERRITORY_STATES) state else country
 
     private fun isAddressInMilitaryState(
         countryCode: String,
@@ -33,5 +37,6 @@ class ShouldRequireCustomsForm @Inject constructor() {
     companion object {
         const val US_COUNTRY_CODE = "US"
         val US_MILITARY_STATES = arrayOf("AA", "AE", "AP")
+        val US_TERRITORY_STATES = arrayOf("AS", "GU", "MP", "PR", "VI", "UM")
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/domain/WooShippingCustomsValidator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/domain/WooShippingCustomsValidator.kt
@@ -12,7 +12,11 @@ class WooShippingCustomsValidator @Inject constructor(
     private val validateHSTariffNumber: ValidateHSTariffNumber,
     private val validateITN: ValidateITN
 ) {
-    fun validate(customsData: CustomsData, destinationCountryCode: String): FormValidationResult {
+    fun validate(
+        customsData: CustomsData,
+        originCountryCode: String,
+        destinationCountryCode: String
+    ): FormValidationResult {
         val itnValidationResult = validateITN.invoke(customsData, destinationCountryCode)
         if (itnValidationResult !is ValidateITN.ITNValidationResult.Valid) {
             return if (itnValidationResult is ValidateITN.ITNValidationResult.Missing) {
@@ -26,7 +30,7 @@ class WooShippingCustomsValidator @Inject constructor(
             validateRestrictionType(customsData.restrictionType, customsData.restrictionDescription).isValid &&
             customsData.items.all {
                 validateHSTariffNumber(it.hsTariffNumber, destinationCountryCode).isValid &&
-                    validateProductDescription(it.description).isValid &&
+                    validateProductDescription(it.description, originCountryCode, destinationCountryCode).isValid &&
                     validateProductValue(it.value.toString()).isValid &&
                     validateProductWeight(it.weight.toString()).isValid
             }
@@ -103,12 +107,31 @@ class WooShippingCustomsValidator @Inject constructor(
         )
     }
 
-    fun validateProductDescription(description: String) = when (description.isBlank()) {
-        false -> FieldValidationResult.Valid
-        true -> FieldValidationResult.Invalid(
+    fun validateProductDescription(
+        description: String,
+        originCountryCode: String,
+        destinationCountryCode: String
+    ): FieldValidationResult = when {
+        description.isBlank() -> FieldValidationResult.Invalid(
             errorMessageId = R.string.woo_shipping_labels_customs_product_details_description_missing
         )
+
+        isUSPSDomesticMailShipment(originCountryCode, destinationCountryCode) &&
+            description.length > MAX_ITEM_DESCRIPTION_LENGTH -> FieldValidationResult.Invalid(
+            errorMessage = UiString.UiStringRes(
+                stringRes = R.string.woo_shipping_labels_customs_product_details_description_too_long,
+                params = listOf(UiString.UiStringText(MAX_ITEM_DESCRIPTION_LENGTH.toString()))
+            )
+        )
+
+        else -> FieldValidationResult.Valid
     }
+
+    private fun isUSPSDomesticMailShipment(
+        originCountryCode: String,
+        destinationCountryCode: String
+    ): Boolean = originCountryCode in ACCEPTED_USPS_ORIGIN_COUNTRIES &&
+        destinationCountryCode in ACCEPTED_USPS_ORIGIN_COUNTRIES
 
     fun validateProductValue(value: String) = when (value.isBlank()) {
         false -> FieldValidationResult.Valid
@@ -142,5 +165,21 @@ class WooShippingCustomsValidator @Inject constructor(
         }
 
         data object Valid : FieldValidationResult
+    }
+
+    companion object {
+        const val MAX_ITEM_DESCRIPTION_LENGTH = 30
+
+        val ACCEPTED_USPS_ORIGIN_COUNTRIES = arrayOf(
+            "US", // United States
+            "PR", // Puerto Rico
+            "VI", // Virgin Islands
+            "GU", // Guam
+            "AS", // American Samoa
+            "UM", // United States Minor Outlying Islands
+            "MH", // Marshall Islands
+            "FM", // Micronesia
+            "MP", // Northern Mariana Islands
+        )
     }
 }

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -761,6 +761,10 @@
         android:name="com.woocommerce.android.ui.orders.wooshippinglabels.customs.WooShippingCustomsFormFragment"
         android:label="WooShippingLabelCustomsFormFragment">
         <argument
+            android:name="originCountryCode"
+            app:argType="string" />
+
+        <argument
             android:name="destinationCountryCode"
             app:argType="string" />
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4444,6 +4444,7 @@
     <string name="woo_shipping_labels_customs_product_details_title">Product Details</string>
     <string name="woo_shipping_labels_customs_product_details_description">Description</string>
     <string name="woo_shipping_labels_customs_product_details_description_missing">Missing Description</string>
+    <string name="woo_shipping_labels_customs_product_details_description_too_long">Description must be %1$s characters or fewer.</string>
     <string name="woo_shipping_labels_customs_product_details_tariff">HS tariff number</string>
     <string name="woo_shipping_labels_customs_product_details_tariff_invalid">The tariff number must be between 6 and 12 digits long</string>
     <string name="woo_shipping_labels_customs_product_details_value_per_unit">Value per unit</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
@@ -980,7 +980,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
             var currentViewState: WooShippingViewState? = null
 
             whenever(shouldRequireCustomsForm.invoke(any())) doReturn true
-            whenever(customsValidator.validate(any(), any())) doReturn
+            whenever(customsValidator.validate(any(), any(), any())) doReturn
                 WooShippingCustomsValidator.FormValidationResult.ItnMissing
             whenever(getShipments(any())) doReturn defaultShipments.map {
                 it.copy(items = defaultShippableItems.map { it.copy(price = BigDecimal(10000)) })

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/ShouldRequireCustomsFormTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/ShouldRequireCustomsFormTest.kt
@@ -113,4 +113,57 @@ class ShouldRequireCustomsFormTest {
         )
         assertFalse(shouldRequireCustomsForm(addressData))
     }
+
+    @Test
+    fun `given destination state is any US territory, when invoked, then customs is required`() {
+        listOf("AS", "GU", "MP", "PR", "VI", "UM").forEach { territory ->
+            val addressData = WooShippingAddresses(
+                shipFrom = OriginShippingAddress.EMPTY.copy(country = "US", state = "CA"),
+                shipTo = DestinationShippingAddress(
+                    Address.EMPTY.copy(
+                        country = Location.EMPTY.copy(code = "US"),
+                        state = AmbiguousLocation.Defined(Location.EMPTY.copy(code = territory))
+                    ),
+                    false
+                ),
+                originAddresses = emptyList()
+            )
+            assertTrue(
+                "Expected customs to be required for US territory state $territory",
+                shouldRequireCustomsForm(addressData)
+            )
+        }
+    }
+
+    @Test
+    fun `given origin is un-normalized US territory and destination is US mainland, when invoked, then customs is required`() {
+        val addressData = WooShippingAddresses(
+            shipFrom = OriginShippingAddress.EMPTY.copy(country = "US", state = "PR"),
+            shipTo = DestinationShippingAddress(
+                Address.EMPTY.copy(
+                    country = Location.EMPTY.copy(code = "US"),
+                    state = AmbiguousLocation.Defined(Location.EMPTY.copy(code = "CA"))
+                ),
+                false
+            ),
+            originAddresses = emptyList()
+        )
+        assertTrue(shouldRequireCustomsForm(addressData))
+    }
+
+    @Test
+    fun `given shipment within the same US territory, when invoked, then customs is not required`() {
+        val addressData = WooShippingAddresses(
+            shipFrom = OriginShippingAddress.EMPTY.copy(country = "US", state = "PR"),
+            shipTo = DestinationShippingAddress(
+                Address.EMPTY.copy(
+                    country = Location.EMPTY.copy(code = "US"),
+                    state = AmbiguousLocation.Defined(Location.EMPTY.copy(code = "PR"))
+                ),
+                false
+            ),
+            originAddresses = emptyList()
+        )
+        assertFalse(shouldRequireCustomsForm(addressData))
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModelTest.kt
@@ -23,6 +23,7 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import java.math.BigDecimal
@@ -41,7 +42,8 @@ class WooShippingCustomsFormViewModelTest : BaseUnitTest() {
         on { validateITN(any(), any()) } doReturn WooShippingCustomsValidator.FieldValidationResult.Valid
         on { validateContentType(any(), any()) } doReturn WooShippingCustomsValidator.FieldValidationResult.Valid
         on { validateRestrictionType(any(), any()) } doReturn WooShippingCustomsValidator.FieldValidationResult.Valid
-        on { validateProductDescription(any()) } doReturn WooShippingCustomsValidator.FieldValidationResult.Valid
+        on { validateProductDescription(any(), any(), any()) } doReturn
+            WooShippingCustomsValidator.FieldValidationResult.Valid
         on { validateProductValue(any()) } doReturn WooShippingCustomsValidator.FieldValidationResult.Valid
         on { validateProductWeight(any()) } doReturn WooShippingCustomsValidator.FieldValidationResult.Valid
         on { validateHSTariffNumber(any(), any()) } doReturn WooShippingCustomsValidator.FieldValidationResult.Valid
@@ -235,7 +237,7 @@ class WooShippingCustomsFormViewModelTest : BaseUnitTest() {
             // Given
             val itemIndex = 0
             val blankDescription = ""
-            whenever(customsValidator.validateProductDescription(blankDescription)).thenReturn(
+            whenever(customsValidator.validateProductDescription(eq(blankDescription), any(), any())).thenReturn(
                 WooShippingCustomsValidator.FieldValidationResult.Invalid(
                     errorMessage = UiString.UiStringRes(
                         R.string.woo_shipping_labels_customs_product_details_description_missing
@@ -485,6 +487,7 @@ class WooShippingCustomsFormViewModelTest : BaseUnitTest() {
         )
 
         val savedState = WooShippingCustomsFormFragmentArgs(
+            originCountryCode = "US",
             destinationCountryCode = "CA",
             customsData = defaultCustomsData,
             storeOptions = StoreOptionsModel(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/domain/WooShippingCustomsValidatorTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/domain/WooShippingCustomsValidatorTest.kt
@@ -54,7 +54,7 @@ class WooShippingCustomsValidatorTest : BaseUnitTest() {
 
     @Test
     fun `given valid customs data, when validating form, then should return Valid`() = testBlocking {
-        val result = validator.validate(defaultCustomsData, "CA")
+        val result = validator.validate(defaultCustomsData, "US", "CA")
 
         assertThat(result).isEqualTo(WooShippingCustomsValidator.FormValidationResult.Valid)
     }
@@ -65,7 +65,7 @@ class WooShippingCustomsValidatorTest : BaseUnitTest() {
             ValidateITN.ITNValidationResult.Missing(ValidateITN.ITNMissingCause.TotalValue)
         )
 
-        val result = validator.validate(defaultCustomsData, "CA")
+        val result = validator.validate(defaultCustomsData, "US", "CA")
 
         assertThat(result).isEqualTo(WooShippingCustomsValidator.FormValidationResult.ItnMissing)
     }
@@ -76,7 +76,7 @@ class WooShippingCustomsValidatorTest : BaseUnitTest() {
             ValidateITN.ITNValidationResult.InvalidFormat
         )
 
-        val result = validator.validate(defaultCustomsData, "CA")
+        val result = validator.validate(defaultCustomsData, "US", "CA")
 
         assertThat(result).isEqualTo(WooShippingCustomsValidator.FormValidationResult.Invalid)
     }
@@ -89,7 +89,7 @@ class WooShippingCustomsValidatorTest : BaseUnitTest() {
             )
         )
 
-        val result = validator.validate(customsDataWithBlankDescription, "CA")
+        val result = validator.validate(customsDataWithBlankDescription, "US", "CA")
 
         assertThat(result).isEqualTo(WooShippingCustomsValidator.FormValidationResult.Invalid)
     }
@@ -234,7 +234,7 @@ class WooShippingCustomsValidatorTest : BaseUnitTest() {
     @Test
     fun `given valid product description, when validating product description, then should return Valid`() =
         testBlocking {
-            val result = validator.validateProductDescription("Test product")
+            val result = validator.validateProductDescription("Test product", "US", "CA")
 
             assertThat(result).isEqualTo(WooShippingCustomsValidator.FieldValidationResult.Valid)
         }
@@ -242,13 +242,70 @@ class WooShippingCustomsValidatorTest : BaseUnitTest() {
     @Test
     fun `given blank product description, when validating product description, then should return Invalid`() =
         testBlocking {
-            val result = validator.validateProductDescription("")
+            val result = validator.validateProductDescription("", "US", "CA")
 
             assertThat(result).isInstanceOf(WooShippingCustomsValidator.FieldValidationResult.Invalid::class.java)
             val invalid = result as WooShippingCustomsValidator.FieldValidationResult.Invalid
             assertThat(invalid.errorMessage).isEqualTo(
                 UiString.UiStringRes(R.string.woo_shipping_labels_customs_product_details_description_missing)
             )
+        }
+
+    @Test
+    fun `given description over 30 chars on USPS domestic mail shipment, when validating description, then should return Invalid`() =
+        testBlocking {
+            val longDescription = "a".repeat(31)
+
+            val result = validator.validateProductDescription(longDescription, "US", "PR")
+
+            assertThat(result).isInstanceOf(WooShippingCustomsValidator.FieldValidationResult.Invalid::class.java)
+            val invalid = result as WooShippingCustomsValidator.FieldValidationResult.Invalid
+            assertThat(invalid.errorMessage).isEqualTo(
+                UiString.UiStringRes(
+                    stringRes = R.string.woo_shipping_labels_customs_product_details_description_too_long,
+                    params = listOf(UiString.UiStringText("30"))
+                )
+            )
+        }
+
+    @Test
+    fun `given description exactly 30 chars on USPS domestic mail shipment, when validating description, then should return Valid`() =
+        testBlocking {
+            val description = "a".repeat(30)
+
+            val result = validator.validateProductDescription(description, "US", "PR")
+
+            assertThat(result).isEqualTo(WooShippingCustomsValidator.FieldValidationResult.Valid)
+        }
+
+    @Test
+    fun `given description over 30 chars on international shipment, when validating description, then should return Valid`() =
+        testBlocking {
+            val longDescription = "a".repeat(50)
+
+            val result = validator.validateProductDescription(longDescription, "US", "CA")
+
+            assertThat(result).isEqualTo(WooShippingCustomsValidator.FieldValidationResult.Valid)
+        }
+
+    @Test
+    fun `given description over 30 chars but origin is not USPS, when validating description, then should return Valid`() =
+        testBlocking {
+            val longDescription = "a".repeat(50)
+
+            val result = validator.validateProductDescription(longDescription, "CA", "US")
+
+            assertThat(result).isEqualTo(WooShippingCustomsValidator.FieldValidationResult.Valid)
+        }
+
+    @Test
+    fun `given description over 30 chars on territory to territory shipment, when validating description, then should return Invalid`() =
+        testBlocking {
+            val longDescription = "a".repeat(31)
+
+            val result = validator.validateProductDescription(longDescription, "PR", "GU")
+
+            assertThat(result).isInstanceOf(WooShippingCustomsValidator.FieldValidationResult.Invalid::class.java)
         }
 
     @Test


### PR DESCRIPTION
Fixes WOOMOB-3124

### Description

Fixes USPS shipping label customs handling for US territories and domestic-mail customs descriptions, matching the desktop fix in [woocommerce/woocommerce-shipping#1588](https://github.com/woocommerce/woocommerce-shipping/pull/1588). iOS counterpart: [woocommerce/woocommerce-ios#17255](https://github.com/woocommerce/woocommerce-ios/pull/17255).

US territory addresses can arrive normalized as territory country codes (PR, GU, etc.) or un-normalized as country US with the territory state. The customs requirement check now compares effective customs countries so un-normalized territory shipments correctly require customs, while intra-territory shipments do not.

The customs item description field now enforces the USPS 30-character limit only for USPS domestic-mail shipments (US, US territories, and military paths). True international shipments are unaffected.

### Test Steps
1. For an order shipping from US mainland to Puerto Rico (un-normalized: \`country=US, state=PR\`), open the shipping label creation flow. Verify the customs form is shown.
2. For an intra-Puerto Rico shipment, verify customs is not required.
3. In the customs form for a USPS domestic-mail shipment with customs required (e.g. US to Puerto Rico), enter a description longer than 30 characters. Verify the error "Description must be 30 characters or fewer." appears.
4. For an international shipment (e.g. US to Canada), verify the description is not limited to 30 characters.

### Images/gif

<img width="300" alt="Screenshot_20260526_010114" src="https://github.com/user-attachments/assets/46dfafa4-f4d3-42b7-8d45-5f58bb5a8fc5" />

- [x] I have considered if this change warrants release notes and have added them to \`RELEASE-NOTES.txt\` if necessary.