### PR TITLE
Add PR-time AI translation pipeline fixture

### DIFF
--- a/WooCommerce/src/main/res/values-ar/strings.xml
+++ b/WooCommerce/src/main/res/values-ar/strings.xml
@@ -3905,4 +3905,17 @@ Language: ar
         <item quantity="many">الإجمالي الفرعي للعناصر (%d من العناصر)</item>
         <item quantity="other">الإجمالي الفرعي للعناصر (%d من العناصر)</item>
     </plurals>
+    <string name="ai_translation_test_product_short_sku">SKU</string>
+    <string name="ai_translation_test_product_medium_low_stock_badge">منتج منخفض المخزون</string>
+    <string name="ai_translation_test_product_placeholder_inventory">تم حفظ %1$s بـ SKU %2$s و%3$d وحدة في المخزون.</string>
+    <string name="ai_translation_test_product_placeholder_sale_window">سعر البيع %1$s أقل بنسبة %2$d%% من السعر العادي ويمتد من %3$s إلى %4$s.</string>
+    <string name="ai_translation_test_product_formatted_false_discount" formatted="false">وفّر 20% على المنتجات المجمّعة واحتفظ بـ 100% من تنسيق SKU.</string>
+    <string name="ai_translation_test_product_html_link">راجع &lt;a href=\'inventory-threshold\'&gt;&lt;u&gt;حدود المخزون&lt;/u&gt;&lt;/a&gt; قبل تفعيل الطلبات المسبقة.</string>
+    <string name="ai_translation_test_product_cdata_confirmation">&lt;b&gt;%1$s&lt;/b&gt; جاهز للنشر. راجع السعر والمخزون والشحن قبل النشر.</string>
+    <string name="ai_translation_test_product_multiline_backorder">المنتج %1$s غير متوفر في المخزون.\nأعد تخزين %2$d وحدة أو ضعه كطلب مسبق.</string>
+    <string-array name="ai_translation_test_product_type_filters">
+        <item>منتج بسيط</item>
+        <item>منتج متغير</item>
+        <item>منتج اشتراك</item>
+    </string-array>
 </resources>

--- a/WooCommerce/src/main/res/values-ar/strings.xml
+++ b/WooCommerce/src/main/res/values-ar/strings.xml
@@ -3918,4 +3918,12 @@ Language: ar
         <item>منتج متغير</item>
         <item>منتج اشتراك</item>
     </string-array>
+    <plurals name="ai_translation_test_product_variations_selected">
+        <item quantity="zero">تم تحديد %1$d متغيرات للتعديل الجماعي</item>
+        <item quantity="one">تم تحديد %1$d متغير للتعديل الجماعي</item>
+        <item quantity="two">تم تحديد %1$d متغيرين للتعديل الجماعي</item>
+        <item quantity="few">تم تحديد %1$d متغيرات للتعديل الجماعي</item>
+        <item quantity="many">تم تحديد %1$d متغيرًا للتعديل الجماعي</item>
+        <item quantity="other">تم تحديد %1$d متغير للتعديل الجماعي</item>
+    </plurals>
 </resources>

--- a/WooCommerce/src/main/res/values-bg/strings.xml
+++ b/WooCommerce/src/main/res/values-bg/strings.xml
@@ -4804,4 +4804,21 @@
     <string name="ai_assistant_chat_error_confirmation_deferred" a8c-src-lib="module:ai-assistant-feature">Потвърждението все още не е налично. Моля, опитайте отново от чата.</string>
     <string name="ai_assistant_chat_error_max_iterations" a8c-src-lib="module:ai-assistant-feature">Асистентът не можа да завърши след няколко стъпки.</string>
     <string name="ai_assistant_chat_error_unknown" a8c-src-lib="module:ai-assistant-feature">Нещо се обърка, докато асистентът работеше.</string>
+    <string name="ai_translation_test_product_short_sku">SKU</string>
+    <string name="ai_translation_test_product_medium_low_stock_badge">Продукт с малко наличност</string>
+    <string name="ai_translation_test_product_placeholder_inventory">Запазено %1$s със SKU %2$s и %3$d бр. в наличност.</string>
+    <string name="ai_translation_test_product_placeholder_sale_window">Промоционалната цена %1$s е с %2$d%% по-ниска от редовната и важи от %3$s до %4$s.</string>
+    <string name="ai_translation_test_product_formatted_false_discount" formatted="false">Спестете 20% от пакетни продукти и запазете 100% от форматирането на SKU.</string>
+    <string name="ai_translation_test_product_html_link">Прегледайте &lt;a href=\'inventory-threshold\'&gt;&lt;u&gt;праговете на инвентара&lt;/u&gt;&lt;/a&gt; преди да разрешите поръчки при изчерпан запас.</string>
+    <string name="ai_translation_test_product_cdata_confirmation">&lt;b&gt;%1$s&lt;/b&gt; е готов за публикуване. Прегледайте цена, инвентар и доставка преди публикуване.</string>
+    <string name="ai_translation_test_product_multiline_backorder">Продукт %1$s е изчерпан.\nДопълнете %2$d бр. или го маркирайте като поръчан предварително.</string>
+    <plurals name="ai_translation_test_product_variations_selected">
+        <item quantity="one">%1$d вариация избрана за групово редактиране</item>
+        <item quantity="other">%1$d вариации избрани за групово редактиране</item>
+    </plurals>
+    <string-array name="ai_translation_test_product_type_filters">
+        <item>Прост продукт</item>
+        <item>Продукт с вариации</item>
+        <item>Абонаментен продукт</item>
+    </string-array>
 </resources>

--- a/WooCommerce/src/main/res/values-cs/strings.xml
+++ b/WooCommerce/src/main/res/values-cs/strings.xml
@@ -4811,4 +4811,23 @@
     <string name="ai_assistant_chat_error_confirmation_deferred" a8c-src-lib="module:ai-assistant-feature">Potvrzení ještě není k dispozici. Zkuste to prosím znovu z chatu.</string>
     <string name="ai_assistant_chat_error_max_iterations" a8c-src-lib="module:ai-assistant-feature">Asistent nemohl dokončit úkol po několika krocích.</string>
     <string name="ai_assistant_chat_error_unknown" a8c-src-lib="module:ai-assistant-feature">Při práci asistenta se něco pokazilo.</string>
+    <string name="ai_translation_test_product_short_sku">SKU</string>
+    <string name="ai_translation_test_product_medium_low_stock_badge">Produkt s nízkým skladem</string>
+    <string name="ai_translation_test_product_placeholder_inventory">Uloženo %1$s se SKU %2$s a %3$d kusů na skladě.</string>
+    <string name="ai_translation_test_product_placeholder_sale_window">Akční cena %1$s je o %2$d%% nižší než běžná cena a platí od %3$s do %4$s.</string>
+    <string name="ai_translation_test_product_formatted_false_discount" formatted="false">Ušetřete 20 % na balíčkových produktech a zachovejte 100 % formátování SKU.</string>
+    <string name="ai_translation_test_product_html_link">Zkontrolujte &lt;a href=\'inventory-threshold\'&gt;&lt;u&gt;limity skladu&lt;/u&gt;&lt;/a&gt; před povolením objednávek na dotaz.</string>
+    <string name="ai_translation_test_product_cdata_confirmation">&lt;b&gt;%1$s&lt;/b&gt; je připraven k publikování. Před zveřejněním zkontrolujte cenu, sklad a dopravu.</string>
+    <string name="ai_translation_test_product_multiline_backorder">Produkt %1$s není skladem.\nDoplňte %2$d kusů nebo označte jako objednávku na dotaz.</string>
+    <plurals name="ai_translation_test_product_variations_selected">
+        <item quantity="one">%1$d varianta vybrána pro hromadnou úpravu</item>
+        <item quantity="few">%1$d varianty vybrány pro hromadnou úpravu</item>
+        <item quantity="many">%1$d varianty vybrány pro hromadnou úpravu</item>
+        <item quantity="other">%1$d variant vybráno pro hromadnou úpravu</item>
+    </plurals>
+    <string-array name="ai_translation_test_product_type_filters">
+        <item>Jednoduchý produkt</item>
+        <item>Variabilní produkt</item>
+        <item>Produkt s předplatným</item>
+    </string-array>
 </resources>

--- a/WooCommerce/src/main/res/values-da/strings.xml
+++ b/WooCommerce/src/main/res/values-da/strings.xml
@@ -4806,4 +4806,21 @@
     <string name="ai_assistant_chat_error_confirmation_deferred" a8c-src-lib="module:ai-assistant-feature">Bekræftelse er endnu ikke tilgængelig. Prøv igen fra chatten.</string>
     <string name="ai_assistant_chat_error_max_iterations" a8c-src-lib="module:ai-assistant-feature">Assistenten kunne ikke afslutte efter flere trin.</string>
     <string name="ai_assistant_chat_error_unknown" a8c-src-lib="module:ai-assistant-feature">Noget gik galt, mens assistenten arbejdede.</string>
+    <string name="ai_translation_test_product_short_sku">SKU</string>
+    <string name="ai_translation_test_product_medium_low_stock_badge">Lavt lager produkt</string>
+    <string name="ai_translation_test_product_placeholder_inventory">Gemte %1$s med SKU %2$s og %3$d enheder på lager.</string>
+    <string name="ai_translation_test_product_placeholder_sale_window">Tilbudspris %1$s er %2$d%% lavere end normalprisen og gælder fra %3$s til %4$s.</string>
+    <string name="ai_translation_test_product_formatted_false_discount" formatted="false">Spar 20% på bundlede produkter og behold 100% af din SKU-formatering.</string>
+    <string name="ai_translation_test_product_html_link">Gennemgå &lt;a href=\'inventory-threshold\'&gt;&lt;u&gt;lagertærskler&lt;/u&gt;&lt;/a&gt; inden du aktiverer restordrer.</string>
+    <string name="ai_translation_test_product_cdata_confirmation">&lt;b&gt;%1$s&lt;/b&gt; er klar til publicering. Gennemgå pris, lager og forsendelse, inden det går live.</string>
+    <string name="ai_translation_test_product_multiline_backorder">Produkt %1$s er ikke på lager.\nGenopfyld %2$d enheder eller markér det som restordre.</string>
+    <plurals name="ai_translation_test_product_variations_selected">
+        <item quantity="one">%1$d variation valgt til masseredigering</item>
+        <item quantity="other">%1$d variationer valgt til masseredigering</item>
+    </plurals>
+    <string-array name="ai_translation_test_product_type_filters">
+        <item>Simpelt produkt</item>
+        <item>Variabelt produkt</item>
+        <item>Abonnementsprodukt</item>
+    </string-array>
 </resources>

