### PR TITLE
Show selected stock alert types in notification settings subtitle

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsSharedViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsSharedViewModel.kt
@@ -563,7 +563,7 @@ class NotificationSettingsSharedViewModel @Inject constructor(
         when (type) {
             NotificationType.NEW_ORDERS -> preferences.storeOrder?.getOrderSubtitle().orEmpty()
             NotificationType.NEW_REVIEWS -> preferences.storeReview?.getReviewSubtitle().orEmpty()
-            NotificationType.STOCK -> resourceProvider.getString(R.string.settings_notifs_stock_subtitle)
+            NotificationType.STOCK -> getStockSubtitle(preferences.storeStock)
         }
 
     private fun StoreOrderPreferences.getOrderSubtitle(): String {
@@ -583,6 +583,28 @@ class NotificationSettingsSharedViewModel @Inject constructor(
                 one = R.string.settings_notifs_new_reviews_selected_rating_one
             )
         } ?: resourceProvider.getString(R.string.settings_notifs_new_reviews_subtitle)
+    }
+
+    private fun getStockSubtitle(stockPreferences: StoreStockPreferences?): String {
+        val enabledTitles = buildList {
+            if (stockPreferences?.lowStock ?: true) add(R.string.settings_notifs_stock_low_stock_title)
+            if (stockPreferences?.outOfStock ?: true) add(R.string.settings_notifs_stock_out_of_stock_title)
+            if (stockPreferences?.onBackorder ?: true) add(R.string.settings_notifs_stock_backorder_title)
+        }
+        return when {
+            enabledTitles.isEmpty() ->
+                resourceProvider.getString(R.string.settings_notifs_stock_no_alerts_subtitle)
+            enabledTitles.size == STOCK_NOTIFICATION_TYPE_COUNT ->
+                resourceProvider.getString(R.string.settings_notifs_stock_subtitle)
+            enabledTitles.size == 1 ->
+                resourceProvider.getString(enabledTitles.first())
+            else ->
+                resourceProvider.getString(
+                    R.string.settings_notifs_stock_two_subtitle,
+                    resourceProvider.getString(enabledTitles[0]),
+                    resourceProvider.getString(enabledTitles[1])
+                )
+        }
     }
 
     private fun NotificationType.isNotificationChannelEnabled(): Boolean {
@@ -658,6 +680,7 @@ class NotificationSettingsSharedViewModel @Inject constructor(
         const val MAX_REVIEW_RATING = 5
         private const val DEFAULT_SELECTED_REVIEW_RATING = 2
         private const val DEFAULT_ORDER_THRESHOLD_AMOUNT = 100
+        private const val STOCK_NOTIFICATION_TYPE_COUNT = 3
         private val MIN_ORDER_THRESHOLD_AMOUNT = BigDecimal.ONE
         private const val NOTIFICATION_PREFERENCES_SAVE_DEBOUNCE_MS = 1000L
     }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2315,6 +2315,8 @@
     <string name="settings_notifs_new_orders_threshold">Minimum value (%1$s)</string>
     <string name="settings_notifs_stock">Stock</string>
     <string name="settings_notifs_stock_subtitle">All stock alerts</string>
+    <string name="settings_notifs_stock_no_alerts_subtitle">No alerts</string>
+    <string name="settings_notifs_stock_two_subtitle">%1$s and %2$s</string>
     <string name="settings_notifs_stock_enable_title">Enable stock notifications</string>
     <string name="settings_notifs_stock_enable_description">Get notified when product stock changes need your attention.</string>
     <string name="settings_notifs_stock_low_stock_title">Low stock</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsSharedViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsSharedViewModelTest.kt
@@ -66,12 +66,18 @@ class NotificationSettingsSharedViewModelTest : BaseUnitTest() {
                 R.string.settings_notifs_new_orders_subtitle -> "All orders"
                 R.string.settings_notifs_new_reviews_subtitle -> "All reviews"
                 R.string.settings_notifs_stock_subtitle -> "All stock alerts"
+                R.string.settings_notifs_stock_no_alerts_subtitle -> "No alerts"
+                R.string.settings_notifs_stock_low_stock_title -> "Low stock"
+                R.string.settings_notifs_stock_out_of_stock_title -> "Out of stock"
+                R.string.settings_notifs_stock_backorder_title -> "On backorder"
                 else -> invocation.arguments[0].toString()
             }
         }
         on { getString(any(), anyVararg()) } doAnswer { invocation ->
             when (invocation.arguments[0] as Int) {
                 R.string.settings_notifs_new_orders_high_value_subtitle -> "Orders over ${invocation.arguments[1]}"
+                R.string.settings_notifs_stock_two_subtitle ->
+                    "${invocation.arguments[1]} and ${invocation.arguments[2]}"
                 else -> invocation.arguments[0].toString()
             }
         }
