### PR TITLE
Add stock notification subtitle strings to frozen strings file

### DIFF
--- a/fastlane/resources/values/strings.xml
+++ b/fastlane/resources/values/strings.xml
@@ -2315,6 +2315,8 @@
     <string name="settings_notifs_new_orders_threshold">Minimum value (%1$s)</string>
     <string name="settings_notifs_stock">Stock</string>
     <string name="settings_notifs_stock_subtitle">All stock alerts</string>
+    <string name="settings_notifs_stock_no_alerts_subtitle">No alerts</string>
+    <string name="settings_notifs_stock_two_subtitle">%1$s and %2$s</string>
     <string name="settings_notifs_stock_enable_title">Enable stock notifications</string>
     <string name="settings_notifs_stock_enable_description">Get notified when product stock changes need your attention.</string>
     <string name="settings_notifs_stock_low_stock_title">Low stock</string>


### PR DESCRIPTION
### Description

#16043 added `settings_notifs_stock_no_alerts_subtitle` and `settings_notifs_stock_two_subtitle` to `release/24.9` after the 24.9 strings were already frozen, so they never made it into `fastlane/resources/values/strings.xml`. The GlotPress import job reads that file from `trunk`, which means these strings were never sent for translation ([Slack thread](https://a8c.slack.com/archives/C6H8C3G23/p1781182081340169?thread_ts=1781169674.638429&cid=C6H8C3G23)).

This adds the two strings to the frozen copy. After merge, the change needs to be backmerged to `trunk` promptly so the import cron picks it up before the 24.9 translations are downloaded.

### Test Steps

1. After this lands on `trunk` via backmerge, wait for the next GlotPress import run (every ~6 hours).
2. Verify the two strings appear in https://translate.wordpress.com/projects/woocommerce/woocommerce-android/

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.