--- a/WooCommerce/src/main/res/values-de/strings.xml
+++ b/WooCommerce/src/main/res/values-de/strings.xml
@@ -3901,4 +3901,21 @@ Language: de
         <item quantity="one">Teilsumme Artikel (%d Artikel)</item>
         <item quantity="other">Teilsumme Artikel (%d Artikel)</item>
     </plurals>
+    <string name="ai_translation_test_product_short_sku">SKU</string>
+    <string name="ai_translation_test_product_medium_low_stock_badge">Produkt mit niedrigem Lagerbestand</string>
+    <string name="ai_translation_test_product_placeholder_inventory">Gespeichert: %1$s mit SKU %2$s und %3$d Einheiten auf Lager.</string>
+    <string name="ai_translation_test_product_placeholder_sale_window">Aktionspreis %1$s ist %2$d%% günstiger als der reguläre Preis und gilt von %3$s bis %4$s.</string>
+    <string name="ai_translation_test_product_formatted_false_discount" formatted="false">Spare 20% auf Bundle-Produkte und behalte 100% deiner SKU-Formatierung.</string>
+    <string name="ai_translation_test_product_html_link">&lt;a href=\'inventory-threshold\'&gt;&lt;u&gt;Lagerbestandsgrenzen&lt;/u&gt;&lt;/a&gt; vor der Aktivierung von Rückbestellungen prüfen.</string>
+    <string name="ai_translation_test_product_cdata_confirmation">&lt;b&gt;%1$s&lt;/b&gt; ist bereit zur Veröffentlichung. Preis, Lagerbestand und Versand vor der Veröffentlichung prüfen.</string>
+    <string name="ai_translation_test_product_multiline_backorder">Produkt %1$s ist nicht vorrätig.\nAuffüllen mit %2$d Einheiten oder als Rückbestellung markieren.</string>
+    <plurals name="ai_translation_test_product_variations_selected">
+        <item quantity="one">%1$d Variante für die Massenbearbeitung ausgewählt</item>
+        <item quantity="other">%1$d Varianten für die Massenbearbeitung ausgewählt</item>
+    </plurals>
+    <string-array name="ai_translation_test_product_type_filters">
+        <item>Einfaches Produkt</item>
+        <item>Variables Produkt</item>
+        <item>Abonnementprodukt</item>
+    </string-array>
 </resources>

--- a/WooCommerce/src/main/res/values-el/strings.xml
+++ b/WooCommerce/src/main/res/values-el/strings.xml
@@ -4804,4 +4804,21 @@
     <string name="ai_assistant_chat_error_confirmation_deferred" a8c-src-lib="module:ai-assistant-feature">Η επιβεβαίωση δεν είναι ακόμα διαθέσιμη. Δοκιμάστε ξανά από τη συνομιλία.</string>
     <string name="ai_assistant_chat_error_max_iterations" a8c-src-lib="module:ai-assistant-feature">Ο βοηθός δεν μπόρεσε να ολοκληρώσει μετά από αρκετά βήματα.</string>
     <string name="ai_assistant_chat_error_unknown" a8c-src-lib="module:ai-assistant-feature">Παρουσιάστηκε σφάλμα κατά τη λειτουργία του βοηθού.</string>
+    <string name="ai_translation_test_product_short_sku">SKU</string>
+    <string name="ai_translation_test_product_medium_low_stock_badge">Προϊόν με χαμηλό απόθεμα</string>
+    <string name="ai_translation_test_product_placeholder_inventory">Αποθηκεύτηκε %1$s με SKU %2$s και %3$d μονάδες σε απόθεμα.</string>
+    <string name="ai_translation_test_product_placeholder_sale_window">Η τιμή προσφοράς %1$s είναι %2$d%% χαμηλότερη από την κανονική τιμή και ισχύει από %3$s έως %4$s.</string>
+    <string name="ai_translation_test_product_formatted_false_discount" formatted="false">Εξοικονομήστε 20% σε προϊόντα πακέτου και διατηρήστε 100% της μορφοποίησης SKU σας.</string>
+    <string name="ai_translation_test_product_html_link">Ελέγξτε τα &lt;a href=\'inventory-threshold\'&gt;&lt;u&gt;όρια αποθέματος&lt;/u&gt;&lt;/a&gt; πριν ενεργοποιήσετε τις παραγγελίες σε αναμονή.</string>
+    <string name="ai_translation_test_product_cdata_confirmation">Το &lt;b&gt;%1$s&lt;/b&gt; είναι έτοιμο για δημοσίευση. Ελέγξτε τιμή, απόθεμα και αποστολή πριν δημοσιευτεί.</string>
+    <string name="ai_translation_test_product_multiline_backorder">Το προϊόν %1$s είναι εξαντλημένο.\nΑνεφοδιάστε %2$d μονάδες ή επισημάνετε το ως σε αναμονή.</string>
+    <plurals name="ai_translation_test_product_variations_selected">
+        <item quantity="one">%1$d παραλλαγή επιλέχθηκε για μαζική επεξεργασία</item>
+        <item quantity="other">%1$d παραλλαγές επιλέχθηκαν για μαζική επεξεργασία</item>
+    </plurals>
+    <string-array name="ai_translation_test_product_type_filters">
+        <item>Απλό προϊόν</item>
+        <item>Μεταβλητό προϊόν</item>
+        <item>Προϊόν συνδρομής</item>
+    </string-array>
 </resources>

--- a/WooCommerce/src/main/res/values-es/strings.xml
+++ b/WooCommerce/src/main/res/values-es/strings.xml
@@ -3901,4 +3901,22 @@ Language: es
         <item quantity="one">Subtotal de artículos (%d artículo)</item>
         <item quantity="other">Subtotal de artículos (%d artículos)</item>
     </plurals>
+    <string name="ai_translation_test_product_short_sku">SKU</string>
+    <string name="ai_translation_test_product_medium_low_stock_badge">Producto con poco stock</string>
+    <string name="ai_translation_test_product_placeholder_inventory">Se guardó %1$s con SKU %2$s y %3$d unidades en stock.</string>
+    <string name="ai_translation_test_product_placeholder_sale_window">El precio de oferta %1$s es un %2$d%% menor que el precio regular y va del %3$s al %4$s.</string>
+    <string name="ai_translation_test_product_formatted_false_discount" formatted="false">Ahorra un 20% en productos en paquete y mantén el 100% del formato de tu SKU.</string>
+    <string name="ai_translation_test_product_html_link">Revisa los &lt;a href=\'inventory-threshold\'&gt;&lt;u&gt;umbrales de inventario&lt;/u&gt;&lt;/a&gt; antes de activar los pedidos pendientes.</string>
+    <string name="ai_translation_test_product_cdata_confirmation">&lt;b&gt;%1$s&lt;/b&gt; está listo para publicar. Revisa el precio, el inventario y el envío antes de publicarlo.</string>
+    <string name="ai_translation_test_product_multiline_backorder">El producto %1$s está agotado.\nReabastece %2$d unidades o márcalo como pedido pendiente.</string>
+    <plurals name="ai_translation_test_product_variations_selected">
+        <item quantity="one">%1$d variación seleccionada para edición masiva</item>
+        <item quantity="many">%1$d variaciones seleccionadas para edición masiva</item>
+        <item quantity="other">%1$d variaciones seleccionadas para edición masiva</item>
+    </plurals>
+    <string-array name="ai_translation_test_product_type_filters">
+        <item>Producto simple</item>
+        <item>Producto variable</item>
+        <item>Producto de suscripción</item>
+    </string-array>
 </resources>

--- a/WooCommerce/src/main/res/values-fi/strings.xml
+++ b/WooCommerce/src/main/res/values-fi/strings.xml
@@ -4804,4 +4804,21 @@
     <string name="ai_assistant_chat_error_confirmation_deferred" a8c-src-lib="module:ai-assistant-feature">Vahvistus ei ole vielä saatavilla. Yritä uudelleen chatissa.</string>
     <string name="ai_assistant_chat_error_max_iterations" a8c-src-lib="module:ai-assistant-feature">Avustaja ei pystynyt suorittamaan tehtävää useiden vaiheiden jälkeen.</string>
     <string name="ai_assistant_chat_error_unknown" a8c-src-lib="module:ai-assistant-feature">Jokin meni pieleen avustajan työskennellessä.</string>
+    <string name="ai_translation_test_product_short_sku">SKU</string>
+    <string name="ai_translation_test_product_medium_low_stock_badge">Vähän varastossa</string>
+    <string name="ai_translation_test_product_placeholder_inventory">Tallennettu %1$s SKU:lla %2$s ja %3$d yksikköä varastossa.</string>
+    <string name="ai_translation_test_product_placeholder_sale_window">Alennushinta %1$s on %2$d%% alempi kuin normaalihinta ja on voimassa %3$s–%4$s.</string>
+    <string name="ai_translation_test_product_formatted_false_discount" formatted="false">Säästä 20 % pakettituotteista ja säilytä 100 % SKU-muotoilustasi.</string>
+    <string name="ai_translation_test_product_html_link">Tarkista &lt;a href=\'inventory-threshold\'&gt;&lt;u&gt;varastorajat&lt;/u&gt;&lt;/a&gt; ennen jälkitilausten käyttöönottoa.</string>
+    <string name="ai_translation_test_product_cdata_confirmation">&lt;b&gt;%1$s&lt;/b&gt; on valmis julkaistavaksi. Tarkista hinta, varasto ja toimitus ennen julkaisua.</string>
+    <string name="ai_translation_test_product_multiline_backorder">Tuote %1$s on loppunut varastosta.\nTäydennä %2$d yksikköä tai merkitse jälkitilattavaksi.</string>
+    <plurals name="ai_translation_test_product_variations_selected">
+        <item quantity="one">%1$d variaatio valittu massamuokkaukseen</item>
+        <item quantity="other">%1$d variaatiota valittu massamuokkaukseen</item>
+    </plurals>
+    <string-array name="ai_translation_test_product_type_filters">
+        <item>Yksinkertainen tuote</item>
+        <item>Muuntuva tuote</item>
+        <item>Tilaustuote</item>
+    </string-array>
 </resources>

