### PR TITLE
[WOOMOB-3058] Improve login errors for TLS certificate issues

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 - [*] Added age-eligibility verification to comply with Google Play age requirements [https://github.com/woocommerce/woocommerce-android/pull/16048]
 - [**] Woo POS is now available in Canada, and the POS refund flow is improved [https://github.com/woocommerce/woocommerce-android/pull/15996]
 - [*] Fixed Tap to Pay being offered on devices that don't support it, and replaced the generic "No reader connected" error with a clear "Tap to Pay is not available" message linking to the requirements [https://github.com/woocommerce/woocommerce-android/pull/16044]
+- [*] Improved login error messages for site security certificate issues [https://github.com/woocommerce/woocommerce-android/pull/16042]
 
 24.9
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -20,12 +20,9 @@
 - [**] Contact support now includes troubleshooting and AI help [https://github.com/woocommerce/woocommerce-android/pull/15979]
 - [*] Fixed USPS shipping label customs handling for US territories and added a 30-character limit on customs item descriptions [https://github.com/woocommerce/woocommerce-android/pull/15999]
 - [Internal] Enabled local flag for self-driven push notifications [https://github.com/woocommerce/woocommerce-android/pull/15997]
-<<<<<<< merge/release-24.9-into-trunk
 - [*] Fixed Woo POS failing to load products on stores whose web server blocks access to the catalog file [https://github.com/woocommerce/woocommerce-android/pull/16059]
-=======
 - [*] Fixed Woo Shipping label "Shipment details" title not expanding the bottom sheet on tap [https://github.com/woocommerce/woocommerce-android/pull/16020]
 - [*] Fixed Shipping Labels Verify button being briefly tappable when the address form input is invalid [https://github.com/woocommerce/woocommerce-android/pull/16021]
->>>>>>> trunk
 
 24.8
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,12 +2,15 @@
 *** Use [*****] to indicate smoke tests of all critical flows should be run on the final APK before release (e.g. major library or targetSdk updates).
 *** For entries which are touching the Android Wear app's, start entry with `[WEAR]` too.
 
+25.1
+-----
+- [*] Improved login error messages for site security certificate issues [https://github.com/woocommerce/woocommerce-android/pull/16042]
+
 25.0
 -----
 - [*] Added age-eligibility verification to comply with Google Play age requirements [https://github.com/woocommerce/woocommerce-android/pull/16048]
 - [**] Woo POS is now available in Canada, and the POS refund flow is improved [https://github.com/woocommerce/woocommerce-android/pull/15996]
 - [*] Fixed Tap to Pay being offered on devices that don't support it, and replaced the generic "No reader connected" error with a clear "Tap to Pay is not available" message linking to the requirements [https://github.com/woocommerce/woocommerce-android/pull/16044]
-- [*] Improved login error messages for site security certificate issues [https://github.com/woocommerce/woocommerce-android/pull/16042]
 
 24.9
 -----

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -58,6 +58,12 @@ import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
 
+private val TLS_CERTIFICATE_VALIDITY_ERROR_TYPES = setOf(
+    GenericErrorType.INVALID_SSL_CERTIFICATE,
+    GenericErrorType.NO_CONNECTION,
+    GenericErrorType.NETWORK_ERROR
+)
+
 @Suppress("LargeClass", "TooManyFunctions", "LongParameterList")
 @Singleton
 class SiteRestClient @Inject constructor(
@@ -412,7 +418,7 @@ class SiteRestClient @Inject constructor(
     }
 
     private fun isTlsCertificateValidityIssue(error: WPComGsonNetworkError): Boolean {
-        if (error.type != GenericErrorType.INVALID_SSL_CERTIFICATE) {
+        if (error.type !in TLS_CERTIFICATE_VALIDITY_ERROR_TYPES) {
             return false
         }
 
@@ -432,9 +438,22 @@ class SiteRestClient @Inject constructor(
                 return true
             }
 
+            if (throwable.isAndroidCertificateValidityException()) {
+                return true
+            }
+
             throwable = throwable.cause
         }
         return false
+    }
+
+    private fun Throwable.isAndroidCertificateValidityException(): Boolean {
+        return this is java.security.cert.CertificateException &&
+            message?.contains("unacceptable certificate", ignoreCase = true) == true &&
+            stackTrace.any { stackTraceElement ->
+                stackTraceElement.className == "com.android.org.conscrypt.OpenSSLX509Certificate" &&
+                    stackTraceElement.methodName == "checkValidity"
+            }
     }
 
     private fun String?.isCertificateValidityMessage(): Boolean {
@@ -443,6 +462,7 @@ class SiteRestClient @Inject constructor(
             message.contains("certificate expired") ||
             message.contains("certificate is not yet valid") ||
             message.contains("certificate not yet valid") ||
+            message.contains("timestamp check failed") ||
             message.contains("notafter") ||
             message.contains("notbefore")
     }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -433,26 +433,13 @@ class SiteRestClient @Inject constructor(
             error.getCombinedErrorMessage().contains("curl error 60", ignoreCase = true)
     }
 
-    private fun Throwable?.hasCertificateValidityIssue(): Boolean {
-        var throwable = this
-        while (throwable != null) {
-            when (throwable) {
-                is CertificateExpiredException,
-                is CertificateNotYetValidException -> return true
-            }
-
-            if (throwable.message.isCertificateValidityMessage()) {
-                return true
-            }
-
-            if (throwable.isAndroidCertificateValidityException()) {
-                return true
-            }
-
-            throwable = throwable.cause
+    private fun Throwable?.hasCertificateValidityIssue(): Boolean =
+        generateSequence(this) { it.cause }.any { throwable ->
+            throwable is CertificateExpiredException ||
+                throwable is CertificateNotYetValidException ||
+                throwable.message.isCertificateValidityMessage() ||
+                throwable.isAndroidCertificateValidityException()
         }
-        return false
-    }
 
     private fun Throwable.isAndroidCertificateValidityException(): Boolean {
         return this is java.security.cert.CertificateException &&

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -41,6 +41,7 @@ import org.wordpress.android.fluxc.store.SiteStore.DomainSupportedStatesResponse
 import org.wordpress.android.fluxc.store.SiteStore.SiteError
 import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType
 import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType.INVALID_SITE
+import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType.REMOTE_SITE_CERTIFICATE_ERROR
 import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType.TLS_CERTIFICATE_VALIDITY_ERROR
 import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType.WORDPRESS_COM_CONNECTIVITY_ERROR
 import org.wordpress.android.fluxc.store.SiteStore.SiteFilter
@@ -63,6 +64,9 @@ private val TLS_CERTIFICATE_VALIDITY_ERROR_TYPES = setOf(
     GenericErrorType.NO_CONNECTION,
     GenericErrorType.NETWORK_ERROR
 )
+
+private val NOT_AFTER_PATTERN = Regex("\\bnot\\s*-?\\s*after\\b")
+private val NOT_BEFORE_PATTERN = Regex("\\bnot\\s*-?\\s*before\\b")
 
 @Suppress("LargeClass", "TooManyFunctions", "LongParameterList")
 @Singleton
@@ -403,6 +407,7 @@ class SiteRestClient @Inject constructor(
                     else -> {
                         when {
                             isTlsCertificateValidityIssue(response.error) -> TLS_CERTIFICATE_VALIDITY_ERROR
+                            isRemoteSiteCertificateIssue(response.error) -> REMOTE_SITE_CERTIFICATE_ERROR
                             isWordPressComConnectivityIssue(response.error) -> WORDPRESS_COM_CONNECTIVITY_ERROR
                             else -> INVALID_SITE
                         }
@@ -424,6 +429,11 @@ class SiteRestClient @Inject constructor(
 
         return error.volleyError.hasCertificateValidityIssue() ||
             error.getCombinedErrorMessage().isCertificateValidityMessage()
+    }
+
+    private fun isRemoteSiteCertificateIssue(error: WPComGsonNetworkError): Boolean {
+        return error.apiError == "follow_redirects_failed" &&
+            error.getCombinedErrorMessage().isRemoteSiteCertificateMessage()
     }
 
     private fun Throwable?.hasCertificateValidityIssue(): Boolean {
@@ -450,6 +460,8 @@ class SiteRestClient @Inject constructor(
     private fun Throwable.isAndroidCertificateValidityException(): Boolean {
         return this is java.security.cert.CertificateException &&
             message?.contains("unacceptable certificate", ignoreCase = true) == true &&
+            // Android Conscrypt can wrap date validity failures as a generic platform CertificateException.
+            // Cause/message matching above remains the portable fallback for other TLS providers.
             stackTrace.any { stackTraceElement ->
                 stackTraceElement.className == "com.android.org.conscrypt.OpenSSLX509Certificate" &&
                     stackTraceElement.methodName == "checkValidity"
@@ -463,8 +475,15 @@ class SiteRestClient @Inject constructor(
             message.contains("certificate is not yet valid") ||
             message.contains("certificate not yet valid") ||
             message.contains("timestamp check failed") ||
-            message.contains("notafter") ||
-            message.contains("notbefore")
+            NOT_AFTER_PATTERN.containsMatchIn(message) ||
+            NOT_BEFORE_PATTERN.containsMatchIn(message)
+    }
+
+    private fun String?.isRemoteSiteCertificateMessage(): Boolean {
+        val message = this?.lowercase() ?: return false
+        return message.contains("curl error 60") ||
+            message.contains("ssl certificate") ||
+            message.isCertificateValidityMessage()
     }
 
     /**

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -466,10 +466,9 @@ class SiteRestClient @Inject constructor(
     }
 
     private fun String?.isCertificateValidityMessage(): Boolean {
-        val message = this?.lowercase() ?: return false
-        return message.contains("certificate has expired") ||
-            message.contains("certificate expired") ||
-            message.contains("not yet valid")
+        return this?.contains("certificate has expired", ignoreCase = true) == true ||
+            this?.contains("certificate expired", ignoreCase = true) == true ||
+            this?.contains("not yet valid", ignoreCase = true) == true
     }
 
     /**

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -53,6 +53,7 @@ import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.UrlUtils
 import java.net.URI
 import java.net.UnknownHostException
+import java.security.cert.CertificateException
 import java.security.cert.CertificateExpiredException
 import java.security.cert.CertificateNotYetValidException
 import javax.inject.Inject
@@ -442,7 +443,7 @@ class SiteRestClient @Inject constructor(
         }
 
     private fun Throwable.isAndroidCertificateValidityException(): Boolean {
-        return this is java.security.cert.CertificateException &&
+        return this is CertificateException &&
             message?.contains("unacceptable certificate", ignoreCase = true) == true &&
             // Android Conscrypt can wrap date validity failures as a generic platform CertificateException.
             // Cause/message matching above remains the portable fallback for other TLS providers.

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -41,6 +41,7 @@ import org.wordpress.android.fluxc.store.SiteStore.DomainSupportedStatesResponse
 import org.wordpress.android.fluxc.store.SiteStore.SiteError
 import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType
 import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType.INVALID_SITE
+import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType.TLS_CERTIFICATE_VALIDITY_ERROR
 import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType.WORDPRESS_COM_CONNECTIVITY_ERROR
 import org.wordpress.android.fluxc.store.SiteStore.SiteFilter
 import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainError
@@ -51,6 +52,8 @@ import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.UrlUtils
 import java.net.URI
 import java.net.UnknownHostException
+import java.security.cert.CertificateExpiredException
+import java.security.cert.CertificateNotYetValidException
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -392,10 +395,10 @@ class SiteRestClient @Inject constructor(
                 val siteErrorType = when (response.error.apiError) {
                     "connection_disabled" -> SiteErrorType.WPCOM_SITE_SUSPENDED
                     else -> {
-                        if (isWordPressComConnectivityIssue(response.error)) {
-                            WORDPRESS_COM_CONNECTIVITY_ERROR
-                        } else {
-                            INVALID_SITE
+                        when {
+                            isTlsCertificateValidityIssue(response.error) -> TLS_CERTIFICATE_VALIDITY_ERROR
+                            isWordPressComConnectivityIssue(response.error) -> WORDPRESS_COM_CONNECTIVITY_ERROR
+                            else -> INVALID_SITE
                         }
                     }
                 }
@@ -406,6 +409,42 @@ class SiteRestClient @Inject constructor(
                 response.data.toConnectSiteInfoPayload(siteUrl)
             }
         }
+    }
+
+    private fun isTlsCertificateValidityIssue(error: WPComGsonNetworkError): Boolean {
+        if (error.type != GenericErrorType.INVALID_SSL_CERTIFICATE) {
+            return false
+        }
+
+        return error.volleyError.hasCertificateValidityIssue() ||
+            error.getCombinedErrorMessage().isCertificateValidityMessage()
+    }
+
+    private fun Throwable?.hasCertificateValidityIssue(): Boolean {
+        var throwable = this
+        while (throwable != null) {
+            when (throwable) {
+                is CertificateExpiredException,
+                is CertificateNotYetValidException -> return true
+            }
+
+            if (throwable.message.isCertificateValidityMessage()) {
+                return true
+            }
+
+            throwable = throwable.cause
+        }
+        return false
+    }
+
+    private fun String?.isCertificateValidityMessage(): Boolean {
+        val message = this?.lowercase() ?: return false
+        return message.contains("certificate has expired") ||
+            message.contains("certificate expired") ||
+            message.contains("certificate is not yet valid") ||
+            message.contains("certificate not yet valid") ||
+            message.contains("notafter") ||
+            message.contains("notbefore")
     }
 
     /**

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -481,9 +481,7 @@ class SiteRestClient @Inject constructor(
 
     private fun String?.isRemoteSiteCertificateMessage(): Boolean {
         val message = this?.lowercase() ?: return false
-        return message.contains("curl error 60") ||
-            message.contains("ssl certificate") ||
-            message.isCertificateValidityMessage()
+        return message.contains("curl error 60")
     }
 
     /**

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -65,9 +65,6 @@ private val TLS_CERTIFICATE_VALIDITY_ERROR_TYPES = setOf(
     GenericErrorType.NETWORK_ERROR
 )
 
-private val NOT_AFTER_PATTERN = Regex("\\bnot\\s*-?\\s*after\\b")
-private val NOT_BEFORE_PATTERN = Regex("\\bnot\\s*-?\\s*before\\b")
-
 @Suppress("LargeClass", "TooManyFunctions", "LongParameterList")
 @Singleton
 class SiteRestClient @Inject constructor(
@@ -433,7 +430,7 @@ class SiteRestClient @Inject constructor(
 
     private fun isRemoteSiteCertificateIssue(error: WPComGsonNetworkError): Boolean {
         return error.apiError == "follow_redirects_failed" &&
-            error.getCombinedErrorMessage().isRemoteSiteCertificateMessage()
+            error.getCombinedErrorMessage().contains("curl error 60", ignoreCase = true)
     }
 
     private fun Throwable?.hasCertificateValidityIssue(): Boolean {
@@ -472,16 +469,7 @@ class SiteRestClient @Inject constructor(
         val message = this?.lowercase() ?: return false
         return message.contains("certificate has expired") ||
             message.contains("certificate expired") ||
-            message.contains("certificate is not yet valid") ||
-            message.contains("certificate not yet valid") ||
-            message.contains("timestamp check failed") ||
-            NOT_AFTER_PATTERN.containsMatchIn(message) ||
-            NOT_BEFORE_PATTERN.containsMatchIn(message)
-    }
-
-    private fun String?.isRemoteSiteCertificateMessage(): Boolean {
-        val message = this?.lowercase() ?: return false
-        return message.contains("curl error 60")
+            message.contains("not yet valid")
     }
 
     /**

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -304,6 +304,7 @@ open class SiteStore @Inject constructor(
         GENERIC_ERROR,
         WPCOM_SITE_SUSPENDED,
         TLS_CERTIFICATE_VALIDITY_ERROR,
+        REMOTE_SITE_CERTIFICATE_ERROR,
         WORDPRESS_COM_CONNECTIVITY_ERROR
     }
 

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -303,6 +303,7 @@ open class SiteStore @Inject constructor(
         NOT_AUTHENTICATED,
         GENERIC_ERROR,
         WPCOM_SITE_SUSPENDED,
+        TLS_CERTIFICATE_VALIDITY_ERROR,
         WORDPRESS_COM_CONNECTIVITY_ERROR
     }
 

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
@@ -274,6 +274,24 @@ class SiteRestClientTest {
         }
 
     @Test
+    fun `given follow redirects failed wrong-host certificate error, when fetching site info, then return remote certificate error`() =
+        test {
+            val error = WPComGsonNetworkError(
+                BaseNetworkError(
+                    GenericErrorType.INVALID_RESPONSE,
+                    "cURL error 60: SSL: no alternative certificate subject name matches target host name"
+                )
+            ).apply {
+                apiError = "follow_redirects_failed"
+            }
+
+            val result = fetchConnectSiteInfoWithError(error)
+
+            assertThat(result.error).isNotNull
+            assertThat(result.error!!.type).isEqualTo(SiteErrorType.REMOTE_SITE_CERTIFICATE_ERROR)
+        }
+
+    @Test
     fun `given follow redirects failed non-certificate error, when fetching site info, then return invalid site error`() =
         test {
             val error = WPComGsonNetworkError(

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
@@ -216,43 +216,52 @@ class SiteRestClientTest {
     @Test
     fun `given a suspended WPCom website, when fetching site info, then return correct error`() = test {
         val urlUtilsMock = mockStatic(UrlUtils::class.java)
-        whenever(UrlUtils.addUrlSchemeIfNeeded(any(), any())).thenAnswer { it.arguments[0] as String }
-        val error = WPComGsonNetworkError(BaseNetworkError(GenericErrorType.INVALID_RESPONSE, "")).apply {
-            apiError = "connection_disabled"
+        try {
+            whenever(UrlUtils.addUrlSchemeIfNeeded(any(), any())).thenAnswer { it.arguments[0] as String }
+            val error = WPComGsonNetworkError(BaseNetworkError(GenericErrorType.INVALID_RESPONSE, "")).apply {
+                apiError = "connection_disabled"
+            }
+            initGetResponse(ConnectSiteInfoResponse::class.java, null, error)
+
+            val result = restClient.fetchConnectSiteInfoSync("test.com")
+
+            assertThat(result.error).isNotNull
+            assertThat(result.error!!.type).isEqualTo(SiteErrorType.WPCOM_SITE_SUSPENDED)
+        } finally {
+            urlUtilsMock.close()
         }
-        initGetResponse(ConnectSiteInfoResponse::class.java, null, error)
-
-        val result = restClient.fetchConnectSiteInfoSync("test.com")
-
-        assertThat(result.error).isNotNull
-        assertThat(result.error!!.type).isEqualTo(SiteErrorType.WPCOM_SITE_SUSPENDED)
-        urlUtilsMock.close()
     }
 
     @Test
     fun `given malformed URL, when fetching site info, then return invalid site error`() = test {
         val urlUtilsMock = mockStatic(UrlUtils::class.java)
-        whenever(UrlUtils.addUrlSchemeIfNeeded(any(), any())).thenReturn("https://[")
+        try {
+            whenever(UrlUtils.addUrlSchemeIfNeeded(any(), any())).thenReturn("https://[")
 
-        val result = restClient.fetchConnectSiteInfoSync("https://[")
+            val result = restClient.fetchConnectSiteInfoSync("https://[")
 
-        assertThat(result.error).isNotNull
-        assertThat(result.error!!.type).isEqualTo(SiteErrorType.INVALID_SITE)
-        urlUtilsMock.close()
+            assertThat(result.error).isNotNull
+            assertThat(result.error!!.type).isEqualTo(SiteErrorType.INVALID_SITE)
+        } finally {
+            urlUtilsMock.close()
+        }
     }
 
     @Test
     fun `given ordinary site info error, when fetching site info, then return invalid site error`() = test {
         val urlUtilsMock = mockStatic(UrlUtils::class.java)
-        whenever(UrlUtils.addUrlSchemeIfNeeded(any(), any())).thenAnswer { it.arguments[0] as String }
-        val error = WPComGsonNetworkError(BaseNetworkError(GenericErrorType.INVALID_RESPONSE, ""))
-        initGetResponse(ConnectSiteInfoResponse::class.java, null, error)
+        try {
+            whenever(UrlUtils.addUrlSchemeIfNeeded(any(), any())).thenAnswer { it.arguments[0] as String }
+            val error = WPComGsonNetworkError(BaseNetworkError(GenericErrorType.INVALID_RESPONSE, ""))
+            initGetResponse(ConnectSiteInfoResponse::class.java, null, error)
 
-        val result = restClient.fetchConnectSiteInfoSync("test.com")
+            val result = restClient.fetchConnectSiteInfoSync("test.com")
 
-        assertThat(result.error).isNotNull
-        assertThat(result.error!!.type).isEqualTo(SiteErrorType.INVALID_SITE)
-        urlUtilsMock.close()
+            assertThat(result.error).isNotNull
+            assertThat(result.error!!.type).isEqualTo(SiteErrorType.INVALID_SITE)
+        } finally {
+            urlUtilsMock.close()
+        }
     }
 
     @Test
@@ -294,23 +303,26 @@ class SiteRestClientTest {
     @Test
     fun `given non-date SSL site info error, when fetching site info, then return invalid site error`() = test {
         val urlUtilsMock = mockStatic(UrlUtils::class.java)
-        whenever(UrlUtils.addUrlSchemeIfNeeded(any(), any())).thenAnswer { it.arguments[0] as String }
-        val sslException = SSLHandshakeException("self signed certificate").apply {
-            initCause(CertificateException("self signed"))
-        }
-        val error = WPComGsonNetworkError(
-            BaseNetworkError(
-                GenericErrorType.INVALID_SSL_CERTIFICATE,
-                VolleyError(sslException)
+        try {
+            whenever(UrlUtils.addUrlSchemeIfNeeded(any(), any())).thenAnswer { it.arguments[0] as String }
+            val sslException = SSLHandshakeException("self signed certificate").apply {
+                initCause(CertificateException("self signed"))
+            }
+            val error = WPComGsonNetworkError(
+                BaseNetworkError(
+                    GenericErrorType.INVALID_SSL_CERTIFICATE,
+                    VolleyError(sslException)
+                )
             )
-        )
-        initGetResponse(ConnectSiteInfoResponse::class.java, null, error)
+            initGetResponse(ConnectSiteInfoResponse::class.java, null, error)
 
-        val result = restClient.fetchConnectSiteInfoSync("test.com")
+            val result = restClient.fetchConnectSiteInfoSync("test.com")
 
-        assertThat(result.error).isNotNull
-        assertThat(result.error!!.type).isEqualTo(SiteErrorType.INVALID_SITE)
-        urlUtilsMock.close()
+            assertThat(result.error).isNotNull
+            assertThat(result.error!!.type).isEqualTo(SiteErrorType.INVALID_SITE)
+        } finally {
+            urlUtilsMock.close()
+        }
     }
 
     @Test
@@ -623,11 +635,13 @@ class SiteRestClientTest {
         error: WPComGsonNetworkError
     ): org.wordpress.android.fluxc.store.SiteStore.ConnectSiteInfoPayload {
         val urlUtilsMock = mockStatic(UrlUtils::class.java)
-        whenever(UrlUtils.addUrlSchemeIfNeeded(any(), any())).thenAnswer { it.arguments[0] as String }
-        initGetResponse(ConnectSiteInfoResponse::class.java, null, error)
+        try {
+            whenever(UrlUtils.addUrlSchemeIfNeeded(any(), any())).thenAnswer { it.arguments[0] as String }
+            initGetResponse(ConnectSiteInfoResponse::class.java, null, error)
 
-        val result = restClient.fetchConnectSiteInfoSync("test.com")
-        urlUtilsMock.close()
-        return result
+            return restClient.fetchConnectSiteInfoSync("test.com")
+        } finally {
+            urlUtilsMock.close()
+        }
     }
 }

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
@@ -315,6 +315,36 @@ class SiteRestClientTest {
         }
 
     @Test
+    fun `given Android no connection certificate validity error, when fetching site info, then return certificate validity error`() =
+        test {
+            val certificateException = CertificateException("Unacceptable certificate: CN=E8").apply {
+                stackTrace = arrayOf(
+                    StackTraceElement(
+                        "com.android.org.conscrypt.OpenSSLX509Certificate",
+                        "checkValidity",
+                        "OpenSSLX509Certificate.java",
+                        266
+                    )
+                )
+            }
+            val sslException = SSLHandshakeException("Unacceptable certificate").apply {
+                initCause(certificateException)
+            }
+            val volleyError = com.android.volley.NoConnectionError(sslException)
+            val error = WPComGsonNetworkError(
+                BaseNetworkError(
+                    GenericErrorType.NO_CONNECTION,
+                    volleyError
+                )
+            )
+
+            val result = fetchConnectSiteInfoWithError(error)
+
+            assertThat(result.error).isNotNull
+            assertThat(result.error!!.type).isEqualTo(SiteErrorType.TLS_CERTIFICATE_VALIDITY_ERROR)
+        }
+
+    @Test
     fun `given a Jetpack site, when fetching site info, then fetch app passwords url from root endpoint`() = test {
         initSiteResponse(
             SiteWPComRestResponse().apply {
@@ -525,14 +555,20 @@ class SiteRestClientTest {
     private suspend fun fetchConnectSiteInfoWithInvalidSslError(
         sslException: SSLHandshakeException
     ): org.wordpress.android.fluxc.store.SiteStore.ConnectSiteInfoPayload {
-        val urlUtilsMock = mockStatic(UrlUtils::class.java)
-        whenever(UrlUtils.addUrlSchemeIfNeeded(any(), any())).thenAnswer { it.arguments[0] as String }
         val error = WPComGsonNetworkError(
             BaseNetworkError(
                 GenericErrorType.INVALID_SSL_CERTIFICATE,
                 VolleyError(sslException)
             )
         )
+        return fetchConnectSiteInfoWithError(error)
+    }
+
+    private suspend fun fetchConnectSiteInfoWithError(
+        error: WPComGsonNetworkError
+    ): org.wordpress.android.fluxc.store.SiteStore.ConnectSiteInfoPayload {
+        val urlUtilsMock = mockStatic(UrlUtils::class.java)
+        whenever(UrlUtils.addUrlSchemeIfNeeded(any(), any())).thenAnswer { it.arguments[0] as String }
         initGetResponse(ConnectSiteInfoResponse::class.java, null, error)
 
         val result = restClient.fetchConnectSiteInfoSync("test.com")

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
@@ -256,6 +256,42 @@ class SiteRestClientTest {
     }
 
     @Test
+    fun `given follow redirects failed certificate error, when fetching site info, then return remote certificate error`() =
+        test {
+            val error = WPComGsonNetworkError(
+                BaseNetworkError(
+                    GenericErrorType.INVALID_RESPONSE,
+                    "cURL error 60: SSL certificate problem: certificate has expired"
+                )
+            ).apply {
+                apiError = "follow_redirects_failed"
+            }
+
+            val result = fetchConnectSiteInfoWithError(error)
+
+            assertThat(result.error).isNotNull
+            assertThat(result.error!!.type).isEqualTo(SiteErrorType.REMOTE_SITE_CERTIFICATE_ERROR)
+        }
+
+    @Test
+    fun `given follow redirects failed non-certificate error, when fetching site info, then return invalid site error`() =
+        test {
+            val error = WPComGsonNetworkError(
+                BaseNetworkError(
+                    GenericErrorType.INVALID_RESPONSE,
+                    "follow_redirects_failed: exceeded maximum number of redirects"
+                )
+            ).apply {
+                apiError = "follow_redirects_failed"
+            }
+
+            val result = fetchConnectSiteInfoWithError(error)
+
+            assertThat(result.error).isNotNull
+            assertThat(result.error!!.type).isEqualTo(SiteErrorType.INVALID_SITE)
+        }
+
+    @Test
     fun `given non-date SSL site info error, when fetching site info, then return invalid site error`() = test {
         val urlUtilsMock = mockStatic(UrlUtils::class.java)
         whenever(UrlUtils.addUrlSchemeIfNeeded(any(), any())).thenAnswer { it.arguments[0] as String }
@@ -309,6 +345,25 @@ class SiteRestClientTest {
             val result = fetchConnectSiteInfoWithInvalidSslError(
                 SSLHandshakeException("certificate has expired")
             )
+
+            assertThat(result.error).isNotNull
+            assertThat(result.error!!.type).isEqualTo(SiteErrorType.TLS_CERTIFICATE_VALIDITY_ERROR)
+        }
+
+    @Test
+    fun `given network error with SSL certificate validity cause, when fetching site info, then return certificate validity error`() =
+        test {
+            val sslException = SSLHandshakeException("certificate expired").apply {
+                initCause(CertificateExpiredException("expired"))
+            }
+            val error = WPComGsonNetworkError(
+                BaseNetworkError(
+                    GenericErrorType.NETWORK_ERROR,
+                    VolleyError(sslException)
+                )
+            )
+
+            val result = fetchConnectSiteInfoWithError(error)
 
             assertThat(result.error).isNotNull
             assertThat(result.error!!.type).isEqualTo(SiteErrorType.TLS_CERTIFICATE_VALIDITY_ERROR)

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.site
 
+import com.android.volley.NoConnectionError
 import com.android.volley.RequestQueue
 import com.android.volley.VolleyError
 import org.assertj.core.api.Assertions.assertThat
@@ -29,6 +30,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteWPComRestResponse.SitesResponse
+import org.wordpress.android.fluxc.store.SiteStore.ConnectSiteInfoPayload
 import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType
 import org.wordpress.android.fluxc.store.SiteStore.SiteFilter.WPCOM
 import org.wordpress.android.fluxc.test
@@ -397,7 +399,7 @@ class SiteRestClientTest {
             val sslException = SSLHandshakeException("Unacceptable certificate").apply {
                 initCause(certificateException)
             }
-            val volleyError = com.android.volley.NoConnectionError(sslException)
+            val volleyError = NoConnectionError(sslException)
             val error = WPComGsonNetworkError(
                 BaseNetworkError(
                     GenericErrorType.NO_CONNECTION,
@@ -621,7 +623,7 @@ class SiteRestClientTest {
 
     private suspend fun fetchConnectSiteInfoWithInvalidSslError(
         sslException: SSLHandshakeException
-    ): org.wordpress.android.fluxc.store.SiteStore.ConnectSiteInfoPayload {
+    ): ConnectSiteInfoPayload {
         val error = WPComGsonNetworkError(
             BaseNetworkError(
                 GenericErrorType.INVALID_SSL_CERTIFICATE,
@@ -633,7 +635,7 @@ class SiteRestClientTest {
 
     private suspend fun fetchConnectSiteInfoWithError(
         error: WPComGsonNetworkError
-    ): org.wordpress.android.fluxc.store.SiteStore.ConnectSiteInfoPayload {
+    ): ConnectSiteInfoPayload {
         val urlUtilsMock = mockStatic(UrlUtils::class.java)
         try {
             whenever(UrlUtils.addUrlSchemeIfNeeded(any(), any())).thenAnswer { it.arguments[0] as String }

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
@@ -34,6 +34,8 @@ import org.wordpress.android.fluxc.store.SiteStore.SiteFilter.WPCOM
 import org.wordpress.android.fluxc.test
 import org.wordpress.android.fluxc.tools.initCoroutineEngine
 import org.wordpress.android.util.UrlUtils
+import java.security.cert.CertificateException
+import javax.net.ssl.SSLHandshakeException
 import kotlin.test.assertNotNull
 
 @Suppress("UnitTestNamingRule")
@@ -222,6 +224,54 @@ class SiteRestClientTest {
 
         assertThat(result.error).isNotNull
         assertThat(result.error!!.type).isEqualTo(SiteErrorType.WPCOM_SITE_SUSPENDED)
+        urlUtilsMock.close()
+    }
+
+    @Test
+    fun `given malformed URL, when fetching site info, then return invalid site error`() = test {
+        val urlUtilsMock = mockStatic(UrlUtils::class.java)
+        whenever(UrlUtils.addUrlSchemeIfNeeded(any(), any())).thenReturn("https://[")
+
+        val result = restClient.fetchConnectSiteInfoSync("https://[")
+
+        assertThat(result.error).isNotNull
+        assertThat(result.error!!.type).isEqualTo(SiteErrorType.INVALID_SITE)
+        urlUtilsMock.close()
+    }
+
+    @Test
+    fun `given ordinary site info error, when fetching site info, then return invalid site error`() = test {
+        val urlUtilsMock = mockStatic(UrlUtils::class.java)
+        whenever(UrlUtils.addUrlSchemeIfNeeded(any(), any())).thenAnswer { it.arguments[0] as String }
+        val error = WPComGsonNetworkError(BaseNetworkError(GenericErrorType.INVALID_RESPONSE, ""))
+        initGetResponse(ConnectSiteInfoResponse::class.java, null, error)
+
+        val result = restClient.fetchConnectSiteInfoSync("test.com")
+
+        assertThat(result.error).isNotNull
+        assertThat(result.error!!.type).isEqualTo(SiteErrorType.INVALID_SITE)
+        urlUtilsMock.close()
+    }
+
+    @Test
+    fun `given non-date SSL site info error, when fetching site info, then return invalid site error`() = test {
+        val urlUtilsMock = mockStatic(UrlUtils::class.java)
+        whenever(UrlUtils.addUrlSchemeIfNeeded(any(), any())).thenAnswer { it.arguments[0] as String }
+        val sslException = SSLHandshakeException("self signed certificate").apply {
+            initCause(CertificateException("self signed"))
+        }
+        val error = WPComGsonNetworkError(
+            BaseNetworkError(
+                GenericErrorType.INVALID_SSL_CERTIFICATE,
+                VolleyError(sslException)
+            )
+        )
+        initGetResponse(ConnectSiteInfoResponse::class.java, null, error)
+
+        val result = restClient.fetchConnectSiteInfoSync("test.com")
+
+        assertThat(result.error).isNotNull
+        assertThat(result.error!!.type).isEqualTo(SiteErrorType.INVALID_SITE)
         urlUtilsMock.close()
     }
 

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
@@ -35,6 +35,8 @@ import org.wordpress.android.fluxc.test
 import org.wordpress.android.fluxc.tools.initCoroutineEngine
 import org.wordpress.android.util.UrlUtils
 import java.security.cert.CertificateException
+import java.security.cert.CertificateExpiredException
+import java.security.cert.CertificateNotYetValidException
 import javax.net.ssl.SSLHandshakeException
 import kotlin.test.assertNotNull
 
@@ -276,6 +278,43 @@ class SiteRestClientTest {
     }
 
     @Test
+    fun `given expired SSL certificate site info error, when fetching site info, then return certificate validity error`() =
+        test {
+            val sslException = SSLHandshakeException("certificate expired").apply {
+                initCause(CertificateExpiredException("expired"))
+            }
+
+            val result = fetchConnectSiteInfoWithInvalidSslError(sslException)
+
+            assertThat(result.error).isNotNull
+            assertThat(result.error!!.type).isEqualTo(SiteErrorType.TLS_CERTIFICATE_VALIDITY_ERROR)
+        }
+
+    @Test
+    fun `given not yet valid SSL certificate site info error, when fetching site info, then return certificate validity error`() =
+        test {
+            val sslException = SSLHandshakeException("certificate not yet valid").apply {
+                initCause(CertificateNotYetValidException("not yet valid"))
+            }
+
+            val result = fetchConnectSiteInfoWithInvalidSslError(sslException)
+
+            assertThat(result.error).isNotNull
+            assertThat(result.error!!.type).isEqualTo(SiteErrorType.TLS_CERTIFICATE_VALIDITY_ERROR)
+        }
+
+    @Test
+    fun `given message-only SSL certificate validity site info error, when fetching site info, then return certificate validity error`() =
+        test {
+            val result = fetchConnectSiteInfoWithInvalidSslError(
+                SSLHandshakeException("certificate has expired")
+            )
+
+            assertThat(result.error).isNotNull
+            assertThat(result.error!!.type).isEqualTo(SiteErrorType.TLS_CERTIFICATE_VALIDITY_ERROR)
+        }
+
+    @Test
     fun `given a Jetpack site, when fetching site info, then fetch app passwords url from root endpoint`() = test {
         initSiteResponse(
             SiteWPComRestResponse().apply {
@@ -481,5 +520,23 @@ class SiteRestClientTest {
             )
         ).thenReturn(response)
         return response
+    }
+
+    private suspend fun fetchConnectSiteInfoWithInvalidSslError(
+        sslException: SSLHandshakeException
+    ): org.wordpress.android.fluxc.store.SiteStore.ConnectSiteInfoPayload {
+        val urlUtilsMock = mockStatic(UrlUtils::class.java)
+        whenever(UrlUtils.addUrlSchemeIfNeeded(any(), any())).thenAnswer { it.arguments[0] as String }
+        val error = WPComGsonNetworkError(
+            BaseNetworkError(
+                GenericErrorType.INVALID_SSL_CERTIFICATE,
+                VolleyError(sslException)
+            )
+        )
+        initGetResponse(ConnectSiteInfoResponse::class.java, null, error)
+
+        val result = restClient.fetchConnectSiteInfoSync("test.com")
+        urlUtilsMock.close()
+        return result
     }
 }

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
@@ -274,24 +274,6 @@ class SiteRestClientTest {
         }
 
     @Test
-    fun `given follow redirects failed wrong-host certificate error, when fetching site info, then return remote certificate error`() =
-        test {
-            val error = WPComGsonNetworkError(
-                BaseNetworkError(
-                    GenericErrorType.INVALID_RESPONSE,
-                    "cURL error 60: SSL: no alternative certificate subject name matches target host name"
-                )
-            ).apply {
-                apiError = "follow_redirects_failed"
-            }
-
-            val result = fetchConnectSiteInfoWithError(error)
-
-            assertThat(result.error).isNotNull
-            assertThat(result.error!!.type).isEqualTo(SiteErrorType.REMOTE_SITE_CERTIFICATE_ERROR)
-        }
-
-    @Test
     fun `given follow redirects failed non-certificate error, when fetching site info, then return invalid site error`() =
         test {
             val error = WPComGsonNetworkError(

--- a/libs/login/src/main/java/org/wordpress/android/login/LoginSiteAddressErrorMapper.java
+++ b/libs/login/src/main/java/org/wordpress/android/login/LoginSiteAddressErrorMapper.java
@@ -1,9 +1,7 @@
 package org.wordpress.android.login;
 
-import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 
-import org.wordpress.android.fluxc.store.SiteStore.ConnectSiteInfoPayload;
 import org.wordpress.android.fluxc.store.SiteStore.SiteError;
 import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType;
 
@@ -21,14 +19,5 @@ class LoginSiteAddressErrorMapper {
         } else {
             return R.string.error_generic_network;
         }
-    }
-
-    @Nullable
-    @StringRes
-    Integer getWooSiteInfoInlineErrorResId(ConnectSiteInfoPayload siteInfo) {
-        if (!siteInfo.exists) {
-            return R.string.invalid_site_url_message;
-        }
-        return null;
     }
 }

--- a/libs/login/src/main/java/org/wordpress/android/login/LoginSiteAddressErrorMapper.java
+++ b/libs/login/src/main/java/org/wordpress/android/login/LoginSiteAddressErrorMapper.java
@@ -12,6 +12,8 @@ class LoginSiteAddressErrorMapper {
     int getSiteInfoErrorResId(SiteError error, boolean networkAvailable) {
         if (error.type == SiteErrorType.WORDPRESS_COM_CONNECTIVITY_ERROR) {
             return R.string.error_wordpress_com_connectivity;
+        } else if (error.type == SiteErrorType.TLS_CERTIFICATE_VALIDITY_ERROR) {
+            return R.string.error_site_url_certificate_validity;
         } else if (networkAvailable) {
             return R.string.invalid_site_url_message;
         } else {

--- a/libs/login/src/main/java/org/wordpress/android/login/LoginSiteAddressErrorMapper.java
+++ b/libs/login/src/main/java/org/wordpress/android/login/LoginSiteAddressErrorMapper.java
@@ -1,0 +1,30 @@
+package org.wordpress.android.login;
+
+import androidx.annotation.Nullable;
+import androidx.annotation.StringRes;
+
+import org.wordpress.android.fluxc.store.SiteStore.ConnectSiteInfoPayload;
+import org.wordpress.android.fluxc.store.SiteStore.SiteError;
+import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType;
+
+class LoginSiteAddressErrorMapper {
+    @StringRes
+    int getSiteInfoErrorResId(SiteError error, boolean networkAvailable) {
+        if (error.type == SiteErrorType.WORDPRESS_COM_CONNECTIVITY_ERROR) {
+            return R.string.error_wordpress_com_connectivity;
+        } else if (networkAvailable) {
+            return R.string.invalid_site_url_message;
+        } else {
+            return R.string.error_generic_network;
+        }
+    }
+
+    @Nullable
+    @StringRes
+    Integer getWooSiteInfoInlineErrorResId(ConnectSiteInfoPayload siteInfo) {
+        if (!siteInfo.exists) {
+            return R.string.invalid_site_url_message;
+        }
+        return null;
+    }
+}

--- a/libs/login/src/main/java/org/wordpress/android/login/LoginSiteAddressErrorMapper.java
+++ b/libs/login/src/main/java/org/wordpress/android/login/LoginSiteAddressErrorMapper.java
@@ -10,10 +10,12 @@ import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType;
 class LoginSiteAddressErrorMapper {
     @StringRes
     int getSiteInfoErrorResId(SiteError error, boolean networkAvailable) {
-        if (error.type == SiteErrorType.WORDPRESS_COM_CONNECTIVITY_ERROR) {
-            return R.string.error_wordpress_com_connectivity;
-        } else if (error.type == SiteErrorType.TLS_CERTIFICATE_VALIDITY_ERROR) {
+        if (error.type == SiteErrorType.TLS_CERTIFICATE_VALIDITY_ERROR) {
             return R.string.error_site_url_certificate_validity;
+        } else if (error.type == SiteErrorType.REMOTE_SITE_CERTIFICATE_ERROR) {
+            return R.string.error_site_url_remote_certificate;
+        } else if (error.type == SiteErrorType.WORDPRESS_COM_CONNECTIVITY_ERROR) {
+            return R.string.error_wordpress_com_connectivity;
         } else if (networkAvailable) {
             return R.string.invalid_site_url_message;
         } else {

--- a/libs/login/src/main/java/org/wordpress/android/login/LoginSiteAddressErrorMapper.java
+++ b/libs/login/src/main/java/org/wordpress/android/login/LoginSiteAddressErrorMapper.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.login;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.StringRes;
 
 import org.wordpress.android.fluxc.store.SiteStore.SiteError;
@@ -7,7 +8,7 @@ import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType;
 
 class LoginSiteAddressErrorMapper {
     @StringRes
-    int getSiteInfoErrorResId(SiteError error, boolean networkAvailable) {
+    int getSiteInfoErrorResId(@NonNull SiteError error, boolean networkAvailable) {
         if (error.type == SiteErrorType.TLS_CERTIFICATE_VALIDITY_ERROR) {
             return R.string.error_site_url_certificate_validity;
         } else if (error.type == SiteErrorType.REMOTE_SITE_CERTIFICATE_ERROR) {

--- a/libs/login/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
+++ b/libs/login/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
@@ -428,10 +428,10 @@ public class LoginSiteAddressFragment extends LoginBaseDiscoveryFragment impleme
     }
 
     private void handleConnectSiteInfoForWoo(ConnectSiteInfoPayload siteInfo) {
-        Integer errorResId = mSiteAddressErrorMapper.getWooSiteInfoInlineErrorResId(siteInfo);
-        if (errorResId != null) {
+        if (!siteInfo.exists) {
             endProgressIfNeeded();
-            showError(errorResId);
+            // Site does not exist
+            showError(R.string.invalid_site_url_message);
         } else if (!siteInfo.isWordPress) {
             endProgressIfNeeded();
             // Not a WordPress site

--- a/libs/login/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
+++ b/libs/login/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
@@ -75,6 +75,7 @@ public class LoginSiteAddressFragment extends LoginBaseDiscoveryFragment impleme
     private boolean mConnectSiteInfoCalculatedHasJetpack;
 
     private LoginSiteAddressValidator mLoginSiteAddressValidator;
+    private final LoginSiteAddressErrorMapper mSiteAddressErrorMapper = new LoginSiteAddressErrorMapper();
 
     @Inject AccountStore mAccountStore;
     @Inject Dispatcher mDispatcher;
@@ -404,13 +405,9 @@ public class LoginSiteAddressFragment extends LoginBaseDiscoveryFragment impleme
                 );
             } else {
                 AppLog.e(T.API, "onFetchedConnectSiteInfo has error: " + event.error.message);
-                if (event.error.type == SiteErrorType.WORDPRESS_COM_CONNECTIVITY_ERROR) {
-                    showError(R.string.error_wordpress_com_connectivity);
-                } else if (NetworkUtils.isNetworkAvailable(requireContext())) {
-                    showError(R.string.invalid_site_url_message);
-                } else {
-                    showError(R.string.error_generic_network);
-                }
+                showError(mSiteAddressErrorMapper.getSiteInfoErrorResId(
+                        event.error,
+                        NetworkUtils.isNetworkAvailable(requireContext())));
             }
             endProgressIfNeeded();
         } else {
@@ -431,10 +428,10 @@ public class LoginSiteAddressFragment extends LoginBaseDiscoveryFragment impleme
     }
 
     private void handleConnectSiteInfoForWoo(ConnectSiteInfoPayload siteInfo) {
-        if (!siteInfo.exists) {
+        Integer errorResId = mSiteAddressErrorMapper.getWooSiteInfoInlineErrorResId(siteInfo);
+        if (errorResId != null) {
             endProgressIfNeeded();
-            // Site does not exist
-            showError(R.string.invalid_site_url_message);
+            showError(errorResId);
         } else if (!siteInfo.isWordPress) {
             endProgressIfNeeded();
             // Not a WordPress site

--- a/libs/login/src/main/res/values/strings.xml
+++ b/libs/login/src/main/res/values/strings.xml
@@ -100,7 +100,8 @@
     <string name="error_generic">An error occurred</string>
     <string name="no_site_error">The site at this address is not a WordPress site. For us to connect to it, the site must use WordPress.</string>
     <string name="invalid_site_url_message">Check that the site URL entered is valid</string>
-    <string name="error_site_url_certificate_validity">We couldn\'t verify this site\'s security certificate. Check your device date and time, then try again.</string>
+    <string name="error_site_url_certificate_validity">We couldn\'t establish a secure connection. Check that your device date and time are correct, then try again.</string>
+    <string name="error_site_url_remote_certificate">We couldn\'t verify this site\'s security certificate. Contact your hosting provider or site administrator, then try again.</string>
     <string name="error_wordpress_com_connectivity">We\'re having trouble reaching WordPress.com. Please check your internet connection settings or try switching networks.</string>
     <string name="xmlrpc_missing_method_error">Couldn\'t connect. Required XML-RPC methods are missing on the server.</string>
     <string name="xmlrpc_post_blocked_error">Couldn\'t connect. Your host is blocking POST requests, and the app needs

--- a/libs/login/src/main/res/values/strings.xml
+++ b/libs/login/src/main/res/values/strings.xml
@@ -100,6 +100,7 @@
     <string name="error_generic">An error occurred</string>
     <string name="no_site_error">The site at this address is not a WordPress site. For us to connect to it, the site must use WordPress.</string>
     <string name="invalid_site_url_message">Check that the site URL entered is valid</string>
+    <string name="error_site_url_certificate_validity">We couldn\'t verify this site\'s security certificate. Check your device date and time, then try again.</string>
     <string name="error_wordpress_com_connectivity">We\'re having trouble reaching WordPress.com. Please check your internet connection settings or try switching networks.</string>
     <string name="xmlrpc_missing_method_error">Couldn\'t connect. Required XML-RPC methods are missing on the server.</string>
     <string name="xmlrpc_post_blocked_error">Couldn\'t connect. Your host is blocking POST requests, and the app needs

--- a/libs/login/src/test/java/org/wordpress/android/login/LoginSiteAddressErrorMapperTest.java
+++ b/libs/login/src/test/java/org/wordpress/android/login/LoginSiteAddressErrorMapperTest.java
@@ -1,7 +1,6 @@
 package org.wordpress.android.login;
 
 import org.junit.Test;
-import org.wordpress.android.fluxc.store.SiteStore.ConnectSiteInfoPayload;
 import org.wordpress.android.fluxc.store.SiteStore.SiteError;
 import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType;
 
@@ -53,32 +52,5 @@ public class LoginSiteAddressErrorMapperTest {
         Integer result = mMapper.getSiteInfoErrorResId(error, false);
 
         assertThat(result).isEqualTo(R.string.error_generic_network);
-    }
-
-    @Test
-    public void mapsNonExistentWooSiteInfoToInvalidUrl() {
-        ConnectSiteInfoPayload siteInfo = new ConnectSiteInfoPayload("test.com");
-
-        Integer result = mMapper.getWooSiteInfoInlineErrorResId(siteInfo);
-
-        assertThat(result).isEqualTo(R.string.invalid_site_url_message);
-    }
-
-    @Test
-    public void mapsExistingWooSiteInfoToNoInlineError() {
-        ConnectSiteInfoPayload siteInfo = new ConnectSiteInfoPayload(
-                "test.com",
-                true,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                null);
-
-        Integer result = mMapper.getWooSiteInfoInlineErrorResId(siteInfo);
-
-        assertThat(result).isNull();
     }
 }

--- a/libs/login/src/test/java/org/wordpress/android/login/LoginSiteAddressErrorMapperTest.java
+++ b/libs/login/src/test/java/org/wordpress/android/login/LoginSiteAddressErrorMapperTest.java
@@ -29,12 +29,21 @@ public class LoginSiteAddressErrorMapperTest {
     }
 
     @Test
-    public void mapsTlsCertificateValidityErrorToCertificateValidityMessage() {
+    public void mapsTlsCertificateValidityErrorToSecureConnectionDateTimeMessage() {
         SiteError error = new SiteError(SiteErrorType.TLS_CERTIFICATE_VALIDITY_ERROR);
 
         Integer result = mMapper.getSiteInfoErrorResId(error, true);
 
         assertThat(result).isEqualTo(R.string.error_site_url_certificate_validity);
+    }
+
+    @Test
+    public void mapsRemoteSiteCertificateErrorToRemoteCertificateMessage() {
+        SiteError error = new SiteError(SiteErrorType.REMOTE_SITE_CERTIFICATE_ERROR);
+
+        Integer result = mMapper.getSiteInfoErrorResId(error, true);
+
+        assertThat(result).isEqualTo(R.string.error_site_url_remote_certificate);
     }
 
     @Test

--- a/libs/login/src/test/java/org/wordpress/android/login/LoginSiteAddressErrorMapperTest.java
+++ b/libs/login/src/test/java/org/wordpress/android/login/LoginSiteAddressErrorMapperTest.java
@@ -29,6 +29,15 @@ public class LoginSiteAddressErrorMapperTest {
     }
 
     @Test
+    public void mapsTlsCertificateValidityErrorToCertificateValidityMessage() {
+        SiteError error = new SiteError(SiteErrorType.TLS_CERTIFICATE_VALIDITY_ERROR);
+
+        Integer result = mMapper.getSiteInfoErrorResId(error, true);
+
+        assertThat(result).isEqualTo(R.string.error_site_url_certificate_validity);
+    }
+
+    @Test
     public void mapsAnyErrorToGenericNetworkWhenNetworkIsUnavailable() {
         SiteError error = new SiteError(SiteErrorType.INVALID_SITE);
 

--- a/libs/login/src/test/java/org/wordpress/android/login/LoginSiteAddressErrorMapperTest.java
+++ b/libs/login/src/test/java/org/wordpress/android/login/LoginSiteAddressErrorMapperTest.java
@@ -1,0 +1,66 @@
+package org.wordpress.android.login;
+
+import org.junit.Test;
+import org.wordpress.android.fluxc.store.SiteStore.ConnectSiteInfoPayload;
+import org.wordpress.android.fluxc.store.SiteStore.SiteError;
+import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LoginSiteAddressErrorMapperTest {
+    private final LoginSiteAddressErrorMapper mMapper = new LoginSiteAddressErrorMapper();
+
+    @Test
+    public void mapsInvalidSiteToInvalidUrlWhenNetworkIsAvailable() {
+        SiteError error = new SiteError(SiteErrorType.INVALID_SITE);
+
+        Integer result = mMapper.getSiteInfoErrorResId(error, true);
+
+        assertThat(result).isEqualTo(R.string.invalid_site_url_message);
+    }
+
+    @Test
+    public void mapsWordPressComConnectivityErrorToConnectivityMessage() {
+        SiteError error = new SiteError(SiteErrorType.WORDPRESS_COM_CONNECTIVITY_ERROR);
+
+        Integer result = mMapper.getSiteInfoErrorResId(error, true);
+
+        assertThat(result).isEqualTo(R.string.error_wordpress_com_connectivity);
+    }
+
+    @Test
+    public void mapsAnyErrorToGenericNetworkWhenNetworkIsUnavailable() {
+        SiteError error = new SiteError(SiteErrorType.INVALID_SITE);
+
+        Integer result = mMapper.getSiteInfoErrorResId(error, false);
+
+        assertThat(result).isEqualTo(R.string.error_generic_network);
+    }
+
+    @Test
+    public void mapsNonExistentWooSiteInfoToInvalidUrl() {
+        ConnectSiteInfoPayload siteInfo = new ConnectSiteInfoPayload("test.com");
+
+        Integer result = mMapper.getWooSiteInfoInlineErrorResId(siteInfo);
+
+        assertThat(result).isEqualTo(R.string.invalid_site_url_message);
+    }
+
+    @Test
+    public void mapsExistingWooSiteInfoToNoInlineError() {
+        ConnectSiteInfoPayload siteInfo = new ConnectSiteInfoPayload(
+                "test.com",
+                true,
+                true,
+                false,
+                false,
+                false,
+                false,
+                false,
+                null);
+
+        Integer result = mMapper.getWooSiteInfoInlineErrorResId(siteInfo);
+
+        assertThat(result).isNull();
+    }
+}


### PR DESCRIPTION
### Description
Fixes WOOMOB-3058

When the device or emulator clock is wrong, HTTPS certificate validation can fail during the login site-address discovery request. That failure was falling through to the generic invalid URL copy, which points users in the wrong direction.

This PR classifies TLS certificate validity failures separately in FluxC and maps them in the login flow to clearer secure-connection/device date-time copy. It also adds a distinct remote-site certificate error for WP.com `follow_redirects_failed` responses that include `curl error 60`, while preserving the existing invalid URL behavior for malformed URLs, ordinary site-info failures, generic follow-redirect failures, and non-date SSL errors.

### Test Steps
1. Install and launch the WooCommerce Wasabi debug app.
2. From the login site-address flow, enter a valid site while the emulator/device date or time is incorrect enough to fail certificate validation.
3. Confirm the inline error says: `We couldn't establish a secure connection. Check that your device date and time are correct, then try again.`
4. Fix the emulator clock
5. Enter a malformed or non-discoverable site URL.
6. Confirm the existing invalid URL message still appears.
7. Use a site with invalid SSL (for example `https://expired.badssl.com`)
8. Confirm the inline error says: `We couldn't verify this site's security certificate. Contact your hosting provider or site administrator, then try again`

### Images/gif
##### Wrong clock
<img width="360" alt="login-site-local-datetime-tls-error-2010-clock" src="https://github.com/user-attachments/assets/39ed50cd-ce19-47b6-9b81-949bbc2dcbc7" />

##### Remote site SSL issue
<img width="360" alt="Screenshot_1780511307" src="https://github.com/user-attachments/assets/fae147c1-94b6-486d-9e45-482af702828a" />



</br></br></br>

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.