### PR TITLE
Fix Codecov PGP key fetch in coverage upload

### DIFF
--- a/.buildkite/commands/upload-code-coverage.sh
+++ b/.buildkite/commands/upload-code-coverage.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
+curl --fail --silent --show-error https://keybase.io/codecovsecops/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
 curl -Os https://uploader.codecov.io/latest/linux/codecov
 curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
 curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig


### PR DESCRIPTION
## Summary

CI was failing in the `Uploading code coverage` step because `curl https://keybase.io/codecovsecurity/pgp_keys.asc` now returns a 32-byte HTTP 404 (`SELF-SIGNED PUBLIC KEY NOT FOUND`). That body gets piped into `gpg --import`, gpg fails with "no valid OpenPGP data found", and `set -e` aborts the rest of the run-unit-tests script before `merge_junit_reports` runs — which is why later steps complain about a missing `merged-test-results.xml` artifact.

Codecov (now under ~Sentry~ Harness) appears to have renamed their Keybase account from `codecovsecurity` to `codecovsecops`. The new URL serves the same signing key (fingerprint `27034E7FDB850E0BBC2C62FF806BB28AED779869`, key ID `ED779869`).

## Changes

- Update the keybase URL: `codecovsecurity` → `codecovsecops`.
- Add `--fail --silent --show-error` to the `curl` call so the next time this URL moves, curl exits non-zero with a clear error instead of silently piping a 404 page into gpg.

Same fix being applied in woocommerce-android: https://github.com/woocommerce/woocommerce-android/pull/16051

## Test plan

- [ ] CI green on this PR (the coverage upload step in particular).
- [ ] Codecov report appears on the PR.

## Follow-up (not in this PR)

The legacy `uploader.codecov.io` is deprecated in favor of the `codecov-cli` at `cli.codecov.io`. Worth migrating in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)