### PR TITLE
Disable POS local catalog when catalog file download is blocked (403)

### DIFF
--- a/.buildkite/commands/upload-code-coverage.sh
+++ b/.buildkite/commands/upload-code-coverage.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
+curl --fail --silent --show-error https://keybase.io/codecovsecops/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
 curl -Os https://uploader.codecov.io/latest/linux/codecov
 curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
 curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -14,6 +14,7 @@
 - [**] Contact support now includes troubleshooting and AI help [https://github.com/woocommerce/woocommerce-android/pull/15979]
 - [*] Fixed USPS shipping label customs handling for US territories and added a 30-character limit on customs item descriptions [https://github.com/woocommerce/woocommerce-android/pull/15999]
 - [Internal] Enabled local flag for self-driven push notifications [https://github.com/woocommerce/woocommerce-android/pull/15997]
+- [*] Fixed Woo POS failing to load products on stores whose web server blocks access to the catalog file [https://github.com/woocommerce/woocommerce-android/pull/16059]
 
 24.8
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosCatalogFileDownloader.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosCatalogFileDownloader.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.woopos.localcatalog
 
 import android.content.Context
 import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
+import com.woocommerce.android.ui.woopos.util.datastore.WooPosPreferencesRepository
 import com.woocommerce.android.util.CoroutineDispatchers
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.withContext
@@ -10,6 +11,7 @@ import okhttp3.Request
 import org.wordpress.android.fluxc.model.LocalOrRemoteId
 import java.io.File
 import java.io.IOException
+import java.net.HttpURLConnection
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
@@ -17,6 +19,7 @@ class WooPosCatalogFileDownloader @Inject constructor(
     @ApplicationContext private val context: Context,
     private val dispatchers: CoroutineDispatchers,
     private val logger: WooPosLogWrapper,
+    private val preferencesRepository: WooPosPreferencesRepository,
 ) {
     private val okHttpClient = OkHttpClient.Builder()
         .connectTimeout(30, TimeUnit.SECONDS)
@@ -41,6 +44,9 @@ class WooPosCatalogFileDownloader @Inject constructor(
 
             okHttpClient.newCall(request).execute().use { response ->
                 if (!response.isSuccessful) {
+                    if (response.code == HttpURLConnection.HTTP_FORBIDDEN) {
+                        preferencesRepository.setLocalCatalogFileAccessBlocked(localSiteId, true)
+                    }
                     val error = "Download failed with code: ${response.code}"
                     logger.e(error)
                     return@withContext Result.failure(IOException(error))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosIsLocalCatalogSupported.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosIsLocalCatalogSupported.kt
@@ -1,11 +1,13 @@
 package com.woocommerce.android.ui.woopos.localcatalog
 
 import com.woocommerce.android.extensions.semverCompareTo
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
 import com.woocommerce.android.ui.woopos.featureflags.WooPosLocalCatalogM1Enabled
 import com.woocommerce.android.ui.woopos.tab.WooPosCanBeLaunchedInTab
 import com.woocommerce.android.ui.woopos.tab.WooPosLaunchability
 import com.woocommerce.android.ui.woopos.tab.WooPosTabShouldBeVisible
+import com.woocommerce.android.ui.woopos.util.datastore.WooPosPreferencesRepository
 import com.woocommerce.android.util.FetchActiveWCPluginVersion
 import com.woocommerce.android.util.GetWooCorePluginCachedVersion
 import javax.inject.Inject
@@ -17,6 +19,8 @@ class WooPosIsLocalCatalogSupported @Inject constructor(
     private val posTabShouldBeVisible: WooPosTabShouldBeVisible,
     private val posCanBeLaunchedInTab: WooPosCanBeLaunchedInTab,
     private val wooPosLogWrapper: WooPosLogWrapper,
+    private val selectedSite: SelectedSite,
+    private val preferencesRepository: WooPosPreferencesRepository,
 ) {
     @Suppress("ReturnCount")
     suspend operator fun invoke(): Boolean {
@@ -28,6 +32,12 @@ class WooPosIsLocalCatalogSupported @Inject constructor(
 
         if (!isSyncApproachSupported()) {
             return false
+        }
+
+        if (isFileAccessBlocked()) {
+            return false.also {
+                wooPosLogWrapper.d("Local Catalog not supported: file access blocked (403).")
+            }
         }
 
         val tabVisibleResult = posTabShouldBeVisible()
@@ -61,6 +71,11 @@ class WooPosIsLocalCatalogSupported @Inject constructor(
     private suspend fun isFileBasedSyncSupported(): Boolean {
         val wooVersion = getWooVersion() ?: fetchWooVersion() ?: return false
         return wooVersion.semverCompareTo(WC_FILE_BASED_SYNC_MIN_VERSION) >= 0
+    }
+
+    private suspend fun isFileAccessBlocked(): Boolean {
+        val site = selectedSite.getOrNull() ?: return false
+        return preferencesRepository.isLocalCatalogFileAccessBlocked(site.localId())
     }
 
     companion object {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosIsLocalCatalogSupportedTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosIsLocalCatalogSupportedTest.kt
@@ -1,10 +1,12 @@
 package com.woocommerce.android.ui.woopos.localcatalog
 
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
 import com.woocommerce.android.ui.woopos.featureflags.WooPosLocalCatalogM1Enabled
 import com.woocommerce.android.ui.woopos.tab.WooPosCanBeLaunchedInTab
 import com.woocommerce.android.ui.woopos.tab.WooPosLaunchability
 import com.woocommerce.android.ui.woopos.tab.WooPosTabShouldBeVisible
+import com.woocommerce.android.ui.woopos.util.datastore.WooPosPreferencesRepository
 import com.woocommerce.android.util.FetchActiveWCPluginVersion
 import com.woocommerce.android.util.GetWooCorePluginCachedVersion
 import com.woocommerce.android.viewmodel.BaseUnitTest
@@ -12,8 +14,10 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.SiteModel
 
 @ExperimentalCoroutinesApi
 class WooPosIsLocalCatalogSupportedTest : BaseUnitTest() {
@@ -24,6 +28,8 @@ class WooPosIsLocalCatalogSupportedTest : BaseUnitTest() {
     private var logger: WooPosLogWrapper = mock()
     private var posTabShouldBeVisible: WooPosTabShouldBeVisible = mock()
     private var posCanBeLaunchedInTab: WooPosCanBeLaunchedInTab = mock()
+    private var selectedSite: SelectedSite = mock()
+    private var preferencesRepository: WooPosPreferencesRepository = mock()
 
     private lateinit var isLocalCatalogSupported: WooPosIsLocalCatalogSupported
 
@@ -33,6 +39,8 @@ class WooPosIsLocalCatalogSupportedTest : BaseUnitTest() {
         whenever(getWooVersion()).thenReturn("10.5.0")
         whenever(posTabShouldBeVisible.invoke(false)).thenReturn(Result.success(true))
         whenever(posCanBeLaunchedInTab.invoke(false)).thenReturn(WooPosLaunchability.Launchable)
+        whenever(selectedSite.getOrNull()).thenReturn(SiteModel().apply { id = 1 })
+        whenever(preferencesRepository.isLocalCatalogFileAccessBlocked(any())).thenReturn(false)
 
         isLocalCatalogSupported = WooPosIsLocalCatalogSupported(
             wooPosLocalCatalogM1Enabled = featureFlagM1Enabled,
@@ -41,6 +49,8 @@ class WooPosIsLocalCatalogSupportedTest : BaseUnitTest() {
             posTabShouldBeVisible = posTabShouldBeVisible,
             posCanBeLaunchedInTab = posCanBeLaunchedInTab,
             wooPosLogWrapper = logger,
+            selectedSite = selectedSite,
+            preferencesRepository = preferencesRepository,
         )
     }
 
@@ -121,6 +131,18 @@ class WooPosIsLocalCatalogSupportedTest : BaseUnitTest() {
         whenever(posTabShouldBeVisible.invoke(false)).thenReturn(
             Result.failure(Exception("Visibility check failed"))
         )
+
+        // WHEN
+        val result = isLocalCatalogSupported()
+
+        // THEN
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `given catalog file access was blocked, when check invoked, then returns false`() = testBlocking {
+        // GIVEN
+        whenever(preferencesRepository.isLocalCatalogFileAccessBlocked(any())).thenReturn(true)
 
         // WHEN
         val result = isLocalCatalogSupported()

--- a/libs/pos/src/main/java/com/woocommerce/android/ui/woopos/util/datastore/WooPosPreferencesRepository.kt
+++ b/libs/pos/src/main/java/com/woocommerce/android/ui/woopos/util/datastore/WooPosPreferencesRepository.kt
@@ -143,6 +143,21 @@ class WooPosPreferencesRepository @Inject constructor(
     private fun buildFileBasedSyncPollAttemptsKey(siteId: LocalOrRemoteId.LocalId): Preferences.Key<Int> =
         intPreferencesKey("pos_file_based_sync_poll_attempts_${siteId.value}")
 
+    suspend fun isLocalCatalogFileAccessBlocked(siteId: LocalOrRemoteId.LocalId): Boolean {
+        val key = buildLocalCatalogFileAccessBlockedKey(siteId)
+        return dataStore.data.map { it[key] ?: false }.first()
+    }
+
+    suspend fun setLocalCatalogFileAccessBlocked(siteId: LocalOrRemoteId.LocalId, blocked: Boolean) {
+        val key = buildLocalCatalogFileAccessBlockedKey(siteId)
+        dataStore.edit { preferences ->
+            preferences[key] = blocked
+        }
+    }
+
+    private fun buildLocalCatalogFileAccessBlockedKey(siteId: LocalOrRemoteId.LocalId): Preferences.Key<Boolean> =
+        booleanPreferencesKey("pos_local_catalog_file_access_blocked_${siteId.value}")
+
     private fun buildSiteSpecificKey(key: String): Preferences.Key<String> =
         stringPreferencesKey("${selectedSite.getOrNull()?.id}_v2_$key")
 


### PR DESCRIPTION
### Description
Temporary beta fix for POS local catalog. When the catalog file download returns `403`, file-based sync can never succeed no matter how many retries. This persists a per-site flag on the first 403 and skips file-based local catalog on subsequent POS launches, falling back to regular product sync.

⚠️ Beta-only fix — **to be removed when this branch is merged back into `trunk`** (a proper fix lives there).

### Test Steps
1. With POS local catalog enabled, make the catalog file download return `403` (e.g. API Faker mocking `POST /wc/pos/v1/catalog/create` to return a `url` that 403s).
2. Open POS → sync fails with the "Unable to sync" error.
3. Re-open POS → local catalog is skipped; POS falls back to regular product sync and loads products.
4. With a catalog already populated, repeat steps 1–2 → existing products stay intact and POS remains usable.

### Images/gif
N/A

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.