### PR TITLE
[WOOMOB-3160] Show scheduled-import delay notice and settings sheet on dashboard cards

### DIFF
--- a/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/settings/analytics_scheduled_import.json
+++ b/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/settings/analytics_scheduled_import.json
@@ -1,0 +1,40 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPath": "/rest/v1.1/jetpack-blogs/161477129/rest-api/",
+    "queryParameters": {
+      "json": {
+        "equalTo": "true"
+      },
+      "path": {
+        "equalTo": "/wc/v3/settings/wc_admin/woocommerce_analytics_scheduled_import/&_method=get"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+      "data": {
+        "id": "woocommerce_analytics_scheduled_import",
+        "label": "Scheduled import",
+        "description": "",
+        "type": "checkbox",
+        "default": "no",
+        "value": "no",
+        "group_id": "wc_admin",
+        "_links": {
+          "self": [{
+            "href": "https:\/\/test.blog\/wp-json\/wc\/v3\/settings\/wc_admin\/woocommerce_analytics_scheduled_import"
+          }],
+          "collection": [{
+            "href": "https:\/\/test.blog\/wp-json\/wc\/v3\/settings\/wc_admin"
+          }]
+        }
+      }
+    },
+    "headers": {
+      "Content-Type": "application/json",
+      "Connection": "keep-alive"
+    }
+  }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
@@ -14,6 +14,8 @@ object AppUrls {
     const val AUTOMATTIC_HIRING = "https://automattic.com/work-with-us"
     const val AUTOMATTIC_AI_GUIDELINES = "https://automattic.com/ai-guidelines/"
 
+    const val ANALYTICS_SCHEDULED_IMPORT_DOCS = "https://woocommerce.com/document/woocommerce-analytics/#section-24"
+
     const val WOOCOMMERCE_UPGRADE = "https://woocommerce.com/document/how-to-update-woocommerce/"
     const val WOOCOMMERCE_PLUGIN = "https://wordpress.org/plugins/woocommerce/"
     const val WOOCOMMERCE_WEB_OPTIONS = "https://woocommerce.com/tracking-and-opt-outs/"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
@@ -200,6 +200,12 @@ class DashboardFragment :
                     )
                 }
 
+                is DashboardViewModel.DashboardEvent.OpenScheduledImportInfo -> {
+                    findNavController().navigateSafely(
+                        DashboardFragmentDirections.actionDashboardToScheduledImportInfoBottomSheet(event.isEnabled)
+                    )
+                }
+
                 else -> event.isHandled = false
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
@@ -30,6 +30,7 @@ import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.Selec
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.OpenEditWidgets
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.RefreshJitm
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetUiModel.NewWidgetsCard
+import com.woocommerce.android.ui.dashboard.data.AnalyticsScheduledImportRepository
 import com.woocommerce.android.ui.dashboard.data.DashboardRepository
 import com.woocommerce.android.ui.prefs.privacy.banner.domain.ShouldShowPrivacyBanner
 import com.woocommerce.android.util.PackageUtils
