### PR TITLE
[WOOMOB-3161] Show scheduled-import delay notice on dashboard pull-to-refresh

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -153,6 +153,7 @@ object AppPrefs {
         AI_PRODUCT_DESCRIPTION_CELEBRATION_SHOWN,
         AI_ASSISTANT_EARLY_ACCESS_NOTICE_DISMISSED,
         AUTO_TAX_RATE_ID,
+        HAS_SEEN_ANALYTICS_SCHEDULED_IMPORT_INFO,
     }
 
     /**
@@ -361,6 +362,13 @@ object AppPrefs {
                 .commit()
             check(committed) { "Failed to persist AI Assistant early access notice dismissal" }
         }
+
+    var hasSeenAnalyticsScheduledImportInfo: Boolean
+        get() = getBoolean(
+            key = DeletableSitePrefKey.HAS_SEEN_ANALYTICS_SCHEDULED_IMPORT_INFO,
+            default = false,
+        )
+        set(value) = setBoolean(key = DeletableSitePrefKey.HAS_SEEN_ANALYTICS_SCHEDULED_IMPORT_INFO, value = value)
 
     private const val FEATURE_FLAG_OVERRIDE_PREFIX = "feature_flag_override"
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -75,6 +75,7 @@ object AppPrefs {
         SUPPORT_NAME,
         IS_USING_V4_API,
         HAS_UNSEEN_REVIEWS,
+        HAS_SEEN_ANALYTICS_SCHEDULED_IMPORT_INFO,
         SELECTED_SHIPMENT_TRACKING_PROVIDER_NAME,
         SELECTED_SHIPMENT_TRACKING_PROVIDER_IS_CUSTOM,
         LOGIN_SITE_ADDRESS,
@@ -153,7 +154,6 @@ object AppPrefs {
         AI_PRODUCT_DESCRIPTION_CELEBRATION_SHOWN,
         AI_ASSISTANT_EARLY_ACCESS_NOTICE_DISMISSED,
         AUTO_TAX_RATE_ID,
-        HAS_SEEN_ANALYTICS_SCHEDULED_IMPORT_INFO,
     }
 
     /**
@@ -365,10 +365,10 @@ object AppPrefs {
 
     var hasSeenAnalyticsScheduledImportInfo: Boolean
         get() = getBoolean(
-            key = DeletableSitePrefKey.HAS_SEEN_ANALYTICS_SCHEDULED_IMPORT_INFO,
+            key = DeletablePrefKey.HAS_SEEN_ANALYTICS_SCHEDULED_IMPORT_INFO,
             default = false,
         )
-        set(value) = setBoolean(key = DeletableSitePrefKey.HAS_SEEN_ANALYTICS_SCHEDULED_IMPORT_INFO, value = value)
+        set(value) = setBoolean(key = DeletablePrefKey.HAS_SEEN_ANALYTICS_SCHEDULED_IMPORT_INFO, value = value)
 
     private const val FEATURE_FLAG_OVERRIDE_PREFIX = "feature_flag_override"
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -46,6 +46,8 @@ open class AppPrefsWrapper @Inject constructor() {
 
     var isAiAssistantEarlyAccessNoticeDismissed by AppPrefs::isAiAssistantEarlyAccessNoticeDismissed
 
+    var hasSeenAnalyticsScheduledImportInfo by AppPrefs::hasSeenAnalyticsScheduledImportInfo
+
     open var orderSummaryMigrated by AppPrefs::orderSummaryMigrated
     open var gatewayMigrated by AppPrefs::gatewayMigrated
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
@@ -36,6 +36,7 @@ import com.woocommerce.android.extensions.verticalOffsetChanges
 import com.woocommerce.android.support.help.HelpOrigin
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.base.TopLevelFragment
+import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.blaze.BlazeUrlsHelper.BlazeFlowSource
 import com.woocommerce.android.ui.blaze.creation.BlazeCampaignCreationDispatcher
 import com.woocommerce.android.ui.blaze.detail.BlazeCampaignDetailWebViewFragment
@@ -101,6 +102,9 @@ class DashboardFragment :
 
     @Inject
     lateinit var authenticatedWebViewLauncher: AuthenticatedWebViewLauncher
+
+    @Inject
+    lateinit var uiMessageResolver: UIMessageResolver
 
     private var _binding: FragmentDashboardBinding? = null
     private val binding get() = _binding!!
@@ -205,6 +209,13 @@ class DashboardFragment :
                         DashboardFragmentDirections.actionDashboardToScheduledImportInfoBottomSheet(event.isEnabled)
                     )
                 }
+
+                is DashboardViewModel.DashboardEvent.ShowScheduledImportNotice ->
+                    uiMessageResolver.showActionSnack(
+                        message = R.string.dashboard_stats_delayed_footer,
+                        actionText = R.string.learn_more,
+                        action = { dashboardViewModel.onDelayedStatsInfoClicked() }
+                    )
 
                 else -> event.isHandled = false
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
@@ -126,8 +126,6 @@ class DashboardViewModel @Inject constructor(
     private val _isScheduledImportEnabled = MutableStateFlow(false)
     val isScheduledImportEnabled: LiveData<Boolean> = _isScheduledImportEnabled.asLiveData()
 
-    private val _hasVisibleDelayedStatsCard = MutableStateFlow(false)
-
     private val refreshingOnBackground = MutableStateFlow(-1)
 
     fun displayRefreshingIndicator() {
@@ -174,13 +172,6 @@ class DashboardViewModel @Inject constructor(
         launch {
             analyticsScheduledImportRepository.refresh()
         }
-        launch {
-            dashboardRepository.widgets.collect { widgets ->
-                _hasVisibleDelayedStatsCard.value = widgets.any {
-                    it.type in DELAYED_STATS_CARD_TYPES && it.isVisible
-                }
-            }
-        }
     }
 
     fun onDelayedStatsInfoClicked() {
@@ -225,12 +216,17 @@ class DashboardViewModel @Inject constructor(
 
     private fun maybeShowScheduledImportNotice() {
         val shouldShow = _isScheduledImportEnabled.value &&
-            _hasVisibleDelayedStatsCard.value &&
+            hasVisibleDelayedStatsCard() &&
             !appPrefsWrapper.hasSeenAnalyticsScheduledImportInfo
         if (shouldShow) {
             triggerEvent(DashboardEvent.ShowScheduledImportNotice)
         }
     }
+
+    private fun hasVisibleDelayedStatsCard(): Boolean =
+        dashboardCardsState.value?.widgets
+            ?.filterIsInstance<DashboardWidgetUiModel.ConfigurableWidget>()
+            ?.any { it.widget.type in DELAYED_STATS_CARD_TYPES && it.isVisible } == true
 
     fun onResume() {
         _refreshTrigger.tryEmit(RefreshEvent())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
@@ -83,6 +83,12 @@ class DashboardViewModel @Inject constructor(
             SelectionType.YEAR_TO_DATE,
             SelectionType.CUSTOM
         )
+
+        // Cards backed by the /reports endpoints that render the delayed-stats footer.
+        private val DELAYED_STATS_CARD_TYPES = setOf(
+            DashboardWidget.Type.STATS,
+            DashboardWidget.Type.POPULAR_PRODUCTS
+        )
     }
 
     val performanceObserver: LifecycleObserver = dashboardTransactionLauncher
@@ -119,6 +125,8 @@ class DashboardViewModel @Inject constructor(
 
     private val _isScheduledImportEnabled = MutableStateFlow(false)
     val isScheduledImportEnabled: LiveData<Boolean> = _isScheduledImportEnabled.asLiveData()
+
+    private val _hasVisibleDelayedStatsCard = MutableStateFlow(false)
 
     private val refreshingOnBackground = MutableStateFlow(-1)
 
@@ -166,6 +174,13 @@ class DashboardViewModel @Inject constructor(
         launch {
             analyticsScheduledImportRepository.refresh()
         }
+        launch {
+            dashboardRepository.widgets.collect { widgets ->
+                _hasVisibleDelayedStatsCard.value = widgets.any {
+                    it.type in DELAYED_STATS_CARD_TYPES && it.isVisible
+                }
+            }
+        }
     }
 
     fun onDelayedStatsInfoClicked() {
@@ -209,7 +224,10 @@ class DashboardViewModel @Inject constructor(
     }
 
     private fun maybeShowScheduledImportNotice() {
-        if (_isScheduledImportEnabled.value && !appPrefsWrapper.hasSeenAnalyticsScheduledImportInfo) {
+        val shouldShow = _isScheduledImportEnabled.value &&
+            _hasVisibleDelayedStatsCard.value &&
+            !appPrefsWrapper.hasSeenAnalyticsScheduledImportInfo
+        if (shouldShow) {
             triggerEvent(DashboardEvent.ShowScheduledImportNotice)
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
@@ -169,6 +169,7 @@ class DashboardViewModel @Inject constructor(
     }
 
     fun onDelayedStatsInfoClicked() {
+        appPrefsWrapper.hasSeenAnalyticsScheduledImportInfo = true
         triggerEvent(DashboardEvent.OpenScheduledImportInfo(isEnabled = _isScheduledImportEnabled.value))
     }
 
@@ -204,6 +205,13 @@ class DashboardViewModel @Inject constructor(
         analyticsTrackerWrapper.track(AnalyticsEvent.DASHBOARD_PULLED_TO_REFRESH)
         _refreshTrigger.tryEmit(RefreshEvent(isForced = true))
         triggerEvent(RefreshJitm)
+        maybeShowScheduledImportNotice()
+    }
+
+    private fun maybeShowScheduledImportNotice() {
+        if (_isScheduledImportEnabled.value && !appPrefsWrapper.hasSeenAnalyticsScheduledImportInfo) {
+            triggerEvent(DashboardEvent.ShowScheduledImportNotice)
+        }
     }
 
     fun onResume() {
@@ -416,6 +424,8 @@ class DashboardViewModel @Inject constructor(
         data object OpenWooPushNotificationsIntroduction : DashboardEvent()
 
         data class OpenScheduledImportInfo(val isEnabled: Boolean) : DashboardEvent()
+
+        data object ShowScheduledImportNotice : DashboardEvent()
     }
 
     data class RefreshEvent(val isForced: Boolean = false)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/developer/DeveloperOptionsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/developer/DeveloperOptionsRepository.kt
@@ -87,6 +87,10 @@ class DeveloperOptionsRepository @Inject constructor(
         appPrefs.savedPrivacySettings = isChecked
     }
 
+    fun resetAnalyticsScheduledImportNoticeSeen() {
+        appPrefs.hasSeenAnalyticsScheduledImportInfo = false
+    }
+
     private fun reinitializeSimulatedReaderIfNeeded() {
         if (cardReaderManager.initialized) {
             cardReaderManager.reinitializeSimulatedTerminal(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/developer/DeveloperOptionsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/developer/DeveloperOptionsViewModel.kt
@@ -137,6 +137,16 @@ class DeveloperOptionsViewModel @Inject constructor(
         )
     )
 
+    private val resetScheduledImportNoticeFlow = flowOf(
+        NonToggleableListItem(
+            icon = R.drawable.ic_info_outline_20dp,
+            iconTint = R.color.color_primary,
+            label = UiString.UiStringText("Reset analytics scheduled import notice"),
+            isEnabled = true,
+            onClick = ::onResetScheduledImportNoticeClicked
+        )
+    )
+
     val viewState = combine(
         simulatedCardReaderFlow,
         readerUpdateFrequencyFlow,
@@ -146,7 +156,8 @@ class DeveloperOptionsViewModel @Inject constructor(
         apiFakerFlow,
         sendSentryReportFlow,
         featureFlagsFlow,
-        fetchTestAnnouncementFlow
+        fetchTestAnnouncementFlow,
+        resetScheduledImportNoticeFlow
     ) { items ->
         DeveloperOptionsViewState(
             rows = items.filterNotNull()
@@ -186,6 +197,13 @@ class DeveloperOptionsViewModel @Inject constructor(
         developerOptionsRepository.sendTestSentryReport()
         triggerEvent(
             DeveloperOptionsEvents.ShowToastText("Sentry report sent")
+        )
+    }
+
+    private fun onResetScheduledImportNoticeClicked() {
+        developerOptionsRepository.resetAnalyticsScheduledImportNoticeSeen()
+        triggerEvent(
+            DeveloperOptionsEvents.ShowToastText("Analytics scheduled import notice reset")
         )
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModelTest.kt
@@ -794,6 +794,8 @@ class DashboardViewModelTest : BaseUnitTest() {
                 whenever(analyticsScheduledImportRepository.observeIsEnabled()).thenReturn(flowOf(true))
                 whenever(appPrefsWrapper.hasSeenAnalyticsScheduledImportInfo).thenReturn(false)
             }
+            // Activate the cards state so a delayed-stats card (STATS) is visible
+            viewModel.dashboardCardsState.getOrAwaitValue()
 
             // WHEN
             val event = viewModel.event.runAndCaptureValues {
@@ -812,6 +814,8 @@ class DashboardViewModelTest : BaseUnitTest() {
                 whenever(analyticsScheduledImportRepository.observeIsEnabled()).thenReturn(flowOf(true))
                 whenever(appPrefsWrapper.hasSeenAnalyticsScheduledImportInfo).thenReturn(true)
             }
+            // Activate the cards state so a delayed-stats card is visible (isolates the seen-flag gate)
+            viewModel.dashboardCardsState.getOrAwaitValue()
 
             // WHEN
             val events = viewModel.event.runAndCaptureValues {
@@ -846,9 +850,17 @@ class DashboardViewModelTest : BaseUnitTest() {
             setup {
                 whenever(analyticsScheduledImportRepository.observeIsEnabled()).thenReturn(flowOf(true))
                 whenever(dashboardRepository.widgets).thenReturn(
-                    flowOf(listOf(dashboardWidget(DashboardWidget.Type.ORDERS)))
+                    flowOf(
+                        listOf(
+                            dashboardWidget(DashboardWidget.Type.STATS, isSelected = false),
+                            dashboardWidget(DashboardWidget.Type.POPULAR_PRODUCTS, isSelected = false),
+                            dashboardWidget(DashboardWidget.Type.ORDERS, isSelected = true)
+                        )
+                    )
                 )
             }
+            // Activate the cards state; the delayed-stats cards (STATS, POPULAR_PRODUCTS) are not visible
+            viewModel.dashboardCardsState.getOrAwaitValue()
 
             // WHEN
             val events = viewModel.event.runAndCaptureValues {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModelTest.kt
@@ -839,6 +839,26 @@ class DashboardViewModelTest : BaseUnitTest() {
             assertThat(events).doesNotContain(DashboardViewModel.DashboardEvent.ShowScheduledImportNotice)
         }
 
+    @Test
+    fun `given no delayed-stats card is visible, when pull to refresh, then scheduled import notice is not shown`() =
+        testBlocking {
+            // GIVEN
+            setup {
+                whenever(analyticsScheduledImportRepository.observeIsEnabled()).thenReturn(flowOf(true))
+                whenever(dashboardRepository.widgets).thenReturn(
+                    flowOf(listOf(dashboardWidget(DashboardWidget.Type.ORDERS)))
+                )
+            }
+
+            // WHEN
+            val events = viewModel.event.runAndCaptureValues {
+                viewModel.onPullToRefresh()
+            }
+
+            // THEN
+            assertThat(events).doesNotContain(DashboardViewModel.DashboardEvent.ShowScheduledImportNotice)
+        }
+
     private companion object {
         fun dashboardWidget(
             type: DashboardWidget.Type,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModelTest.kt
@@ -774,6 +774,71 @@ class DashboardViewModelTest : BaseUnitTest() {
                 .isEqualTo(DashboardViewModel.DashboardEvent.OpenScheduledImportInfo(isEnabled = true))
         }
 
+    @Test
+    fun `when delayed stats info is clicked, then the info sheet is marked as seen`() = testBlocking {
+        // GIVEN
+        setup {}
+
+        // WHEN
+        viewModel.onDelayedStatsInfoClicked()
+
+        // THEN
+        verify(appPrefsWrapper).hasSeenAnalyticsScheduledImportInfo = true
+    }
+
+    @Test
+    fun `given import enabled and info not seen, when pull to refresh, then scheduled import notice is shown`() =
+        testBlocking {
+            // GIVEN
+            setup {
+                whenever(analyticsScheduledImportRepository.observeIsEnabled()).thenReturn(flowOf(true))
+                whenever(appPrefsWrapper.hasSeenAnalyticsScheduledImportInfo).thenReturn(false)
+            }
+
+            // WHEN
+            val event = viewModel.event.runAndCaptureValues {
+                viewModel.onPullToRefresh()
+            }.last()
+
+            // THEN
+            assertThat(event).isEqualTo(DashboardViewModel.DashboardEvent.ShowScheduledImportNotice)
+        }
+
+    @Test
+    fun `given the info sheet has been seen, when pull to refresh, then scheduled import notice is not shown`() =
+        testBlocking {
+            // GIVEN
+            setup {
+                whenever(analyticsScheduledImportRepository.observeIsEnabled()).thenReturn(flowOf(true))
+                whenever(appPrefsWrapper.hasSeenAnalyticsScheduledImportInfo).thenReturn(true)
+            }
+
+            // WHEN
+            val events = viewModel.event.runAndCaptureValues {
+                viewModel.onPullToRefresh()
+            }
+
+            // THEN
+            assertThat(events).doesNotContain(DashboardViewModel.DashboardEvent.ShowScheduledImportNotice)
+        }
+
+    @Test
+    fun `given import disabled, when pull to refresh, then scheduled import notice is not shown`() =
+        testBlocking {
+            // GIVEN
+            setup {
+                whenever(analyticsScheduledImportRepository.observeIsEnabled()).thenReturn(flowOf(false))
+            }
+
+            // WHEN
+            val events = viewModel.event.runAndCaptureValues {
+                viewModel.onPullToRefresh()
+            }
+
+            // THEN
+            assertThat(events).doesNotContain(DashboardViewModel.DashboardEvent.ShowScheduledImportNotice)
+        }
+
     private companion object {
         fun dashboardWidget(
             type: DashboardWidget.Type,


### PR DESCRIPTION
### Description

Fixes WOOMOB-3161


Some stores enable a "scheduled import" setting that batches analytics updates roughly every 12 hours, so the dashboard stats can be stale. PR 2 added a delayed-stats footer on the cards plus an info bottom sheet that explains the delay and lets the merchant change the setting. This PR adds the proactive notice:

- When the merchant **pulls to refresh** the My Store dashboard, if scheduled import is enabled **and** they have never opened the info bottom sheet, we show an action snackbar — "Stats may be up to 12 hours delayed" with a **Learn more** action that opens the PR 2 info sheet.
- Opening the info sheet (from the card (i) icon **or** the snackbar action) sets an `AppPrefs` flag `hasSeenAnalyticsScheduledImportInfo` (a `DeletablePrefKey`, so it is cleared on logout), so the notice is only shown until the merchant has seen the explanation once.

To make testing easier, I've added a Developer Options entry ("Reset analytics scheduled import notice") that resets the seen flag so the notice can be re-triggered.

### Test Steps

Use a store with the analytics scheduled-import setting **enabled**.

1. In **Settings → Developer options**, tap **Reset analytics scheduled import notice** (this clears the "seen" flag).
2. Go to the My Store dashboard and **pull to refresh**.
3. Verify a snackbar appears: "Stats may be up to 12 hours delayed" with a **Learn more** action.
4. Tap **Learn more** → the scheduled-import info bottom sheet opens.
5. Dismiss the sheet and **pull to refresh** again → verify the snackbar no longer appears.
6. Reset the flag again (step 1), then open the sheet via a card's (i) icon instead, dismiss it, and pull to refresh → verify the snackbar does not appear (opening the sheet from either entry point marks it as seen).
7. On a store with scheduled import **disabled**, pull to refresh → verify no snackbar appears.

### Images/gif


https://github.com/user-attachments/assets/1ef8f2d5-79dc-47f5-99ba-434370a210ce

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.