--- a/WooCommerce/src/main/res/values-fr/strings.xml
+++ b/WooCommerce/src/main/res/values-fr/strings.xml
@@ -3901,4 +3901,22 @@ Language: fr
         <item quantity="one">Sous-total des articles (%d article)</item>
         <item quantity="other">Sous-total des articles (%d articles)</item>
     </plurals>
+    <string name="ai_translation_test_product_short_sku">SKU</string>
+    <string name="ai_translation_test_product_medium_low_stock_badge">Produit en stock faible</string>
+    <string name="ai_translation_test_product_placeholder_inventory">Enregistré %1$s avec le SKU %2$s et %3$d unités en stock.</string>
+    <string name="ai_translation_test_product_placeholder_sale_window">Le prix promotionnel %1$s est %2$d%% inférieur au prix normal et est valable du %3$s au %4$s.</string>
+    <string name="ai_translation_test_product_formatted_false_discount" formatted="false">Économisez 20% sur les produits groupés et conservez 100% de votre formatage SKU.</string>
+    <string name="ai_translation_test_product_html_link">Consultez les &lt;a href=\'inventory-threshold\'&gt;&lt;u&gt;seuils de stock&lt;/u&gt;&lt;/a&gt; avant d\'activer les commandes en souffrance.</string>
+    <string name="ai_translation_test_product_cdata_confirmation">&lt;b&gt;%1$s&lt;/b&gt; est prêt à être publié. Vérifiez le prix, le stock et la livraison avant la mise en ligne.</string>
+    <string name="ai_translation_test_product_multiline_backorder">Le produit %1$s est en rupture de stock.\nRéapprovisionnez %2$d unités ou marquez-le en commande en souffrance.</string>
+    <plurals name="ai_translation_test_product_variations_selected">
+        <item quantity="one">%1$d variation sélectionnée pour la modification en masse</item>
+        <item quantity="many">%1$d variations sélectionnées pour la modification en masse</item>
+        <item quantity="other">%1$d variations sélectionnées pour la modification en masse</item>
+    </plurals>
+    <string-array name="ai_translation_test_product_type_filters">
+        <item>Produit simple</item>
+        <item>Produit variable</item>
+        <item>Produit par abonnement</item>
+    </string-array>
 </resources>

--- a/WooCommerce/src/main/res/values-he/strings.xml
+++ b/WooCommerce/src/main/res/values-he/strings.xml
@@ -3901,4 +3901,23 @@ Language: he_IL
         <item quantity="many">סכום ביניים (%d פריטים)</item>
         <item quantity="other">סכום ביניים (%d פריטים)</item>
     </plurals>
+    <string name="ai_translation_test_product_short_sku">מק\"ט</string>
+    <string name="ai_translation_test_product_medium_low_stock_badge">מוצר במלאי נמוך</string>
+    <string name="ai_translation_test_product_placeholder_inventory">נשמר %1$s עם מק\"ט %2$s ו-%3$d יחידות במלאי.</string>
+    <string name="ai_translation_test_product_placeholder_sale_window">מחיר המבצע %1$s נמוך ב-%2$d%% מהמחיר הרגיל ותקף מ-%3$s עד %4$s.</string>
+    <string name="ai_translation_test_product_formatted_false_discount" formatted="false">חסכו 20% על מוצרים בחבילה ושמרו 100% על עיצוב המק\"ט שלכם.</string>
+    <string name="ai_translation_test_product_html_link">סקרו &lt;a href=\'inventory-threshold\'&gt;&lt;u&gt;סף מלאי&lt;/u&gt;&lt;/a&gt; לפני הפעלת הזמנות לוג.</string>
+    <string name="ai_translation_test_product_cdata_confirmation">&lt;b&gt;%1$s&lt;/b&gt; מוכן לפרסום. בדקו מחיר, מלאי ומשלוח לפני שיפורסם.</string>
+    <string name="ai_translation_test_product_multiline_backorder">המוצר %1$s אזל מהמלאי.\nחדשו %2$d יחידות או סמנו אותו כהזמנה לוג.</string>
+    <plurals name="ai_translation_test_product_variations_selected">
+        <item quantity="one">%1$d וריאציה נבחרה לעריכה מרוכזת</item>
+        <item quantity="two">%1$d וריאציות נבחרו לעריכה מרוכזת</item>
+        <item quantity="many">%1$d וריאציות נבחרו לעריכה מרוכזת</item>
+        <item quantity="other">%1$d וריאציות נבחרו לעריכה מרוכזת</item>
+    </plurals>
+    <string-array name="ai_translation_test_product_type_filters">
+        <item>מוצר פשוט</item>
+        <item>מוצר משתנה</item>
+        <item>מוצר מנוי</item>
+    </string-array>
 </resources>

--- a/WooCommerce/src/main/res/values-hi/strings.xml
+++ b/WooCommerce/src/main/res/values-hi/strings.xml
@@ -4801,4 +4801,21 @@
     <string name="ai_assistant_chat_error_confirmation_deferred" a8c-src-lib="module:ai-assistant-feature">पुष्टि अभी उपलब्ध नहीं है। कृपया चैट से पुनः प्रयास करें।</string>
     <string name="ai_assistant_chat_error_max_iterations" a8c-src-lib="module:ai-assistant-feature">सहायक कई चरणों के बाद समाप्त नहीं कर सका।</string>
     <string name="ai_assistant_chat_error_unknown" a8c-src-lib="module:ai-assistant-feature">सहायक काम करते समय कुछ गलत हो गया।</string>
+    <string name="ai_translation_test_product_short_sku">SKU</string>
+    <string name="ai_translation_test_product_medium_low_stock_badge">कम स्टॉक उत्पाद</string>
+    <string name="ai_translation_test_product_placeholder_inventory">SKU %2$s और %3$d यूनिट स्टॉक के साथ %1$s सहेजा गया।</string>
+    <string name="ai_translation_test_product_placeholder_sale_window">सेल मूल्य %1$s नियमित मूल्य से %2$d%% कम है और %3$s से %4$s तक चलता है।</string>
+    <string name="ai_translation_test_product_formatted_false_discount" formatted="false">बंडल उत्पादों पर 20% बचाएं और अपना SKU फ़ॉर्मेटिंग 100% बनाए रखें।</string>
+    <string name="ai_translation_test_product_html_link">बैकऑर्डर सक्षम करने से पहले &lt;a href=\'inventory-threshold\'&gt;&lt;u&gt;इन्वेंटरी थ्रेशोल्ड&lt;/u&gt;&lt;/a&gt; की समीक्षा करें।</string>
+    <string name="ai_translation_test_product_cdata_confirmation">&lt;b&gt;%1$s&lt;/b&gt; प्रकाशित करने के लिए तैयार है। लाइव होने से पहले मूल्य, इन्वेंटरी और शिपिंग की जांच करें।</string>
+    <string name="ai_translation_test_product_multiline_backorder">उत्पाद %1$s स्टॉक से बाहर है।\n%2$d यूनिट फिर से स्टॉक करें या इसे बैकऑर्डर के रूप में चिह्नित करें।</string>
+    <plurals name="ai_translation_test_product_variations_selected">
+        <item quantity="one">बल्क संपादन के लिए %1$d वेरिएशन चुना गया</item>
+        <item quantity="other">बल्क संपादन के लिए %1$d वेरिएशन चुने गए</item>
+    </plurals>
+    <string-array name="ai_translation_test_product_type_filters">
+        <item>सरल उत्पाद</item>
+        <item>वेरिएबल उत्पाद</item>
+        <item>सब्सक्रिप्शन उत्पाद</item>
+    </string-array>
 </resources>

--- a/WooCommerce/src/main/res/values-hu/strings.xml
+++ b/WooCommerce/src/main/res/values-hu/strings.xml
@@ -4804,4 +4804,21 @@
     <string name="ai_assistant_chat_error_confirmation_deferred" a8c-src-lib="module:ai-assistant-feature">A megerősítés még nem érhető el. Kérem, próbálja újra a chatből.</string>
     <string name="ai_assistant_chat_error_max_iterations" a8c-src-lib="module:ai-assistant-feature">Az asszisztens több lépés után sem tudta befejezni a feladatot.</string>
     <string name="ai_assistant_chat_error_unknown" a8c-src-lib="module:ai-assistant-feature">Valami hiba történt, miközben az asszisztens dolgozott.</string>
+    <string name="ai_translation_test_product_short_sku">SKU</string>
+    <string name="ai_translation_test_product_medium_low_stock_badge">Alacsony készletű termék</string>
+    <string name="ai_translation_test_product_placeholder_inventory">Mentve: %1$s, SKU: %2$s, készleten: %3$d egység.</string>
+    <string name="ai_translation_test_product_placeholder_sale_window">Az akciós ár %1$s %2$d%%-kal alacsonyabb a normál árnál, és %3$s-tól %4$s-ig érvényes.</string>
+    <string name="ai_translation_test_product_formatted_false_discount" formatted="false">Spórolj 20%-ot a csomagtermékeken, és tartsd meg 100%-ban az SKU-formázást.</string>
+    <string name="ai_translation_test_product_html_link">Tekintsd át a &lt;a href=\'inventory-threshold\'&gt;&lt;u&gt;készletküszöböket&lt;/u&gt;&lt;/a&gt; a visszarendelés engedélyezése előtt.</string>
+    <string name="ai_translation_test_product_cdata_confirmation">&lt;b&gt;%1$s&lt;/b&gt; készen áll a közzétételre. Ellenőrizd az árat, a készletet és a szállítást, mielőtt élesbe kerül.</string>
+    <string name="ai_translation_test_product_multiline_backorder">A(z) %1$s termék elfogyott.\nTöltsd fel %2$d egységgel, vagy jelöld visszarendelhetőként.</string>
+    <plurals name="ai_translation_test_product_variations_selected">
+        <item quantity="one">%1$d variáció kiválasztva tömeges szerkesztéshez</item>
+        <item quantity="other">%1$d variáció kiválasztva tömeges szerkesztéshez</item>
+    </plurals>
+    <string-array name="ai_translation_test_product_type_filters">
+        <item>Egyszerű termék</item>
+        <item>Változó termék</item>
+        <item>Előfizetéses termék</item>
+    </string-array>
 </resources>

