### PR TITLE
POC: Route POS checkout through Store API behind feature flag

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/DECISIONS.md
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/DECISIONS.md
@@ -4,9 +4,14 @@ Paired with the WooCommerce server-side architectural spike at
 `plugins/woocommerce/src/Internal/POS/StoreApi/` in `woocommerce/woocommerce`,
 this is the Android side: behind the
 `WOO_POS_STORE_API_CHECKOUT` feature flag, the moment the cashier taps "Charge"
-runs the in-memory cart through the new `wc/pos/v1/cart/add-item` + `/checkout`
-endpoints instead of `POST /wc/v3/orders`. Everything downstream of order
-creation (payment flow, card reader SDK, cash mark-paid) is unchanged.
+runs the in-memory cart through the new `wc/internal/pos/v1/cart/add-item` +
+`/checkout` endpoints instead of `POST /wc/v3/orders`. Everything downstream of
+order creation (payment flow, card reader SDK, cash mark-paid) is unchanged.
+
+The namespace is `wc/internal/pos/v1` (not `wc/pos/v1`, which is the public POS
+catalog feed): the cart/checkout shape is still a spike and not a committed
+public contract, and the routes exist only when the server's `point_of_sale`
+feature is enabled.
 
 This document records the judgement calls made while wiring it up.
 
@@ -30,8 +35,8 @@ assembly, coupon/fee composition) don't grow.
 ## Why per-item `cart/add-item` instead of a batch endpoint
 
 The Store API has `/wc/store/v1/batch` which can issue multiple operations in
-one HTTP request. We could expose it as `/wc/pos/v1/batch` and post all items
-+ the checkout in one round-trip.
+one HTTP request. We could expose it as `/wc/internal/pos/v1/batch` and post all
+items + the checkout in one round-trip.
 
 For the spike we stuck with per-item add + final checkout because:
 
@@ -44,8 +49,8 @@ For the spike we stuck with per-item add + final checkout because:
 - Lets us test the Store API integration on the simplest possible code path
   before optimising.
 
-A `/wc/pos/v1/batch` follow-up is a sensible optimisation once the per-item
-flow is validated end-to-end against real extensions.
+A `/wc/internal/pos/v1/batch` follow-up is a sensible optimisation once the
+per-item flow is validated end-to-end against real extensions.
 
 ## Why fetch the order after `/checkout` instead of constructing it locally
 
@@ -88,7 +93,7 @@ Practical paths forward, in order of preference:
 1. **Make `StoreApi\SessionHandler` non-final upstream and extend it as
    `POSSessionHandler`.** Mobile sends/receives `Cart-Token` via header. This
    is what Block Checkout already does — POS would share the model.
-2. **Add a `/wc/pos/v1/cart-token` endpoint** that issues a fresh signed
+2. **Add a `/wc/internal/pos/v1/cart-token` endpoint** that issues a fresh signed
    cart-token. Mobile calls it once at sale start; passes the token via
    `?session=` on subsequent requests.
 3. **Configure an OkHttp `CookieJar` per POS transaction** in the Android
@@ -102,12 +107,25 @@ session — i.e. the cart on checkout will not contain the prior items. This
 is documented in the server-side `DECISIONS.md` too. Unit tests mock the
 REST client so they're unaffected.
 
+## Coupons and custom amounts
+
+Both flow through dedicated POS cart endpoints before checkout, so server-side
+validation and composition run unchanged:
+
+- **Coupons** (`ItemClickedData.Coupon`) → `cart/apply-coupon`, one call per
+  code. Coupon validation (usage limits, per-customer limits, product
+  restrictions) runs server-side.
+- **Custom amounts** (`ItemClickedData.CustomAmount`) → `cart/add-fee`, one
+  call per fee, carrying name/amount/taxable. The server persists each fee in
+  the session and re-applies it on every cart recalculation, and fee identity
+  is content-derived so re-adding an identical fee is idempotent.
+
+The sequence is items → coupons → custom amounts → checkout; ordering is not
+load-bearing (coupons never discount fees, and fee/coupon persistence both span
+the cart-building phase), but it keeps the call order predictable.
+
 ## What this spike deliberately does NOT include
 
-- **Coupons** (`ItemClickedData.Coupon`) and **custom fees**
-  (`ItemClickedData.CustomAmount`) — the Store API uses separate endpoints
-  for these (`cart/apply-coupon`, etc.). Silently dropped for now;
-  `addProductsToCart` filters to `ItemClickedData.Product` only.
 - **Customer pre-fill on the order** — guest checkout in all cases. The
   agent/customer identity model from the server proposal hasn't been
   implemented yet, so there's no `customer_id` to send.

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/DECISIONS.md
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/DECISIONS.md
@@ -1,0 +1,124 @@
+# POS Store API integration — Android client decisions
+
+Paired with the WooCommerce server-side architectural spike at
+`plugins/woocommerce/src/Internal/POS/StoreApi/` in `woocommerce/woocommerce`,
+this is the Android side: behind the
+`WOO_POS_STORE_API_CHECKOUT` feature flag, the moment the cashier taps "Charge"
+runs the in-memory cart through the new `wc/pos/v1/cart/add-item` + `/checkout`
+endpoints instead of `POST /wc/v3/orders`. Everything downstream of order
+creation (payment flow, card reader SDK, cash mark-paid) is unchanged.
+
+This document records the judgement calls made while wiring it up.
+
+## Why a flag-gated branch in `WooPosTotalsRepository` rather than a parallel repo
+
+`WooPosTotalsRepository.createOrderFromCartItems` is the single funnel through
+which the totals/checkout screen materialises an order. The flag check lives
+there because:
+
+- One place to switch on/off; collaborators (ViewModel, payment flow) see no
+  difference in the returned `Result<Order>` contract.
+- The existing REST path stays the default and is untouched in code, only
+  short-circuited when the flag is on. Easy to revert.
+- A parallel repository would have required wiring choice into the ViewModel,
+  duplicating the orderCreationJob cancellation logic, and divergent tests.
+
+The new flow lives in a separate `PosStoreApiCheckoutUseCase` so it can be
+tested in isolation and so the repository's existing responsibilities (Order
+assembly, coupon/fee composition) don't grow.
+
+## Why per-item `cart/add-item` instead of a batch endpoint
+
+The Store API has `/wc/store/v1/batch` which can issue multiple operations in
+one HTTP request. We could expose it as `/wc/pos/v1/batch` and post all items
++ the checkout in one round-trip.
+
+For the spike we stuck with per-item add + final checkout because:
+
+- It matches the canonical Store API web flow, so any extension hooks that
+  fire per add (gift card line-item data setup, subscription validation) fire
+  in the same sequence as on web.
+- Per-call latency is the same order of magnitude as the existing
+  REST-`POST /wc/v3/orders` round-trip, which already involves several
+  internal calls server-side for line composition.
+- Lets us test the Store API integration on the simplest possible code path
+  before optimising.
+
+A `/wc/pos/v1/batch` follow-up is a sensible optimisation once the per-item
+flow is validated end-to-end against real extensions.
+
+## Why fetch the order after `/checkout` instead of constructing it locally
+
+The Store API `/checkout` response carries the full order schema, so we could
+deserialise totals/items directly and build an `Order` without a follow-up
+fetch. We chose the fetch path because:
+
+- It keeps the `Order` mapping path identical to the existing REST flow
+  (`OrderRestClient` → `OrderEntity` → `OrderMapper.toAppModel`). No new
+  mapper, no two-source-of-truth bug surface in this spike.
+- The local `OrderEntity` cache is populated as a side effect, which the rest
+  of the app already assumes for freshly-created orders.
+- It costs one extra round-trip in exchange for fully-shaped `Order` data.
+  Worth it for the spike's narrow scope; an obvious optimisation later.
+
+## Open question: session continuity across requests
+
+This is the load-bearing follow-up for end-to-end testing.
+
+The Store API server-side spike uses a custom `POSSessionHandler` that:
+
+1. Generates a guest-style session ID (`t_xxx`) on the first request so the
+   cart isn't keyed by the cashier's user ID.
+2. Reads the existing `?session=<cart_token>` query parameter to identify the
+   cart on subsequent requests.
+
+But:
+
+- `WooNetwork` does not configure an OkHttp `CookieJar`. The default
+  WC_Session_Handler sends `Set-Cookie` on responses with cart mutations, but
+  we don't capture it.
+- `CartTokenUtils::get_cart_token` requires the server's `wp_salt()` — mobile
+  cannot mint a fresh cart token client-side.
+- The Store API's own `SessionHandler` reads an `HTTP_CART_TOKEN` *header*
+  instead of `?session=`, which would be the cleanest fit for mobile, but
+  that class is `final` server-side.
+
+Practical paths forward, in order of preference:
+
+1. **Make `StoreApi\SessionHandler` non-final upstream and extend it as
+   `POSSessionHandler`.** Mobile sends/receives `Cart-Token` via header. This
+   is what Block Checkout already does — POS would share the model.
+2. **Add a `/wc/pos/v1/cart-token` endpoint** that issues a fresh signed
+   cart-token. Mobile calls it once at sale start; passes the token via
+   `?session=` on subsequent requests.
+3. **Configure an OkHttp `CookieJar` per POS transaction** in the Android
+   network stack. Heavier change to WooNetwork; couples POS to the legacy
+   WC_Session_Handler cookie format.
+
+Option 1 is the right long-term answer. Until one of these lands, the new
+flow will work for the first `cart/add-item` (creates a new server-side
+session) but every subsequent call in the same flow gets its own fresh
+session — i.e. the cart on checkout will not contain the prior items. This
+is documented in the server-side `DECISIONS.md` too. Unit tests mock the
+REST client so they're unaffected.
+
+## What this spike deliberately does NOT include
+
+- **Coupons** (`ItemClickedData.Coupon`) and **custom fees**
+  (`ItemClickedData.CustomAmount`) — the Store API uses separate endpoints
+  for these (`cart/apply-coupon`, etc.). Silently dropped for now;
+  `addProductsToCart` filters to `ItemClickedData.Product` only.
+- **Customer pre-fill on the order** — guest checkout in all cases. The
+  agent/customer identity model from the server proposal hasn't been
+  implemented yet, so there's no `customer_id` to send.
+- **Resilient retry / partial-cart recovery** — if `add-item` succeeds for
+  three items and fails on the fourth, we return failure but the
+  server-side cart still has three items. Cleanup would need a `/cart`
+  destroy call or a transaction-scoped cart token that's discarded.
+- **The cash-paid endpoint integration** — server-side spike documents this
+  as the one net-new endpoint needed; not in scope for the Android spike
+  because the existing cash flow already calls `payment_complete()` on the
+  order ID it receives.
+- **End-to-end integration tests against a real device with a real site.**
+  Unit tests cover the wiring; smoke testing against a real Woo install with
+  the server-side spike applied is the natural follow-up.

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/PosStoreApiCheckoutUseCase.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/PosStoreApiCheckoutUseCase.kt
@@ -18,10 +18,11 @@ import javax.inject.Inject
  * namespace, instead of the legacy REST POST /wc/v3/orders path.
  *
  * The flow is: for each distinct product/variation in the in-memory cart,