@@ -322,7 +328,7 @@ class NotificationSettingsSharedViewModelTest : BaseUnitTest() {
 
             val stockItem = notificationTypeItems.first { it.type == NotificationType.STOCK }
             assertThat(stockItem.isEnabled).isFalse()
-            assertThat(stockItem.subtitle).isEqualTo("All stock alerts")
+            assertThat(stockItem.subtitle).isEqualTo("Out of stock")
 
             val orderViewState = viewModel.newOrderNotificationSettingsViewState.captureValues().last()
             assertThat(orderViewState.notificationsEnabled).isFalse()
@@ -340,6 +346,72 @@ class NotificationSettingsSharedViewModelTest : BaseUnitTest() {
             assertThat(stockViewState.lowStockNotificationsEnabled).isFalse()
             assertThat(stockViewState.outOfStockNotificationsEnabled).isTrue()
             assertThat(stockViewState.backorderNotificationsEnabled).isFalse()
+        }
+
+    @Test
+    fun `given all stock types enabled, when loaded, then stock subtitle shows all stock alerts`() =
+        testBlocking {
+            setup {
+                mockSuccessfulFetch(
+                    WooPushNotificationPreferences(
+                        storeStock = StoreStockPreferences(
+                            enabled = true,
+                            lowStock = true,
+                            outOfStock = true,
+                            onBackorder = true
+                        )
+                    )
+                )
+            }
+            advanceUntilIdle()
+
+            val stockItem = viewModel.notificationTypeItems.captureValues().last()
+                .first { it.type == NotificationType.STOCK }
+            assertThat(stockItem.subtitle).isEqualTo("All stock alerts")
+        }
+
+    @Test
+    fun `given two stock types enabled, when loaded, then stock subtitle joins their names`() =
+        testBlocking {
+            setup {
+                mockSuccessfulFetch(
+                    WooPushNotificationPreferences(
+                        storeStock = StoreStockPreferences(
+                            enabled = true,
+                            lowStock = true,
+                            outOfStock = true,
+                            onBackorder = false
+                        )
+                    )
+                )
+            }
+            advanceUntilIdle()
+
+            val stockItem = viewModel.notificationTypeItems.captureValues().last()
+                .first { it.type == NotificationType.STOCK }
+            assertThat(stockItem.subtitle).isEqualTo("Low stock and Out of stock")
+        }
+
+    @Test
+    fun `given no stock types enabled, when loaded, then stock subtitle shows no alerts`() =
+        testBlocking {
+            setup {
+                mockSuccessfulFetch(
+                    WooPushNotificationPreferences(
+                        storeStock = StoreStockPreferences(
+                            enabled = true,
+                            lowStock = false,
+                            outOfStock = false,
+                            onBackorder = false
+                        )
+                    )
+                )
+            }
+            advanceUntilIdle()
+
+            val stockItem = viewModel.notificationTypeItems.captureValues().last()
+                .first { it.type == NotificationType.STOCK }
+            assertThat(stockItem.subtitle).isEqualTo("No alerts")
         }
 
     @Test


### PR DESCRIPTION
### Description

On Android the Stock row in notification settings always showed a static "All stock alerts" subtitle, regardless of the selected alert types. iOS already shows a dynamic subtitle here; this was simply missed on Android.

The Stock row subtitle now reflects the selection:
- None → "No alerts"
- One or two → the selected names joined, e.g. "Low stock and Out of stock"
- All three → "All stock alerts"

On Android each row has its own on/off switch, so whether Stock is enabled is shown by the switch (as with New orders and New reviews). The subtitle only lists the selected alert types. iOS shows "Off" here because its rows have no switch, so that text isn't needed on Android.

Targets `release/24.9`. No dedicated beta will be cut for this change.

### Test Steps
1. On a Woo-driven site with smarter notifications enabled, open Settings → Notifications → Stock.
2. Toggle Low stock / Out of stock / On backorder in different combinations, then go back to the list.
3. Verify the Stock row subtitle updates:
   - All three → "All stock alerts"
   - Two → e.g. "Low stock and Out of stock"
   - One → e.g. "On backorder"
   - None → "No alerts"

### Images/gif
<img width="300" alt="Screenshot_20260603_234305" src="https://github.com/user-attachments/assets/bdc04753-c431-43b2-bf06-3dec94ced501" /> <img width="300" alt="Screenshot_20260603_234312" src="https://github.com/user-attachments/assets/bd85a385-b6cd-4fe6-a796-8aec95348996" /> <img width="300" alt="Screenshot_20260603_234259" src="https://github.com/user-attachments/assets/adee5b54-132d-4f03-9c67-66079a7fea98" />

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.