### PR TITLE
Unify support entry point wording

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/help/HelpActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/help/HelpActivity.kt
@@ -20,7 +20,6 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_SOURCE_F
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_SOURCE_STEP
 import com.woocommerce.android.databinding.ActivityHelpBinding
 import com.woocommerce.android.extensions.doOnApplyWindowInsets
-import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.extensions.isNotNullOrEmpty
 import com.woocommerce.android.extensions.serializable
 import com.woocommerce.android.extensions.show
@@ -98,10 +97,12 @@ class HelpActivity : AppCompatActivity() {
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
 
         val isAiSupportChatAvailable = isAiSupportChatAvailable()
-        if (HelpAiSupportChatEntryPoint.shouldShowContactSupport(isAiSupportChatAvailable)) {
-            binding.contactContainer.setOnClickListener { viewModel.contactSupport(TicketType.MobileApp) }
-        } else {
-            binding.contactContainer.hide()
+        binding.contactContainer.setOnClickListener {
+            if (HelpAiSupportChatEntryPoint.shouldOpenAiSupportChatFromContactSupport(isAiSupportChatAvailable)) {
+                showAiSupportChat()
+            } else {
+                viewModel.contactSupport(TicketType.MobileApp)
+            }
         }
         binding.identityContainer.setOnClickListener { showIdentityDialog(TicketType.MobileApp) }
         binding.faqContainer.setOnClickListener {
@@ -121,8 +122,6 @@ class HelpActivity : AppCompatActivity() {
         }
 
         if (isAiSupportChatAvailable) {
-            binding.aiSupportChatContainer.show()
-            binding.aiSupportChatContainer.setOnClickListener { showAiSupportChat() }
             binding.aiSupportChatHistoryContainer.show()
             binding.aiSupportChatHistoryContainer.setOnClickListener { showAiSupportChatHistory() }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/help/HelpAiSupportChatEntryPoint.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/help/HelpAiSupportChatEntryPoint.kt
@@ -3,7 +3,7 @@ package com.woocommerce.android.support.help
 object HelpAiSupportChatEntryPoint {
     fun isAvailable(featureFlagEnabled: Boolean): Boolean = featureFlagEnabled
 
-    fun shouldShowContactSupport(aiSupportChatAvailable: Boolean): Boolean = !aiSupportChatAvailable
+    fun shouldOpenAiSupportChatFromContactSupport(aiSupportChatAvailable: Boolean): Boolean = aiSupportChatAvailable
 
     fun shouldUsePreLoginLaunchMode(isUserLoggedIn: Boolean): Boolean = !isUserLoggedIn
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/troubleshooting/TroubleshootConnectionScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/troubleshooting/TroubleshootConnectionScreen.kt
@@ -138,7 +138,7 @@ fun TroubleshootConnectionScreen(
                     )
                     .fillMaxWidth()
             ) {
-                Text(stringResource(id = R.string.ai_support_chat_connectivity_action))
+                Text(stringResource(id = R.string.orderlist_connectivity_tool_contact_support_action))
             }
         }
         if (shouldDisplayContactSupportButton) {

--- a/WooCommerce/src/main/res/drawable/ic_support_agent_24dp.xml
+++ b/WooCommerce/src/main/res/drawable/ic_support_agent_24dp.xml
@@ -1,0 +1,19 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M21,12.22C21,6.73 16.74,3 12,3C7.31,3 3,6.65 3,12.28C2.4,12.62 2,13.26 2,14V16C2,17.1 2.9,18 4,18H5V11.9C5,8.03 8.13,4.9 12,4.9C15.87,4.9 19,8.03 19,11.9V19H11V21H19C20.1,21 21,20.1 21,19V17.78C21.59,17.47 22,16.86 22,16.14V13.84C22,13.14 21.59,12.53 21,12.22Z" />
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M9,13m-1,0a1,1 0,1 1,2 0a1,1 0,1 1,-2 0" />
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M15,13m-1,0a1,1 0,1 1,2 0a1,1 0,1 1,-2 0" />
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M18,11.03A6.04,6.04 0,0 0,12.05 6C9.02,6 5.76,8.51 6.02,12.45A8.08,8.08 0,0 0,10.88 6.56C12.19,9.19 14.88,11 18,11.03Z" />
+</vector>

--- a/WooCommerce/src/main/res/layout/activity_help.xml
+++ b/WooCommerce/src/main/res/layout/activity_help.xml
@@ -85,14 +85,6 @@
                 android:visibility="gone" />
 
             <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
-                android:id="@+id/aiSupportChatContainer"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                app:optionTitle="@string/ai_support_chat_help_row_title"
-                app:optionValue="@string/ai_support_chat_help_row_subtitle"
-                android:visibility="gone" />
-
-            <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
                 android:id="@+id/aiSupportChatHistoryContainer"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/WooCommerce/src/main/res/menu/menu_ai_support_chat.xml
+++ b/WooCommerce/src/main/res/menu/menu_ai_support_chat.xml
@@ -5,7 +5,7 @@
     <item
         android:id="@+id/menu_contact_support"
         android:contentDescription="@string/ai_support_chat_toolbar_contact_support"
-        android:icon="@drawable/ic_help_24dp"
+        android:icon="@drawable/ic_support_agent_24dp"
         android:title="@string/ai_support_chat_toolbar_contact_support"
         android:visible="false"
         app:showAsAction="always" />

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2399,8 +2399,8 @@
     <string name="support_subtitle">How can we help?</string>
     <string name="support_help_center">Help Center</string>
     <string name="support_faq_detail">Get answers to questions you have</string>
-    <string name="support_contact">Contact support</string>
-    <string name="support_contact_detail">Reach our happiness engineers who can help answer tough questions</string>
+    <string name="support_contact">Contact Support</string>
+    <string name="support_contact_detail">Get help with app or store issues</string>
     <string name="support_application_log">Application log</string>
     <string name="support_application_log_detail">Advanced tool to review the app status</string>
     <string name="support_system_status_report">System status report</string>
@@ -2413,7 +2413,7 @@
 
     <string name="ai_support_chat_help_row_title">Chat with support</string>
     <string name="ai_support_chat_help_row_subtitle">Chat with our AI assistant to diagnose store issues</string>
-    <string name="ai_support_chat_screen_title">Chat with support</string>
+    <string name="ai_support_chat_screen_title">Contact Support</string>
     <string name="ai_support_chat_history_row_title">Chat history</string>
     <string name="ai_support_chat_history_row_subtitle">Revisit past support conversations</string>
     <string name="ai_support_chat_history_title">Chat history</string>
@@ -2432,10 +2432,10 @@
     <string name="ai_support_chat_suggested_fix_error">Unable to apply this fix. Check your connection and try again.</string>
     <string name="ai_support_chat_typing">Thinking…</string>
     <string name="ai_support_chat_human_support_message">It looks like you might need additional help. Would you like to contact our support team?</string>
-    <string name="ai_support_chat_contact_support">Contact Support</string>
+    <string name="ai_support_chat_contact_support">Ask a Happiness Engineer</string>
     <string name="ai_support_chat_ticket_created_message">A support ticket has been created for this chat. We\'ll respond via email.</string>
     <string name="ai_support_chat_resolved_message">This chat has been marked as resolved.</string>
-    <string name="ai_support_chat_toolbar_contact_support">Contact Support</string>
+    <string name="ai_support_chat_toolbar_contact_support">Ask a Happiness Engineer</string>
     <string name="ai_support_chat_mark_resolved">Mark Resolved</string>
     <string name="ai_support_chat_mark_resolved_cancel">Cancel</string>
     <string name="ai_support_chat_mark_resolved_confirmation_title">Mark chat as resolved?</string>
@@ -2486,7 +2486,7 @@
     <string name="ai_support_chat_diagnostics_push_registration_failure">This device is not registered to receive push notifications for your store.</string>
     <string name="ai_support_chat_diagnostics_push_check_failure">We couldn\'t check your push notification registration.</string>
     <string name="ai_support_chat_connectivity_initial_message">Help me troubleshoot my store connection.</string>
-    <string name="ai_support_chat_connectivity_action">Chat with support</string>
+    <string name="ai_support_chat_connectivity_action">Contact Support</string>
     <string name="ai_support_chat_feedback_helpful">Helpful</string>
     <string name="ai_support_chat_feedback_not_helpful">Not helpful</string>
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/support/help/HelpAiSupportChatEntryPointTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/support/help/HelpAiSupportChatEntryPointTest.kt
@@ -19,21 +19,23 @@ class HelpAiSupportChatEntryPointTest {
     }
 
     @Test
-    fun `given AI support chat unavailable, when checking contact support, then contact support is shown`() {
-        val shouldShowContactSupport = HelpAiSupportChatEntryPoint.shouldShowContactSupport(
-            aiSupportChatAvailable = false
-        )
+    fun `given AI support chat unavailable, when checking contact support, then support form is used`() {
+        val shouldOpenAiSupportChatFromContactSupport = HelpAiSupportChatEntryPoint
+            .shouldOpenAiSupportChatFromContactSupport(
+                aiSupportChatAvailable = false
+            )
 
-        assertThat(shouldShowContactSupport).isTrue()
+        assertThat(shouldOpenAiSupportChatFromContactSupport).isFalse()
     }
 
     @Test
-    fun `given AI support chat available, when checking contact support, then contact support is hidden`() {
-        val shouldShowContactSupport = HelpAiSupportChatEntryPoint.shouldShowContactSupport(
-            aiSupportChatAvailable = true
-        )
+    fun `given AI support chat available, when checking contact support, then AI support chat is used`() {
+        val shouldOpenAiSupportChatFromContactSupport = HelpAiSupportChatEntryPoint
+            .shouldOpenAiSupportChatFromContactSupport(
+                aiSupportChatAvailable = true
+            )
 
-        assertThat(shouldShowContactSupport).isFalse()
+        assertThat(shouldOpenAiSupportChatFromContactSupport).isTrue()
     }
 
     @Test


### PR DESCRIPTION
### Description
Unifies support entry points around the existing `Contact Support` CTA, matching the direction from https://github.com/woocommerce/woocommerce-ios/pull/17292.

- Keeps the Help screen's `Contact Support` row visible when AI support chat is enabled.
- Routes that row to AI support chat when the feature flag is on, and to the support form when it is off.
- Removes the separate `Chat with support` row from Help.
- Reuses `Contact Support` copy in the connectivity entry point.
- Updates the AI support chat title, human escalation copy, and toolbar icon to better clarify human help.

### Test Steps
1. Enable the AI support chat feature flag.
2. Open Help & support.
3. Confirm there is a single `Contact Support` row, no separate `Chat with support` row, and `Chat history` remains visible.
4. Tap `Contact Support` and confirm it opens AI support chat with the `Contact Support` title.
5. From a chat where human support escalation is available, confirm the toolbar action uses a headset icon and is announced as `Ask a Happiness Engineer`.
6. Open the connectivity tool after checks complete with AI support chat available, confirm the button reads `Contact Support`, and confirm it opens AI support chat.
7. Disable the AI support chat feature flag.
8. Open Help & support, tap `Contact Support`, and confirm it opens the support form.
9. Open the connectivity tool after checks complete with AI support chat available, confirm the button reads `Contact Support`, and confirm it opens the support form.

### Images/gif
Connectivity Tool | Chat screen | Help
--- | --- | ---
<img width="320" alt="Screenshot_20260601_142452" src="https://github.com/user-attachments/assets/f35dd0d5-8e54-4a8f-a5bd-1c311bef5507" /> | <img width="320" alt="Screenshot_20260601_142544" src="https://github.com/user-attachments/assets/799db372-bf83-46d7-ab8e-6668099d3d76" /> | <img width="320" alt="Screenshot_20260601_142506" src="https://github.com/user-attachments/assets/0c92d299-d7e5-475c-9bfb-89977617ac35" />


- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