--- a/WooCommerce/src/main/res/values-id/strings.xml
+++ b/WooCommerce/src/main/res/values-id/strings.xml
@@ -3899,4 +3899,20 @@ Language: id
     <plurals name="woopos_orders_items_subtotal_count_plural">
         <item quantity="other">Subtotal item (%d item)</item>
     </plurals>
+    <string name="ai_translation_test_product_short_sku">SKU</string>
+    <string name="ai_translation_test_product_medium_low_stock_badge">Produk stok rendah</string>
+    <string name="ai_translation_test_product_placeholder_inventory">Disimpan %1$s dengan SKU %2$s dan %3$d unit dalam stok.</string>
+    <string name="ai_translation_test_product_placeholder_sale_window">Harga diskon %1$s lebih rendah %2$d%% dari harga normal dan berlaku dari %3$s hingga %4$s.</string>
+    <string name="ai_translation_test_product_formatted_false_discount" formatted="false">Hemat 20% untuk produk bundel dan pertahankan 100% format SKU Anda.</string>
+    <string name="ai_translation_test_product_html_link">Tinjau &lt;a href=\'inventory-threshold\'&gt;&lt;u&gt;batas inventaris&lt;/u&gt;&lt;/a&gt; sebelum mengaktifkan backorder.</string>
+    <string name="ai_translation_test_product_cdata_confirmation">&lt;b&gt;%1$s&lt;/b&gt; siap dipublikasikan. Tinjau harga, inventaris, dan pengiriman sebelum ditayangkan.</string>
+    <string name="ai_translation_test_product_multiline_backorder">Produk %1$s kehabisan stok.\nIsi ulang %2$d unit atau tandai sebagai backorder.</string>
+    <plurals name="ai_translation_test_product_variations_selected">
+        <item quantity="other">%1$d variasi dipilih untuk pengeditan massal</item>
+    </plurals>
+    <string-array name="ai_translation_test_product_type_filters">
+        <item>Produk sederhana</item>
+        <item>Produk variabel</item>
+        <item>Produk langganan</item>
+    </string-array>
 </resources>

--- a/WooCommerce/src/main/res/values-it/strings.xml
+++ b/WooCommerce/src/main/res/values-it/strings.xml
@@ -3901,4 +3901,22 @@ Language: it
         <item quantity="one">Subtotale elementi (%d elemento)</item>
         <item quantity="other">Subtotale elementi: (%d elementi)</item>
     </plurals>
+    <string name="ai_translation_test_product_short_sku">SKU</string>
+    <string name="ai_translation_test_product_medium_low_stock_badge">Prodotto in esaurimento</string>
+    <string name="ai_translation_test_product_placeholder_inventory">Salvato %1$s con SKU %2$s e %3$d unità in magazzino.</string>
+    <string name="ai_translation_test_product_placeholder_sale_window">Il prezzo scontato %1$s è del %2$d%% inferiore al prezzo normale e vale dal %3$s al %4$s.</string>
+    <string name="ai_translation_test_product_formatted_false_discount" formatted="false">Risparmia il 20% sui prodotti in bundle e mantieni il 100% della formattazione SKU.</string>
+    <string name="ai_translation_test_product_html_link">Rivedi le &lt;a href=\'inventory-threshold\'&gt;&lt;u&gt;soglie di inventario&lt;/u&gt;&lt;/a&gt; prima di abilitare gli ordini arretrati.</string>
+    <string name="ai_translation_test_product_cdata_confirmation">&lt;b&gt;%1$s&lt;/b&gt; è pronto per la pubblicazione. Controlla prezzo, inventario e spedizione prima di pubblicarlo.</string>
+    <string name="ai_translation_test_product_multiline_backorder">Il prodotto %1$s è esaurito.\nRifornisci %2$d unità o contrassegnalo come in arretrato.</string>
+    <plurals name="ai_translation_test_product_variations_selected">
+        <item quantity="one">%1$d variazione selezionata per la modifica in blocco</item>
+        <item quantity="many">%1$d variazioni selezionate per la modifica in blocco</item>
+        <item quantity="other">%1$d variazioni selezionate per la modifica in blocco</item>
+    </plurals>
+    <string-array name="ai_translation_test_product_type_filters">
+        <item>Prodotto semplice</item>
+        <item>Prodotto variabile</item>
+        <item>Prodotto in abbonamento</item>
+    </string-array>
 </resources>

--- a/WooCommerce/src/main/res/values-ja/strings.xml
+++ b/WooCommerce/src/main/res/values-ja/strings.xml
@@ -3900,4 +3900,20 @@ Language: ja_JP
     <plurals name="woopos_orders_items_subtotal_count_plural">
         <item quantity="other">商品小計 (%d点の商品)</item>
     </plurals>
+    <string name="ai_translation_test_product_short_sku">SKU</string>
+    <string name="ai_translation_test_product_medium_low_stock_badge">在庫わずかの商品</string>
+    <string name="ai_translation_test_product_placeholder_inventory">SKU %2$s、在庫数 %3$d 個の %1$s を保存しました。</string>
+    <string name="ai_translation_test_product_placeholder_sale_window">セール価格 %1$s は通常価格より %2$d%% 安く、%3$s から %4$s まで適用されます。</string>
+    <string name="ai_translation_test_product_formatted_false_discount" formatted="false">バンドル商品を20%割引にして、SKUのフォーマットはそのまま維持します。</string>
+    <string name="ai_translation_test_product_html_link">バックオーダーを有効にする前に、&lt;a href=\'inventory-threshold\'&gt;&lt;u&gt;在庫しきい値&lt;/u&gt;&lt;/a&gt;を確認してください。</string>
+    <string name="ai_translation_test_product_cdata_confirmation">&lt;b&gt;%1$s&lt;/b&gt; を公開する準備ができました。公開前に価格、在庫、配送を確認してください。</string>
+    <string name="ai_translation_test_product_multiline_backorder">商品 %1$s は在庫切れです。\n%2$d 個を補充するか、バックオーダーとしてマークしてください。</string>
+    <plurals name="ai_translation_test_product_variations_selected">
+        <item quantity="other">%1$d 個のバリエーションを一括編集用に選択しました</item>
+    </plurals>
+    <string-array name="ai_translation_test_product_type_filters">
+        <item>シンプル商品</item>
+        <item>バリアブル商品</item>
+        <item>サブスクリプション商品</item>
+    </string-array>
 </resources>

--- a/WooCommerce/src/main/res/values-ko/strings.xml
+++ b/WooCommerce/src/main/res/values-ko/strings.xml
@@ -3900,4 +3900,20 @@ Language: ko_KR
     <plurals name="woopos_orders_items_subtotal_count_plural">
         <item quantity="other">품목 소계(%d개 품목)</item>
     </plurals>
+    <string name="ai_translation_test_product_short_sku">SKU</string>
+    <string name="ai_translation_test_product_medium_low_stock_badge">재고 부족 상품</string>
+    <string name="ai_translation_test_product_placeholder_inventory">SKU %2$s, 재고 %3$d개인 %1$s이(가) 저장되었습니다.</string>
+    <string name="ai_translation_test_product_placeholder_sale_window">할인가 %1$s은(는) 정가보다 %2$d%% 낮으며 %3$s부터 %4$s까지 적용됩니다.</string>
+    <string name="ai_translation_test_product_formatted_false_discount" formatted="false">번들 상품 20% 할인 혜택을 누리고 SKU 형식은 100% 유지하세요.</string>
+    <string name="ai_translation_test_product_html_link">백오더를 활성화하기 전에 &lt;a href=\'inventory-threshold\'&gt;&lt;u&gt;재고 임계값&lt;/u&gt;&lt;/a&gt;을 검토하세요.</string>
+    <string name="ai_translation_test_product_cdata_confirmation">&lt;b&gt;%1$s&lt;/b&gt;을(를) 게시할 준비가 되었습니다. 게시 전에 가격, 재고, 배송을 확인하세요.</string>
+    <string name="ai_translation_test_product_multiline_backorder">상품 %1$s의 재고가 없습니다.\n%2$d개를 재입고하거나 백오더로 표시하세요.</string>
+    <plurals name="ai_translation_test_product_variations_selected">
+        <item quantity="other">%1$d개의 변형이 일괄 편집을 위해 선택되었습니다</item>
+    </plurals>
+    <string-array name="ai_translation_test_product_type_filters">
+        <item>단순 상품</item>
+        <item>가변 상품</item>
+        <item>구독 상품</item>
+    </string-array>
 </resources>

--- a/WooCommerce/src/main/res/values-ms/strings.xml
+++ b/WooCommerce/src/main/res/values-ms/strings.xml
@@ -4803,4 +4803,20 @@
     <string name="ai_assistant_chat_error_confirmation_deferred" a8c-src-lib="module:ai-assistant-feature">Pengesahan belum tersedia. Sila cuba semula dari sembang.</string>
     <string name="ai_assistant_chat_error_max_iterations" a8c-src-lib="module:ai-assistant-feature">Pembantu tidak dapat menyelesaikan selepas beberapa langkah.</string>
     <string name="ai_assistant_chat_error_unknown" a8c-src-lib="module:ai-assistant-feature">Sesuatu telah berlaku semasa pembantu sedang bekerja.</string>
+    <string name="ai_translation_test_product_short_sku">SKU</string>
+    <string name="ai_translation_test_product_medium_low_stock_badge">Produk stok rendah</string>
+    <string name="ai_translation_test_product_placeholder_inventory">Disimpan %1$s dengan SKU %2$s dan %3$d unit dalam stok.</string>
+    <string name="ai_translation_test_product_placeholder_sale_window">Harga jualan %1$s adalah %2$d%% lebih rendah daripada harga biasa dan berlangsung dari %3$s hingga %4$s.</string>
+    <string name="ai_translation_test_product_formatted_false_discount" formatted="false">Jimat 20% pada produk bundle dan kekalkan 100% format SKU anda.</string>
+    <string name="ai_translation_test_product_html_link">Semak &lt;a href=\'inventory-threshold\'&gt;&lt;u&gt;ambang inventori&lt;/u&gt;&lt;/a&gt; sebelum mengaktifkan pesanan belakang.</string>
+    <string name="ai_translation_test_product_cdata_confirmation">&lt;b&gt;%1$s&lt;/b&gt; sedia untuk diterbitkan. Semak harga, inventori, dan penghantaran sebelum ia disiarkan.</string>
+    <string name="ai_translation_test_product_multiline_backorder">Produk %1$s kehabisan stok.\nIsi semula %2$d unit atau tandakan sebagai pesanan belakang.</string>
+    <plurals name="ai_translation_test_product_variations_selected">
+        <item quantity="other">%1$d variasi dipilih untuk pengeditan pukal</item>
+    </plurals>
+    <string-array name="ai_translation_test_product_type_filters">
+        <item>Produk mudah</item>
+        <item>Produk variabel</item>
+        <item>Produk langganan</item>
+    </string-array>
 </resources>

