### PR TITLE
Emit unified_login_step (qr_error) for QR-login tracking parity

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModel.kt
@@ -240,7 +240,7 @@ class QrLoginScannerViewModel @Inject constructor(
     }
 
     private fun trackFailure(reason: ErrorReason, failedAt: String? = null) {
-        unifiedLoginTracker.setStep(Step.QR_ERROR)
+        unifiedLoginTracker.track(Flow.LOGIN_QR, Step.QR_ERROR)
         val description = reason::class.simpleName.orEmpty()
             .let { simpleName -> if (failedAt != null) "$simpleName:$failedAt" else simpleName }
         unifiedLoginTracker.trackFailure(description)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModelTest.kt
@@ -205,7 +205,7 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
             advanceUntilIdle()
 
             inOrder(unifiedLoginTracker).apply {
-                verify(unifiedLoginTracker).setStep(Step.QR_ERROR)
+                verify(unifiedLoginTracker).track(Flow.LOGIN_QR, Step.QR_ERROR)
                 verify(unifiedLoginTracker).trackFailure("Network:Scan")
             }
         }
@@ -221,7 +221,7 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
                 retryable = false,
             )
         )
-        verify(unifiedLoginTracker).setStep(Step.QR_ERROR)
+        verify(unifiedLoginTracker).track(Flow.LOGIN_QR, Step.QR_ERROR)
         verify(unifiedLoginTracker).trackFailure("Scanner")
     }
 


### PR DESCRIPTION
### Description

Closes [WOOMOB-3135](https://linear.app/a8c/issue/WOOMOB-3135).

On the QR-login error screen, iOS emits a `unified_login_step` event with `step: qr_error` **before** the `unified_login_failure`. Android emitted only the failure, because `QrLoginScannerViewModel.trackFailure()` called `unifiedLoginTracker.setStep(Step.QR_ERROR)` — which silently updates internal state without sending an event — instead of `track(...)`, which emits `UNIFIED_LOGIN_STEP`.

This switches that one call to `track(Flow.LOGIN_QR, Step.QR_ERROR)`, so Android now emits the step event then the failure, matching iOS and the pattern already used elsewhere in this VM (e.g. `QR_AUTHENTICATING`, `QR_NUMBER_MATCH`).

### Test Steps

- Drive a QR-login error (invalid/expired QR, or a server/network error during scan).
- Confirm logcat displays: 
```
Tracked: woocommerceandroid_unified_login_failure, Properties: {"source":"default","flow":"login_qr","step":"qr_error","failure":"InvalidPayload","is_debug":true}
```

