### PR TITLE
Add dependabot bundler block for Ruby deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,3 +39,14 @@ updates:
       - dependency-name: "org.wordpress:wellsql"
       - dependency-name: "org.wordpress.wellsql:wellsql-processor"
       - dependency-name: "com.github.PhilJay:MPAndroidChart"
+
+  - package-ecosystem: "bundler"
+    open-pull-requests-limit: 5
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "bot: dependencies update"
+    groups:
+      ruby-minor-and-patch:
+        update-types: [minor, patch]


### PR DESCRIPTION
### Description

Sets up Dependabot to check Ruby dependencies daily so we can more easily address security updates. See [AINFRA-2437](https://linear.app/a8c/issue/AINFRA-2437).

The existing `gradle` ecosystem entry is untouched; this PR only appends a new `bundler` block targeting the root `Gemfile`, with the standard campaign settings: `daily` schedule, `ruby-minor-and-patch` grouping for minor/patch updates, and `open-pull-requests-limit: 5`.

### Test Steps

Dependabot config is consumed by GitHub, not the repo's CI. `yq` validation passes and the existing `gradle` entry is untouched (`git diff` shows only the appended block).

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

---

Posted by Claude (Opus 4.7, 1M context) on behalf of @mokagio with approval.