--- a/WooCommerce/src/main/res/values-nb/strings.xml
+++ b/WooCommerce/src/main/res/values-nb/strings.xml
@@ -4804,4 +4804,21 @@
     <string name="ai_assistant_chat_error_confirmation_deferred" a8c-src-lib="module:ai-assistant-feature">Bekreftelse er ikke tilgjengelig ennå. Prøv igjen fra chatten.</string>
     <string name="ai_assistant_chat_error_max_iterations" a8c-src-lib="module:ai-assistant-feature">Assistenten klarte ikke å fullføre etter flere forsøk.</string>
     <string name="ai_assistant_chat_error_unknown" a8c-src-lib="module:ai-assistant-feature">Noe gikk galt mens assistenten jobbet.</string>
+    <string name="ai_translation_test_product_short_sku">SKU</string>
+    <string name="ai_translation_test_product_medium_low_stock_badge">Produkt med lavt lager</string>
+    <string name="ai_translation_test_product_placeholder_inventory">Lagret %1$s med SKU %2$s og %3$d enheter på lager.</string>
+    <string name="ai_translation_test_product_placeholder_sale_window">Salgspris %1$s er %2$d%% lavere enn ordinær pris og gjelder fra %3$s til %4$s.</string>
+    <string name="ai_translation_test_product_formatted_false_discount" formatted="false">Spar 20% på pakkeprodukter og behold 100% av SKU-formateringen.</string>
+    <string name="ai_translation_test_product_html_link">Gjennomgå &lt;a href=\'inventory-threshold\'&gt;&lt;u&gt;lagerterskler&lt;/u&gt;&lt;/a&gt; før du aktiverer restordre.</string>
+    <string name="ai_translation_test_product_cdata_confirmation">&lt;b&gt;%1$s&lt;/b&gt; er klar til publisering. Gjennomgå pris, lager og frakt før den publiseres.</string>
+    <string name="ai_translation_test_product_multiline_backorder">Produkt %1$s er utsolgt.\nFyll på %2$d enheter eller merk det som restordre.</string>
+    <plurals name="ai_translation_test_product_variations_selected">
+        <item quantity="one">%1$d variant valgt for masseredigering</item>
+        <item quantity="other">%1$d varianter valgt for masseredigering</item>
+    </plurals>
+    <string-array name="ai_translation_test_product_type_filters">
+        <item>Enkelt produkt</item>
+        <item>Variabelt produkt</item>
+        <item>Abonnementsprodukt</item>
+    </string-array>
 </resources>

--- a/WooCommerce/src/main/res/values-nl/strings.xml
+++ b/WooCommerce/src/main/res/values-nl/strings.xml
@@ -3901,4 +3901,21 @@ Language: nl
         <item quantity="one">Subtotaal artikelen (%d artikel)</item>
         <item quantity="other">Subtotaal artikelen (%d artikelen)</item>
     </plurals>
+    <string name="ai_translation_test_product_short_sku">SKU</string>
+    <string name="ai_translation_test_product_medium_low_stock_badge">Product met lage voorraad</string>
+    <string name="ai_translation_test_product_placeholder_inventory">Opgeslagen %1$s met SKU %2$s en %3$d eenheden op voorraad.</string>
+    <string name="ai_translation_test_product_placeholder_sale_window">Actieprijs %1$s is %2$d%% lager dan de reguliere prijs en loopt van %3$s tot %4$s.</string>
+    <string name="ai_translation_test_product_formatted_false_discount" formatted="false">Bespaar 20% op gebundelde producten en behoud 100% van je SKU-opmaak.</string>
+    <string name="ai_translation_test_product_html_link">Bekijk &lt;a href=\'inventory-threshold\'&gt;&lt;u&gt;voorraaddrempels&lt;/u&gt;&lt;/a&gt; voordat je nabestellingen inschakelt.</string>
+    <string name="ai_translation_test_product_cdata_confirmation">&lt;b&gt;%1$s&lt;/b&gt; is klaar om te publiceren. Controleer prijs, voorraad en verzending voordat het live gaat.</string>
+    <string name="ai_translation_test_product_multiline_backorder">Product %1$s is niet op voorraad.\nBestel %2$d eenheden bij of markeer het als nabestelling.</string>
+    <plurals name="ai_translation_test_product_variations_selected">
+        <item quantity="one">%1$d variatie geselecteerd voor bulkbewerking</item>
+        <item quantity="other">%1$d variaties geselecteerd voor bulkbewerking</item>
+    </plurals>
+    <string-array name="ai_translation_test_product_type_filters">
+        <item>Eenvoudig product</item>
+        <item>Variabel product</item>
+        <item>Abonnementsproduct</item>
+    </string-array>
 </resources>

--- a/WooCommerce/src/main/res/values-pl/strings.xml
+++ b/WooCommerce/src/main/res/values-pl/strings.xml
@@ -4804,4 +4804,23 @@
     <string name="product_filter_explore_plugin">Odkryj!</string>
     <string name="scan_barcode_to_update_inventory_menu_item_title">Skanuj kod kreskowy, aby zaktualizować stan magazynowy</string>
     <string name="product_creation_survey_title">Twoja opinia jest dla nas ważna!</string>
+    <string name="ai_translation_test_product_short_sku">SKU</string>
+    <string name="ai_translation_test_product_medium_low_stock_badge">Produkt z niskim stanem magazynowym</string>
+    <string name="ai_translation_test_product_placeholder_inventory">Zapisano %1$s z SKU %2$s i %3$d jednostkami w magazynie.</string>
+    <string name="ai_translation_test_product_placeholder_sale_window">Cena promocyjna %1$s jest o %2$d%% niższa od ceny regularnej i obowiązuje od %3$s do %4$s.</string>
+    <string name="ai_translation_test_product_formatted_false_discount" formatted="false">Zaoszczędź 20% na produktach w zestawie i zachowaj 100% formatowania SKU.</string>
+    <string name="ai_translation_test_product_html_link">Sprawdź &lt;a href=\'inventory-threshold\'&gt;&lt;u&gt;progi magazynowe&lt;/u&gt;&lt;/a&gt; przed włączeniem zamówień zaległych.</string>
+    <string name="ai_translation_test_product_cdata_confirmation">&lt;b&gt;%1$s&lt;/b&gt; jest gotowy do publikacji. Sprawdź cenę, stan magazynowy i wysyłkę przed opublikowaniem.</string>
+    <string name="ai_translation_test_product_multiline_backorder">Produkt %1$s jest niedostępny.\nUzupełnij %2$d jednostek lub oznacz jako zamówienie zaległe.</string>
+    <plurals name="ai_translation_test_product_variations_selected">
+        <item quantity="one">%1$d wariant wybrany do edycji zbiorczej</item>
+        <item quantity="few">%1$d warianty wybrane do edycji zbiorczej</item>
+        <item quantity="many">%1$d wariantów wybranych do edycji zbiorczej</item>
+        <item quantity="other">%1$d wariantów wybranych do edycji zbiorczej</item>
+    </plurals>
+    <string-array name="ai_translation_test_product_type_filters">
+        <item>Produkt prosty</item>
+        <item>Produkt zmienny</item>
+        <item>Produkt subskrypcyjny</item>
+    </string-array>
 </resources>

--- a/WooCommerce/src/main/res/values-pt-rBR/strings.xml
+++ b/WooCommerce/src/main/res/values-pt-rBR/strings.xml
@@ -3901,4 +3901,22 @@ Language: pt_BR
         <item quantity="one">Subtotal de itens (%d item)</item>
         <item quantity="other">Subtotal de itens (%d itens)</item>
     </plurals>
+    <string name="ai_translation_test_product_short_sku">SKU</string>
+    <string name="ai_translation_test_product_medium_low_stock_badge">Produto com estoque baixo</string>
+    <string name="ai_translation_test_product_placeholder_inventory">Salvo %1$s com SKU %2$s e %3$d unidades em estoque.</string>
+    <string name="ai_translation_test_product_placeholder_sale_window">O preço promocional %1$s é %2$d%% menor que o preço regular e vai de %3$s a %4$s.</string>
+    <string name="ai_translation_test_product_formatted_false_discount" formatted="false">Economize 20% em produtos em pacote e mantenha 100% da formatação do seu SKU.</string>
+    <string name="ai_translation_test_product_html_link">Revise os &lt;a href=\'inventory-threshold\'&gt;&lt;u&gt;limites de estoque&lt;/u&gt;&lt;/a&gt; antes de ativar pedidos em espera.</string>
+    <string name="ai_translation_test_product_cdata_confirmation">&lt;b&gt;%1$s&lt;/b&gt; está pronto para publicar. Revise preço, estoque e envio antes de publicar.</string>
+    <string name="ai_translation_test_product_multiline_backorder">O produto %1$s está sem estoque.\nReabasteça %2$d unidades ou marque como em espera.</string>
+    <plurals name="ai_translation_test_product_variations_selected">
+        <item quantity="one">%1$d variação selecionada para edição em massa</item>
+        <item quantity="many">%1$d variações selecionadas para edição em massa</item>
+        <item quantity="other">%1$d variações selecionadas para edição em massa</item>
+    </plurals>
+    <string-array name="ai_translation_test_product_type_filters">
+        <item>Produto simples</item>
+        <item>Produto variável</item>
+        <item>Produto de assinatura</item>
+    </string-array>
 </resources>

--- a/WooCommerce/src/main/res/values-pt-rPT/strings.xml
+++ b/WooCommerce/src/main/res/values-pt-rPT/strings.xml
@@ -4810,4 +4810,21 @@
     <string name="ai_assistant_chat_error_confirmation_deferred" a8c-src-lib="module:ai-assistant-feature">A confirmação ainda não está disponível. Por favor, tente novamente a partir do chat.</string>
     <string name="ai_assistant_chat_error_max_iterations" a8c-src-lib="module:ai-assistant-feature">O assistente não conseguiu concluir após vários passos.</string>
     <string name="ai_assistant_chat_error_unknown" a8c-src-lib="module:ai-assistant-feature">Ocorreu um erro enquanto o assistente estava a trabalhar.</string>