- * POST cart/add-item; then POST checkout to materialise the cart into a
- * pending order. The newly-created order is then fetched via the existing
- * orders REST client so the rest of the POS payment flow sees an Order
- * with fully-populated totals.
+ * POST cart/add-item; then POST cart/apply-coupon for each coupon in the
+ * cart; then POST checkout to materialise the cart into a pending order.
+ * The newly-created order is then fetched via the existing orders REST
+ * client so the rest of the POS payment flow sees an Order with
+ * fully-populated totals.
  *
  * Session continuity across the request sequence is maintained by
  * capturing the `Cart-Token` HTTP response header emitted by the first
@@ -30,9 +31,9 @@ import javax.inject.Inject
  * header-based session swap on the server picks it up so each request
  * operates on the same server-side cart.
  *
- * Coupons and custom fees are deliberately not supported in this spike;
- * the in-memory WooPosItemsViewModel.ItemClickedData types for those are
- * silently dropped. See DECISIONS.md alongside this file for scope notes.
+ * Custom fees are deliberately not supported in this spike; the in-memory
+ * WooPosItemsViewModel.ItemClickedData.CustomAmount items are silently
+ * dropped. Coupons are applied via cart/apply-coupon.
  *
  * Routed behind the FeatureFlag.WOO_POS_STORE_API_CHECKOUT flag from
  * WooPosTotalsRepository.createOrderFromCartItems.