@@ -68,6 +69,7 @@ class DashboardViewModel @Inject constructor(
     dashboardTransactionLauncher: DashboardTransactionLauncher,
     shouldShowPrivacyBanner: ShouldShowPrivacyBanner,
     private val dashboardRepository: DashboardRepository,
+    private val analyticsScheduledImportRepository: AnalyticsScheduledImportRepository,
     private val pushNotificationRegistrationStatus: PushNotificationRegistrationStatus,
     private val shouldShowEnablePushNotificationsUi: ShouldShowEnablePushNotificationsUi,
     private val feedbackPrefs: FeedbackPrefs,
@@ -115,6 +117,9 @@ class DashboardViewModel @Inject constructor(
 
     val hasNewWidgets = dashboardRepository.hasNewWidgets.asLiveData()
 
+    private val _isScheduledImportEnabled = MutableStateFlow(false)
+    val isScheduledImportEnabled: LiveData<Boolean> = _isScheduledImportEnabled.asLiveData()
+
     private val refreshingOnBackground = MutableStateFlow(-1)
 
     fun displayRefreshingIndicator() {
@@ -149,6 +154,22 @@ class DashboardViewModel @Inject constructor(
 
         updateShareStoreButtonVisibility()
         insertAIAssistantWidgetByDefault()
+        observeScheduledImportState()
+    }
+
+    private fun observeScheduledImportState() {
+        launch {
+            analyticsScheduledImportRepository.observeIsEnabled().collect { enabled ->
+                _isScheduledImportEnabled.value = enabled
+            }
+        }
+        launch {
+            analyticsScheduledImportRepository.refresh()
+        }
+    }
+
+    fun onDelayedStatsInfoClicked() {
+        triggerEvent(DashboardEvent.OpenScheduledImportInfo(isEnabled = _isScheduledImportEnabled.value))
     }
 
     private fun insertAIAssistantWidgetByDefault() {
@@ -393,6 +414,8 @@ class DashboardViewModel @Inject constructor(
         data object RefreshJitm : DashboardEvent()
 
         data object OpenWooPushNotificationsIntroduction : DashboardEvent()
+
+        data class OpenScheduledImportInfo(val isEnabled: Boolean) : DashboardEvent()
     }
 
     data class RefreshEvent(val isForced: Boolean = false)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/ScheduledImportInfoBottomSheetFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/ScheduledImportInfoBottomSheetFragment.kt
@@ -1,0 +1,293 @@
+package com.woocommerce.android.ui.dashboard
+
+import android.content.res.Configuration
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.fragment.app.viewModels
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.clickableAnnotatedStringRes
+import com.woocommerce.android.ui.compose.component.BottomSheetHandle
+import com.woocommerce.android.ui.compose.theme.WooTheme
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.util.ChromeCustomTabUtils
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.LaunchUrlInChromeTab
+import com.woocommerce.android.widgets.WCBottomSheetDialogFragment
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class ScheduledImportInfoBottomSheetFragment : WCBottomSheetDialogFragment() {
+    private val viewModel: ScheduledImportInfoViewModel by viewModels()
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        return ComposeView(requireContext()).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+
+            setContent {
+                WooTheme {
+                    val state by viewModel.viewState.observeAsState()
+                    state?.let {
+                        ScheduledImportInfoContent(
+                            state = it,
+                            onOptionSelected = viewModel::onOptionSelected,
+                            onLearnMoreClick = viewModel::onLearnMoreClicked
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        viewModel.event.observe(viewLifecycleOwner) { event ->
+            when (event) {
+                is ScheduledImportInfoViewModel.SettingUpdated -> dismiss()
+
+                is LaunchUrlInChromeTab ->
+                    ChromeCustomTabUtils.launchUrl(requireContext(), event.url)
+
+                else -> event.isHandled = false
+            }
+        }
+    }
+}
+
+@Composable
+private fun ScheduledImportInfoContent(
+    state: ScheduledImportInfoViewModel.ViewState,
+    onOptionSelected: (Boolean) -> Unit,
+    onLearnMoreClick: () -> Unit
+) {
+    Surface(
+        shape = RoundedCornerShape(
+            topStart = dimensionResource(id = R.dimen.minor_100),
+            topEnd = dimensionResource(id = R.dimen.minor_100)
+        )
+    ) {
+        // The horizontal padding is applied per child (not on the Column) so the tappable option
+        // rows can draw their ripple across the full width of the sheet.
+        val contentPadding = Modifier.padding(horizontal = dimensionResource(id = R.dimen.major_100))
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_100))
+        ) {
+            Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.minor_100)))
+            BottomSheetHandle(Modifier.align(Alignment.CenterHorizontally))
+
+            Text(
+                text = stringResource(id = R.string.dashboard_scheduled_import_sheet_title),
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold,
+                color = colorResource(id = R.color.color_on_surface_high),
+                modifier = contentPadding
+            )
+
+            Text(
+                text = clickableAnnotatedStringRes(
+                    stringResId = R.string.dashboard_scheduled_import_sheet_description,
+                    onUrlClick = { onLearnMoreClick() }
+                ),
+                style = MaterialTheme.typography.bodyMedium,
+                color = colorResource(id = R.color.color_on_surface_medium),
+                modifier = contentPadding
+            )
+
+            Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.minor_50)))
+
+            AnalyticsUpdateOption(
+                title = stringResource(id = R.string.dashboard_scheduled_import_option_scheduled_title),
+                description = stringResource(id = R.string.dashboard_scheduled_import_option_scheduled_description),
+                isSelected = state.isEnabled,
+                isLoading = state.isUpdating && state.isEnabled,
+                enabled = !state.isUpdating,
+                onClick = { onOptionSelected(true) }
+            )
+
+            AnalyticsUpdateOption(
+                title = stringResource(id = R.string.dashboard_scheduled_import_option_immediately_title),
+                description = stringResource(id = R.string.dashboard_scheduled_import_option_immediately_description),
+                isSelected = !state.isEnabled,
+                isLoading = state.isUpdating && !state.isEnabled,
+                enabled = !state.isUpdating,
+                onClick = { onOptionSelected(false) }
+            )
+
+            if (state.hasError) {
+                Text(
+                    text = stringResource(id = R.string.dashboard_scheduled_import_update_error),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                    modifier = contentPadding
+                )
+            }
+
+            Text(
+                text = stringResource(id = R.string.dashboard_scheduled_import_store_wide_note),
+                style = MaterialTheme.typography.bodySmall,
+                color = colorResource(id = R.color.color_on_surface_medium),
+                modifier = contentPadding
+            )
+
+            Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
+        }
+    }
+}
+
+@Composable
+private fun AnalyticsUpdateOption(
+    title: String,
+    description: String,
+    isSelected: Boolean,
+    isLoading: Boolean,
+    enabled: Boolean,
+    onClick: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(enabled = enabled, onClick = onClick)
+            .padding(
+                horizontal = dimensionResource(id = R.dimen.major_100),
+                vertical = dimensionResource(id = R.dimen.minor_100)
+            ),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.minor_50))
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                color = colorResource(id = R.color.color_on_surface_high)
+            )
+            Text(
+                text = description,
+                style = MaterialTheme.typography.bodyMedium,
+                color = colorResource(id = R.color.color_on_surface_medium)
+            )
+        }
+        // Fixed-size trailing slot so the text column keeps a constant width whether or not
+        // the checkmark/progress is shown.
+        Box(
+            modifier = Modifier
+                .padding(start = dimensionResource(id = R.dimen.major_100))
+                .size(dimensionResource(id = R.dimen.major_150)),
+            contentAlignment = Alignment.Center
+        ) {
+            when {
+                isLoading -> CircularProgressIndicator(
+                    modifier = Modifier.size(dimensionResource(id = R.dimen.major_125)),
+                    strokeWidth = 2.dp,
+                    color = colorResource(id = R.color.color_primary)
+                )
+
+                isSelected -> Icon(
+                    painter = painterResource(id = R.drawable.ic_check_24dp),
+                    contentDescription = stringResource(id = R.string.dashboard_scheduled_import_option_selected),
+                    tint = colorResource(id = R.color.color_primary)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+@Preview(name = "scheduled selected - light", uiMode = Configuration.UI_MODE_NIGHT_NO)
+@Preview(name = "scheduled selected - dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Preview(name = "large screen", device = Devices.NEXUS_10)
+private fun ScheduledImportInfoContentScheduledPreview() {
+    WooThemeWithBackground {
+        Box(
+            contentAlignment = Alignment.BottomCenter,
+            modifier = Modifier.fillMaxSize()
+        ) {
+            ScheduledImportInfoContent(
+                state = ScheduledImportInfoViewModel.ViewState(
+                    isEnabled = true,
+                    isUpdating = false,
+                    hasError = false
+                ),
+                onOptionSelected = {},
+                onLearnMoreClick = {}
+            )
+        }
+    }
+}
+
+@Composable
+@Preview(name = "immediately selected - light", uiMode = Configuration.UI_MODE_NIGHT_NO)
+private fun ScheduledImportInfoContentImmediatelyPreview() {
+    WooThemeWithBackground {
+        Box(
+            contentAlignment = Alignment.BottomCenter,
+            modifier = Modifier.fillMaxSize()
+        ) {
+            ScheduledImportInfoContent(
+                state = ScheduledImportInfoViewModel.ViewState(
+                    isEnabled = false,
+                    isUpdating = false,
+                    hasError = true
+                ),
+                onOptionSelected = {},
+                onLearnMoreClick = {}
+            )
+        }
+    }
+}
+
+@Composable
+@Preview(name = "updating - light", uiMode = Configuration.UI_MODE_NIGHT_NO)
+private fun ScheduledImportInfoContentUpdatingPreview() {
+    WooThemeWithBackground {
+        Box(
+            contentAlignment = Alignment.BottomCenter,
+            modifier = Modifier.fillMaxSize()
+        ) {
+            ScheduledImportInfoContent(
+                state = ScheduledImportInfoViewModel.ViewState(
+                    isEnabled = true,
+                    isUpdating = true,
+                    hasError = false
+                ),
+                onOptionSelected = {},
+                onLearnMoreClick = {}
+            )
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/ScheduledImportInfoBottomSheetFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/ScheduledImportInfoBottomSheetFragment.kt
@@ -16,7 +16,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -102,7 +104,9 @@ private fun ScheduledImportInfoContent(
         // rows can draw their ripple across the full width of the sheet.
         val contentPadding = Modifier.padding(horizontal = dimensionResource(id = R.dimen.major_100))
         Column(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState()),
             verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_100))
         ) {
             Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.minor_100)))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/ScheduledImportInfoViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/ScheduledImportInfoViewModel.kt
@@ -1,0 +1,63 @@
+package com.woocommerce.android.ui.dashboard
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.asLiveData
+import com.woocommerce.android.AppUrls
+import com.woocommerce.android.ui.dashboard.data.AnalyticsScheduledImportRepository
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
+import com.woocommerce.android.viewmodel.ScopedViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class ScheduledImportInfoViewModel @Inject constructor(
+    savedState: SavedStateHandle,
+    private val scheduledImportRepository: AnalyticsScheduledImportRepository,
+) : ScopedViewModel(savedState) {
+    private val navArgs = ScheduledImportInfoBottomSheetFragmentArgs.fromSavedStateHandle(savedState)
+
+    private val _viewState = MutableStateFlow(
+        ViewState(
+            isEnabled = navArgs.isEnabled,
+            isUpdating = false,
+            hasError = false
+        )
+    )
+    val viewState = _viewState.asLiveData()
+
+    fun onOptionSelected(scheduledEnabled: Boolean) {
+        if (_viewState.value.isUpdating) return
+        if (scheduledEnabled == _viewState.value.isEnabled) {
+            // Tapping the already-selected option keeps the value and simply closes the sheet.
+            triggerEvent(SettingUpdated)
+            return
+        }
+        val previous = _viewState.value.isEnabled
+        _viewState.update { it.copy(isEnabled = scheduledEnabled, isUpdating = true, hasError = false) }
+        launch {
+            val result = scheduledImportRepository.setEnabled(scheduledEnabled)
+            val updatedValue = result.model
+            if (result.isError || updatedValue == null) {
+                _viewState.update { it.copy(isEnabled = previous, isUpdating = false, hasError = true) }
+            } else {
+                _viewState.update { it.copy(isEnabled = updatedValue, isUpdating = false, hasError = false) }
+                triggerEvent(SettingUpdated)
+            }
+        }
+    }
+
+    fun onLearnMoreClicked() {
+        triggerEvent(Event.LaunchUrlInChromeTab(AppUrls.ANALYTICS_SCHEDULED_IMPORT_DOCS))
+    }
+
+    data class ViewState(
+        val isEnabled: Boolean,
+        val isUpdating: Boolean,
+        val hasError: Boolean,
+    )
+
+    data object SettingUpdated : Event()
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/StatsInfoFooter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/StatsInfoFooter.kt
@@ -1,0 +1,78 @@
+package com.woocommerce.android.ui.dashboard
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+
+@Composable
+fun StatsInfoFooter(
+    text: String,
+    onInfoClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        // The whole row is the touch target (rather than just the 16dp icon) so it meets the
+        // minimum touch-target size without making the footer any taller.
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable(onClick = onInfoClick)
+            .padding(dimensionResource(id = R.dimen.major_100)),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.Center
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodyMedium,
+            color = colorResource(id = R.color.color_on_surface_medium),
+            textAlign = TextAlign.Center
+        )
+        Spacer(modifier = Modifier.width(dimensionResource(id = R.dimen.minor_50)))
+        Icon(
+            painter = painterResource(id = R.drawable.ic_tintable_info_outline_24dp),
+            contentDescription = stringResource(id = R.string.dashboard_stats_info_content_description),
+            tint = colorResource(id = R.color.color_primary),
+            modifier = Modifier.size(dimensionResource(id = R.dimen.major_100))
+        )
+    }
+}
+
+@LightDarkThemePreviews
+@Composable
+private fun StatsInfoFooterDelayedPreview() {
+    WooThemeWithBackground {
+        StatsInfoFooter(
+            text = stringResource(id = R.string.dashboard_stats_delayed_footer),
+            onInfoClick = {}
+        )
+    }
+}
+
+@LightDarkThemePreviews
+@Composable
+private fun StatsInfoFooterLastUpdatePreview() {
+    WooThemeWithBackground {
+        StatsInfoFooter(
+            text = "Last update: 8:52 AM",
+            onInfoClick = {}
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
@@ -86,6 +86,7 @@ fun DashboardStatsCard(
     val revenueStatsState by viewModel.revenueStatsState.observeAsState()
     val visitorsStatsState by viewModel.visitorStatsState.observeAsState()
     val lastUpdateState by viewModel.lastUpdateStats.observeAsState()
+    val isScheduledImportEnabled by parentViewModel.isScheduledImportEnabled.observeAsState(false)
     val selectedRevenueStatsType = viewModel.selectedRevenueStatsType.observeAsState().value ?: return
     val orderDateTypeState by viewModel.orderDateTypeState.collectAsStateWithLifecycle()
     var showOrderDateTypeBottomSheet by rememberSaveable { mutableStateOf(false) }
@@ -130,6 +131,8 @@ fun DashboardStatsCard(
                     revenueStatsState = revenueStatsState,
                     visitorsStatsState = visitorsStatsState,
                     lastUpdateState = lastUpdateState,
+                    showDelayedFooter = isScheduledImportEnabled,
+                    onDelayedStatsInfoClick = parentViewModel::onDelayedStatsInfoClicked,
                     selectedRevenueStatsType = selectedRevenueStatsType,
                     selectedOrderDateType = orderDateTypeState.selectedType,
                     dateUtils = viewModel.dateUtils,
@@ -174,6 +177,8 @@ private fun DashboardStatsContent(
     revenueStatsState: DashboardStatsViewModel.RevenueStatsViewState?,
     visitorsStatsState: DashboardStatsViewModel.VisitorStatsViewState?,
     lastUpdateState: Long?,
+    showDelayedFooter: Boolean,
+    onDelayedStatsInfoClick: () -> Unit,
     selectedRevenueStatsType: DashboardStatsViewModel.RevenueStatsType,
     selectedOrderDateType: WCAnalyticsOrderDateType,
     dateUtils: DateUtils,
@@ -209,6 +214,8 @@ private fun DashboardStatsContent(
             revenueStatsState = revenueStatsState,
             visitorsStatsState = visitorsStatsState,
             lastUpdateState = lastUpdateState,
+            showDelayedFooter = showDelayedFooter,
+            onDelayedStatsInfoClick = onDelayedStatsInfoClick,
             selectedRevenueStatsType = selectedRevenueStatsType,
             selectedOrderDateType = selectedOrderDateType,
             dateUtils = dateUtils,
@@ -228,6 +235,8 @@ private fun StatsChart(
     revenueStatsState: DashboardStatsViewModel.RevenueStatsViewState?,
     visitorsStatsState: DashboardStatsViewModel.VisitorStatsViewState?,
     lastUpdateState: Long?,
+    showDelayedFooter: Boolean,
+    onDelayedStatsInfoClick: () -> Unit,
     selectedRevenueStatsType: DashboardStatsViewModel.RevenueStatsType,
     selectedOrderDateType: WCAnalyticsOrderDateType,
     dateUtils: DateUtils,
@@ -275,8 +284,12 @@ private fun StatsChart(
         statsView.loadDashboardStats(dateRange.rangeSelection)
     }
 
-    LaunchedEffect(lastUpdateState) {
-        statsView.showLastUpdate(lastUpdateState)
+    LaunchedEffect(lastUpdateState, showDelayedFooter) {
+        statsView.showStatsFooter(
+            lastUpdateMillis = lastUpdateState,
+            isDelayed = showDelayedFooter,
+            onInfoClick = onDelayedStatsInfoClick
+        )
     }
 
     LaunchedEffect(selectedOrderDateType) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsView.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.dashboard.stats
 
 import android.content.Context
+import android.content.res.ColorStateList
 import android.os.Handler
 import android.os.Looper
 import android.util.AttributeSet
@@ -11,8 +12,11 @@ import android.widget.FrameLayout
 import android.widget.TextView
 import androidx.annotation.ColorRes
 import androidx.core.content.ContextCompat
+import androidx.core.view.ViewCompat
+import androidx.core.view.accessibility.AccessibilityNodeInfoCompat.AccessibilityActionCompat
 import androidx.core.view.doOnDetach
 import androidx.core.view.isVisible
+import androidx.core.widget.TextViewCompat
 import androidx.core.widget.addTextChangedListener
 import androidx.lifecycle.LifecycleCoroutineScope
 import com.github.mikephil.charting.charts.Chart
@@ -509,21 +513,63 @@ class DashboardStatsView @JvmOverloads constructor(
         binding.statsViewRow.emptyConversionRateIndicator.isVisible = true
     }
 
-    fun showLastUpdate(lastUpdateMillis: Long?) {
-        if (lastUpdateMillis != null) {
-            val lastUpdateFormatted = dateUtils.getDateOrTimeFromMillis(lastUpdateMillis)
-            lastUpdated.isVisible = true
-            fadeInLabelValue(
-                lastUpdated,
-                String.format(
+    fun showStatsFooter(lastUpdateMillis: Long?, isDelayed: Boolean, onInfoClick: () -> Unit) {
+        when {
+            isDelayed -> applyStatsFooter(
+                text = resources.getString(R.string.dashboard_stats_delayed_footer),
+                onInfoClick = onInfoClick
+            )
+
+            lastUpdateMillis != null -> applyStatsFooter(
+                text = String.format(
                     Locale.getDefault(),
                     resources.getString(R.string.last_update),
-                    lastUpdateFormatted
-                )
+                    dateUtils.getDateOrTimeFromMillis(lastUpdateMillis)
+                ),
+                onInfoClick = onInfoClick
             )
-        } else {
-            lastUpdated.isVisible = false
+
+            else -> {
+                lastUpdated.isVisible = false
+                clearStatsFooter()
+            }
         }
+    }
+
+    private fun applyStatsFooter(text: String, onInfoClick: () -> Unit) {
+        lastUpdated.isVisible = true
+        lastUpdated.text = text
+        lastUpdated.setTextColor(ContextCompat.getColor(context, R.color.color_on_surface_medium))
+        val iconSize = resources.getDimensionPixelSize(R.dimen.major_100)
+        val infoIcon = ContextCompat.getDrawable(context, R.drawable.ic_tintable_info_outline_24dp)?.apply {
+            setBounds(0, 0, iconSize, iconSize)
+        }
+        lastUpdated.setCompoundDrawablesRelative(null, null, infoIcon, null)
+        lastUpdated.compoundDrawablePadding = resources.getDimensionPixelSize(R.dimen.minor_50)
+        TextViewCompat.setCompoundDrawableTintList(
+            lastUpdated,
+            ColorStateList.valueOf(ContextCompat.getColor(context, R.color.color_primary))
+        )
+        lastUpdated.setOnClickListener { onInfoClick() }
+        // Tell screen readers what activating the footer does (the visible text is still read).
+        ViewCompat.replaceAccessibilityAction(
+            lastUpdated,
+            AccessibilityActionCompat.ACTION_CLICK,
+            resources.getString(R.string.dashboard_stats_info_content_description),
+            null
+        )
+    }
+
+    private fun clearStatsFooter() {
+        lastUpdated.setCompoundDrawablesRelative(null, null, null, null)
+        lastUpdated.setOnClickListener(null)
+        lastUpdated.isClickable = false
+        ViewCompat.replaceAccessibilityAction(
+            lastUpdated,
+            AccessibilityActionCompat.ACTION_CLICK,
+            null,
+            null
+        )
     }
 
     @Suppress("MagicNumber")
@@ -548,6 +594,7 @@ class DashboardStatsView @JvmOverloads constructor(
 
     fun clearStatsHeaderValues() {
         lastUpdated.text = ""
+        clearStatsFooter()
         updateColorForStatsHeaderValues(R.color.skeleton_color)
 
         visitorsValue.setText(R.string.emdash)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topperformers/DashboardTopPerformersWidgetCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topperformers/DashboardTopPerformersWidgetCard.kt
@@ -25,7 +25,6 @@ import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -47,6 +46,7 @@ import com.woocommerce.android.ui.dashboard.DashboardViewModel
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.OpenRangePicker
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetAction
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetMenu
+import com.woocommerce.android.ui.dashboard.StatsInfoFooter
 import com.woocommerce.android.ui.dashboard.TopPerformerProductUiModel
 import com.woocommerce.android.ui.dashboard.WCAnalyticsNotAvailableErrorView
 import com.woocommerce.android.ui.dashboard.WidgetCard
@@ -76,6 +76,7 @@ fun DashboardTopPerformersWidgetCard(
 ) {
     topPerformersViewModel.topPerformersState.observeAsState().value?.let { topPerformersState ->
         val lastUpdateState by topPerformersViewModel.lastUpdateTopPerformers.observeAsState()
+        val isScheduledImportEnabled by parentViewModel.isScheduledImportEnabled.observeAsState(false)
         val selectedDateRange by topPerformersViewModel.selectedDateRange.observeAsState()
         WidgetCard(
             titleResource = topPerformersState.titleStringRes,
@@ -95,6 +96,8 @@ fun DashboardTopPerformersWidgetCard(
                     topPerformersState = topPerformersState,
                     selectedDateRange = selectedDateRange,
                     lastUpdateState = lastUpdateState,
+                    showDelayedFooter = isScheduledImportEnabled,
+                    onDelayedStatsInfoClick = parentViewModel::onDelayedStatsInfoClicked,
                     onTabSelected = topPerformersViewModel::onRangeChanged,
                     onEditCustomRangeTapped = topPerformersViewModel::onEditCustomRangeTapped
                 )
@@ -122,6 +125,8 @@ fun DashboardTopPerformersContent(
     topPerformersState: TopPerformersState?,
     selectedDateRange: TopPerformersDateRange?,
     lastUpdateState: String?,
+    showDelayedFooter: Boolean,
+    onDelayedStatsInfoClick: () -> Unit,
     onTabSelected: (SelectionType) -> Unit,
     onEditCustomRangeTapped: () -> Unit,
 ) {
@@ -144,7 +149,9 @@ fun DashboardTopPerformersContent(
             else -> {
                 TopPerformersContent(
                     topPerformersState = topPerformersState,
-                    lastUpdateState = lastUpdateState
+                    lastUpdateState = lastUpdateState,
+                    showDelayedFooter = showDelayedFooter,
+                    onDelayedStatsInfoClick = onDelayedStatsInfoClick
                 )
             }
         }
@@ -187,6 +194,8 @@ private fun HandleEvents(
 private fun TopPerformersContent(
     topPerformersState: TopPerformersState?,
     lastUpdateState: String?,
+    showDelayedFooter: Boolean,
+    onDelayedStatsInfoClick: () -> Unit,
 ) {
     Column {
         Row(
@@ -214,17 +223,13 @@ private fun TopPerformersContent(
             )
         }
 
-        if (!lastUpdateState.isNullOrEmpty()) {
-            Text(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(16.dp)
-                    .align(Alignment.CenterHorizontally),
-                text = lastUpdateState,
-                style = MaterialTheme.typography.body2,
-                color = colorResource(id = R.color.color_on_surface_medium_selector),
-                textAlign = TextAlign.Center
-            )
+        val footerText = if (showDelayedFooter) {
+            stringResource(id = R.string.dashboard_stats_delayed_footer)
+        } else {
+            lastUpdateState
+        }
+        if (!footerText.isNullOrEmpty()) {
+            StatsInfoFooter(text = footerText, onInfoClick = onDelayedStatsInfoClick)
         }
     }
 }
@@ -432,6 +437,8 @@ private fun TopPerformersWidgetCardPreview() {
             topPerformersState = topPerformersState,
             lastUpdateState = "Last update: 8:52 AM",
             selectedDateRange = selectedDateRange,
+            showDelayedFooter = false,
+            onDelayedStatsInfoClick = {},
             onTabSelected = {},
             onEditCustomRangeTapped = {}
         )
@@ -439,6 +446,8 @@ private fun TopPerformersWidgetCardPreview() {
             topPerformersState = topPerformersState.copy(isLoading = true),
             lastUpdateState = "Last update: 8:52 AM",
             selectedDateRange = selectedDateRange,
+            showDelayedFooter = false,
+            onDelayedStatsInfoClick = {},
             onTabSelected = {},
             onEditCustomRangeTapped = {}
         )
@@ -446,6 +455,8 @@ private fun TopPerformersWidgetCardPreview() {
             topPerformersState = topPerformersState.copy(error = DashboardTopPerformersViewModel.ErrorType.Generic),
             lastUpdateState = "Last update: 8:52 AM",
             selectedDateRange = selectedDateRange,
+            showDelayedFooter = false,
+            onDelayedStatsInfoClick = {},
             onTabSelected = {},
             onEditCustomRangeTapped = {}
         )
@@ -453,6 +464,8 @@ private fun TopPerformersWidgetCardPreview() {
             topPerformersState = topPerformersState.copy(topPerformers = emptyList()),
             lastUpdateState = "Last update: 8:52 AM",
             selectedDateRange = selectedDateRange,
+            showDelayedFooter = true,
+            onDelayedStatsInfoClick = {},
             onTabSelected = {},
             onEditCustomRangeTapped = {}
         )

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -96,6 +96,9 @@
         <action
             android:id="@+id/action_dashboard_to_aiAssistantHostFragment"
             app:destination="@id/aiAssistantHostFragment" />
+        <action
+            android:id="@+id/action_dashboard_to_scheduledImportInfoBottomSheet"
+            app:destination="@id/scheduledImportInfoBottomSheet" />
     </fragment>
     <fragment
         android:id="@+id/orders"
@@ -792,6 +795,15 @@
         <action
             android:id="@+id/action_addProductWithAIBottomSheet_to_aiProductPromptFragment"
             app:destination="@id/AiProductPromptFragment" />
+    </dialog>
+    <dialog
+        android:id="@+id/scheduledImportInfoBottomSheet"
+        android:name="com.woocommerce.android.ui.dashboard.ScheduledImportInfoBottomSheetFragment"
+        android:label="ScheduledImportInfoBottomSheetFragment">
+        <argument
+            android:name="isEnabled"
+            android:defaultValue="false"
+            app:argType="boolean" />
     </dialog>
     <fragment
         android:id="@+id/AiProductPromptFragment"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -373,6 +373,19 @@
     <string name="dashboard_top_performers_net_sales">Net sales: %s</string>
     <string name="dashboard_top_performers_wcanalytics_inactive_title">Unable to load the top performers</string>
 
+    <!-- Analytics scheduled-import delay -->
+    <string name="dashboard_stats_delayed_footer">Stats may be up to 12 hours delayed</string>
+    <string name="dashboard_stats_info_content_description">Analytics update settings</string>
+    <string name="dashboard_scheduled_import_sheet_title">Analytics updates</string>
+    <string name="dashboard_scheduled_import_sheet_description"><![CDATA[Choose how WooCommerce processes analytics data updates. <a href="learn_more"><u>Learn more</u></a>]]></string>
+    <string name="dashboard_scheduled_import_option_scheduled_title">Scheduled</string>
+    <string name="dashboard_scheduled_import_option_scheduled_description">Automatically updates analytics data every 12 hours. Recommended for high order volume stores.</string>
+    <string name="dashboard_scheduled_import_option_immediately_title">Immediately</string>
+    <string name="dashboard_scheduled_import_option_immediately_description">Updates analytics data as soon as new data becomes available.</string>
+    <string name="dashboard_scheduled_import_store_wide_note">This is a store-wide setting, which also controls the \"Updates\" option in WooCommerce admin analytics settings.</string>
+    <string name="dashboard_scheduled_import_option_selected">Selected</string>
+    <string name="dashboard_scheduled_import_update_error">Couldn\'t update the setting. Please try again.</string>
+
     <string name="dashboard_action_view_all_orders">View all orders</string>
 
     <string name="dashboard_action_view_all_messages">View all messages</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModelTest.kt
@@ -13,6 +13,7 @@ import com.woocommerce.android.notifications.push.ShouldShowEnablePushNotificati
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetUiModel.ConfigurableWidget
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetUiModel.NewWidgetsCard
+import com.woocommerce.android.ui.dashboard.data.AnalyticsScheduledImportRepository
 import com.woocommerce.android.ui.dashboard.data.DashboardRepository
 import com.woocommerce.android.ui.prefs.privacy.banner.domain.ShouldShowPrivacyBanner
 import com.woocommerce.android.util.captureValues
@@ -72,6 +73,9 @@ class DashboardViewModelTest : BaseUnitTest() {
     private val shouldShowEnablePushNotificationsUi: ShouldShowEnablePushNotificationsUi = mock {
         on { invoke() } doReturn flowOf(false)
     }
+    private val analyticsScheduledImportRepository: AnalyticsScheduledImportRepository = mock {
+        on { observeIsEnabled() } doReturn flowOf(false)
+    }
     private lateinit var viewModel: DashboardViewModel
 
     suspend fun setup(prepareMocks: suspend () -> Unit) {
@@ -87,6 +91,7 @@ class DashboardViewModelTest : BaseUnitTest() {
             selectedSite = selectedSite,
             shouldShowPrivacyBanner = shouldShowPrivacyBanner,
             dashboardRepository = dashboardRepository,
+            analyticsScheduledImportRepository = analyticsScheduledImportRepository,
             pushNotificationRegistrationStatus = pushNotificationRegistrationStatus,
             shouldShowEnablePushNotificationsUi = shouldShowEnablePushNotificationsUi,
             feedbackPrefs = feedbackPrefs,
@@ -716,6 +721,58 @@ class DashboardViewModelTest : BaseUnitTest() {
         jetpackBenefitsBanner = viewModel.jetpackBenefitsBannerState.getOrAwaitValue()
         assertThat(jetpackBenefitsBanner!!.show).isFalse()
     }
+
+    @Test
+    fun `given scheduled import is enabled, when dashboard starts, then isScheduledImportEnabled is true`() =
+        testBlocking {
+            // GIVEN
+            setup {
+                whenever(analyticsScheduledImportRepository.observeIsEnabled()).thenReturn(flowOf(true))
+            }
+
+            // THEN
+            assertThat(viewModel.isScheduledImportEnabled.getOrAwaitValue()).isTrue()
+        }
+
+    @Test
+    fun `given no cached scheduled import setting, when dashboard starts, then isScheduledImportEnabled is false`() =
+        testBlocking {
+            // GIVEN
+            setup {
+                whenever(analyticsScheduledImportRepository.observeIsEnabled()).thenReturn(flowOf(false))
+            }
+
+            // THEN
+            assertThat(viewModel.isScheduledImportEnabled.getOrAwaitValue()).isFalse()
+        }
+
+    @Test
+    fun `when dashboard starts, then scheduled import setting is refreshed from remote`() =
+        testBlocking {
+            // GIVEN
+            setup {}
+
+            // THEN
+            verify(analyticsScheduledImportRepository).refresh()
+        }
+
+    @Test
+    fun `given import enabled, when delayed stats info clicked, then info event is emitted with current state`() =
+        testBlocking {
+            // GIVEN
+            setup {
+                whenever(analyticsScheduledImportRepository.observeIsEnabled()).thenReturn(flowOf(true))
+            }
+
+            // WHEN
+            val event = viewModel.event.runAndCaptureValues {
+                viewModel.onDelayedStatsInfoClicked()
+            }.last()
+
+            // THEN
+            assertThat(event)
+                .isEqualTo(DashboardViewModel.DashboardEvent.OpenScheduledImportInfo(isEnabled = true))
+        }
 
     private companion object {
         fun dashboardWidget(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/ScheduledImportInfoViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/ScheduledImportInfoViewModelTest.kt
@@ -1,0 +1,151 @@
+package com.woocommerce.android.ui.dashboard
+
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.AppUrls
+import com.woocommerce.android.ui.dashboard.data.AnalyticsScheduledImportRepository
+import com.woocommerce.android.util.getOrAwaitValue
+import com.woocommerce.android.util.runAndCaptureValues
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.LaunchUrlInChromeTab
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.doSuspendableAnswer
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.network.BaseRequest
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+
+@ExperimentalCoroutinesApi
+class ScheduledImportInfoViewModelTest : BaseUnitTest() {
+    private val scheduledImportRepository: AnalyticsScheduledImportRepository = mock()
+
+    private lateinit var viewModel: ScheduledImportInfoViewModel
+
+    private fun createViewModel(isEnabled: Boolean = false) {
+        viewModel = ScheduledImportInfoViewModel(
+            savedState = SavedStateHandle(mapOf("isEnabled" to isEnabled)),
+            scheduledImportRepository = scheduledImportRepository,
+        )
+    }
+
+    @Test
+    fun `given enabled nav arg, when the sheet is shown, then initial state reflects it`() = testBlocking {
+        createViewModel(isEnabled = true)
+
+        assertThat(viewModel.viewState.getOrAwaitValue().isEnabled).isTrue()
+    }
+
+    @Test
+    fun `given disabled nav arg, when the sheet is shown, then initial state reflects it`() = testBlocking {
+        createViewModel(isEnabled = false)
+
+        assertThat(viewModel.viewState.getOrAwaitValue().isEnabled).isFalse()
+    }
+
+    @Test
+    fun `when toggle is changed and update succeeds, then state reflects the new value and event is triggered`() =
+        testBlocking {
+            createViewModel(isEnabled = false)
+            whenever(scheduledImportRepository.setEnabled(true)).thenReturn(WooResult(true))
+
+            val event = viewModel.event.runAndCaptureValues {
+                viewModel.onOptionSelected(true)
+            }.last()
+
+            val state = viewModel.viewState.getOrAwaitValue()
+            assertThat(state.isEnabled).isTrue()
+            assertThat(state.isUpdating).isFalse()
+            assertThat(state.hasError).isFalse()
+            assertThat(event).isEqualTo(ScheduledImportInfoViewModel.SettingUpdated)
+        }
+
+    @Test
+    fun `when toggle is changed and update fails, then state reverts and shows an error`() = testBlocking {
+        createViewModel(isEnabled = false)
+        whenever(scheduledImportRepository.setEnabled(true)).thenReturn(
+            WooResult(
+                error = WooError(
+                    type = WooErrorType.GENERIC_ERROR,
+                    original = BaseRequest.GenericErrorType.NETWORK_ERROR,
+                    message = "error"
+                )
+            )
+        )
+
+        viewModel.onOptionSelected(true)
+
+        val state = viewModel.viewState.getOrAwaitValue()
+        assertThat(state.isEnabled).isFalse()
+        assertThat(state.isUpdating).isFalse()
+        assertThat(state.hasError).isTrue()
+    }
+
+    @Test
+    fun `given an update is in progress, when toggle is changed again, then the second change is ignored`() =
+        testBlocking {
+            createViewModel(isEnabled = false)
+            val gate = CompletableDeferred<WooResult<Boolean>>()
+            whenever(scheduledImportRepository.setEnabled(true)).doSuspendableAnswer { gate.await() }
+
+            // First toggle suspends on the gate, keeping isUpdating = true
+            viewModel.onOptionSelected(true)
+            assertThat(viewModel.viewState.getOrAwaitValue().isUpdating).isTrue()
+
+            // Second toggle while the first is still in flight must be ignored
+            viewModel.onOptionSelected(false)
+            gate.complete(WooResult(true))
+
+            verify(scheduledImportRepository).setEnabled(true)
+            verify(scheduledImportRepository, never()).setEnabled(false)
+        }
+
+    @Test
+    fun `when learn more is clicked, then docs url is launched`() = testBlocking {
+        createViewModel()
+
+        val event = viewModel.event.runAndCaptureValues {
+            viewModel.onLearnMoreClicked()
+        }.last()
+
+        assertThat(event).isEqualTo(LaunchUrlInChromeTab(AppUrls.ANALYTICS_SCHEDULED_IMPORT_DOCS))
+    }
+
+    @Test
+    fun `given update fails, when toggle is changed, then no setting updated event is triggered`() = testBlocking {
+        createViewModel(isEnabled = false)
+        whenever(scheduledImportRepository.setEnabled(true)).thenReturn(
+            WooResult(
+                error = WooError(
+                    type = WooErrorType.GENERIC_ERROR,
+                    original = BaseRequest.GenericErrorType.NETWORK_ERROR,
+                    message = "error"
+                )
+            )
+        )
+
+        val events = viewModel.event.runAndCaptureValues {
+            viewModel.onOptionSelected(true)
+        }
+
+        assertThat(events.filterIsInstance<ScheduledImportInfoViewModel.SettingUpdated>()).isEmpty()
+    }
+
+    @Test
+    fun `given an option is already selected, when it is tapped, then the sheet closes without calling the repository`() =
+        testBlocking {
+            createViewModel(isEnabled = true)
+
+            val event = viewModel.event.runAndCaptureValues {
+                viewModel.onOptionSelected(true)
+            }.last()
+
+            assertThat(event).isEqualTo(ScheduledImportInfoViewModel.SettingUpdated)
+            verify(scheduledImportRepository, never()).setEnabled(true)
+        }
+}


### PR DESCRIPTION
### Description
Fixes WOOMOB-3160

WooCommerce Analytics can import order/sales data on a schedule (the "Updates" option in Analytics → Settings) rather than in real time. When scheduled, the figures on the `/reports`-backed dashboard cards can lag by up to 12 hours. This PR surfaces that to merchants and lets them change the setting from inside the app.

**What changed**

- The **Performance** and **Top performers** cards now show a small line — *"Stats may be up to 12 hours delayed"* with a tappable ⓘ — when the scheduled-import setting is enabled. When it's disabled they keep the existing *"Last update: %s"* line, now also with the ⓘ so the setting is always reachable. The line sits in each card's existing last-update spot (Performance: between the metrics and the chart; Top performers: at the bottom of the list), matching trunk's placement.
- Tapping ⓘ opens a new **Analytics updates** bottom sheet — a single-choice picker (**Scheduled** vs **Immediately**) that writes the setting via the repository, shows a spinner in place of the checkmark while saving, and reverts with an inline error on failure. The setting is store-wide.
- The cards react to the change via the Room-backed `observeIsEnabled()` flow from the data layer, so flipping the option in the sheet updates the cards without any manual result plumbing.


### Test Steps
1. On a store, open the **My Store** tab.
2. On the **Performance** and **Top performers** cards, find the small centered line under the data ("Stats may be up to 12 hours delayed" or "Last update: …") with an ⓘ icon, and tap the ⓘ.
3. The **Analytics updates** sheet opens with two options (Scheduled / Immediately); the current setting is checked.
4. Tap the other option → a spinner replaces the checkmark while it saves, the sheet closes on success, and the card line updates (delay notice ↔ "Last update: …").
5. Reopen the sheet and tap **Learn more** → the WooCommerce analytics docs open in a Custom Tab.
6. Reopen the sheet, disable the network, and tap the other option → the spinner stops, an inline error appears, and the selection reverts.

### Images/gif

https://github.com/user-attachments/assets/7c4ab30c-4ff8-4e7b-ad0e-a88c231ecf4e


- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.