+    <string name="ai_translation_test_product_short_sku">SKU</string>
+    <string name="ai_translation_test_product_medium_low_stock_badge">Produto com stock baixo</string>
+    <string name="ai_translation_test_product_placeholder_inventory">Guardado %1$s com SKU %2$s e %3$d unidades em stock.</string>
+    <string name="ai_translation_test_product_placeholder_sale_window">O preço de promoção %1$s é %2$d%% inferior ao preço normal e decorre de %3$s a %4$s.</string>
+    <string name="ai_translation_test_product_formatted_false_discount" formatted="false">Poupe 20% em produtos agrupados e mantenha 100% da formatação do SKU.</string>
+    <string name="ai_translation_test_product_html_link">Reveja os &lt;a href=\'inventory-threshold\'&gt;&lt;u&gt;limites de inventário&lt;/u&gt;&lt;/a&gt; antes de ativar as encomendas pendentes.</string>
+    <string name="ai_translation_test_product_cdata_confirmation">&lt;b&gt;%1$s&lt;/b&gt; está pronto para publicar. Reveja o preço, inventário e envio antes de ficar disponível.</string>
+    <string name="ai_translation_test_product_multiline_backorder">O produto %1$s está esgotado.\nReponha %2$d unidades ou marque-o como encomenda pendente.</string>
+    <plurals name="ai_translation_test_product_variations_selected">
+        <item quantity="one">%1$d variação selecionada para edição em massa</item>
+        <item quantity="other">%1$d variações selecionadas para edição em massa</item>
+    </plurals>
+    <string-array name="ai_translation_test_product_type_filters">
+        <item>Produto simples</item>
+        <item>Produto variável</item>
+        <item>Produto de subscrição</item>
+    </string-array>
 </resources>

--- a/WooCommerce/src/main/res/values-ro/strings.xml
+++ b/WooCommerce/src/main/res/values-ro/strings.xml
@@ -4805,4 +4805,22 @@
     <string name="ai_assistant_chat_error_confirmation_deferred" a8c-src-lib="module:ai-assistant-feature">Confirmarea nu este disponibilă încă. Te rugăm să încerci din nou din chat.</string>
     <string name="ai_assistant_chat_error_max_iterations" a8c-src-lib="module:ai-assistant-feature">Asistentul nu a putut finaliza după mai mulți pași.</string>
     <string name="ai_assistant_chat_error_unknown" a8c-src-lib="module:ai-assistant-feature">A apărut o eroare în timp ce asistentul lucra.</string>
+    <string name="ai_translation_test_product_short_sku">SKU</string>
+    <string name="ai_translation_test_product_medium_low_stock_badge">Produs cu stoc redus</string>
+    <string name="ai_translation_test_product_placeholder_inventory">Salvat %1$s cu SKU %2$s și %3$d unități în stoc.</string>
+    <string name="ai_translation_test_product_placeholder_sale_window">Prețul promoțional %1$s este cu %2$d%% mai mic decât prețul obișnuit și este valabil din %3$s până în %4$s.</string>
+    <string name="ai_translation_test_product_formatted_false_discount" formatted="false">Economisești 20% la produsele din pachet și păstrezi 100% din formatarea SKU.</string>
+    <string name="ai_translation_test_product_html_link">Verifică &lt;a href=\'inventory-threshold\'&gt;&lt;u&gt;pragurile de inventar&lt;/u&gt;&lt;/a&gt; înainte de a activa comenzile în așteptare.</string>
+    <string name="ai_translation_test_product_cdata_confirmation">&lt;b&gt;%1$s&lt;/b&gt; este gata de publicare. Verifică prețul, inventarul și livrarea înainte de a fi publicat.</string>
+    <string name="ai_translation_test_product_multiline_backorder">Produsul %1$s este epuizat.\nReaprovizionează cu %2$d unități sau marchează-l ca în așteptare.</string>
+    <plurals name="ai_translation_test_product_variations_selected">
+        <item quantity="one">%1$d variație selectată pentru editare în masă</item>
+        <item quantity="few">%1$d variații selectate pentru editare în masă</item>
+        <item quantity="other">%1$d variații selectate pentru editare în masă</item>
+    </plurals>
+    <string-array name="ai_translation_test_product_type_filters">
+        <item>Produs simplu</item>
+        <item>Produs variabil</item>
+        <item>Produs cu abonament</item>
+    </string-array>
 </resources>

--- a/WooCommerce/src/main/res/values-ru/strings.xml
+++ b/WooCommerce/src/main/res/values-ru/strings.xml
@@ -3902,4 +3902,23 @@ Language: ru
         <item quantity="few">Промежуточный итог по товарам (позиций: %d)</item>
         <item quantity="many">Промежуточный итог по товарам (позиций: %d)</item>
     </plurals>
+    <string name="ai_translation_test_product_short_sku">SKU</string>
+    <string name="ai_translation_test_product_medium_low_stock_badge">Мало на складе</string>
+    <string name="ai_translation_test_product_placeholder_inventory">Сохранено %1$s с SKU %2$s и %3$d ед. на складе.</string>
+    <string name="ai_translation_test_product_placeholder_sale_window">Цена со скидкой %1$s на %2$d%% ниже обычной и действует с %3$s по %4$s.</string>
+    <string name="ai_translation_test_product_formatted_false_discount" formatted="false">Сэкономьте 20% на комплектах и сохраните 100% форматирования SKU.</string>
+    <string name="ai_translation_test_product_html_link">Проверьте &lt;a href=\'inventory-threshold\'&gt;&lt;u&gt;пороги запасов&lt;/u&gt;&lt;/a&gt; перед включением предзаказа.</string>
+    <string name="ai_translation_test_product_cdata_confirmation">&lt;b&gt;%1$s&lt;/b&gt; готов к публикации. Проверьте цену, запасы и доставку перед публикацией.</string>
+    <string name="ai_translation_test_product_multiline_backorder">Товар %1$s отсутствует на складе.\nПополните запас на %2$d ед. или отметьте как предзаказ.</string>
+    <plurals name="ai_translation_test_product_variations_selected">
+        <item quantity="one">%1$d вариация выбрана для массового редактирования</item>
+        <item quantity="few">%1$d вариации выбраны для массового редактирования</item>
+        <item quantity="many">%1$d вариаций выбрано для массового редактирования</item>
+        <item quantity="other">%1$d вариации выбраны для массового редактирования</item>
+    </plurals>
+    <string-array name="ai_translation_test_product_type_filters">
+        <item>Простой товар</item>
+        <item>Вариативный товар</item>
+        <item>Товар с подпиской</item>
+    </string-array>
 </resources>

--- a/WooCommerce/src/main/res/values-sv/strings.xml
+++ b/WooCommerce/src/main/res/values-sv/strings.xml
@@ -3901,4 +3901,21 @@ Language: sv_SE
         <item quantity="one">Delsumma artiklar (%d artikel)</item>
         <item quantity="other">Delsumma artiklar (%d artiklar)</item>
     </plurals>
+    <string name="ai_translation_test_product_short_sku">SKU</string>
+    <string name="ai_translation_test_product_medium_low_stock_badge">Produkt med lågt lager</string>
+    <string name="ai_translation_test_product_placeholder_inventory">Sparade %1$s med SKU %2$s och %3$d enheter i lager.</string>
+    <string name="ai_translation_test_product_placeholder_sale_window">Kampanjpriset %1$s är %2$d%% lägre än ordinarie pris och gäller från %3$s till %4$s.</string>
+    <string name="ai_translation_test_product_formatted_false_discount" formatted="false">Spara 20% på paketprodukter och behåll 100% av din SKU-formatering.</string>
+    <string name="ai_translation_test_product_html_link">Granska &lt;a href=\'inventory-threshold\'&gt;&lt;u&gt;lagertrösklar&lt;/u&gt;&lt;/a&gt; innan du aktiverar restorder.</string>
+    <string name="ai_translation_test_product_cdata_confirmation">&lt;b&gt;%1$s&lt;/b&gt; är redo att publiceras. Granska pris, lager och frakt innan det publiceras.</string>
+    <string name="ai_translation_test_product_multiline_backorder">Produkten %1$s är slut i lager.\nFyll på %2$d enheter eller markera den som restbeställd.</string>
+    <plurals name="ai_translation_test_product_variations_selected">
+        <item quantity="one">%1$d variation vald för massredigering</item>
+        <item quantity="other">%1$d variationer valda för massredigering</item>
+    </plurals>
+    <string-array name="ai_translation_test_product_type_filters">
+        <item>Enkel produkt</item>
+        <item>Variabel produkt</item>
+        <item>Prenumerationsprodukt</item>
+    </string-array>
 </resources>

--- a/WooCommerce/src/main/res/values-th/strings.xml
+++ b/WooCommerce/src/main/res/values-th/strings.xml
@@ -4800,4 +4800,20 @@
     <string name="ai_assistant_chat_error_confirmation_deferred" a8c-src-lib="module:ai-assistant-feature">ยังไม่สามารถยืนยันได้ในขณะนี้ กรุณาลองอีกครั้งจากแชท</string>
     <string name="ai_assistant_chat_error_max_iterations" a8c-src-lib="module:ai-assistant-feature">ผู้ช่วยไม่สามารถดำเนินการเสร็จสิ้นได้หลังจากหลายขั้นตอน</string>
     <string name="ai_assistant_chat_error_unknown" a8c-src-lib="module:ai-assistant-feature">เกิดข้อผิดพลาดขณะที่ผู้ช่วยกำลังทำงาน</string>
