### PR TITLE
Fix open-in-new icon position when low stock threshold is null

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NewStockNotificationSettingsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NewStockNotificationSettingsScreen.kt
@@ -212,25 +212,27 @@ private fun LowStockDetails(
     }
     val openInNewIconId = "openInNewIcon"
     val textWithIcon = remember(text) {
-        val linkAnnotation = text.getLinkAnnotations(start = 0, end = text.length).lastOrNull()?.item
+        val linkRange = text.getLinkAnnotations(start = 0, end = text.length).lastOrNull()
         val thresholdPlaceholderStart = text.text.indexOf(LOW_STOCK_THRESHOLD_PLACEHOLDER)
         val thresholdPlaceholderEnd = thresholdPlaceholderStart + LOW_STOCK_THRESHOLD_PLACEHOLDER.length
+        val iconInsertionIndex = linkRange?.end ?: text.length
         buildAnnotatedString {
-            if (thresholdPlaceholderStart >= 0) {
+            if (thresholdPlaceholderStart in 0 until iconInsertionIndex) {
                 append(text.subSequence(0, thresholdPlaceholderStart))
                 appendInlineContent(thresholdPlaceholderId, "[Threshold]")
-                append(text.subSequence(thresholdPlaceholderEnd, text.length))
+                append(text.subSequence(thresholdPlaceholderEnd, iconInsertionIndex))
             } else {
-                append(text)
+                append(text.subSequence(0, iconInsertionIndex))
             }
             append(" ")
-            if (linkAnnotation != null) {
-                pushLink(linkAnnotation)
+            if (linkRange != null) {
+                pushLink(linkRange.item)
                 appendInlineContent(openInNewIconId, "[Icon]")
                 pop()
             } else {
                 appendInlineContent(openInNewIconId, "[Icon]")
             }
+            append(text.subSequence(iconInsertionIndex, text.length))
         }
     }
     val iconColor = MaterialTheme.colorScheme.primary


### PR DESCRIPTION
### Description
When the store-wide low stock threshold is null, the open-in-new (↗) icon in the "View store-wide threshold" helper renders at the end of the sentence instead of next to the link. The original `LowStockDetails` composable always appended the icon to the end of the text, which lined up with the link in the "set" copy (link at end) but broke in the "null" copy (link mid-sentence). This change anchors the icon to the link annotation's end so it stays adjacent to the link in both copies.

Reported by Adam Grzybkowski in a DM.

### Test Steps
1. Open Settings, Notifications, Stock notifications.
2. To produce the "null" state: tap "View store-wide threshold", clear the "Low stock threshold" field in the store admin, save, and return to the app.
3. Verify the ↗ icon sits between "View store-wide threshold" and "to see the current value."
4. To produce the "set" state: open the link again, set the threshold to a value, save, and return to the app.
5. Verify the ↗ icon sits right after "Edit store-wide threshold" at the end of the sentence.

### Images/gif
|before|after|
|-|-|
|<img width="300" src="https://github.com/user-attachments/assets/5d60cd3f-837b-4551-9992-5bc11e3430c7" />|<img width="300" src="https://github.com/user-attachments/assets/98831349-3a72-441b-8212-07af45635532" />|

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.