### PR TITLE
Fix typos in comments and test names

### DIFF
--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/support/help/HelpViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/support/help/HelpViewModelTest.kt
@@ -40,7 +40,7 @@ class HelpViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given site doesnt exist, when on contact clicked, then create event triggered`() {
+    fun `given site doesn't exist, when on contact clicked, then create event triggered`() {
         // GIVEN
         whenever(selectedSite.exists()).thenReturn(false)
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/tracker/TrackStoreSnapshotTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/tracker/TrackStoreSnapshotTest.kt
@@ -324,7 +324,7 @@ class TrackStoreSnapshotTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given plugins returned but name doesnt match, when invoke, then track event with not_installed`() =
+    fun `given plugins returned but name doesn't match, when invoke, then track event with not_installed`() =
         testBlocking {
             // GIVEN
             whenever(selectedSite.getIfExists()).thenReturn(selectedSiteModel)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/jitm/JitmStoreInMemoryCacheTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/jitm/JitmStoreInMemoryCacheTest.kt
@@ -62,7 +62,7 @@ class JitmStoreInMemoryCacheTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given site doesnt exist, when init, then should not fetch messages`() = testBlocking {
+    fun `given site doesn't exist, when init, then should not fetch messages`() = testBlocking {
         // GIVEN
         whenever(selectedSite.exists()).thenReturn(false)
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/customerlist/CustomerListSelectionViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/customerlist/CustomerListSelectionViewModelTest.kt
@@ -452,7 +452,7 @@ class CustomerListSelectionViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given empty list from repo and non email search, when add customer manually clicked, then event doesnt have email`() =
+    fun `given empty list from repo and non email search, when add customer manually clicked, then event doesn't have email`() =
         testBlocking {
             // GIVEN
             whenever(customerListRepository.searchCustomerListWithEmail(any(), any(), any(), any()))
@@ -738,7 +738,7 @@ class CustomerListSelectionViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given less than page returned from repo, when onEndOfListReached, then next call doesnt load more customers`() =
+    fun `given less than page returned from repo, when onEndOfListReached, then next call doesn't load more customers`() =
         testBlocking {
             // GIVEN
             val viewModel = initViewModel()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderPaymentViewModelTest.kt
@@ -1912,7 +1912,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given unknown error, when contact support clicked, then contact support event emited`() =
+    fun `given unknown error, when contact support clicked, then contact support event emitted`() =
         testBlocking {
             setupViewModelForInteracRefund()
             whenever(
@@ -2663,7 +2663,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given AppKilledWhileInBackground, when vm starts, then payment collection doesnt start`() =
+    fun `given AppKilledWhileInBackground, when vm starts, then payment collection doesn't start`() =
         testBlocking {
             val cardReader: CardReader = mock()
             whenever(cardReaderManager.readerStatus).thenReturn(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentControllerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentControllerTest.kt
@@ -1382,7 +1382,7 @@ class CardReaderPaymentControllerTest : BaseUnitTest() {
         }
 
     @Test
-    fun `when payment succeeds, then receiptUrl stored into a persistant storage`() =
+    fun `when payment succeeds, then receiptUrl stored into a persistent storage`() =
         testBlocking {
             val receiptUrl = "testUrl"
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
@@ -2905,7 +2905,7 @@ class CardReaderPaymentControllerTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given unknown error, when contact support clicked, then contact support event emited`() =
+    fun `given unknown error, when contact support clicked, then contact support event emitted`() =
         testBlocking {
             setupControllerForInteracRefund()
             whenever(
@@ -3769,7 +3769,7 @@ class CardReaderPaymentControllerTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given AppKilledWhileInBackground, when vm starts, then payment collection doesnt start`() =
+    fun `given AppKilledWhileInBackground, when vm starts, then payment collection doesn't start`() =
         testBlocking {
             val cardReader: CardReader = mock()
             whenever(cardReaderManager.readerStatus).thenReturn(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/taptopay/about/TapToPayAboutViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/taptopay/about/TapToPayAboutViewModelTest.kt
@@ -78,7 +78,7 @@ class TapToPayAboutViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given card reader config for the us, when view model init, then state doesnt contain`() {
+    fun `given card reader config for the us, when view model init, then state doesn't contain`() {
         // GIVEN
         val cardReaderConfig = CardReaderConfigForUSA
 

--- a/docs/right-to-left-layout-guidelines.md
+++ b/docs/right-to-left-layout-guidelines.md
@@ -13,7 +13,7 @@ Writing direction also affects time flow direction -> some asymmetric images/ico
 In order to have consistencty on text aligment when suporting RTL locales keep in mind the following:
 
 - Never test text using device developer setting: "Force RTL layout". It does not work well with `android:gravity="start"`. When testing we recommend setting your device language to an RTL locale such as Arabic or Hebrew. 
-- The recommended way to align text on xml layout is using `gravity="start"`. Most of the defined styles for texts existing in the app already set gravity and textAligment. Example: 
+- The recommended way to align text on xml layout is using `gravity="start"`. Most of the defined styles for texts existing in the app already set gravity and textAlignment. Example: 
 ```xml
 <style name="Woo.TextView.Subtitle2">
     <item name="android:textAppearance">?attr/textAppearanceSubtitle2</item>

--- a/docs/right-to-left-layout-guidelines.md
+++ b/docs/right-to-left-layout-guidelines.md
@@ -12,8 +12,8 @@ Writing direction also affects time flow direction -> some asymmetric images/ico
 
 In order to have consistencty on text aligment when suporting RTL locales keep in mind the following:
 
-- Never test text using device developer setting: "Force RTL layout". It does not work well with `android:gravity="start"`. When testing we recomend setting your device language to an RTL locale such as Arabic or Hebrew. 
-- The recomended way to align text on xml layout is using `gravity="start"`. Most of the defined styles for texts existing in the app already set gravity and textAligment. Example: 
+- Never test text using device developer setting: "Force RTL layout". It does not work well with `android:gravity="start"`. When testing we recommend setting your device language to an RTL locale such as Arabic or Hebrew. 
+- The recommended way to align text on xml layout is using `gravity="start"`. Most of the defined styles for texts existing in the app already set gravity and textAligment. Example: 
 ```xml
 <style name="Woo.TextView.Subtitle2">
     <item name="android:textAppearance">?attr/textAppearanceSubtitle2</item>

--- a/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
+++ b/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
@@ -576,7 +576,7 @@ class SiteRestClientTest {
     }
 
     @Test
-    fun `given not authenticated, when all domains are requested, then retun auth required error`() = test {
+    fun `given not authenticated, when all domains are requested, then return auth required error`() = test {
         val tokenErrorMessage = "An active access token must be used to query information about the current user."
         val error = WPComGsonNetworkError(BaseNetworkError(GenericErrorType.NOT_AUTHENTICATED, tokenErrorMessage))
         initAllDomainsResponse(error = error)


### PR DESCRIPTION
### Description

Mechanical typo fixes in code comments, a developer doc, and backticked test names.
No behavior changes.

Each commit fixes typos in a single file so the diff can be reviewed file-by-file.

### Test Steps

- Skim the diff; verify each replacement is the obvious correction.
- CI should be green.

- [x] No user-facing changes — release notes not needed.

---

*Posted by Claude (Opus 4.7) on behalf of @mokagio with approval.*