+    <string name="ai_translation_test_product_short_sku">SKU</string>
+    <string name="ai_translation_test_product_medium_low_stock_badge">สินค้าใกล้หมด</string>
+    <string name="ai_translation_test_product_placeholder_inventory">บันทึก %1$s ด้วย SKU %2$s และสินค้าคงเหลือ %3$d ชิ้น</string>
+    <string name="ai_translation_test_product_placeholder_sale_window">ราคาลด %1$s ต่ำกว่าราคาปกติ %2$d%% และมีผลตั้งแต่ %3$s ถึง %4$s</string>
+    <string name="ai_translation_test_product_formatted_false_discount" formatted="false">ประหยัด 20% สำหรับสินค้าแบบบันเดิลและรักษารูปแบบ SKU ของคุณ 100%</string>
+    <string name="ai_translation_test_product_html_link">ตรวจสอบ &lt;a href=\'inventory-threshold\'&gt;&lt;u&gt;เกณฑ์สินค้าคงคลัง&lt;/u&gt;&lt;/a&gt; ก่อนเปิดใช้การสั่งจองล่วงหน้า</string>
+    <string name="ai_translation_test_product_cdata_confirmation">&lt;b&gt;%1$s&lt;/b&gt; พร้อมเผยแพร่แล้ว ตรวจสอบราคา สินค้าคงคลัง และการจัดส่งก่อนเปิดตัว</string>
+    <string name="ai_translation_test_product_multiline_backorder">สินค้า %1$s หมดสต็อก\nเติมสต็อก %2$d ชิ้น หรือทำเครื่องหมายว่าสั่งจองล่วงหน้า</string>
+    <plurals name="ai_translation_test_product_variations_selected">
+        <item quantity="other">เลือก %1$d รูปแบบสำหรับแก้ไขจำนวนมาก</item>
+    </plurals>
+    <string-array name="ai_translation_test_product_type_filters">
+        <item>สินค้าธรรมดา</item>
+        <item>สินค้าแบบตัวแปร</item>
+        <item>สินค้าแบบสมัครสมาชิก</item>
+    </string-array>
 </resources>

--- a/WooCommerce/src/main/res/values-tr/strings.xml
+++ b/WooCommerce/src/main/res/values-tr/strings.xml
@@ -3901,4 +3901,20 @@ Language: tr
         <item quantity="one">Ürün alt toplamı (%d ürün)</item>
         <item quantity="other">Ürün alt toplamı (%d ürün)</item>
     </plurals>
+    <string name="ai_translation_test_product_short_sku">SKU</string>
+    <string name="ai_translation_test_product_medium_low_stock_badge">Düşük stoklu ürün</string>
+    <string name="ai_translation_test_product_placeholder_inventory">%1$s SKU\'lu ve stokta %3$d adet bulunan ürün kaydedildi: %2$s.</string>
+    <string name="ai_translation_test_product_formatted_false_discount" formatted="false">Paket ürünlerde %%20 tasarruf edin ve SKU biçimlendirmenizin %%100\'ünü koruyun.</string>
+    <string name="ai_translation_test_product_html_link">Arka siparişleri etkinleştirmeden önce &lt;a href=\'inventory-threshold\'&gt;&lt;u&gt;stok eşiklerini&lt;/u&gt;&lt;/a&gt; inceleyin.</string>
+    <string name="ai_translation_test_product_cdata_confirmation">&lt;b&gt;%1$s&lt;/b&gt; yayınlanmaya hazır. Yayına girmeden önce fiyat, stok ve kargo bilgilerini kontrol edin.</string>
+    <string name="ai_translation_test_product_multiline_backorder">%1$s ürünü stokta yok.\n%2$d adet yeniden stoklayın veya arka sipariş olarak işaretleyin.</string>
+    <plurals name="ai_translation_test_product_variations_selected">
+        <item quantity="one">Toplu düzenleme için %1$d varyasyon seçildi</item>
+        <item quantity="other">Toplu düzenleme için %1$d varyasyon seçildi</item>
+    </plurals>
+    <string-array name="ai_translation_test_product_type_filters">
+        <item>Basit ürün</item>
+        <item>Değişken ürün</item>
+        <item>Abonelik ürünü</item>
+    </string-array>
 </resources>

--- a/WooCommerce/src/main/res/values-uk/strings.xml
+++ b/WooCommerce/src/main/res/values-uk/strings.xml
@@ -4806,4 +4806,23 @@
     <string name="ai_assistant_chat_error_confirmation_deferred" a8c-src-lib="module:ai-assistant-feature">Підтвердження ще недоступне. Спробуйте ще раз у чаті.</string>
     <string name="ai_assistant_chat_error_max_iterations" a8c-src-lib="module:ai-assistant-feature">Асистент не зміг завершити завдання після кількох спроб.</string>
     <string name="ai_assistant_chat_error_unknown" a8c-src-lib="module:ai-assistant-feature">Під час роботи асистента сталася помилка.</string>
+    <string name="ai_translation_test_product_short_sku">SKU</string>
+    <string name="ai_translation_test_product_medium_low_stock_badge">Товар із низьким запасом</string>
+    <string name="ai_translation_test_product_placeholder_inventory">Збережено %1$s з SKU %2$s та %3$d одиниць на складі.</string>
+    <string name="ai_translation_test_product_placeholder_sale_window">Ціна зі знижкою %1$s на %2$d%% нижча за звичайну і діє з %3$s по %4$s.</string>
+    <string name="ai_translation_test_product_formatted_false_discount" formatted="false">Заощаджуйте 20% на комплектних товарах і зберігайте 100% форматування SKU.</string>
+    <string name="ai_translation_test_product_html_link">Перегляньте &lt;a href=\'inventory-threshold\'&gt;&lt;u&gt;порогові значення запасів&lt;/u&gt;&lt;/a&gt; перед увімкненням беклогу.</string>
+    <string name="ai_translation_test_product_cdata_confirmation">&lt;b&gt;%1$s&lt;/b&gt; готовий до публікації. Перевірте ціну, запаси та доставку перед публікацією.</string>
+    <string name="ai_translation_test_product_multiline_backorder">Товар %1$s відсутній на складі.\nПоповніть %2$d одиниць або позначте як беклог.</string>
+    <plurals name="ai_translation_test_product_variations_selected">
+        <item quantity="one">%1$d варіацію вибрано для масового редагування</item>
+        <item quantity="few">%1$d варіації вибрано для масового редагування</item>
+        <item quantity="many">%1$d варіацій вибрано для масового редагування</item>
+        <item quantity="other">%1$d варіацій вибрано для масового редагування</item>
+    </plurals>
+    <string-array name="ai_translation_test_product_type_filters">
+        <item>Простий товар</item>
+        <item>Варіативний товар</item>
+        <item>Товар із підпискою</item>
+    </string-array>
 </resources>

--- a/WooCommerce/src/main/res/values-vi/strings.xml
+++ b/WooCommerce/src/main/res/values-vi/strings.xml
@@ -4803,4 +4803,20 @@
     <string name="ai_assistant_chat_error_confirmation_deferred" a8c-src-lib="module:ai-assistant-feature">Xác nhận chưa có sẵn. Vui lòng thử lại từ cuộc trò chuyện.</string>
     <string name="ai_assistant_chat_error_max_iterations" a8c-src-lib="module:ai-assistant-feature">Trợ lý không thể hoàn thành sau nhiều bước.</string>
     <string name="ai_assistant_chat_error_unknown" a8c-src-lib="module:ai-assistant-feature">Đã xảy ra lỗi trong khi trợ lý đang làm việc.</string>
+    <string name="ai_translation_test_product_short_sku">SKU</string>
+    <string name="ai_translation_test_product_medium_low_stock_badge">Sản phẩm sắp hết hàng</string>
+    <string name="ai_translation_test_product_placeholder_inventory">Đã lưu %1$s với SKU %2$s và %3$d đơn vị trong kho.</string>
+    <string name="ai_translation_test_product_placeholder_sale_window">Giá khuyến mãi %1$s thấp hơn %2$d%% so với giá thường và có hiệu lực từ %3$s đến %4$s.</string>
+    <string name="ai_translation_test_product_formatted_false_discount" formatted="false">Tiết kiệm 20% cho sản phẩm theo gói và giữ nguyên 100% định dạng SKU của bạn.</string>
+    <string name="ai_translation_test_product_html_link">Xem lại &lt;a href=\'inventory-threshold\'&gt;&lt;u&gt;ngưỡng tồn kho&lt;/u&gt;&lt;/a&gt; trước khi bật đặt hàng trước.</string>
+    <string name="ai_translation_test_product_cdata_confirmation">&lt;b&gt;%1$s&lt;/b&gt; đã sẵn sàng để đăng. Kiểm tra giá, tồn kho và vận chuyển trước khi xuất bản.</string>
+    <string name="ai_translation_test_product_multiline_backorder">Sản phẩm %1$s đã hết hàng.\nNhập thêm %2$d đơn vị hoặc đánh dấu là đặt hàng trước.</string>
+    <plurals name="ai_translation_test_product_variations_selected">
+        <item quantity="other">%1$d biến thể được chọn để chỉnh sửa hàng loạt</item>
+    </plurals>
+    <string-array name="ai_translation_test_product_type_filters">
+        <item>Sản phẩm đơn giản</item>
+        <item>Sản phẩm có biến thể</item>
+        <item>Sản phẩm đăng ký</item>
+    </string-array>
 </resources>

--- a/WooCommerce/src/main/res/values-zh-rCN/strings.xml
+++ b/WooCommerce/src/main/res/values-zh-rCN/strings.xml
@@ -3900,4 +3900,20 @@ Language: zh_CN
     <plurals name="woopos_orders_items_subtotal_count_plural">
         <item quantity="other">商品小计（共 %d 件商品）</item>
     </plurals>
+    <string name="ai_translation_test_product_short_sku">SKU</string>
+    <string name="ai_translation_test_product_medium_low_stock_badge">库存不足商品</string>
+    <string name="ai_translation_test_product_placeholder_inventory">已保存 %1$s，SKU 为 %2$s，库存 %3$d 件</string>
+    <string name="ai_translation_test_product_placeholder_sale_window">促销价 %1$s 比原价低 %2$d%%，活动时间为 %3$s 至 %4$s</string>
+    <string name="ai_translation_test_product_formatted_false_discount" formatted="false">捆绑商品享八折优惠，SKU 格式保持不变</string>
+    <string name="ai_translation_test_product_html_link">启用缺货订购前请查看&lt;a href=\'inventory-threshold\'&gt;&lt;u&gt;库存阈值&lt;/u&gt;&lt;/a&gt;</string>
+    <string name="ai_translation_test_product_cdata_confirmation">&lt;b&gt;%1$s&lt;/b&gt; 已准备好发布，上线前请检查价格、库存和配送信息</string>
+    <string name="ai_translation_test_product_multiline_backorder">商品 %1$s 已缺货。\n请补货 %2$d 件或将其标记为缺货可订</string>
+    <plurals name="ai_translation_test_product_variations_selected">
+        <item quantity="other">已选择 %1$d 个变体进行批量编辑</item>
+    </plurals>
+    <string-array name="ai_translation_test_product_type_filters">
+        <item>简单商品</item>
+        <item>可变商品</item>
+        <item>订阅商品</item>
+    </string-array>
 </resources>

