### PR TITLE
Updates the support chat escalation path with persistent CTA

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
@@ -16,6 +16,7 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.aisupportchat.AiSupportChatAnalyticsTracker
 import com.woocommerce.android.ui.aisupportchat.AiSupportChatTicketAnalyticsContext
 import com.woocommerce.android.ui.aisupportchat.AiSupportChatTicketRoute
+import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow
@@ -162,6 +163,9 @@ class SupportRequestFormViewModel @Inject constructor(
         error: Throwable,
         aiSupportChatTicketAnalyticsContext: AiSupportChatTicketAnalyticsContext?
     ) {
+        aiSupportChatTicketAnalyticsContext?.let {
+            WooLog.e(WooLog.T.AI, "Support chat ticket creation failed via support form", error)
+        }
         tracks.track(AnalyticsEvent.SUPPORT_NEW_REQUEST_FAILED)
         aiSupportChatTicketAnalyticsContext?.let {
             aiSupportChatAnalyticsTracker.trackTicketCreationFailed(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatFragment.kt
@@ -24,8 +24,8 @@ import com.woocommerce.android.support.zendesk.ZendeskTicketRepository
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.compose.composeView
 import com.woocommerce.android.ui.dialog.WooDialog
-import com.woocommerce.android.util.WooPermissionUtils
 import com.woocommerce.android.util.WooLog
+import com.woocommerce.android.util.WooPermissionUtils
 import com.woocommerce.android.widgets.CustomProgressDialog
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatFragment.kt
@@ -25,6 +25,7 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.compose.composeView
 import com.woocommerce.android.ui.dialog.WooDialog
 import com.woocommerce.android.util.WooPermissionUtils
+import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.widgets.CustomProgressDialog
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
@@ -177,6 +178,11 @@ class AiSupportChatFragment : Fragment(), MenuProvider {
                         showTicketCreatedDialog()
                     }
                     .onFailure { error ->
+                        WooLog.e(
+                            WooLog.T.AI,
+                            "Support chat ticket creation failed via direct ticket creation",
+                            error
+                        )
                         analyticsTracker.trackTicketCreationFailed(
                             route = AiSupportChatTicketRoute.DIRECT_TICKET_CREATION,
                             context = event.ticketAnalyticsContext,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatScreen.kt
@@ -126,6 +126,7 @@ fun AiSupportChatScreen(
             messageRatings = viewState.messageRatings,
             isSending = viewState.isSending,
             isLoadingHistory = viewState.isLoadingHistory,
+            issuePickerEnabled = viewState.canHandleDiagnosticAction,
             showDiagnosticActions = viewState.showDiagnosticActions,
             diagnosticSuggestedAction = viewState.currentDiagnosticSuggestedAction,
             isExecutingFixAction = viewState.isExecutingFixAction,
@@ -184,6 +185,7 @@ private fun MessageList(
     messageRatings: Map<Long, AiSupportChatFeedbackRating>,
     isSending: Boolean,
     isLoadingHistory: Boolean,
+    issuePickerEnabled: Boolean,
     showDiagnosticActions: Boolean,
     diagnosticSuggestedAction: SuggestedFixAction?,
     isExecutingFixAction: Boolean,
@@ -225,6 +227,7 @@ private fun MessageList(
             MessageBubble(
                 message = message,
                 feedbackRating = message.messageId?.let { messageRatings[it] },
+                issuePickerEnabled = issuePickerEnabled,
                 showDiagnosticActions = showDiagnosticActions,
                 diagnosticSuggestedAction = diagnosticSuggestedAction,
                 isExecutingFixAction = isExecutingFixAction,
@@ -247,6 +250,7 @@ private fun MessageList(
 private fun MessageBubble(
     message: AiSupportChatMessage,
     feedbackRating: AiSupportChatFeedbackRating?,
+    issuePickerEnabled: Boolean,
     showDiagnosticActions: Boolean,
     diagnosticSuggestedAction: SuggestedFixAction?,
     isExecutingFixAction: Boolean,
@@ -284,6 +288,7 @@ private fun MessageBubble(
                     content = message.content,
                     textColor = textColor,
                     shouldFormatMarkdown = message.role == AiSupportChatMessageRole.BOT,
+                    issuePickerEnabled = issuePickerEnabled,
                     showDiagnosticActions = showDiagnosticActions,
                     diagnosticSuggestedAction = diagnosticSuggestedAction,
                     isExecutingFixAction = isExecutingFixAction,
@@ -380,6 +385,7 @@ private fun MessageContent(
     content: AiSupportChatMessageContent,
     textColor: Color,
     shouldFormatMarkdown: Boolean,
+    issuePickerEnabled: Boolean,
     showDiagnosticActions: Boolean,
     diagnosticSuggestedAction: SuggestedFixAction?,
     isExecutingFixAction: Boolean,
@@ -395,6 +401,7 @@ private fun MessageContent(
         )
         AiSupportChatMessageContent.IssuePicker -> IssuePickerContent(
             textColor = textColor,
+            enabled = issuePickerEnabled,
             onIssueSelected = onIssueSelected
         )
         AiSupportChatMessageContent.PostDiagnosticsGreeting -> TextContent(
@@ -464,6 +471,7 @@ private fun TextContent(
 @Composable
 private fun IssuePickerContent(
     textColor: Color,
+    enabled: Boolean,
     onIssueSelected: (SupportIssueType, String) -> Unit
 ) {
     Column(
@@ -479,6 +487,7 @@ private fun IssuePickerContent(
             val issueLabel = stringResource(issueType.displayLabel)
             WCOutlinedButton(
                 onClick = { onIssueSelected(issueType, issueLabel) },
+                enabled = enabled,
                 modifier = Modifier.fillMaxWidth()
             ) {
                 Text(text = issueLabel)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatViewModel.kt
@@ -237,7 +237,7 @@ class AiSupportChatViewModel @Inject constructor(
         shouldTrackIssueSelection: Boolean
     ) {
         val state = _viewState.value
-        if (state.hasProceededToChat || state.isSending || state.isRunningDiagnostics) return
+        if (!state.canHandleDiagnosticAction) return
         if (shouldTrackIssueSelection) {
             analyticsTracker.trackIssueSelected(issueType = issueType, entryPoint = state.entryPoint)
         }
@@ -1036,7 +1036,11 @@ data class AiSupportChatViewState(
     val messageRatings: Map<Long, AiSupportChatFeedbackRating> = emptyMap()
 ) {
     val canUseDiagnosticActions: Boolean
-        get() = !hasProceededToChat && !isSending && !isExecutingFixAction
+        get() = !hasProceededToChat &&
+            !isSending &&
+            !isExecutingFixAction &&
+            !hasCreatedTicket &&
+            !isChatResolved
 
     val canHandleDiagnosticAction: Boolean
         get() = canUseDiagnosticActions && !isRunningDiagnostics
@@ -1066,8 +1070,7 @@ data class AiSupportChatViewState(
             !isChatResolved &&
             !isSending &&
             !isLoadingHistory &&
-            !showLoadHistoryError &&
-            (isIssuePickerActive || canSendMessages)
+            !showLoadHistoryError
 
     val shouldShowResolvedButton: Boolean
         get() {
@@ -1085,9 +1088,6 @@ data class AiSupportChatViewState(
     private companion object {
         const val MIN_BOT_RESPONSES_FOR_RESOLUTION_ACTION = 2
     }
-
-    private val isIssuePickerActive: Boolean
-        get() = !hasProceededToChat && selectedIssueType == null && !isRunningDiagnostics
 }
 
 enum class HumanSupportContactSource {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatViewModel.kt
@@ -461,6 +461,7 @@ class AiSupportChatViewModel @Inject constructor(
                 sessionId = response.sessionId,
                 botSlug = response.botSlug,
                 hasSentChatMessage = response.messages.any { message -> message.role == SupportChatRole.USER },
+                hasReceivedBotResponse = response.messages.hasBotResponse(),
                 userMessageCount = response.messages.count { message -> message.role == SupportChatRole.USER },
                 completedUserMessageResponseCount = response.messages.count { message ->
                     message.role == SupportChatRole.BOT && !message.isBotEscalationPrompt()
@@ -573,8 +574,9 @@ class AiSupportChatViewModel @Inject constructor(
         _viewState.update {
             val remoteMessages = response.messages.toUiMessages(isNewInSession = true)
             val latestSupportArea = response.messages.latestSupportArea() ?: it.latestSupportArea
+            val hasBotResponse = response.messages.hasBotResponse()
             val completedUserMessageResponseCount = it.completedUserMessageResponseCount +
-                if (response.messages.hasBotResponse()) 1 else 0
+                if (hasBotResponse) 1 else 0
             val messages = if (remoteMessages.isEmpty()) {
                 it.messages
             } else {
@@ -595,6 +597,7 @@ class AiSupportChatViewModel @Inject constructor(
                 botSlug = response.botSlug,
                 hasStartedChat = true,
                 hasSentChatMessage = true,
+                hasReceivedBotResponse = it.hasReceivedBotResponse || hasBotResponse,
                 completedUserMessageResponseCount = completedUserMessageResponseCount,
                 latestSupportArea = latestSupportArea,
                 showHumanSupportPrompt = shouldPromptHumanSupport && !it.hasCreatedTicket,
@@ -906,8 +909,9 @@ class AiSupportChatViewModel @Inject constructor(
             mode = mode,
             ticketType = supportArea?.ticketType,
             subjectResId = supportArea?.subjectResId,
-            extraTags = supportArea.extraTags(),
+            extraTags = supportArea.extraTags(_viewState.value.hasReceivedBotResponse),
             siteAddress = siteAddress,
+            hasReceivedBotResponse = _viewState.value.hasReceivedBotResponse,
             ticketAnalyticsContext = supportArea.toTicketAnalyticsContext(_viewState.value.entryPoint)
         )
     }
@@ -959,10 +963,12 @@ class AiSupportChatViewModel @Inject constructor(
         )
     }
 
-    private fun SupportChatSupportArea?.extraTags(): List<String> =
+    private fun SupportChatSupportArea?.extraTags(hasReceivedBotResponse: Boolean): List<String> =
         buildList {
             add(SOURCE_TAG)
-            add(AI_SKIP_TAG)
+            if (hasReceivedBotResponse) {
+                add(AI_SKIP_TAG)
+            }
             this@extraTags?.topic?.takeIf { it.isNotBlank() }?.let { add(it) }
         }
 
@@ -1023,6 +1029,7 @@ data class AiSupportChatViewState(
     val isChatResolved: Boolean = false,
     val showMarkResolvedConfirmation: Boolean = false,
     val hasSentChatMessage: Boolean = false,
+    val hasReceivedBotResponse: Boolean = false,
     val userMessageCount: Int = 0,
     val completedUserMessageResponseCount: Int = 0,
     val latestSupportArea: SupportChatSupportArea? = null,
@@ -1055,7 +1062,12 @@ data class AiSupportChatViewState(
         get() = diagnosticSuggestedActionOverride ?: diagnosticResult?.suggestedAction
 
     val canContactHumanSupportFromToolbar: Boolean
-        get() = canSendMessages && completedUserMessageResponseCount >= MIN_USER_MESSAGE_RESPONSES_FOR_TOOLBAR
+        get() = !hasCreatedTicket &&
+            !isChatResolved &&
+            !isSending &&
+            !isLoadingHistory &&
+            !showLoadHistoryError &&
+            (isIssuePickerActive || canSendMessages)
 
     val shouldShowResolvedButton: Boolean
         get() {
@@ -1071,9 +1083,11 @@ data class AiSupportChatViewState(
         }
 
     private companion object {
-        const val MIN_USER_MESSAGE_RESPONSES_FOR_TOOLBAR = 1
         const val MIN_BOT_RESPONSES_FOR_RESOLUTION_ACTION = 2
     }
+
+    private val isIssuePickerActive: Boolean
+        get() = !hasProceededToChat && selectedIssueType == null && !isRunningDiagnostics
 }
 
 enum class HumanSupportContactSource {
@@ -1101,6 +1115,7 @@ data class ContactHumanSupport(
     val subjectResId: Int?,
     val extraTags: List<String>,
     val siteAddress: String,
+    val hasReceivedBotResponse: Boolean,
     val ticketAnalyticsContext: AiSupportChatTicketAnalyticsContext
 ) : Event()
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatViewModelTest.kt
@@ -80,10 +80,27 @@ class AiSupportChatViewModelTest : BaseUnitTest() {
         assertThat(state.canUseDiagnosticActions).isTrue()
         assertThat(state.showInputBar).isFalse()
         assertThat(state.showDiagnosticActions).isFalse()
+        assertThat(state.canContactHumanSupportFromToolbar).isTrue()
         assertThat(state.messages.map { it.content }).containsExactly(
             AiSupportChatMessageContent.Greeting,
             AiSupportChatMessageContent.IssuePicker
         )
+    }
+
+    @Test
+    fun `given issue picker is shown, when contact support is clicked, then event excludes ai skip tag`() {
+        val events = mutableListOf<MultiLiveEvent.Event>()
+        viewModel.event.observeForever { events.add(it) }
+
+        viewModel.onContactSupportClicked(
+            source = HumanSupportContactSource.TOOLBAR,
+            canCreateTicketDirectly = false
+        )
+
+        val event = events.single() as ContactHumanSupport
+        assertThat(event.mode).isEqualTo(HumanSupportContactMode.OPEN_FORM)
+        assertThat(event.hasReceivedBotResponse).isFalse()
+        assertThat(event.extraTags).containsExactly("in_app_support_escalate")
     }
 
     @Test
@@ -97,6 +114,7 @@ class AiSupportChatViewModelTest : BaseUnitTest() {
             assertThat(state.input).isEmpty()
             assertThat(state.hasStartedChat).isTrue()
             assertThat(state.showSendError).isFalse()
+            assertThat(state.canContactHumanSupportFromToolbar).isTrue()
             assertThat(state.messages.map { it.content }).containsExactly(
                 AiSupportChatMessageContent.Greeting
             )
@@ -1111,6 +1129,7 @@ class AiSupportChatViewModelTest : BaseUnitTest() {
             assertThat(event.ticketType).isEqualTo(TicketType.Payments)
             assertThat(event.subjectResId).isEqualTo(R.string.ai_support_chat_support_request_subject_woo_payments)
             assertThat(event.siteAddress).isEqualTo(SITE_URL)
+            assertThat(event.hasReceivedBotResponse).isTrue()
             assertThat(event.extraTags).containsExactly(
                 "in_app_support_escalate",
                 "ai_skip",
@@ -1178,7 +1197,7 @@ class AiSupportChatViewModelTest : BaseUnitTest() {
     @Test
     fun `given no support area and identity, when contact support is clicked, then form event has no preselected type`() =
         testBlocking {
-            startChat(createSuccessDiagnosticResult())
+            startChatWithBotResponse()
             val events = mutableListOf<MultiLiveEvent.Event>()
             viewModel.event.observeForever { events.add(it) }
 
@@ -1191,6 +1210,7 @@ class AiSupportChatViewModelTest : BaseUnitTest() {
             assertThat(event.mode).isEqualTo(HumanSupportContactMode.OPEN_FORM)
             assertThat(event.ticketType).isNull()
             assertThat(event.subjectResId).isNull()
+            assertThat(event.hasReceivedBotResponse).isTrue()
             assertThat(event.extraTags).containsExactly("in_app_support_escalate", "ai_skip")
         }
 
@@ -1318,6 +1338,7 @@ class AiSupportChatViewModelTest : BaseUnitTest() {
             assertThat(state.hasStartedChat).isFalse()
             assertThat(state.sessionId).isNull()
             assertThat(state.diagnosticResult?.statuses).hasSize(2)
+            assertThat(state.canContactHumanSupportFromToolbar).isTrue()
             assertThat(state.diagnosticResult?.statuses?.map { it.test }).containsExactly(
                 DiagnosticTest.INTERNET_CONNECTION,
                 DiagnosticTest.WPCOM_SERVERS
@@ -1393,6 +1414,7 @@ class AiSupportChatViewModelTest : BaseUnitTest() {
         assertThat(state.showSendError).isFalse()
         assertThat(state.showLoadHistoryError).isFalse()
         assertThat(state.canContactHumanSupportFromToolbar).isTrue
+        assertThat(state.hasReceivedBotResponse).isTrue()
         assertThat(state.messages.map { it.content }).containsExactly(
             AiSupportChatMessageContent.Text(ISSUE_DETAILS),
             AiSupportChatMessageContent.Text(BOT_RESPONSE)
@@ -1429,6 +1451,45 @@ class AiSupportChatViewModelTest : BaseUnitTest() {
         assertThat(state.showInputBar).isFalse
         assertThat(state.shouldShowResolvedButton).isFalse
     }
+
+    @Test
+    fun `given resumed chat has filtered bot escalation response, when contact support clicked, then ai skip is included`() =
+        testBlocking {
+            val response = createResponse(
+                messages = listOf(
+                    createMessage(messageId = 1L, role = SupportChatRole.USER, content = ISSUE_DETAILS),
+                    createMessage(
+                        messageId = 2L,
+                        role = SupportChatRole.BOT,
+                        content = BOT_RESPONSE,
+                        context = SupportChatMessageContext(flags = SupportChatFlags(forwardToHumanSupport = true))
+                    )
+                )
+            )
+            whenever(repository.fetchChat(DEFAULT_BOT_SLUG, CHAT_ID, SESSION_ID)).thenReturn(Result.success(response))
+            val events = mutableListOf<MultiLiveEvent.Event>()
+            viewModel.event.observeForever { events.add(it) }
+
+            viewModel.onLaunchModeLoaded(
+                AiSupportChatLaunchMode.Resume(
+                    chatId = CHAT_ID,
+                    botSlug = DEFAULT_BOT_SLUG,
+                    sessionId = SESSION_ID
+                )
+            )
+            viewModel.onContactSupportClicked(
+                source = HumanSupportContactSource.BANNER,
+                canCreateTicketDirectly = false
+            )
+
+            val event = events.single() as ContactHumanSupport
+            assertThat(viewModel.viewState.value.hasReceivedBotResponse).isTrue()
+            assertThat(viewModel.viewState.value.messages.map { it.content }).doesNotContain(
+                AiSupportChatMessageContent.Text(BOT_RESPONSE)
+            )
+            assertThat(event.hasReceivedBotResponse).isTrue()
+            assertThat(event.extraTags).containsExactly("in_app_support_escalate", "ai_skip")
+        }
 
     @Test
     fun `given resumed chat has created ticket, when loaded, then ticket created state is restored`() = testBlocking {
@@ -1658,7 +1719,7 @@ class AiSupportChatViewModelTest : BaseUnitTest() {
             assertThat(state.hasStartedChat).isFalse()
             assertThat(state.isSending).isFalse()
             assertThat(state.showSendError).isTrue()
-            assertThat(state.canContactHumanSupportFromToolbar).isFalse()
+            assertThat(state.canContactHumanSupportFromToolbar).isTrue()
             verify(repository, never()).registerChat(any(), any(), any(), any())
         }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatViewModelTest.kt
@@ -1294,7 +1294,27 @@ class AiSupportChatViewModelTest : BaseUnitTest() {
 
             val state = viewModel.viewState.value
             assertThat(state.hasCreatedTicket).isTrue
+            assertThat(state.canUseDiagnosticActions).isFalse()
+            assertThat(state.canHandleDiagnosticAction).isFalse()
             verify(repository, never()).markChatAsTicketCreated(any())
+        }
+
+    @Test
+    fun `given ticket is created while issue picker is shown, when issue selected, then issue picker is ignored`() =
+        testBlocking {
+            viewModel.onSupportTicketCreated()
+
+            viewModel.onIssueSelected(SupportIssueType.LOADING_ORDERS, ISSUE_LABEL)
+
+            val state = viewModel.viewState.value
+            assertThat(state.hasCreatedTicket).isTrue()
+            assertThat(state.hasProceededToChat).isFalse()
+            assertThat(state.selectedIssueType).isNull()
+            assertThat(state.messages.map { it.content }).containsExactly(
+                AiSupportChatMessageContent.Greeting,
+                AiSupportChatMessageContent.IssuePicker
+            )
+            verify(diagnosticsService, never()).runDiagnostics(any())
         }
 
     @Test


### PR DESCRIPTION
Mimics iOS https://github.com/woocommerce/woocommerce-ios/pull/17274

### Description
Updates the support chat escalation path so merchants can contact support from the toolbar immediately, including while the issue picker is displayed.

Also logs ticket creation failures with error details and avoids adding the ai_skip Zendesk tag when a ticket is created before the chat has received a bot response.

### Test Steps
1. Open Help & Support and start a new support chat.
2. Confirm the top-right Contact Support CTA is visible while the issue picker is displayed.
3. Tap Contact Support before sending a message and confirm the support form opens.
4. Create a test ticket and confirm that the ticket still receives AI response through email.
5. Send a chat message, then tap Contact Support again and confirm the support form/escalation flow still opens.

### Images/gif

<img width="2560" height="1600" alt="Screenshot_20260528_103608" src="https://github.com/user-attachments/assets/eedacc04-b92c-4575-ba61-de7d4f34565a" />
<img width="2560" height="1600" alt="Screenshot_20260528_103630" src="https://github.com/user-attachments/assets/c396ec5f-cea8-444a-80ff-f4a11e06896f" />
<img width="2560" height="1600" alt="Screenshot_20260528_103638" src="https://github.com/user-attachments/assets/147f8f61-8f00-4009-8cbb-2fc34b954a00" />

