### PR TITLE
Make local builds load-only build cache consumers for faster incremental builds

### DIFF
--- a/developer.properties-example
+++ b/developer.properties-example
@@ -1,6 +1,11 @@
 # Build settings
 use_remote_build_cache_locally=true
 
+# When false, local builds are read-only consumers of the build cache, which speeds up incremental
+# builds. Clean builds still restore CI-built states via the remote build cache. Set to true if you
+# rely on cache entries from your own local builds.
+store_local_build_cache=false
+
 # Changing values below  will affect performance of remote build cache on local builds.
 # Consider using the default values for local builds, if it's not necessary to change them.
 # See details on internal P2: https://wp.me/paaHJt-82c

--- a/settings.gradle
+++ b/settings.gradle
@@ -58,6 +58,17 @@ static def readPropertiesFromFile(File file) {
 }
 
 buildCache {
+    if (!gradle.ext.isCi && !gradle.ext.developerProperties.getProperty("store_local_build_cache", "false").toBoolean()) {
+        /*
+         Local builds only read from the build cache, they don't store to it. Packing the app
+         module's huge task outputs into the cache slows every incremental build down by more
+         than it ever saves (see the introducing PR for measurements). Opt out with
+         store_local_build_cache=true in developer.properties.
+        */
+        local {
+            push = false
+        }
+    }
     if (gradle.ext.isCi) {
         remote(HttpBuildCache) {
             url = "http://10.0.2.214:5071/cache/"


### PR DESCRIPTION
## Description

Local (non-CI) builds no longer **store** task outputs into the Gradle build cache — they keep **reading** from the local and remote caches. CI is unchanged and continues to populate the remote cache.

Storing the app module's outputs (~20k files each for Kotlin classes, dex archives, and ASM-instrumented classes) costs more on every incremental build than the incremental work itself, and entries produced by local builds are rarely ever restored (every edit produces inputs nobody has built before).

Opt out per developer with `store_local_build_cache=true` in `developer.properties` (e.g. if you rely on cache entries from your own local builds after `clean`).

## Measurements

gradle-profiler, `:WooCommerce:assembleWasabiDebug`, non-ABI change in a leaf ViewModel, 2 warm-ups + 5 measured builds, M4 Max:

| Scenario | trunk | this PR |
|---|---|---|
| Incremental build (one-line change) | **36.2s** (35.8–38.9) | **16.9s** (16.4–18.5) |
| Clean build with populated cache | 17.5s | 16.8s (restores still work) |


## Reproduce locally

```bash
brew install gradle-profiler

cat > incremental.scenarios <<'SCENARIO'
incremental_change {
    tasks = [":WooCommerce:assembleWasabiDebug"]
    apply-non-abi-change-to = "WooCommerce/src/main/kotlin/com/woocommerce/android/support/WooLogViewerViewModel.kt"
    warm-ups = 2
    iterations = 5
}
SCENARIO

# current behavior (cache stores enabled)
echo 'store_local_build_cache=true' >> developer.properties
gradle-profiler --benchmark --scenario-file incremental.scenarios --output-dir bench-store incremental_change

# this PR's behavior (load-only)
sed -i '' '/store_local_build_cache=true/d' developer.properties
gradle-profiler --benchmark --scenario-file incremental.scenarios --output-dir bench-load-only incremental_change
```

Compare the two `benchmark.html` reports. Note: results are sensitive to antivirus scanning of dev folders — if absolute numbers look far higher than the table above, check your AV exclusions for the project and Gradle home directories.