@@ -52,12 +53,17 @@ class PosStoreApiCheckoutUseCase @Inject constructor(
 
         val products = itemClickedDataList
             .filterIsInstance<WooPosItemsViewModel.ItemClickedData.Product>()
+        val coupons = itemClickedDataList
+            .filterIsInstance<WooPosItemsViewModel.ItemClickedData.Coupon>()
 
         // The first add-item call creates the server-side cart; its response carries
         // the Cart-Token we replay on every subsequent call so we stay on that cart.
         val cartTokenHolder = CartTokenHolder()
 
         addProductsToCart(site, products, cartTokenHolder)
+            .onFailure { return@withContext Result.failure(it) }
+
+        applyCoupons(site, coupons, cartTokenHolder)
             .onFailure { return@withContext Result.failure(it) }
 
         val checkoutPayload = restClient.checkout(site, cartToken = cartTokenHolder.value)
@@ -105,6 +111,29 @@ class PosStoreApiCheckoutUseCase @Inject constructor(
                 return Result.failure(
                     IllegalStateException(
                         "Store API add-item failed for $id: ${payload.error?.message}"
+                    )
+                )
+            }
+            cartTokenHolder.updateFrom(payload)
+        }
+        return Result.success(Unit)
+    }
+
+    private suspend fun applyCoupons(
+        site: SiteModel,
+        coupons: List<WooPosItemsViewModel.ItemClickedData.Coupon>,
+        cartTokenHolder: CartTokenHolder,
+    ): Result<Unit> {
+        for (coupon in coupons) {
+            val payload = restClient.applyCoupon(
+                site = site,
+                code = coupon.couponCode,
+                cartToken = cartTokenHolder.value,
+            )
+            if (payload.isError) {
+                return Result.failure(
+                    IllegalStateException(
+                        "Store API apply-coupon failed for ${coupon.couponCode}: ${payload.error?.message}"
                     )
                 )
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/PosStoreApiCheckoutUseCase.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/PosStoreApiCheckoutUseCase.kt
@@ -1,0 +1,112 @@
+package com.woocommerce.android.ui.woopos.home.totals
+
+import com.woocommerce.android.model.Order
+import com.woocommerce.android.model.OrderMapper
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.woopos.common.data.WooPosGetVariationById
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel
+import kotlinx.coroutines.Dispatchers.IO
+import kotlinx.coroutines.withContext
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.pos.PosStoreApiRestClient
+import org.wordpress.android.fluxc.store.WCOrderStore
+import javax.inject.Inject
+
+/**
+ * Drives order creation through the POS Store API under the wc/pos/v1
+ * namespace, instead of the legacy REST POST /wc/v3/orders path.
+ *
+ * The flow is: for each distinct product/variation in the in-memory cart,
+ * POST cart/add-item; then POST checkout to materialise the cart into a
+ * pending order. The newly-created order is then fetched via the existing
+ * orders REST client so the rest of the POS payment flow sees an Order
+ * with fully-populated totals.
+ *
+ * Coupons and custom fees are deliberately not supported in this spike;
+ * the in-memory WooPosItemsViewModel.ItemClickedData types for those are
+ * silently dropped. See DECISIONS.md alongside this file for scope notes.
+ *
+ * Routed behind the FeatureFlag.WOO_POS_STORE_API_CHECKOUT flag from
+ * WooPosTotalsRepository.createOrderFromCartItems.
+ */
+class PosStoreApiCheckoutUseCase @Inject constructor(
+    private val restClient: PosStoreApiRestClient,
+    private val selectedSite: SelectedSite,
+    private val getVariationById: WooPosGetVariationById,
+    private val orderStore: WCOrderStore,
+    private val orderMapper: OrderMapper,
+) {
+    suspend operator fun invoke(
+        itemClickedDataList: List<WooPosItemsViewModel.ItemClickedData>,
+    ): Result<Order> = withContext(IO) {
+        val site = selectedSite.getOrNull()
+            ?: return@withContext Result.failure(IllegalStateException("No selected site"))
+
+        val products = itemClickedDataList
+            .filterIsInstance<WooPosItemsViewModel.ItemClickedData.Product>()
+
+        addProductsToCart(site, products)
+            .onFailure { return@withContext Result.failure(it) }
+
+        val checkoutPayload = restClient.checkout(site)
+        if (checkoutPayload.isError) {
+            return@withContext Result.failure(
+                IllegalStateException("Store API checkout failed: ${checkoutPayload.error?.message}")
+            )
+        }
+        val orderId = checkoutPayload.result?.orderId
+            ?: return@withContext Result.failure(IllegalStateException("Store API checkout returned no order id"))
+
+        val fetched = orderStore.fetchSingleOrderSync(site, orderId)
+        if (fetched.isError) {
+            return@withContext Result.failure(
+                IllegalStateException("Could not fetch newly created order $orderId: ${fetched.error?.message}")
+            )
+        }
+        val orderEntity = fetched.model
+            ?: return@withContext Result.failure(IllegalStateException("Order $orderId missing after fetch"))
+
+        Result.success(orderMapper.toAppModel(orderEntity))
+    }
+
+    private suspend fun addProductsToCart(
+        site: SiteModel,
+        products: List<WooPosItemsViewModel.ItemClickedData.Product>,
+    ): Result<Unit> {
+        // Group identical scans so we issue one /cart/add-item per distinct line.
+        val quantitiesById = products.groupingBy { it.id }.eachCount()
+
+        for ((id, quantity) in quantitiesById) {
+            val item = products.first { it.id == id }
+            val variationAttributes = variationAttributesFor(item)
+
+            val payload = restClient.addToCart(
+                site = site,
+                productId = item.id,
+                quantity = quantity,
+                variation = variationAttributes,
+            )
+            if (payload.isError) {
+                return Result.failure(
+                    IllegalStateException(
+                        "Store API add-item failed for $id: ${payload.error?.message}"
+                    )
+                )
+            }
+        }
+        return Result.success(Unit)
+    }
+
+    private suspend fun variationAttributesFor(
+        item: WooPosItemsViewModel.ItemClickedData.Product,
+    ): List<PosStoreApiRestClient.VariationAttribute> {
+        if (item !is WooPosItemsViewModel.ItemClickedData.Product.Variation) return emptyList()
+
+        val variation = getVariationById(productId = item.productId, variationId = item.id)
+            ?: return emptyList()
+
+        return variation.attributes
+            .filterNot { it.name.isNullOrEmpty() || it.option.isNullOrEmpty() }
+            .map { PosStoreApiRestClient.VariationAttribute(it.name!!, it.option!!) }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/PosStoreApiCheckoutUseCase.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/PosStoreApiCheckoutUseCase.kt
@@ -8,6 +8,7 @@ import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.pos.PosStoreApiRestClient
 import org.wordpress.android.fluxc.store.WCOrderStore
 import javax.inject.Inject
@@ -21,6 +22,13 @@ import javax.inject.Inject
  * pending order. The newly-created order is then fetched via the existing
  * orders REST client so the rest of the POS payment flow sees an Order
  * with fully-populated totals.
+ *
+ * Session continuity across the request sequence is maintained by
+ * capturing the `Cart-Token` HTTP response header emitted by the first
+ * call and replaying it (as a `?cart_token=` URL parameter) on all
+ * subsequent calls in the same transaction. The Store API's existing
+ * header-based session swap on the server picks it up so each request
+ * operates on the same server-side cart.
  *
  * Coupons and custom fees are deliberately not supported in this spike;
  * the in-memory WooPosItemsViewModel.ItemClickedData types for those are
@@ -45,15 +53,20 @@ class PosStoreApiCheckoutUseCase @Inject constructor(
         val products = itemClickedDataList
             .filterIsInstance<WooPosItemsViewModel.ItemClickedData.Product>()
 
-        addProductsToCart(site, products)
+        // The first add-item call creates the server-side cart; its response carries
+        // the Cart-Token we replay on every subsequent call so we stay on that cart.
+        val cartTokenHolder = CartTokenHolder()
+
+        addProductsToCart(site, products, cartTokenHolder)
             .onFailure { return@withContext Result.failure(it) }
 
-        val checkoutPayload = restClient.checkout(site)
+        val checkoutPayload = restClient.checkout(site, cartToken = cartTokenHolder.value)
         if (checkoutPayload.isError) {
             return@withContext Result.failure(
                 IllegalStateException("Store API checkout failed: ${checkoutPayload.error?.message}")
             )
         }
+        cartTokenHolder.updateFrom(checkoutPayload)
         val orderId = checkoutPayload.result?.orderId
             ?: return@withContext Result.failure(IllegalStateException("Store API checkout returned no order id"))
 
@@ -72,6 +85,7 @@ class PosStoreApiCheckoutUseCase @Inject constructor(
     private suspend fun addProductsToCart(
         site: SiteModel,
         products: List<WooPosItemsViewModel.ItemClickedData.Product>,
+        cartTokenHolder: CartTokenHolder,
     ): Result<Unit> {
         // Group identical scans so we issue one /cart/add-item per distinct line.
         val quantitiesById = products.groupingBy { it.id }.eachCount()
@@ -85,6 +99,7 @@ class PosStoreApiCheckoutUseCase @Inject constructor(
                 productId = item.id,
                 quantity = quantity,
                 variation = variationAttributes,
+                cartToken = cartTokenHolder.value,
             )
             if (payload.isError) {
                 return Result.failure(
@@ -93,6 +108,7 @@ class PosStoreApiCheckoutUseCase @Inject constructor(
                     )
                 )
             }
+            cartTokenHolder.updateFrom(payload)
         }
         return Result.success(Unit)
     }
@@ -108,5 +124,23 @@ class PosStoreApiCheckoutUseCase @Inject constructor(
         return variation.attributes
             .filterNot { it.name.isNullOrEmpty() || it.option.isNullOrEmpty() }
             .map { PosStoreApiRestClient.VariationAttribute(it.name!!, it.option!!) }
+    }
+
+    /**
+     * Transaction-scoped holder of the Cart-Token returned by the server.
+     * Captures the latest non-empty Cart-Token from each response so the
+     * caller can pass it along on the next call.
+     */
+    private class CartTokenHolder {
+        var value: String? = null
+            private set
+
+        fun updateFrom(payload: WooPayload<*>) {
+            payload.headers
+                .firstOrNull { it.key.equals(PosStoreApiRestClient.CART_TOKEN_HEADER, ignoreCase = true) }
+                ?.value
+                ?.takeIf { it.isNotBlank() }
+                ?.let { value = it }
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/PosStoreApiCheckoutUseCase.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/PosStoreApiCheckoutUseCase.kt
@@ -14,15 +14,15 @@ import org.wordpress.android.fluxc.store.WCOrderStore
 import javax.inject.Inject
 
 /**
- * Drives order creation through the POS Store API under the wc/pos/v1
+ * Drives order creation through the POS Store API under the wc/internal/pos/v1
  * namespace, instead of the legacy REST POST /wc/v3/orders path.
  *
  * The flow is: for each distinct product/variation in the in-memory cart,
  * POST cart/add-item; then POST cart/apply-coupon for each coupon in the
- * cart; then POST checkout to materialise the cart into a pending order.
- * The newly-created order is then fetched via the existing orders REST
- * client so the rest of the POS payment flow sees an Order with
- * fully-populated totals.
+ * cart; then POST cart/add-fee for each custom amount; then POST checkout to
+ * materialise the cart into a pending order. The newly-created order is then
+ * fetched via the existing orders REST client so the rest of the POS payment
+ * flow sees an Order with fully-populated totals.
  *
  * Session continuity across the request sequence is maintained by
  * capturing the `Cart-Token` HTTP response header emitted by the first
@@ -31,9 +31,8 @@ import javax.inject.Inject
  * header-based session swap on the server picks it up so each request
  * operates on the same server-side cart.
  *
- * Custom fees are deliberately not supported in this spike; the in-memory
- * WooPosItemsViewModel.ItemClickedData.CustomAmount items are silently
- * dropped. Coupons are applied via cart/apply-coupon.
+ * Coupons are applied via cart/apply-coupon and custom amounts via
+ * cart/add-fee.
  *
  * Routed behind the FeatureFlag.WOO_POS_STORE_API_CHECKOUT flag from
  * WooPosTotalsRepository.createOrderFromCartItems.
@@ -55,6 +54,8 @@ class PosStoreApiCheckoutUseCase @Inject constructor(
             .filterIsInstance<WooPosItemsViewModel.ItemClickedData.Product>()
         val coupons = itemClickedDataList
             .filterIsInstance<WooPosItemsViewModel.ItemClickedData.Coupon>()
+        val customAmounts = itemClickedDataList
+            .filterIsInstance<WooPosItemsViewModel.ItemClickedData.CustomAmount>()
 
         // The first add-item call creates the server-side cart; its response carries
         // the Cart-Token we replay on every subsequent call so we stay on that cart.
@@ -64,6 +65,9 @@ class PosStoreApiCheckoutUseCase @Inject constructor(
             .onFailure { return@withContext Result.failure(it) }
 
         applyCoupons(site, coupons, cartTokenHolder)
+            .onFailure { return@withContext Result.failure(it) }
+
+        applyCustomFees(site, customAmounts, cartTokenHolder)
             .onFailure { return@withContext Result.failure(it) }
 
         val checkoutPayload = restClient.checkout(site, cartToken = cartTokenHolder.value)
@@ -134,6 +138,31 @@ class PosStoreApiCheckoutUseCase @Inject constructor(
                 return Result.failure(
                     IllegalStateException(
                         "Store API apply-coupon failed for ${coupon.couponCode}: ${payload.error?.message}"
+                    )
+                )
+            }
+            cartTokenHolder.updateFrom(payload)
+        }
+        return Result.success(Unit)
+    }
+
+    private suspend fun applyCustomFees(
+        site: SiteModel,
+        customAmounts: List<WooPosItemsViewModel.ItemClickedData.CustomAmount>,
+        cartTokenHolder: CartTokenHolder,
+    ): Result<Unit> {
+        for (customAmount in customAmounts) {
+            val payload = restClient.addFee(
+                site = site,
+                name = customAmount.name,
+                amount = customAmount.amount,
+                taxable = customAmount.isTaxable,
+                cartToken = cartTokenHolder.value,
+            )
+            if (payload.isError) {
+                return Result.failure(
+                    IllegalStateException(
+                        "Store API add-fee failed for ${customAmount.name}: ${payload.error?.message}"
                     )
                 )
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsRepository.kt
@@ -12,6 +12,8 @@ import com.woocommerce.android.ui.woopos.common.data.getName
 import com.woocommerce.android.ui.woopos.common.data.getNameForPOS
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel
 import com.woocommerce.android.util.DateUtils
+import com.woocommerce.android.util.FeatureFlag
+import com.woocommerce.android.util.FeatureFlagRepository
 import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers.IO
@@ -32,6 +34,8 @@ class WooPosTotalsRepository @Inject constructor(
     private val orderMapper: OrderMapper,
     private val resourceProvider: ResourceProvider,
     private val variationMapper: WooPosVariationMapper,
+    private val featureFlagRepository: FeatureFlagRepository,
+    private val storeApiCheckoutUseCase: PosStoreApiCheckoutUseCase,
 ) {
     private var orderCreationJob: Deferred<Result<Order>>? = null
 
@@ -45,8 +49,15 @@ class WooPosTotalsRepository @Inject constructor(
         return withContext(IO) {
             check(itemClickedDataList.all { it.id >= 0 }) { "Invalid item ID" }
             val job = async {
-                val order = createOrder(itemClickedDataList)
-                orderCreateEditRepository.createOrUpdateOrder(order, source = OrderCreationSource.POINT_OF_SALE)
+                if (featureFlagRepository.isEnabled(FeatureFlag.WOO_POS_STORE_API_CHECKOUT)) {
+                    storeApiCheckoutUseCase(itemClickedDataList)
+                } else {
+                    val order = createOrder(itemClickedDataList)
+                    orderCreateEditRepository.createOrUpdateOrder(
+                        order,
+                        source = OrderCreationSource.POINT_OF_SALE
+                    )
+                }
             }
             orderCreationJob = job
             job.await()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -23,6 +23,7 @@ enum class FeatureFlag(
     WOO_POS_TAP_TO_PAY("woo_pos_tap_to_pay", localValue = PackageUtils.isDebugBuild()),
     WOO_POS_SCAN_TO_PAY("woo_pos_scan_to_pay", localValue = PackageUtils.isDebugBuild()),
     WOO_POS_MARK_ORDER_AS_PAID("woo_pos_mark_order_as_complete", localValue = PackageUtils.isDebugBuild()),
+    WOO_POS_STORE_API_CHECKOUT("woo_pos_store_api_checkout", localValue = PackageUtils.isDebugBuild()),
     APP_PASSWORDS_FOR_JETPACK_SITES("woo_app_passwords_for_jetpack_sites"),
     WOO_POS_LOCAL_CATALOG_M1("woo_pos_local_catalog_m1"),
     WOO_POS_TABLET_PROMO_BANNER("woo_pos_tablet_promo_banner"),

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/PosStoreApiCheckoutUseCaseTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/PosStoreApiCheckoutUseCaseTest.kt
@@ -9,14 +9,17 @@ import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
+import org.wordpress.android.fluxc.network.rest.Header
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
@@ -56,8 +59,8 @@ class PosStoreApiCheckoutUseCaseTest {
 
     @Test
     fun `given simple products, when invoked, then add-item called once per distinct id with summed quantity`() = runTest {
-        whenever(restClient.addToCart(any(), any(), any(), any())) doReturn WooPayload(Unit)
-        whenever(restClient.checkout(site)) doReturn WooPayload(checkoutResponse(orderId = 42L))
+        givenAddToCartSucceeds()
+        givenCheckoutSucceeds(orderId = 42L)
         givenOrderFetchSucceeds(orderId = 42L)
 
         sut(
@@ -72,31 +75,33 @@ class PosStoreApiCheckoutUseCaseTest {
             site = eq(site),
             productId = eq(1L),
             quantity = eq(2),
-            variation = eq(emptyList())
+            variation = eq(emptyList()),
+            cartToken = anyOrNull(),
         )
         verify(restClient).addToCart(
             site = eq(site),
             productId = eq(2L),
             quantity = eq(1),
-            variation = eq(emptyList())
+            variation = eq(emptyList()),
+            cartToken = anyOrNull(),
         )
     }
 
     @Test
     fun `given add-item fails, when invoked, then checkout is not called`() = runTest {
-        whenever(restClient.addToCart(any(), any(), any(), any())) doReturn
+        whenever(restClient.addToCart(any(), any(), any(), any(), anyOrNull())) doReturn
             WooPayload(WooError(WooErrorType.GENERIC_ERROR, GenericErrorType.UNKNOWN, "boom"))
 
         val result = sut(listOf(WooPosItemsViewModel.ItemClickedData.Product.Simple(id = 1L)))
 
         assertThat(result.isFailure).isTrue
-        verify(restClient, never()).checkout(any())
+        verify(restClient, never()).checkout(any(), anyOrNull())
     }
 
     @Test
     fun `given checkout fails, when invoked, then order fetch is not attempted`() = runTest {
-        whenever(restClient.addToCart(any(), any(), any(), any())) doReturn WooPayload(Unit)
-        whenever(restClient.checkout(site)) doReturn
+        givenAddToCartSucceeds()
+        whenever(restClient.checkout(eq(site), anyOrNull())) doReturn
             WooPayload(WooError(WooErrorType.GENERIC_ERROR, GenericErrorType.UNKNOWN, "checkout boom"))
 
         val result = sut(listOf(WooPosItemsViewModel.ItemClickedData.Product.Simple(id = 1L)))
@@ -108,14 +113,88 @@ class PosStoreApiCheckoutUseCaseTest {
     @Test
     fun `given checkout succeeds, when invoked, then returns mapped Order`() = runTest {
         val mappedOrder: Order = mock()
-        whenever(restClient.addToCart(any(), any(), any(), any())) doReturn WooPayload(Unit)
-        whenever(restClient.checkout(site)) doReturn WooPayload(checkoutResponse(orderId = 99L))
+        givenAddToCartSucceeds()
+        givenCheckoutSucceeds(orderId = 99L)
         givenOrderFetchSucceeds(orderId = 99L, mapsTo = mappedOrder)
 
         val result = sut(listOf(WooPosItemsViewModel.ItemClickedData.Product.Simple(id = 1L)))
 
         assertThat(result.isSuccess).isTrue
         assertThat(result.getOrNull()).isSameAs(mappedOrder)
+    }
+
+    @Test
+    fun `given first add-item returns cart token, when invoked, then it is replayed on subsequent calls and checkout`() = runTest {
+        // First add-item returns Cart-Token in response headers; subsequent add-item
+        // returns the same (or a refreshed) token; checkout should be called with the
+        // latest captured token.
+        whenever(
+            restClient.addToCart(
+                site = eq(site),
+                productId = eq(1L),
+                quantity = any(),
+                variation = anyOrNull(),
+                cartToken = anyOrNull(),
+            )
+        ) doReturn WooPayload(Unit, listOf(Header("Cart-Token", "token-from-first")))
+
+        whenever(
+            restClient.addToCart(
+                site = eq(site),
+                productId = eq(2L),
+                quantity = any(),
+                variation = anyOrNull(),
+                cartToken = anyOrNull(),
+            )
+        ) doReturn WooPayload(Unit, listOf(Header("Cart-Token", "token-from-second")))
+
+        givenCheckoutSucceeds(orderId = 7L, cartTokenHeaderValue = "token-from-second")
+        givenOrderFetchSucceeds(orderId = 7L)
+
+        sut(
+            listOf(
+                WooPosItemsViewModel.ItemClickedData.Product.Simple(id = 1L),
+                WooPosItemsViewModel.ItemClickedData.Product.Simple(id = 2L),
+            )
+        )
+
+        inOrder(restClient) {
+            // First add-item: no token to send yet.
+            verify(restClient).addToCart(
+                site = eq(site),
+                productId = eq(1L),
+                quantity = eq(1),
+                variation = eq(emptyList()),
+                cartToken = eq(null),
+            )
+            // Second add-item: replays the token captured from the first response.
+            verify(restClient).addToCart(
+                site = eq(site),
+                productId = eq(2L),
+                quantity = eq(1),
+                variation = eq(emptyList()),
+                cartToken = eq("token-from-first"),
+            )
+            // Checkout: replays the latest captured token (from the second response).
+            verify(restClient).checkout(eq(site), eq("token-from-second"))
+        }
+    }
+
+    private suspend fun givenAddToCartSucceeds() {
+        whenever(restClient.addToCart(any(), any(), any(), any(), anyOrNull())) doReturn WooPayload(Unit)
+    }
+
+    private suspend fun givenCheckoutSucceeds(
+        orderId: Long,
+        cartTokenHeaderValue: String? = null,
+    ) {
+        val headers = if (cartTokenHeaderValue != null) {
+            listOf(Header("Cart-Token", cartTokenHeaderValue))
+        } else {
+            emptyList()
+        }
+        whenever(restClient.checkout(eq(site), anyOrNull())) doReturn
+            WooPayload(checkoutResponse(orderId), headers)
     }
 
     private fun checkoutResponse(orderId: Long) =

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/PosStoreApiCheckoutUseCaseTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/PosStoreApiCheckoutUseCaseTest.kt
@@ -95,13 +95,13 @@ class PosStoreApiCheckoutUseCaseTest {
         val result = sut(listOf(WooPosItemsViewModel.ItemClickedData.Product.Simple(id = 1L)))
 
         assertThat(result.isFailure).isTrue
-        verify(restClient, never()).checkout(any(), anyOrNull())
+        verify(restClient, never()).checkout(any(), anyOrNull(), any(), any())
     }
 
     @Test
     fun `given checkout fails, when invoked, then order fetch is not attempted`() = runTest {
         givenAddToCartSucceeds()
-        whenever(restClient.checkout(eq(site), anyOrNull())) doReturn
+        whenever(restClient.checkout(eq(site), anyOrNull(), any(), any())) doReturn
             WooPayload(WooError(WooErrorType.GENERIC_ERROR, GenericErrorType.UNKNOWN, "checkout boom"))
 
         val result = sut(listOf(WooPosItemsViewModel.ItemClickedData.Product.Simple(id = 1L)))
@@ -176,7 +176,7 @@ class PosStoreApiCheckoutUseCaseTest {
                 cartToken = eq("token-from-first"),
             )
             // Checkout: replays the latest captured token (from the second response).
-            verify(restClient).checkout(eq(site), eq("token-from-second"))
+            verify(restClient).checkout(eq(site), eq("token-from-second"), any(), any())
         }
     }
 
@@ -193,7 +193,7 @@ class PosStoreApiCheckoutUseCaseTest {
         } else {
             emptyList()
         }
-        whenever(restClient.checkout(eq(site), anyOrNull())) doReturn
+        whenever(restClient.checkout(eq(site), anyOrNull(), any(), any())) doReturn
             WooPayload(checkoutResponse(orderId), headers)
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/PosStoreApiCheckoutUseCaseTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/PosStoreApiCheckoutUseCaseTest.kt
@@ -95,13 +95,13 @@ class PosStoreApiCheckoutUseCaseTest {
         val result = sut(listOf(WooPosItemsViewModel.ItemClickedData.Product.Simple(id = 1L)))
 
         assertThat(result.isFailure).isTrue
-        verify(restClient, never()).checkout(any(), anyOrNull(), any(), any())
+        verify(restClient, never()).checkout(any(), anyOrNull())
     }
 
     @Test
     fun `given checkout fails, when invoked, then order fetch is not attempted`() = runTest {
         givenAddToCartSucceeds()
-        whenever(restClient.checkout(eq(site), anyOrNull(), any(), any())) doReturn
+        whenever(restClient.checkout(eq(site), anyOrNull())) doReturn
             WooPayload(WooError(WooErrorType.GENERIC_ERROR, GenericErrorType.UNKNOWN, "checkout boom"))
 
         val result = sut(listOf(WooPosItemsViewModel.ItemClickedData.Product.Simple(id = 1L)))
@@ -176,7 +176,7 @@ class PosStoreApiCheckoutUseCaseTest {
                 cartToken = eq("token-from-first"),
             )
             // Checkout: replays the latest captured token (from the second response).
-            verify(restClient).checkout(eq(site), eq("token-from-second"), any(), any())
+            verify(restClient).checkout(eq(site), eq("token-from-second"))
         }
     }
 
@@ -193,7 +193,7 @@ class PosStoreApiCheckoutUseCaseTest {
         } else {
             emptyList()
         }
-        whenever(restClient.checkout(eq(site), anyOrNull(), any(), any())) doReturn
+        whenever(restClient.checkout(eq(site), anyOrNull())) doReturn
             WooPayload(checkoutResponse(orderId), headers)
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/PosStoreApiCheckoutUseCaseTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/PosStoreApiCheckoutUseCaseTest.kt
@@ -88,6 +88,74 @@ class PosStoreApiCheckoutUseCaseTest {
     }
 
     @Test
+    fun `given coupons in cart, when invoked, then apply-coupon is called once per coupon code`() = runTest {
+        givenAddToCartSucceeds()
+        givenApplyCouponSucceeds()
+        givenCheckoutSucceeds(orderId = 42L)
+        givenOrderFetchSucceeds(orderId = 42L)
+
+        sut(
+            listOf(
+                WooPosItemsViewModel.ItemClickedData.Product.Simple(id = 1L),
+                WooPosItemsViewModel.ItemClickedData.Coupon(id = 10L, couponCode = "SAVE10"),
+                WooPosItemsViewModel.ItemClickedData.Coupon(id = 11L, couponCode = "FREESHIP"),
+            )
+        )
+
+        verify(restClient).applyCoupon(site = eq(site), code = eq("SAVE10"), cartToken = anyOrNull())
+        verify(restClient).applyCoupon(site = eq(site), code = eq("FREESHIP"), cartToken = anyOrNull())
+    }
+
+    @Test
+    fun `given a coupon, when invoked, then it is applied after items and before checkout`() = runTest {
+        givenAddToCartSucceeds()
+        givenApplyCouponSucceeds()
+        givenCheckoutSucceeds(orderId = 42L)
+        givenOrderFetchSucceeds(orderId = 42L)
+
+        sut(
+            listOf(
+                WooPosItemsViewModel.ItemClickedData.Product.Simple(id = 1L),
+                WooPosItemsViewModel.ItemClickedData.Coupon(id = 10L, couponCode = "SAVE10"),
+            )
+        )
+
+        inOrder(restClient) {
+            verify(restClient).addToCart(any(), eq(1L), any(), anyOrNull(), anyOrNull())
+            verify(restClient).applyCoupon(eq(site), eq("SAVE10"), anyOrNull())
+            verify(restClient).checkout(eq(site), anyOrNull())
+        }
+    }
+
+    @Test
+    fun `given apply-coupon fails, when invoked, then checkout is not called`() = runTest {
+        givenAddToCartSucceeds()
+        whenever(restClient.applyCoupon(any(), any(), anyOrNull())) doReturn
+            WooPayload(WooError(WooErrorType.GENERIC_ERROR, GenericErrorType.UNKNOWN, "invalid coupon"))
+
+        val result = sut(
+            listOf(
+                WooPosItemsViewModel.ItemClickedData.Product.Simple(id = 1L),
+                WooPosItemsViewModel.ItemClickedData.Coupon(id = 10L, couponCode = "BAD"),
+            )
+        )
+
+        assertThat(result.isFailure).isTrue
+        verify(restClient, never()).checkout(any(), anyOrNull())
+    }
+
+    @Test
+    fun `given no coupons, when invoked, then apply-coupon is never called`() = runTest {
+        givenAddToCartSucceeds()
+        givenCheckoutSucceeds(orderId = 42L)
+        givenOrderFetchSucceeds(orderId = 42L)
+
+        sut(listOf(WooPosItemsViewModel.ItemClickedData.Product.Simple(id = 1L)))
+
+        verify(restClient, never()).applyCoupon(any(), any(), anyOrNull())
+    }
+
+    @Test
     fun `given add-item fails, when invoked, then checkout is not called`() = runTest {
         whenever(restClient.addToCart(any(), any(), any(), any(), anyOrNull())) doReturn
             WooPayload(WooError(WooErrorType.GENERIC_ERROR, GenericErrorType.UNKNOWN, "boom"))
@@ -182,6 +250,10 @@ class PosStoreApiCheckoutUseCaseTest {
 
     private suspend fun givenAddToCartSucceeds() {
         whenever(restClient.addToCart(any(), any(), any(), any(), anyOrNull())) doReturn WooPayload(Unit)
+    }
+
+    private suspend fun givenApplyCouponSucceeds() {
+        whenever(restClient.applyCoupon(any(), any(), anyOrNull())) doReturn WooPayload(Unit)
     }
 
     private suspend fun givenCheckoutSucceeds(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/PosStoreApiCheckoutUseCaseTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/PosStoreApiCheckoutUseCaseTest.kt
@@ -28,6 +28,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.pos.PosStoreApiRestClie
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.pos.PosStoreApiRestClient.CheckoutResponseDto
 import org.wordpress.android.fluxc.persistence.entity.OrderEntity
 import org.wordpress.android.fluxc.store.WCOrderStore
+import java.math.BigDecimal
 
 class PosStoreApiCheckoutUseCaseTest {
 
@@ -156,6 +157,109 @@ class PosStoreApiCheckoutUseCaseTest {
     }
 
     @Test
+    fun `given custom amounts in cart, when invoked, then add-fee is called once per custom amount`() = runTest {
+        givenAddToCartSucceeds()
+        givenAddFeeSucceeds()
+        givenCheckoutSucceeds(orderId = 42L)
+        givenOrderFetchSucceeds(orderId = 42L)
+
+        sut(
+            listOf(
+                WooPosItemsViewModel.ItemClickedData.Product.Simple(id = 1L),
+                WooPosItemsViewModel.ItemClickedData.CustomAmount(
+                    id = 20L,
+                    name = "Gift wrap",
+                    amount = BigDecimal("5.00"),
+                    isTaxable = true,
+                ),
+                WooPosItemsViewModel.ItemClickedData.CustomAmount(
+                    id = 21L,
+                    name = "Handling",
+                    amount = BigDecimal("1.50"),
+                    isTaxable = false,
+                ),
+            )
+        )
+
+        verify(restClient).addFee(
+            site = eq(site),
+            name = eq("Gift wrap"),
+            amount = eq(BigDecimal("5.00")),
+            taxable = eq(true),
+            cartToken = anyOrNull(),
+        )
+        verify(restClient).addFee(
+            site = eq(site),
+            name = eq("Handling"),
+            amount = eq(BigDecimal("1.50")),
+            taxable = eq(false),
+            cartToken = anyOrNull(),
+        )
+    }
+
+    @Test
+    fun `given a custom amount, when invoked, then it is added after coupons and before checkout`() = runTest {
+        givenAddToCartSucceeds()
+        givenApplyCouponSucceeds()
+        givenAddFeeSucceeds()
+        givenCheckoutSucceeds(orderId = 42L)
+        givenOrderFetchSucceeds(orderId = 42L)
+
+        sut(
+            listOf(
+                WooPosItemsViewModel.ItemClickedData.Product.Simple(id = 1L),
+                WooPosItemsViewModel.ItemClickedData.Coupon(id = 10L, couponCode = "SAVE10"),
+                WooPosItemsViewModel.ItemClickedData.CustomAmount(
+                    id = 20L,
+                    name = "Gift wrap",
+                    amount = BigDecimal("5.00"),
+                    isTaxable = false,
+                ),
+            )
+        )
+
+        inOrder(restClient) {
+            verify(restClient).addToCart(any(), eq(1L), any(), anyOrNull(), anyOrNull())
+            verify(restClient).applyCoupon(eq(site), eq("SAVE10"), anyOrNull())
+            verify(restClient).addFee(eq(site), eq("Gift wrap"), any(), any(), anyOrNull())
+            verify(restClient).checkout(eq(site), anyOrNull())
+        }
+    }
+
+    @Test
+    fun `given add-fee fails, when invoked, then checkout is not called`() = runTest {
+        givenAddToCartSucceeds()
+        whenever(restClient.addFee(any(), any(), any(), any(), anyOrNull())) doReturn
+            WooPayload(WooError(WooErrorType.GENERIC_ERROR, GenericErrorType.UNKNOWN, "bad fee"))
+
+        val result = sut(
+            listOf(
+                WooPosItemsViewModel.ItemClickedData.Product.Simple(id = 1L),
+                WooPosItemsViewModel.ItemClickedData.CustomAmount(
+                    id = 20L,
+                    name = "Gift wrap",
+                    amount = BigDecimal("5.00"),
+                    isTaxable = false,
+                ),
+            )
+        )
+
+        assertThat(result.isFailure).isTrue
+        verify(restClient, never()).checkout(any(), anyOrNull())
+    }
+
+    @Test
+    fun `given no custom amounts, when invoked, then add-fee is never called`() = runTest {
+        givenAddToCartSucceeds()
+        givenCheckoutSucceeds(orderId = 42L)
+        givenOrderFetchSucceeds(orderId = 42L)
+
+        sut(listOf(WooPosItemsViewModel.ItemClickedData.Product.Simple(id = 1L)))
+
+        verify(restClient, never()).addFee(any(), any(), any(), any(), anyOrNull())
+    }
+
+    @Test
     fun `given add-item fails, when invoked, then checkout is not called`() = runTest {
         whenever(restClient.addToCart(any(), any(), any(), any(), anyOrNull())) doReturn
             WooPayload(WooError(WooErrorType.GENERIC_ERROR, GenericErrorType.UNKNOWN, "boom"))
@@ -254,6 +358,10 @@ class PosStoreApiCheckoutUseCaseTest {
 
     private suspend fun givenApplyCouponSucceeds() {
         whenever(restClient.applyCoupon(any(), any(), anyOrNull())) doReturn WooPayload(Unit)
+    }
+
+    private suspend fun givenAddFeeSucceeds() {
+        whenever(restClient.addFee(any(), any(), any(), any(), anyOrNull())) doReturn WooPayload(Unit)
     }
 
     private suspend fun givenCheckoutSucceeds(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/PosStoreApiCheckoutUseCaseTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/PosStoreApiCheckoutUseCaseTest.kt
@@ -1,0 +1,129 @@
+package com.woocommerce.android.ui.woopos.home.totals
+
+import com.woocommerce.android.model.Order
+import com.woocommerce.android.model.OrderMapper
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.woopos.common.data.WooPosGetVariationById
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.pos.PosStoreApiRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.pos.PosStoreApiRestClient.CheckoutResponseDto
+import org.wordpress.android.fluxc.persistence.entity.OrderEntity
+import org.wordpress.android.fluxc.store.WCOrderStore
+
+class PosStoreApiCheckoutUseCaseTest {
+
+    private val site: SiteModel = mock()
+    private val restClient: PosStoreApiRestClient = mock()
+    private val selectedSite: SelectedSite = mock {
+        on { getOrNull() } doReturn site
+    }
+    private val getVariationById: WooPosGetVariationById = mock()
+    private val orderStore: WCOrderStore = mock()
+    private val orderMapper: OrderMapper = mock()
+
+    private val sut = PosStoreApiCheckoutUseCase(
+        restClient,
+        selectedSite,
+        getVariationById,
+        orderStore,
+        orderMapper,
+    )
+
+    @Test
+    fun `given no selected site, when invoked, then returns failure`() = runTest {
+        whenever(selectedSite.getOrNull()) doReturn null
+
+        val result = sut(listOf(WooPosItemsViewModel.ItemClickedData.Product.Simple(id = 1L)))
+
+        assertThat(result.isFailure).isTrue
+    }
+
+    @Test
+    fun `given simple products, when invoked, then add-item called once per distinct id with summed quantity`() = runTest {
+        whenever(restClient.addToCart(any(), any(), any(), any())) doReturn WooPayload(Unit)
+        whenever(restClient.checkout(site)) doReturn WooPayload(checkoutResponse(orderId = 42L))
+        givenOrderFetchSucceeds(orderId = 42L)
+
+        sut(
+            listOf(
+                WooPosItemsViewModel.ItemClickedData.Product.Simple(id = 1L),
+                WooPosItemsViewModel.ItemClickedData.Product.Simple(id = 1L),
+                WooPosItemsViewModel.ItemClickedData.Product.Simple(id = 2L),
+            )
+        )
+
+        verify(restClient).addToCart(
+            site = eq(site),
+            productId = eq(1L),
+            quantity = eq(2),
+            variation = eq(emptyList())
+        )
+        verify(restClient).addToCart(
+            site = eq(site),
+            productId = eq(2L),
+            quantity = eq(1),
+            variation = eq(emptyList())
+        )
+    }
+
+    @Test
+    fun `given add-item fails, when invoked, then checkout is not called`() = runTest {
+        whenever(restClient.addToCart(any(), any(), any(), any())) doReturn
+            WooPayload(WooError(WooErrorType.GENERIC_ERROR, GenericErrorType.UNKNOWN, "boom"))
+
+        val result = sut(listOf(WooPosItemsViewModel.ItemClickedData.Product.Simple(id = 1L)))
+
+        assertThat(result.isFailure).isTrue
+        verify(restClient, never()).checkout(any())
+    }
+
+    @Test
+    fun `given checkout fails, when invoked, then order fetch is not attempted`() = runTest {
+        whenever(restClient.addToCart(any(), any(), any(), any())) doReturn WooPayload(Unit)
+        whenever(restClient.checkout(site)) doReturn
+            WooPayload(WooError(WooErrorType.GENERIC_ERROR, GenericErrorType.UNKNOWN, "checkout boom"))
+
+        val result = sut(listOf(WooPosItemsViewModel.ItemClickedData.Product.Simple(id = 1L)))
+
+        assertThat(result.isFailure).isTrue
+        verify(orderStore, never()).fetchSingleOrderSync(any(), any())
+    }
+
+    @Test
+    fun `given checkout succeeds, when invoked, then returns mapped Order`() = runTest {
+        val mappedOrder: Order = mock()
+        whenever(restClient.addToCart(any(), any(), any(), any())) doReturn WooPayload(Unit)
+        whenever(restClient.checkout(site)) doReturn WooPayload(checkoutResponse(orderId = 99L))
+        givenOrderFetchSucceeds(orderId = 99L, mapsTo = mappedOrder)
+
+        val result = sut(listOf(WooPosItemsViewModel.ItemClickedData.Product.Simple(id = 1L)))
+
+        assertThat(result.isSuccess).isTrue
+        assertThat(result.getOrNull()).isSameAs(mappedOrder)
+    }
+
+    private fun checkoutResponse(orderId: Long) =
+        CheckoutResponseDto(orderId = orderId, status = "pending", orderKey = "wc_order_$orderId")
+
+    private suspend fun givenOrderFetchSucceeds(orderId: Long, mapsTo: Order = mock()) {
+        val entity: OrderEntity = mock()
+        whenever(orderStore.fetchSingleOrderSync(site, orderId)) doReturn WooResult(entity)
+        whenever(orderMapper.toAppModel(entity)) doReturn mapsTo
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsRepositoryTest.kt
@@ -11,16 +11,20 @@ import com.woocommerce.android.ui.woopos.common.data.WooPosVariationMapper
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel
 import com.woocommerce.android.ui.woopos.util.generateWooPosProduct
 import com.woocommerce.android.util.DateUtils
+import com.woocommerce.android.util.FeatureFlag
+import com.woocommerce.android.util.FeatureFlagRepository
 import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.store.WCOrderStore
 import java.math.BigDecimal
@@ -35,6 +39,10 @@ class WooPosTotalsRepositoryTest {
     private val orderMapper: OrderMapper = mock()
     private val resourceProvider: ResourceProvider = mock()
     private val variationMapper: WooPosVariationMapper = mock()
+    private val featureFlagRepository: FeatureFlagRepository = mock {
+        on { isEnabled(FeatureFlag.WOO_POS_STORE_API_CHECKOUT) } doReturn false
+    }
+    private val storeApiCheckoutUseCase: PosStoreApiCheckoutUseCase = mock()
 
     private lateinit var repository: WooPosTotalsRepository
 
@@ -341,6 +349,46 @@ class WooPosTotalsRepositoryTest {
         assertThat(feesLines.first().taxStatus).isEqualTo(Order.FeeLine.FeeLineTaxStatus.NONE)
     }
 
+    @Test
+    fun `given store-api flag off, when createOrderFromCartItems, then existing REST path is used`() = runTest {
+        // GIVEN
+        whenever(featureFlagRepository.isEnabled(FeatureFlag.WOO_POS_STORE_API_CHECKOUT)) doReturn false
+        repository = createRepository()
+        val itemClickedData = listOf<WooPosItemsViewModel.ItemClickedData>(
+            WooPosItemsViewModel.ItemClickedData.Product.Simple(id = 1L)
+        )
+        whenever(getProductById(1L)).thenReturn(product1)
+
+        // WHEN
+        repository.createOrderFromCartItems(itemClickedData)
+
+        // THEN
+        verify(orderCreateEditRepository).createOrUpdateOrder(
+            any(),
+            eq(OrderCreationSource.POINT_OF_SALE),
+            eq("")
+        )
+        verifyNoInteractions(storeApiCheckoutUseCase)
+    }
+
+    @Test
+    fun `given store-api flag on, when createOrderFromCartItems, then Store API use case is invoked`() = runTest {
+        // GIVEN
+        whenever(featureFlagRepository.isEnabled(FeatureFlag.WOO_POS_STORE_API_CHECKOUT)) doReturn true
+        whenever(storeApiCheckoutUseCase.invoke(any())) doReturn Result.success(mock<Order>())
+        repository = createRepository()
+        val itemClickedData = listOf<WooPosItemsViewModel.ItemClickedData>(
+            WooPosItemsViewModel.ItemClickedData.Product.Simple(id = 1L)
+        )
+
+        // WHEN
+        repository.createOrderFromCartItems(itemClickedData)
+
+        // THEN
+        verify(storeApiCheckoutUseCase).invoke(itemClickedData)
+        verify(orderCreateEditRepository, never()).createOrUpdateOrder(any(), any(), any())
+    }
+
     private fun createRepository() = WooPosTotalsRepository(
         orderCreateEditRepository,
         dateUtils,
@@ -351,5 +399,7 @@ class WooPosTotalsRepositoryTest {
         orderMapper,
         resourceProvider,
         variationMapper,
+        featureFlagRepository,
+        storeApiCheckoutUseCase,
     )
 }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pos/PosStoreApiRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pos/PosStoreApiRestClient.kt
@@ -73,35 +73,28 @@ class PosStoreApiRestClient @Inject constructor(
     /**
      * POST /wc/pos/v1/checkout.
      *
-     * Finalises the in-progress cart into an order. No `payment_method` is
-     * supplied — the Store API creates the order in `pending` status and
-     * does not attempt to process payment, leaving the existing POS
-     * payment flow to take over (WooPayments capture, or cash mark-paid).
+     * Finalises the in-progress cart into an order. The body is empty:
+     * no payment_method, no billing_address, no shipping_address. The POS
+     * route on the server opts out of all three Store API guards that
+     * would otherwise reject this for web checkout. The order is created
+     * in `pending` status, and the existing POS payment flow takes over
+     * (WooPayments terminal capture for cards, cash mark-paid endpoint).
      *
-     * Billing and shipping addresses are sent as placeholders by the use
-     * case caller. The POS route relaxes the schema-level requirement on
-     * those fields, but a deeper pipeline-layer validation in
-     * OrderController still enforces per-field rules driven by store
-     * settings (postcode, phone, etc.) — sending placeholders is the
-     * simplest way to satisfy those today. Smarter cart-aware logic that
-     * only requires fields the products in the cart actually need is a
-     * planned follow-up.
+     * For product types that genuinely need address/email data (gift
+     * cards delivered by email, downloadables, shipped goods sold for
+     * delivery), the cashier will capture those fields and the request
+     * shape will grow to carry them. Today the API accepts what's sent
+     * and the order can be edited later via admin if needed.
      */
     suspend fun checkout(
         site: SiteModel,
         cartToken: String? = null,
-        billingAddress: Map<String, String> = placeholderAddress(),
-        shippingAddress: Map<String, String> = placeholderAddress(),
     ): WooPayload<CheckoutResponseDto> {
-        val body = buildMap<String, Any> {
-            put("billing_address", billingAddress)
-            put("shipping_address", shippingAddress)
-        }
         val response = wooNetwork.executePostGsonRequest(
             site = site,
             path = appendCartToken(CHECKOUT_PATH, cartToken),
             clazz = CheckoutResponseDto::class.java,
-            body = body
+            body = emptyMap()
         )
 
         return when (response) {
@@ -109,26 +102,6 @@ class PosStoreApiRestClient @Inject constructor(
             is Error -> WooPayload(response.error.toWooError())
         }
     }
-
-    /**
-     * Placeholder address fields that satisfy WC's per-field validation
-     * for in-store retail sales where the cashier doesn't have customer
-     * address info to capture. The order is created with this address and
-     * the cashier can edit it later via the orders admin if needed.
-     */
-    private fun placeholderAddress(): Map<String, String> = mapOf(
-        "first_name" to "POS",
-        "last_name" to "Customer",
-        "company" to "",
-        "address_1" to "In-store sale",
-        "address_2" to "",
-        "city" to "In-store sale",
-        "state" to "",
-        "postcode" to "00000",
-        "country" to "US",
-        "email" to "",
-        "phone" to "0000000000",
-    )
 
     private fun appendCartToken(path: String, cartToken: String?): String {
         if (cartToken.isNullOrEmpty()) return path

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pos/PosStoreApiRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pos/PosStoreApiRestClient.kt
@@ -7,6 +7,7 @@ import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse.Success
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
+import java.net.URLEncoder
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -20,10 +21,14 @@ import javax.inject.Singleton
  * `plugins/woocommerce/src/Internal/POS/StoreApi/` in woocommerce/woocommerce
  * for the server side.
  *
- * This is a spike client paired with the server-side architectural spike.
- * Session continuity across requests is currently unresolved (see
- * DECISIONS.md alongside the use case); tests mock this client, so unit
- * coverage is unaffected.
+ * **Session continuity.** Each call optionally accepts a `cartToken` returned
+ * by a prior call's `Cart-Token` response header. Mobile passes the token
+ * back via a `?cart_token=` URL parameter (mirroring the URL-parameter
+ * transport agentic commerce uses for `checkout_session_id`); the server
+ * route validates it and injects it as the `HTTP_CART_TOKEN` env so the
+ * Store API's existing header-based session swap picks it up. The URL-
+ * parameter transport is used because `WooNetwork` does not currently
+ * expose a way to add custom request headers per call.
  */
 @Singleton
 class PosStoreApiRestClient @Inject constructor(
@@ -33,14 +38,16 @@ class PosStoreApiRestClient @Inject constructor(
     /**
      * POST /wc/pos/v1/cart/add-item.
      *
-     * Adds one cart line. Currently called once per distinct product/quantity
-     * pair built by the in-memory POS cart.
+     * Adds one cart line. Returns the response together with any
+     * `Cart-Token` header the server emitted, so the caller can replay
+     * it on subsequent calls in the same transaction.
      */
     suspend fun addToCart(
         site: SiteModel,
         productId: Long,
         quantity: Int,
         variation: List<VariationAttribute> = emptyList(),
+        cartToken: String? = null,
     ): WooPayload<Unit> {
         val body = buildMap<String, Any> {
             put("id", productId)
@@ -52,13 +59,13 @@ class PosStoreApiRestClient @Inject constructor(
 
         val response = wooNetwork.executePostGsonRequest(
             site = site,
-            path = ADD_ITEM_PATH,
+            path = appendCartToken(ADD_ITEM_PATH, cartToken),
             clazz = AddItemResponseDto::class.java,
             body = body
         )
 
         return when (response) {
-            is Success -> WooPayload(Unit)
+            is Success -> WooPayload(Unit, response.headers)
             is Error -> WooPayload(response.error.toWooError())
         }
     }
@@ -71,18 +78,27 @@ class PosStoreApiRestClient @Inject constructor(
      * does not attempt to process payment, leaving the existing POS
      * payment flow to take over (WooPayments capture, or cash mark-paid).
      */
-    suspend fun checkout(site: SiteModel): WooPayload<CheckoutResponseDto> {
+    suspend fun checkout(
+        site: SiteModel,
+        cartToken: String? = null,
+    ): WooPayload<CheckoutResponseDto> {
         val response = wooNetwork.executePostGsonRequest(
             site = site,
-            path = CHECKOUT_PATH,
+            path = appendCartToken(CHECKOUT_PATH, cartToken),
             clazz = CheckoutResponseDto::class.java,
             body = emptyMap()
         )
 
         return when (response) {
-            is Success -> WooPayload(response.data)
+            is Success -> WooPayload(response.data, response.headers)
             is Error -> WooPayload(response.error.toWooError())
         }
+    }
+
+    private fun appendCartToken(path: String, cartToken: String?): String {
+        if (cartToken.isNullOrEmpty()) return path
+        val separator = if (path.contains('?')) "&" else "?"
+        return path + separator + CART_TOKEN_PARAM + "=" + URLEncoder.encode(cartToken, Charsets.UTF_8.name())
     }
 
     data class VariationAttribute(
@@ -115,7 +131,16 @@ class PosStoreApiRestClient @Inject constructor(
     )
 
     companion object {
+        /**
+         * Name of the response header the Store API emits carrying the
+         * server-signed cart-token JWT. Callers should look this up
+         * case-insensitively in [WooPayload.headers] and replay the value
+         * on subsequent calls in the same transaction.
+         */
+        const val CART_TOKEN_HEADER = "Cart-Token"
+
         private const val ADD_ITEM_PATH = "/wc/pos/v1/cart/add-item"
         private const val CHECKOUT_PATH = "/wc/pos/v1/checkout"
+        private const val CART_TOKEN_PARAM = "cart_token"
     }
 }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pos/PosStoreApiRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pos/PosStoreApiRestClient.kt
@@ -77,16 +77,31 @@ class PosStoreApiRestClient @Inject constructor(
      * supplied — the Store API creates the order in `pending` status and
      * does not attempt to process payment, leaving the existing POS
      * payment flow to take over (WooPayments capture, or cash mark-paid).
+     *
+     * Billing and shipping addresses are sent as placeholders by the use
+     * case caller. The POS route relaxes the schema-level requirement on
+     * those fields, but a deeper pipeline-layer validation in
+     * OrderController still enforces per-field rules driven by store
+     * settings (postcode, phone, etc.) — sending placeholders is the
+     * simplest way to satisfy those today. Smarter cart-aware logic that
+     * only requires fields the products in the cart actually need is a
+     * planned follow-up.
      */
     suspend fun checkout(
         site: SiteModel,
         cartToken: String? = null,
+        billingAddress: Map<String, String> = placeholderAddress(),
+        shippingAddress: Map<String, String> = placeholderAddress(),
     ): WooPayload<CheckoutResponseDto> {
+        val body = buildMap<String, Any> {
+            put("billing_address", billingAddress)
+            put("shipping_address", shippingAddress)
+        }
         val response = wooNetwork.executePostGsonRequest(
             site = site,
             path = appendCartToken(CHECKOUT_PATH, cartToken),
             clazz = CheckoutResponseDto::class.java,
-            body = emptyMap()
+            body = body
         )
 
         return when (response) {
@@ -94,6 +109,26 @@ class PosStoreApiRestClient @Inject constructor(
             is Error -> WooPayload(response.error.toWooError())
         }
     }
+
+    /**
+     * Placeholder address fields that satisfy WC's per-field validation
+     * for in-store retail sales where the cashier doesn't have customer
+     * address info to capture. The order is created with this address and
+     * the cashier can edit it later via the orders admin if needed.
+     */
+    private fun placeholderAddress(): Map<String, String> = mapOf(
+        "first_name" to "POS",
+        "last_name" to "Customer",
+        "company" to "",
+        "address_1" to "In-store sale",
+        "address_2" to "",
+        "city" to "In-store sale",
+        "state" to "",
+        "postcode" to "00000",
+        "country" to "US",
+        "email" to "",
+        "phone" to "0000000000",
+    )
 
     private fun appendCartToken(path: String, cartToken: String?): String {
         if (cartToken.isNullOrEmpty()) return path

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pos/PosStoreApiRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pos/PosStoreApiRestClient.kt
@@ -71,6 +71,33 @@ class PosStoreApiRestClient @Inject constructor(
     }
 
     /**
+     * POST /wc/pos/v1/cart/apply-coupon.
+     *
+     * Applies a single coupon to the in-progress cart. Coupon validation
+     * (usage limits, per-customer limits, product restrictions, etc.) runs
+     * server-side; an invalid code comes back as an error payload. Returns
+     * the response together with any refreshed `Cart-Token` header so the
+     * caller can replay it on subsequent calls in the same transaction.
+     */
+    suspend fun applyCoupon(
+        site: SiteModel,
+        code: String,
+        cartToken: String? = null,
+    ): WooPayload<Unit> {
+        val response = wooNetwork.executePostGsonRequest(
+            site = site,
+            path = appendCartToken(APPLY_COUPON_PATH, cartToken),
+            clazz = ApplyCouponResponseDto::class.java,
+            body = mapOf("code" to code)
+        )
+
+        return when (response) {
+            is Success -> WooPayload(Unit, response.headers)
+            is Error -> WooPayload(response.error.toWooError())
+        }
+    }
+
+    /**
      * POST /wc/pos/v1/checkout.
      *
      * Finalises the in-progress cart into an order. The body is empty:
@@ -128,6 +155,14 @@ class PosStoreApiRestClient @Inject constructor(
     private class AddItemResponseDto
 
     /**
+     * Minimal projection of the apply-coupon response. As with add-item, the
+     * in-memory POS cart stays the client-side source of truth, so we don't
+     * consume the returned cart payload here.
+     */
+    @Suppress("unused")
+    private class ApplyCouponResponseDto
+
+    /**
      * Minimal projection of the checkout response. The full schema is much
      * larger; we only need the order identification fields to hand off to
      * the existing payment flow.
@@ -148,6 +183,7 @@ class PosStoreApiRestClient @Inject constructor(
         const val CART_TOKEN_HEADER = "Cart-Token"
 
         private const val ADD_ITEM_PATH = "/wc/pos/v1/cart/add-item"
+        private const val APPLY_COUPON_PATH = "/wc/pos/v1/cart/apply-coupon"
         private const val CHECKOUT_PATH = "/wc/pos/v1/checkout"
         private const val CART_TOKEN_PARAM = "cart_token"
     }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pos/PosStoreApiRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pos/PosStoreApiRestClient.kt
@@ -1,0 +1,121 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.pos
+
+import com.google.gson.annotations.SerializedName
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse.Error
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse.Success
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * REST client for the POS Store API namespace (`wc/pos/v1`).
+ *
+ * These endpoints run the WooCommerce checkout pipeline (and therefore fire
+ * the checkout-time extension hooks that fulfilment of gift cards,
+ * subscriptions, bookings and downloadable products relies on), with
+ * POS-specific session scoping. See
+ * `plugins/woocommerce/src/Internal/POS/StoreApi/` in woocommerce/woocommerce
+ * for the server side.
+ *
+ * This is a spike client paired with the server-side architectural spike.
+ * Session continuity across requests is currently unresolved (see
+ * DECISIONS.md alongside the use case); tests mock this client, so unit
+ * coverage is unaffected.
+ */
+@Singleton
+class PosStoreApiRestClient @Inject constructor(
+    private val wooNetwork: WooNetwork
+) {
+
+    /**
+     * POST /wc/pos/v1/cart/add-item.
+     *
+     * Adds one cart line. Currently called once per distinct product/quantity
+     * pair built by the in-memory POS cart.
+     */
+    suspend fun addToCart(
+        site: SiteModel,
+        productId: Long,
+        quantity: Int,
+        variation: List<VariationAttribute> = emptyList(),
+    ): WooPayload<Unit> {
+        val body = buildMap<String, Any> {
+            put("id", productId)
+            put("quantity", quantity)
+            if (variation.isNotEmpty()) {
+                put("variation", variation.map { it.toMap() })
+            }
+        }
+
+        val response = wooNetwork.executePostGsonRequest(
+            site = site,
+            path = ADD_ITEM_PATH,
+            clazz = AddItemResponseDto::class.java,
+            body = body
+        )
+
+        return when (response) {
+            is Success -> WooPayload(Unit)
+            is Error -> WooPayload(response.error.toWooError())
+        }
+    }
+
+    /**
+     * POST /wc/pos/v1/checkout.
+     *
+     * Finalises the in-progress cart into an order. No `payment_method` is
+     * supplied — the Store API creates the order in `pending` status and
+     * does not attempt to process payment, leaving the existing POS
+     * payment flow to take over (WooPayments capture, or cash mark-paid).
+     */
+    suspend fun checkout(site: SiteModel): WooPayload<CheckoutResponseDto> {
+        val response = wooNetwork.executePostGsonRequest(
+            site = site,
+            path = CHECKOUT_PATH,
+            clazz = CheckoutResponseDto::class.java,
+            body = emptyMap()
+        )
+
+        return when (response) {
+            is Success -> WooPayload(response.data)
+            is Error -> WooPayload(response.error.toWooError())
+        }
+    }
+
+    data class VariationAttribute(
+        val attribute: String,
+        val value: String,
+    ) {
+        fun toMap(): Map<String, String> = mapOf(
+            "attribute" to attribute,
+            "value" to value,
+        )
+    }
+
+    /**
+     * Minimal projection of the add-item response. We don't consume the cart
+     * payload itself here — the in-memory POS cart remains the source of
+     * truth client-side until checkout — so an empty class deserialises fine.
+     */
+    @Suppress("unused")
+    private class AddItemResponseDto
+
+    /**
+     * Minimal projection of the checkout response. The full schema is much
+     * larger; we only need the order identification fields to hand off to
+     * the existing payment flow.
+     */
+    data class CheckoutResponseDto(
+        @SerializedName("order_id") val orderId: Long,
+        @SerializedName("status") val status: String?,
+        @SerializedName("order_key") val orderKey: String?,
+    )
+
+    companion object {
+        private const val ADD_ITEM_PATH = "/wc/pos/v1/cart/add-item"
+        private const val CHECKOUT_PATH = "/wc/pos/v1/checkout"
+    }
+}

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pos/PosStoreApiRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pos/PosStoreApiRestClient.kt
@@ -7,12 +7,18 @@ import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse.Success
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
+import java.math.BigDecimal
 import java.net.URLEncoder
 import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
- * REST client for the POS Store API namespace (`wc/pos/v1`).
+ * REST client for the POS Store API namespace (`wc/internal/pos/v1`).
+ *
+ * The namespace is `internal` because the cart/checkout shape is still a spike
+ * and not a committed public contract; the routes exist only when the server's
+ * `point_of_sale` feature is enabled. (The public `wc/pos/v1` namespace is a
+ * separate thing — the POS catalog feed — and must not be confused with this.)
  *
  * These endpoints run the WooCommerce checkout pipeline (and therefore fire
  * the checkout-time extension hooks that fulfilment of gift cards,
@@ -36,7 +42,7 @@ class PosStoreApiRestClient @Inject constructor(
 ) {
 
     /**
-     * POST /wc/pos/v1/cart/add-item.
+     * POST /wc/internal/pos/v1/cart/add-item.
      *
      * Adds one cart line. Returns the response together with any
      * `Cart-Token` header the server emitted, so the caller can replay
@@ -71,7 +77,7 @@ class PosStoreApiRestClient @Inject constructor(
     }
 
     /**
-     * POST /wc/pos/v1/cart/apply-coupon.
+     * POST /wc/internal/pos/v1/cart/apply-coupon.
      *
      * Applies a single coupon to the in-progress cart. Coupon validation
      * (usage limits, per-customer limits, product restrictions, etc.) runs
@@ -98,7 +104,43 @@ class PosStoreApiRestClient @Inject constructor(
     }
 
     /**
-     * POST /wc/pos/v1/checkout.
+     * POST /wc/internal/pos/v1/cart/add-fee.
+     *
+     * Adds one ad-hoc custom fee (a "custom amount" in POS terms) to the
+     * in-progress cart. The server persists the fee in the session and
+     * re-applies it on every cart recalculation, so it survives until
+     * checkout. Fee identity is content-derived server-side (name + amount +
+     * tax), so re-adding an identical fee is idempotent. The amount must be
+     * greater than zero — the server rejects non-positive fees. Returns the
+     * response together with any refreshed `Cart-Token` header so the caller
+     * can replay it on subsequent calls in the same transaction.
+     */
+    suspend fun addFee(
+        site: SiteModel,
+        name: String,
+        amount: BigDecimal,
+        taxable: Boolean = false,
+        cartToken: String? = null,
+    ): WooPayload<Unit> {
+        val response = wooNetwork.executePostGsonRequest(
+            site = site,
+            path = appendCartToken(ADD_FEE_PATH, cartToken),
+            clazz = AddFeeResponseDto::class.java,
+            body = mapOf(
+                "name" to name,
+                "amount" to amount,
+                "taxable" to taxable,
+            )
+        )
+
+        return when (response) {
+            is Success -> WooPayload(Unit, response.headers)
+            is Error -> WooPayload(response.error.toWooError())
+        }
+    }
+
+    /**
+     * POST /wc/internal/pos/v1/checkout.
      *
      * Finalises the in-progress cart into an order. The body is empty:
      * no payment_method, no billing_address, no shipping_address. The POS
@@ -163,6 +205,14 @@ class PosStoreApiRestClient @Inject constructor(
     private class ApplyCouponResponseDto
 
     /**
+     * Minimal projection of the add-fee response. As with add-item, the
+     * in-memory POS cart stays the client-side source of truth, so we don't
+     * consume the returned cart payload here.
+     */
+    @Suppress("unused")
+    private class AddFeeResponseDto
+
+    /**
      * Minimal projection of the checkout response. The full schema is much
      * larger; we only need the order identification fields to hand off to
      * the existing payment flow.
@@ -182,9 +232,10 @@ class PosStoreApiRestClient @Inject constructor(
          */
         const val CART_TOKEN_HEADER = "Cart-Token"
 
-        private const val ADD_ITEM_PATH = "/wc/pos/v1/cart/add-item"
-        private const val APPLY_COUPON_PATH = "/wc/pos/v1/cart/apply-coupon"
-        private const val CHECKOUT_PATH = "/wc/pos/v1/checkout"
+        private const val ADD_ITEM_PATH = "/wc/internal/pos/v1/cart/add-item"
+        private const val APPLY_COUPON_PATH = "/wc/internal/pos/v1/cart/apply-coupon"
+        private const val ADD_FEE_PATH = "/wc/internal/pos/v1/cart/add-fee"
+        private const val CHECKOUT_PATH = "/wc/internal/pos/v1/checkout"
         private const val CART_TOKEN_PARAM = "cart_token"
     }
 }


### PR DESCRIPTION
**This is a proof-of-concept and should not be merged.**

Paired with the server-side POC at woocommerce/woocommerce#65314 (branch `pos-store-api-spike`). Both branches together demonstrate the architectural shape proposed in the [POS × Store API P2 thread](https://peacockp2.wordpress.com/2026/03/12/pos-x-store-api/) and Thomas Roberts's follow-up. The goal of this draft is to give Rubik / Peacock something concrete to look at when discussing whether to pursue this for real.

## What this does

Behind the `WOO_POS_STORE_API_CHECKOUT` feature flag, the moment the cashier taps "Charge" runs the in-memory cart through the new `wc/pos/v1/cart/add-item` + `/checkout` endpoints instead of `POST /wc/v3/orders`. Everything downstream of order creation (payment flow, card reader SDK, cash mark-paid) is unchanged.

Value proposition: the WooCommerce checkout pipeline runs, so checkout-time extension hooks fire and fulfilment of gift cards, subscriptions, bookings, and downloadable products works without the apps needing per-product-type handling.

## What's in the branch

- `WooCommerce/.../util/FeatureFlag.kt` — adds `WOO_POS_STORE_API_CHECKOUT`, debug-only default.
- `libs/fluxc-plugin/.../wc/pos/PosStoreApiRestClient.kt` — thin client over `WooNetwork` for `/wc/pos/v1/cart/add-item` and `/wc/pos/v1/checkout`. Minimal DTOs.
- `WooCommerce/.../woopos/home/totals/PosStoreApiCheckoutUseCase.kt` — orchestrates per-item add + checkout + freshly-created-order fetch. Returns `Result<Order>` matching the existing repo contract so the payment flow downstream is untouched.
- `WooCommerce/.../woopos/home/totals/WooPosTotalsRepository.kt` — single flag-gated branch in `createOrderFromCartItems` routes to the new use case when the flag is on; existing REST path is the default.
- `DECISIONS.md` alongside the use case records the judgement calls.

## Verification

- Kotlin compiles clean (`compileWasabiDebugKotlin` + KSP both green).
- All 17 tests in the touched suites pass: 5 new use-case tests + 2 new routing tests + 10 pre-existing repository tests.
- Detekt clean.

## The load-bearing follow-up (open question)

Session continuity across the multiple Store API requests is unresolved. `WooNetwork` doesn't manage cookies, and `CartTokenUtils::get_cart_token` is server-signed so mobile can't mint one. The cleanest path is making `StoreApi\SessionHandler` non-final upstream (it's already header-based via `HTTP_CART_TOKEN`) and extending it as `POSSessionHandler` — which is exactly the open question raised in the server-side spike too. Until that lands, this flow will work for the first request but lose context on subsequent ones. Unit tests are unaffected because they mock the REST client.

## Deliberately out of scope

- **Coupons** and **custom fees** — Store API uses separate endpoints; silently dropped for this spike.
- **Customer pre-fill** — guest checkout in all cases; the agent/customer identity model isn't implemented yet.
- **Resilient retry / partial-cart recovery.**
- **End-to-end smoke testing against a real device with a real Woo install** — natural follow-up once the session continuity question is resolved.

## Test plan

- [ ] (Once session continuity lands) install woocommerce/woocommerce#65314 build, enable `WOO_POS_STORE_API_CHECKOUT` flag, scan a Gift Card product, verify gift card email is delivered after order is marked paid.
- [ ] Same for a downloadable product (download permission + email).
- [ ] Same for a subscription product.
- [ ] Verify behaviour with feature flag off matches today's POS flow exactly.