### PR TITLE
Fix QR site-URL prefill deep-link NPE (defer prefill until validator ready)

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/overrides/WooLoginSiteAddressFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/overrides/WooLoginSiteAddressFragment.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.login.overrides
 
 import android.os.Bundle
+import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.LayoutRes
 import com.woocommerce.android.R
@@ -25,20 +26,24 @@ class WooLoginSiteAddressFragment : LoginSiteAddressFragment() {
         super.setupContent(rootView)
     }
 
-    @Suppress("DEPRECATION", "OVERRIDE_DEPRECATION")
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
         val prefilledSiteUrl = arguments?.getString(ARG_PREFILLED_SITE_URL)
         if (prefilledSiteUrl.isNotNullOrEmpty()) {
-            val siteAddressEditText = view?.findViewById<WPLoginInputRow>(R.id.login_site_address_row)
+            val siteAddressEditText = view.findViewById<WPLoginInputRow>(R.id.login_site_address_row)
                 ?.editText
                 ?: return
-            siteAddressEditText.setText(prefilledSiteUrl)
-            // Auto-submit so the merchant goes from "scan QR" to the next login step with no taps,
-            // mirroring WooLoginEmailFragment which calls next(prefilledEmail) on the email screen.
-            discover()
-            // Single-shot: prevent replay on rotation / process recovery.
-            arguments?.remove(ARG_PREFILLED_SITE_URL)
+            // Defer until the view is attached so the base fragment's onActivityCreated has run and
+            // its LoginSiteAddressValidator exists; setText() here fires the base TextWatcher, which
+            // dereferences that validator (a null validator was the WOOMOB-3107 crash).
+            siteAddressEditText.post {
+                siteAddressEditText.setText(prefilledSiteUrl)
+                // Auto-submit so the merchant goes from "scan QR" to the next login step with no taps,
+                // mirroring WooLoginEmailFragment which calls next(prefilledEmail) on the email screen.
+                discover()
+                // Single-shot: prevent replay on rotation / process recovery.
+                arguments?.remove(ARG_PREFILLED_SITE_URL)
+            }
         }
     }
 }


### PR DESCRIPTION
### Description

Closes [WOOMOB-3107](https://linear.app/a8c/issue/WOOMOB-3107).

Opening a `woocommerce://qr-login?siteUrl=…` deep link could crash with a `NullPointerException` in the base `LoginSiteAddressFragment.afterTextChanged()` (`LoginSiteAddressValidator.setAddress` on null).

**Root cause:** the base `LoginSiteAddressFragment` registers its `TextWatcher` in `setupContent()` (during `onCreateView`) but only creates `mLoginSiteAddressValidator` later in `onActivityCreated()`. Pre-filling the field in `onViewCreated` (between those two points) made `setText()` fire `afterTextChanged()`, which dereferences the not-yet-created validator → NPE.

A prior commit (`d46ce`) worked around it by moving the prefill into the **deprecated** `onActivityCreated`. This PR replaces that with a robust, non-deprecated approach: prefill in `onViewCreated` but defer the `setText()` + auto-submit via `editText.post { }`, so it runs once the view is attached (after `onActivityCreated`, when the validator exists). This also aligns with the sibling `WooLoginEmailFragment`, which prefills in `onViewCreated`.

### Test Steps

1. `wasabi` debug build with the `woo_qr_code_login` flag enabled.
2. Fire the site-URL-only deep link:
   ```
   adb shell am start -a android.intent.action.VIEW \
     -d 'woocommerce://qr-login?siteUrl=https://example.com' com.woocommerce.android.dev
   ```
3. **Expected:** the site-address screen opens, pre-filled with the URL and auto-submitting — no crash. (When already signed in, confirm the "You're already signed in" sheet first.)
4. Rotate the screen and confirm the prefill is not replayed.

**Verified on an emulator:** the deep link routes to the site-address screen, the field is pre-filled with `https://example.com`, `discover()` auto-submits, and there is no NPE.

### Images/gif

N/A.

- [x] I have considered if this change warrants release notes — crash-hardening on an unreleased feature branch, no separate release note needed.