--- a/WooCommerce/src/main/res/values-zh-rTW/strings.xml
+++ b/WooCommerce/src/main/res/values-zh-rTW/strings.xml
@@ -3900,4 +3900,20 @@ Language: zh_TW
     <plurals name="woopos_orders_items_subtotal_count_plural">
         <item quantity="other">項目小計 (%d 個商品)</item>
     </plurals>
+    <string name="ai_translation_test_product_short_sku">SKU</string>
+    <string name="ai_translation_test_product_medium_low_stock_badge">庫存不足商品</string>
+    <string name="ai_translation_test_product_placeholder_inventory">已儲存 %1$s，SKU 為 %2$s，庫存 %3$d 件</string>
+    <string name="ai_translation_test_product_placeholder_sale_window">特價 %1$s 比原價低 %2$d%%，活動期間為 %3$s 至 %4$s</string>
+    <string name="ai_translation_test_product_formatted_false_discount" formatted="false">組合商品享 8 折優惠，SKU 格式完整保留 100%%</string>
+    <string name="ai_translation_test_product_html_link">啟用延期交貨前，請先查看&lt;a href=\'inventory-threshold\'&gt;&lt;u&gt;庫存門檻&lt;/u&gt;&lt;/a&gt;</string>
+    <string name="ai_translation_test_product_cdata_confirmation">&lt;b&gt;%1$s&lt;/b&gt; 已準備好發佈。上架前請確認價格、庫存及運送設定</string>
+    <string name="ai_translation_test_product_multiline_backorder">商品 %1$s 已無庫存。\n請補貨 %2$d 件或標記為延期交貨</string>
+    <plurals name="ai_translation_test_product_variations_selected">
+        <item quantity="other">已選取 %1$d 個變體進行批次編輯</item>
+    </plurals>
+    <string-array name="ai_translation_test_product_type_filters">
+        <item>簡單商品</item>
+        <item>可變商品</item>
+        <item>訂閱商品</item>
+    </string-array>
 </resources>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3347,10 +3347,12 @@
     <string name="ai_translation_test_product_cdata_confirmation"><![CDATA[<b>%1$s</b> is ready to publish. Review price, inventory, and shipping before it goes live.]]></string>
     <!-- No usage found in source code -->
     <string name="ai_translation_test_product_multiline_backorder">Product %1$s is out of stock.\nRestock %2$d units or mark it as backordered.</string>
+    <!-- No usage found in source code -->
     <plurals name="ai_translation_test_product_variations_selected">
         <item quantity="one">%1$d variation selected for bulk editing</item>
         <item quantity="other">%1$d variations selected for bulk editing</item>
     </plurals>
+    <!-- No usage found in source code -->
     <string-array name="ai_translation_test_product_type_filters">
         <item>Simple product</item>
         <item>Variable product</item>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3331,6 +3331,23 @@
     <string name="product_sku_summary">Helps to easily identify this product</string>
     <!-- Context: Helper text displayed below the 'Product Global Unique Id' input field on the product inventory screen, guiding users to enter a barcode or product identifier that can be used for multi-channel product listings. The text appears as secondary guidance in an editable text field next to a barcode scanner button. -->
     <string name="product_global_unique_id_summary">Enter a barcode or any other identifier unique to this product. It can help you list this product on other channels or marketplaces.</string>
+    <string name="ai_translation_test_product_short_sku">SKU</string>
+    <string name="ai_translation_test_product_medium_low_stock_badge">Low stock product</string>
+    <string name="ai_translation_test_product_placeholder_inventory">Saved %1$s with SKU %2$s and %3$d units in stock.</string>
+    <string name="ai_translation_test_product_placeholder_sale_window">Sale price %1$s is %2$d%% lower than the regular price and runs from %3$s to %4$s.</string>
+    <string name="ai_translation_test_product_formatted_false_discount" formatted="false">Save 20% on bundled products and keep 100% of your SKU formatting.</string>
+    <string name="ai_translation_test_product_html_link">Review &lt;a href=\'inventory-threshold\'&gt;&lt;u&gt;inventory thresholds&lt;/u&gt;&lt;/a&gt; before enabling backorders.</string>
+    <string name="ai_translation_test_product_cdata_confirmation"><![CDATA[<b>%1$s</b> is ready to publish. Review price, inventory, and shipping before it goes live.]]></string>
+    <string name="ai_translation_test_product_multiline_backorder">Product %1$s is out of stock.\nRestock %2$d units or mark it as backordered.</string>
+    <plurals name="ai_translation_test_product_variations_selected">
+        <item quantity="one">%1$d variation selected for bulk editing</item>
+        <item quantity="other">%1$d variations selected for bulk editing</item>
+    </plurals>
+    <string-array name="ai_translation_test_product_type_filters">
+        <item>Simple product</item>
+        <item>Variable product</item>
+        <item>Subscription product</item>
+    </string-array>
     <!-- Context: A dialog title used in the product inventory management screen when selecting a product's stock status (in stock, out of stock, on backorder). This appears as the header of a selector dialog that allows users to choose and update the stock status for a product. -->
     <string name="product_stock_status">Stock status</string>
     <!-- Context: This is a section title label used in a product preview/details view that displays product information. It serves as the heading for a property card showing the specific product type (Virtual, Downloadable, Physical, Variable, Grouped, External, or Subscription). -->

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3331,13 +3331,21 @@
     <string name="product_sku_summary">Helps to easily identify this product</string>
     <!-- Context: Helper text displayed below the 'Product Global Unique Id' input field on the product inventory screen, guiding users to enter a barcode or product identifier that can be used for multi-channel product listings. The text appears as secondary guidance in an editable text field next to a barcode scanner button. -->
     <string name="product_global_unique_id_summary">Enter a barcode or any other identifier unique to this product. It can help you list this product on other channels or marketplaces.</string>
+    <!-- No usage found in source code -->
     <string name="ai_translation_test_product_short_sku">SKU</string>
+    <!-- No usage found in source code -->
     <string name="ai_translation_test_product_medium_low_stock_badge">Low stock product</string>
+    <!-- No usage found in source code -->
     <string name="ai_translation_test_product_placeholder_inventory">Saved %1$s with SKU %2$s and %3$d units in stock.</string>
+    <!-- No usage found in source code -->
     <string name="ai_translation_test_product_placeholder_sale_window">Sale price %1$s is %2$d%% lower than the regular price and runs from %3$s to %4$s.</string>
+    <!-- No usage found in source code -->
     <string name="ai_translation_test_product_formatted_false_discount" formatted="false">Save 20% on bundled products and keep 100% of your SKU formatting.</string>
+    <!-- No usage found in source code -->
     <string name="ai_translation_test_product_html_link">Review &lt;a href=\'inventory-threshold\'&gt;&lt;u&gt;inventory thresholds&lt;/u&gt;&lt;/a&gt; before enabling backorders.</string>
+    <!-- No usage found in source code -->
     <string name="ai_translation_test_product_cdata_confirmation"><![CDATA[<b>%1$s</b> is ready to publish. Review price, inventory, and shipping before it goes live.]]></string>
+    <!-- No usage found in source code -->
     <string name="ai_translation_test_product_multiline_backorder">Product %1$s is out of stock.\nRestock %2$d units or mark it as backordered.</string>
     <plurals name="ai_translation_test_product_variations_selected">
         <item quantity="one">%1$d variation selected for bulk editing</item>


### PR DESCRIPTION
### Description

Adds a small dummy `ai_translation_test_*` source-string fixture and the bot-generated locale updates that exercise the PR-time AI translation pipeline end-to-end.

This supersedes the closed [#15984](https://github.com/woocommerce/woocommerce-android/pull/15984), which accumulated noise from a stale rebase chain. This clean re-do is based on [#16004](https://github.com/woocommerce/woocommerce-android/pull/16004) (15-locale Android string backfill).

Key difference vs #15984: the initial source fixture intentionally omitted inline `<!-- Context: ... -->` comments. The bot follow-up commit added generated `<!-- No usage found in source code -->` comments above the eight `<string>` entries, and this PR now also includes the matching generated context markers above the `<plurals>` and `<string-array>` fixture entries after the generator was fixed in #15962.

The source fixture covers 10 resource units:

- 8 `<string>` resources.
- Positional placeholders (`%1$s`, `%2$s`, `%3$d`).
- Literal percent signs (`%%`).
- `formatted="false"` opt-out.
- Inline HTML and escaped quotes (`<a href=\'...\'>`).
- CDATA-wrapped rich text.
- Multiline strings with `\n`.
- 1 `<plurals>` block with `one` / `other` source quantities.
- 1 `<string-array>`.

The AI translation Buildkite job has already committed generated entries for the supported `values-*/strings.xml` files, updated `fastlane/ai_translation/translation-manifest.json`, and updated `values/strings.xml` with generated comments for all 10 fixture resource units. The PR remains draft while this fixture and the generated output are reviewed.

Stacked on top of #16004; merges in order with the rest of the translation stack.

### Test Steps

1. Confirm the AI translations Buildkite job runs and either updates or cleanly no-ops after the bot commit.
2. Verify generated source comments exist above all 10 `ai_translation_test_*` fixture resource units, including the `<plurals>` and `<string-array>` entries.
3. Spot-check one Latin-script locale (e.g. `values-de`) and one non-Latin-script locale (e.g. `values-th`) for placeholder, HTML, CDATA, and plural integrity in the generated translations.
4. Build the app (`./gradlew :WooCommerce:assembleJalapenoDebug`) if this fixture moves out of draft.

Additional local validation for the review follow-up:

- [x] All `WooCommerce/src/main/res/values*/strings.xml` files parse with `REXML`.
- [x] `fastlane/ai_translation/translation-manifest.json` parses as JSON.
- [x] `git diff --check`.

### Current State

- Draft PR.
- Base: #16004.
- Current GitHub checks are green on the latest head.

### Images/gif

N/A - translation-pipeline fixture, no UI surface.

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
