### PR TITLE
Enable smarter notifications feature flag

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -37,7 +37,7 @@ enum class FeatureFlag(
     LOGGED_OUT_FF_PANEL("logged_out_ff_panel", localValue = PackageUtils.isDebugBuild()),
     AI_ASSISTANT("woo_mobile_ai_assistant"),
     AI_SUPPORT_CHAT("ai_support_chat"),
-    SMARTER_NOTIFICATIONS("smarter_notifications", localValue = PackageUtils.isDebugBuild()),
+    SMARTER_NOTIFICATIONS("smarter_notifications"),
     IPP_COUNTRY_EXPANSION("woo_ipp_country_expansion"),
     IPP_COUNTRY_EXPANSION_EU_EXTENDED("woo_ipp_country_expansion_eu_extended"),
     IPP_AUSTRALIA_WOOPAYMENTS("woo_ipp_australia_woopayments"),


### PR DESCRIPTION
### Description
Enables the `SMARTER_NOTIFICATIONS` local feature flag so the new smarter notifications settings ship in app version 24.9.

### Test Steps
1. Install a release build.
2. Log in to a site registered for Woo-driven push notifications.
3. Open **Settings → Notification settings** and confirm the smarter notifications screen is shown.