### PR TITLE
[WOOMOB-2501] Android fallback to site credentials after site-info failure

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -121,6 +121,7 @@ class LoginActivity :
         private const val JETPACK_CONNECT_URL = "https://wordpress.com/jetpack/connect"
         private const val JETPACK_CONNECTED_REDIRECT_URL = "woocommerce://jetpack-connected"
         private const val APPLICATION_PASSWORD_LOGIN_ZENDESK_TAG = "application_password_login_error"
+        private val PROTOCOL_REGEX = Regex("^(http[s]?://)", IGNORE_CASE)
 
         private const val KEY_UNIFIED_TRACKER_SOURCE = "KEY_UNIFIED_TRACKER_SOURCE"
         private const val KEY_UNIFIED_TRACKER_FLOW = "KEY_UNIFIED_TRACKER_FLOW"
@@ -696,8 +697,7 @@ class LoginActivity :
         // logs into the app. Strip the protocol from this url string prior to saving to AppPrefs since it's
         // not needed and may cause issues when attempting to match the url to the authenticated account later
         // in the login process.
-        val protocolRegex = Regex("^(http[s]?://)", IGNORE_CASE)
-        val siteAddressClean = inputSiteAddress.replaceFirst(protocolRegex, "")
+        val siteAddressClean = inputSiteAddress.replaceFirst(PROTOCOL_REGEX, "")
         appPrefsWrapper.setLoginSiteAddress(siteAddressClean)
         if (result.hasJetpack || connectSiteInfo?.shouldUseWPComAuth == true) {
             showEmailLoginScreen(null)
@@ -723,6 +723,8 @@ class LoginActivity :
     override fun loginViaSiteCredentials(inputSiteAddress: String?) {
         // hide the keyboard
         org.wordpress.android.util.ActivityUtils.hideKeyboard(this)
+
+        inputSiteAddress?.let { appPrefsWrapper.setLoginSiteAddress(it.replaceFirst(PROTOCOL_REGEX, "")) }
 
         unifiedLoginTracker.trackClick(Click.LOGIN_WITH_SITE_CREDS)
 
@@ -1039,10 +1041,11 @@ class LoginActivity :
      * Allows for special handling of errors that come up during the login by address: check site address.
      */
     override fun handleSiteAddressError(siteInfo: ConnectSiteInfoPayload) {
-        if (!siteInfo.isWordPress) {
-            // hide the keyboard
-            org.wordpress.android.util.ActivityUtils.hideKeyboard(this)
-
+        org.wordpress.android.util.ActivityUtils.hideKeyboard(this)
+        if (siteInfo.error?.wpApiDiscovery?.wpApiBaseUrl != null) {
+            LoginSiteInfoFallbackDialogFragment.newInstance(siteInfo.url)
+                .show(LoginSiteInfoFallbackDialogFragment.TAG)
+        } else if (!siteInfo.isWordPress) {
             // show the "not WordPress error" screen
             LoginNotWPDialogFragment().show(LoginNotWPDialogFragment.TAG)
         } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginNoJetpackRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginNoJetpackRepository.kt
@@ -9,6 +9,7 @@ import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode.MAIN
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.SiteActionBuilder
+import org.wordpress.android.fluxc.store.SiteStore.FetchConnectSiteInfoPayload
 import org.wordpress.android.fluxc.store.SiteStore.OnConnectSiteInfoChecked
 import javax.inject.Inject
 
@@ -27,7 +28,7 @@ class LoginNoJetpackRepository @Inject constructor(
 
     suspend fun verifyJetpackAvailable(siteAddress: String): Boolean {
         val result = continuationFetchSiteInfo.callAndWaitUntilTimeout(AppConstants.REQUEST_TIMEOUT) {
-            dispatcher.dispatch(SiteActionBuilder.newFetchConnectSiteInfoAction(siteAddress))
+            dispatcher.dispatch(SiteActionBuilder.newFetchConnectSiteInfoAction(FetchConnectSiteInfoPayload(siteAddress)))
         }
         return when (result) {
             is Cancellation -> false

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginSiteInfoFallbackDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginSiteInfoFallbackDialogFragment.kt
@@ -1,0 +1,43 @@
+package com.woocommerce.android.ui.login
+
+import android.app.Dialog
+import android.os.Bundle
+import android.view.ContextThemeWrapper
+import androidx.core.os.bundleOf
+import androidx.fragment.app.DialogFragment
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.woocommerce.android.R
+import com.woocommerce.android.R.style
+import org.wordpress.android.login.LoginListener
+
+class LoginSiteInfoFallbackDialogFragment : DialogFragment() {
+    override fun onStart() {
+        super.onStart()
+        dialog?.window?.attributes?.windowAnimations = R.style.Woo_Animations_Dialog
+    }
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val siteAddress = requireArguments().getString(ARG_SITE_ADDRESS).orEmpty()
+        return MaterialAlertDialogBuilder(ContextThemeWrapper(requireActivity(), style.Theme_Woo_Dialog))
+            .setTitle(R.string.login_site_info_fallback_dialog_title)
+            .setMessage(R.string.login_site_info_fallback_dialog_message)
+            .setPositiveButton(R.string.login_site_info_fallback_dialog_cta) { dialog, _ ->
+                (requireActivity() as LoginListener).loginViaSiteCredentials(siteAddress)
+                dialog.dismiss()
+            }
+            .setNegativeButton(R.string.cancel) { dialog, _ ->
+                dialog.dismiss()
+            }
+            .setCancelable(true)
+            .create()
+    }
+
+    companion object {
+        const val TAG = "LoginSiteInfoFallbackDialogFragment"
+        private const val ARG_SITE_ADDRESS = "site_address"
+
+        fun newInstance(siteAddress: String) = LoginSiteInfoFallbackDialogFragment().apply {
+            arguments = bundleOf(ARG_SITE_ADDRESS to siteAddress)
+        }
+    }
+}

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -304,6 +304,9 @@
     <string name="login_open_installation_page">Open installation page</string>
     <string name="login_no_jetpack">To use this app for %1$s you\'ll need to have the Jetpack plugin setup and connected to a WordPress.com account</string>
     <string name="login_not_wordpress_site_v2">We were not able to detect a WordPress site at the address you entered. Please make sure WordPress is installed and that you are running the latest available version.</string>
+    <string name="login_site_info_fallback_dialog_title">Connection Issue</string>
+    <string name="login_site_info_fallback_dialog_message">We couldn\'t verify your site details. You can try logging in with your site credentials instead.</string>
+    <string name="login_site_info_fallback_dialog_cta">Log In with Site Credentials</string>
     <string name="login_view_connected_stores">View connected stores</string>
     <string name="login_jetpack_what_is">What is Jetpack?</string>
     <string name="login_jetpack_what_is_description">Jetpack is a free WordPress plugin that connects your store with the tools needed to give you the best mobile experience, including push notifications and stats</string>

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
@@ -8,6 +8,7 @@ import org.wordpress.android.fluxc.store.SiteStore.ConnectSiteInfoPayload;
 import org.wordpress.android.fluxc.store.SiteStore.DesignatePrimaryDomainPayload;
 import org.wordpress.android.fluxc.store.SiteStore.DesignatedPrimaryDomainPayload;
 import org.wordpress.android.fluxc.store.SiteStore.DomainSupportedStatesResponsePayload;
+import org.wordpress.android.fluxc.store.SiteStore.FetchConnectSiteInfoPayload;
 import org.wordpress.android.fluxc.store.SiteStore.FetchSitesPayload;
 import org.wordpress.android.fluxc.store.SiteStore.RefreshSitesXMLRPCPayload;
 import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainsPayload;
@@ -26,7 +27,7 @@ public enum SiteAction implements IAction {
     FETCH_SITES_XML_RPC,
     @Action(payloadType = SuggestDomainsPayload.class)
     SUGGEST_DOMAINS,
-    @Action(payloadType = String.class)
+    @Action(payloadType = FetchConnectSiteInfoPayload.class)
     FETCH_CONNECT_SITE_INFO,
     @Action(payloadType = String.class)
     FETCH_DOMAIN_SUPPORTED_STATES,

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -55,7 +55,6 @@ import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.UrlUtils
 import java.net.URI
-import java.net.UnknownHostException
 import java.security.cert.CertificateException
 import java.security.cert.CertificateExpiredException
 import java.security.cert.CertificateNotYetValidException
@@ -430,18 +429,25 @@ class SiteRestClient @Inject constructor(
             apiError == "connection_disabled" -> SiteError(SiteErrorType.WPCOM_SITE_SUSPENDED, message)
             isTlsCertificateValidityIssue(this) -> SiteError(TLS_CERTIFICATE_VALIDITY_ERROR, message)
             isRemoteSiteCertificateIssue(this) -> SiteError(REMOTE_SITE_CERTIFICATE_ERROR, message)
-            isWordPressComConnectivityIssue(this) -> SiteError(WORDPRESS_COM_CONNECTIVITY_ERROR, message)
+            isWordPressComConnectivityIssue(this) -> SiteError(
+                WORDPRESS_COM_CONNECTIVITY_ERROR,
+                message,
+                wpApiDiscovery = toWPAPIDiscoveryResult(discoverWPAPIOnFailure)
+            )
             else -> SiteError(
                 INVALID_SITE,
                 message,
-                wpApiDiscovery = if (discoverWPAPIOnFailure) {
-                    WPAPIDiscoveryResult(connectSiteInfoApiError = apiError)
-                } else {
-                    null
-                }
+                wpApiDiscovery = toWPAPIDiscoveryResult(discoverWPAPIOnFailure)
             )
         }
     }
+
+    private fun WPComGsonNetworkError.toWPAPIDiscoveryResult(discoverWPAPIOnFailure: Boolean) =
+        if (discoverWPAPIOnFailure) {
+            WPAPIDiscoveryResult(connectSiteInfoApiError = apiError)
+        } else {
+            null
+        }
 
     private fun isTlsCertificateValidityIssue(error: WPComGsonNetworkError): Boolean {
         if (error.type !in TLS_CERTIFICATE_VALIDITY_ERROR_TYPES) {
@@ -490,23 +496,9 @@ class SiteRestClient @Inject constructor(
         return when (error.type) {
             GenericErrorType.NO_CONNECTION,
             GenericErrorType.NETWORK_ERROR,
-            GenericErrorType.TIMEOUT -> {
-                val volleyError = error.volleyError ?: return false
-                val cause = volleyError.cause ?: return volleyError.message.containsWordPressComApiHost()
-                when (cause) {
-                    is UnknownHostException -> cause.message.containsWordPressComApiHost()
-                    else -> {
-                        volleyError.message.containsWordPressComApiHost() ||
-                            cause.message.containsWordPressComApiHost()
-                    }
-                }
-            }
+            GenericErrorType.TIMEOUT -> true
             else -> false
         }
-    }
-
-    private fun String?.containsWordPressComApiHost(): Boolean {
-        return this?.contains("public-api.wordpress.com", ignoreCase = true) == true
     }
 
     /**

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -5,6 +5,7 @@ import android.text.TextUtils
 import androidx.annotation.VisibleForTesting
 import com.android.volley.RequestQueue
 import com.google.gson.reflect.TypeToken
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
@@ -409,7 +410,7 @@ class SiteRestClient @Inject constructor(
                 var siteError = response.error.toConnectSiteInfoError(discoverWPAPIOnFailure)
                 val discovery = siteError.wpApiDiscovery
                 if (discovery != null) {
-                    val wpApiBaseUrl = withContext(kotlinx.coroutines.Dispatchers.IO) {
+                    val wpApiBaseUrl = withContext(Dispatchers.IO) {
                         discoveryWPAPIRestClient.discoverWPAPIBaseURL(uri.toString())
                             ?.let { discoveryWPAPIRestClient.verifyWPAPIV2Support(it) }
                     }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -491,19 +491,22 @@ class SiteRestClient @Inject constructor(
             GenericErrorType.NO_CONNECTION,
             GenericErrorType.NETWORK_ERROR,
             GenericErrorType.TIMEOUT -> {
-                error.volleyError?.cause?.let { cause ->
-                    when (cause) {
-                        is UnknownHostException -> {
-                            cause.message?.contains("public-api.wordpress.com", ignoreCase = true) == true
-                        }
-                        else -> {
-                            error.volleyError.message?.contains("public-api.wordpress.com", ignoreCase = true) == true
-                        }
+                val volleyError = error.volleyError ?: return false
+                val cause = volleyError.cause ?: return volleyError.message.containsWordPressComApiHost()
+                when (cause) {
+                    is UnknownHostException -> cause.message.containsWordPressComApiHost()
+                    else -> {
+                        volleyError.message.containsWordPressComApiHost() ||
+                            cause.message.containsWordPressComApiHost()
                     }
-                } ?: false
+                }
             }
             else -> false
         }
+    }
+
+    private fun String?.containsWordPressComApiHost(): Boolean {
+        return this?.contains("public-api.wordpress.com", ignoreCase = true) == true
     }
 
     /**

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -8,6 +8,7 @@ import com.google.gson.reflect.TypeToken
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.withContext
 import org.apache.commons.text.StringEscapeUtils
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.action.SiteAction
@@ -19,6 +20,7 @@ import org.wordpress.android.fluxc.model.SitesModel
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
 import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.discovery.DiscoveryWPAPIRestClient
 import org.wordpress.android.fluxc.network.discovery.RootWPAPIRestResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest
@@ -48,6 +50,7 @@ import org.wordpress.android.fluxc.store.SiteStore.SiteFilter
 import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainError
 import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainErrorType.EMPTY_RESULTS
 import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainsResponsePayload
+import org.wordpress.android.fluxc.store.SiteStore.WPAPIDiscoveryResult
 import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.UrlUtils
@@ -75,6 +78,7 @@ class SiteRestClient @Inject constructor(
     private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
     private val jetpackTunnelGsonRequestBuilder: JetpackTunnelGsonRequestBuilder,
     private val coroutineEngine: CoroutineEngine,
+    private val discoveryWPAPIRestClient: DiscoveryWPAPIRestClient,
     accessToken: AccessToken?,
     userAgent: UserAgent?
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
@@ -354,16 +358,19 @@ class SiteRestClient @Inject constructor(
     }
 
     // Unauthenticated network calls
-    fun fetchConnectSiteInfo(siteUrl: String) {
+    fun fetchConnectSiteInfo(siteUrl: String, discoverWPAPIOnFailure: Boolean = false) {
         coroutineEngine.launch(AppLog.T.API, this, "fetchConnectSiteInfo") {
-            fetchConnectSiteInfoSync(siteUrl).let { payload ->
+            fetchConnectSiteInfoSync(siteUrl, discoverWPAPIOnFailure).let { payload ->
                 mDispatcher.dispatch(SiteActionBuilder.newFetchedConnectSiteInfoAction(payload))
             }
         }
     }
 
     @Suppress("SwallowedException")
-    suspend fun fetchConnectSiteInfoSync(siteUrl: String): ConnectSiteInfoPayload {
+    suspend fun fetchConnectSiteInfoSync(
+        siteUrl: String,
+        discoverWPAPIOnFailure: Boolean = false
+    ): ConnectSiteInfoPayload {
         fun ConnectSiteInfoResponse.toConnectSiteInfoPayload(url: String): ConnectSiteInfoPayload {
             return ConnectSiteInfoPayload(
                 url,
@@ -400,23 +407,39 @@ class SiteRestClient @Inject constructor(
 
         return when (response) {
             is Error -> {
-                val siteErrorType = when (response.error.apiError) {
-                    "connection_disabled" -> SiteErrorType.WPCOM_SITE_SUSPENDED
-                    else -> {
-                        when {
-                            isTlsCertificateValidityIssue(response.error) -> TLS_CERTIFICATE_VALIDITY_ERROR
-                            isRemoteSiteCertificateIssue(response.error) -> REMOTE_SITE_CERTIFICATE_ERROR
-                            isWordPressComConnectivityIssue(response.error) -> WORDPRESS_COM_CONNECTIVITY_ERROR
-                            else -> INVALID_SITE
-                        }
+                var siteError = response.error.toConnectSiteInfoError(discoverWPAPIOnFailure)
+                val discovery = siteError.wpApiDiscovery
+                if (discovery != null) {
+                    val wpApiBaseUrl = withContext(kotlinx.coroutines.Dispatchers.IO) {
+                        discoveryWPAPIRestClient.discoverWPAPIBaseURL(uri.toString())
+                            ?.let { discoveryWPAPIRestClient.verifyWPAPIV2Support(it) }
                     }
+                    siteError = siteError.copy(wpApiDiscovery = discovery.copy(wpApiBaseUrl = wpApiBaseUrl))
                 }
-
-                ConnectSiteInfoPayload(siteUrl, SiteError(siteErrorType))
+                ConnectSiteInfoPayload(siteUrl, siteError)
             }
             is Success -> {
                 response.data.toConnectSiteInfoPayload(siteUrl)
             }
+        }
+    }
+
+    private fun WPComGsonNetworkError.toConnectSiteInfoError(discoverWPAPIOnFailure: Boolean): SiteError {
+        val message = getCombinedErrorMessage()
+        return when {
+            apiError == "connection_disabled" -> SiteError(SiteErrorType.WPCOM_SITE_SUSPENDED, message)
+            isTlsCertificateValidityIssue(this) -> SiteError(TLS_CERTIFICATE_VALIDITY_ERROR, message)
+            isRemoteSiteCertificateIssue(this) -> SiteError(REMOTE_SITE_CERTIFICATE_ERROR, message)
+            isWordPressComConnectivityIssue(this) -> SiteError(WORDPRESS_COM_CONNECTIVITY_ERROR, message)
+            else -> SiteError(
+                INVALID_SITE,
+                message,
+                wpApiDiscovery = if (discoverWPAPIOnFailure) {
+                    WPAPIDiscoveryResult(connectSiteInfoApiError = apiError)
+                } else {
+                    null
+                }
+            )
         }
     }
 

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -129,6 +129,11 @@ open class SiteStore @Inject constructor(
         }
     }
 
+    data class FetchConnectSiteInfoPayload @JvmOverloads constructor(
+        @JvmField val siteUrl: String,
+        @JvmField val discoverWPAPIOnFailure: Boolean = false
+    ) : Payload<BaseNetworkError>()
+
     data class ConnectSiteInfoPayload @JvmOverloads constructor(
         @JvmField val url: String,
         @JvmField val exists: Boolean = false,
@@ -153,6 +158,11 @@ open class SiteStore @Inject constructor(
         }
     }
 
+    data class WPAPIDiscoveryResult @JvmOverloads constructor(
+        @JvmField val connectSiteInfoApiError: String? = null,
+        @JvmField val wpApiBaseUrl: String? = null
+    )
+
     data class DesignatePrimaryDomainPayload(
         @JvmField val site: SiteModel,
         @JvmField val domain: String
@@ -169,7 +179,8 @@ open class SiteStore @Inject constructor(
     data class SiteError @JvmOverloads constructor(
         @JvmField val type: SiteErrorType,
         @JvmField val message: String? = null,
-        @JvmField val selfHostedErrorType: SelfHostedErrorType = NOT_SET
+        @JvmField val selfHostedErrorType: SelfHostedErrorType = NOT_SET,
+        @JvmField val wpApiDiscovery: WPAPIDiscoveryResult? = null
     ) : OnChangedError
 
     data class DomainSupportedStatesError
@@ -461,7 +472,7 @@ open class SiteStore @Inject constructor(
             }
             REMOVE_SITE -> removeSite(action.payload as SiteModel)
             REMOVE_ALL_SITES -> removeAllSites()
-            FETCH_CONNECT_SITE_INFO -> fetchConnectSiteInfo(action.payload as String)
+            FETCH_CONNECT_SITE_INFO -> fetchConnectSiteInfo(action.payload as FetchConnectSiteInfoPayload)
             FETCHED_CONNECT_SITE_INFO -> handleFetchedConnectSiteInfo(action.payload as ConnectSiteInfoPayload)
             SUGGEST_DOMAINS -> suggestDomains(action.payload as SuggestDomainsPayload)
             SUGGESTED_DOMAINS -> handleSuggestedDomains(action.payload as SuggestDomainsResponsePayload)
@@ -617,13 +628,16 @@ open class SiteStore @Inject constructor(
         emitChange(event)
     }
 
-    private fun fetchConnectSiteInfo(payload: String) {
-        siteRestClient.fetchConnectSiteInfo(payload)
+    private fun fetchConnectSiteInfo(payload: FetchConnectSiteInfoPayload) {
+        siteRestClient.fetchConnectSiteInfo(payload.siteUrl, payload.discoverWPAPIOnFailure)
     }
 
-    suspend fun fetchConnectSiteInfoSync(siteUrl: String): ConnectSiteInfoPayload {
+    suspend fun fetchConnectSiteInfoSync(
+        siteUrl: String,
+        discoverWPAPIOnFailure: Boolean = false
+    ): ConnectSiteInfoPayload {
         return coroutineEngine.withDefaultContext(T.API, this, "Fetch Connect Site Info") {
-            siteRestClient.fetchConnectSiteInfoSync(siteUrl)
+            siteRestClient.fetchConnectSiteInfoSync(siteUrl, discoverWPAPIOnFailure)
         }
     }
 

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
@@ -14,6 +14,8 @@ import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
 import org.wordpress.android.fluxc.Dispatcher
@@ -21,6 +23,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
 import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.discovery.DiscoveryWPAPIRestClient
 import org.wordpress.android.fluxc.network.discovery.RootWPAPIRestResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
@@ -51,6 +54,8 @@ class SiteRestClientTest {
 
     private val jetpackTunnelGsonRequestBuilder: JetpackTunnelGsonRequestBuilder = mock()
 
+    private val discoveryWPAPIRestClient: DiscoveryWPAPIRestClient = mock()
+
     private val requestQueue: RequestQueue = mock()
 
     private val accessToken: AccessToken = mock()
@@ -78,6 +83,7 @@ class SiteRestClientTest {
             wpComGsonRequestBuilder = wpComGsonRequestBuilder,
             jetpackTunnelGsonRequestBuilder = jetpackTunnelGsonRequestBuilder,
             coroutineEngine = initCoroutineEngine(),
+            discoveryWPAPIRestClient = discoveryWPAPIRestClient,
             accessToken = accessToken,
             userAgent = userAgent
         )
@@ -250,17 +256,22 @@ class SiteRestClientTest {
     }
 
     @Test
-    fun `given ordinary site info error, when fetching site info, then return invalid site error`() = test {
+    fun `given ordinary site info error, when fetching site info, then WP API discovery state is attached`() = test {
         val urlUtilsMock = mockStatic(UrlUtils::class.java)
         try {
             whenever(UrlUtils.addUrlSchemeIfNeeded(any(), any())).thenAnswer { it.arguments[0] as String }
-            val error = WPComGsonNetworkError(BaseNetworkError(GenericErrorType.INVALID_RESPONSE, ""))
+            val error = WPComGsonNetworkError(BaseNetworkError(GenericErrorType.INVALID_RESPONSE, "origin failed")).apply {
+                apiError = "origin_failed"
+            }
             initGetResponse(ConnectSiteInfoResponse::class.java, null, error)
 
-            val result = restClient.fetchConnectSiteInfoSync("test.com")
+            val result = restClient.fetchConnectSiteInfoSync("test.com", discoverWPAPIOnFailure = true)
 
             assertThat(result.error).isNotNull
             assertThat(result.error!!.type).isEqualTo(SiteErrorType.INVALID_SITE)
+            assertThat(result.error!!.message).contains("origin failed")
+            assertThat(result.error!!.wpApiDiscovery).isNotNull
+            assertThat(result.error!!.wpApiDiscovery!!.connectSiteInfoApiError).isEqualTo("origin_failed")
         } finally {
             urlUtilsMock.close()
         }
@@ -296,10 +307,86 @@ class SiteRestClientTest {
                 apiError = "follow_redirects_failed"
             }
 
-            val result = fetchConnectSiteInfoWithError(error)
+            val result = fetchConnectSiteInfoWithError(error, discoverWPAPIOnFailure = true)
 
             assertThat(result.error).isNotNull
             assertThat(result.error!!.type).isEqualTo(SiteErrorType.INVALID_SITE)
+            assertThat(result.error!!.wpApiDiscovery).isNotNull
+            assertThat(result.error!!.wpApiDiscovery!!.connectSiteInfoApiError).isEqualTo("follow_redirects_failed")
+        }
+
+    @Test
+    fun `given follow redirects failed timeout, when fetching site info, then WP API discovery state is attached`() =
+        test {
+            val error = WPComGsonNetworkError(
+                BaseNetworkError(
+                    GenericErrorType.INVALID_RESPONSE,
+                    "cURL error 28: Operation timed out"
+                )
+            ).apply {
+                apiError = "follow_redirects_failed"
+            }
+
+            val result = fetchConnectSiteInfoWithError(error, discoverWPAPIOnFailure = true)
+
+            assertThat(result.error).isNotNull
+            assertThat(result.error!!.type).isEqualTo(SiteErrorType.INVALID_SITE)
+            assertThat(result.error!!.wpApiDiscovery).isNotNull
+            assertThat(result.error!!.wpApiDiscovery!!.connectSiteInfoApiError).isEqualTo("follow_redirects_failed")
+        }
+
+    @Test
+    fun `given eligible site info error and successful probe, when fetching site info, then WP API base URL is attached`() =
+        test {
+            val error = WPComGsonNetworkError(BaseNetworkError(GenericErrorType.INVALID_RESPONSE, "origin failed"))
+            whenever(discoveryWPAPIRestClient.discoverWPAPIBaseURL("test.com")).thenReturn("https://test.com/wp-json/")
+            whenever(discoveryWPAPIRestClient.verifyWPAPIV2Support("https://test.com/wp-json/"))
+                .thenReturn("https://test.com/wp-json/")
+
+            val result = fetchConnectSiteInfoWithError(error, discoverWPAPIOnFailure = true)
+
+            assertThat(result.error!!.wpApiDiscovery!!.wpApiBaseUrl).isEqualTo("https://test.com/wp-json/")
+            verify(discoveryWPAPIRestClient).discoverWPAPIBaseURL("test.com")
+            verify(discoveryWPAPIRestClient).verifyWPAPIV2Support("https://test.com/wp-json/")
+        }
+
+    @Test
+    fun `given eligible site info error and missing link header, when fetching site info, then WP API base URL is null`() =
+        test {
+            val error = WPComGsonNetworkError(BaseNetworkError(GenericErrorType.INVALID_RESPONSE, "origin failed"))
+            whenever(discoveryWPAPIRestClient.discoverWPAPIBaseURL("test.com")).thenReturn(null)
+
+            val result = fetchConnectSiteInfoWithError(error, discoverWPAPIOnFailure = true)
+
+            assertThat(result.error!!.wpApiDiscovery).isNotNull
+            assertThat(result.error!!.wpApiDiscovery!!.wpApiBaseUrl).isNull()
+            verify(discoveryWPAPIRestClient).discoverWPAPIBaseURL("test.com")
+        }
+
+    @Test
+    fun `given eligible site info error and unsupported WP API, when fetching site info, then WP API base URL is null`() =
+        test {
+            val error = WPComGsonNetworkError(BaseNetworkError(GenericErrorType.INVALID_RESPONSE, "origin failed"))
+            whenever(discoveryWPAPIRestClient.discoverWPAPIBaseURL("test.com")).thenReturn("https://test.com/wp-json/")
+            whenever(discoveryWPAPIRestClient.verifyWPAPIV2Support("https://test.com/wp-json/")).thenReturn(null)
+
+            val result = fetchConnectSiteInfoWithError(error, discoverWPAPIOnFailure = true)
+
+            assertThat(result.error!!.wpApiDiscovery).isNotNull
+            assertThat(result.error!!.wpApiDiscovery!!.wpApiBaseUrl).isNull()
+            verify(discoveryWPAPIRestClient).discoverWPAPIBaseURL("test.com")
+            verify(discoveryWPAPIRestClient).verifyWPAPIV2Support("https://test.com/wp-json/")
+        }
+
+    @Test
+    fun `given eligible site info error and discovery opt-out, when fetching site info, then discovery is not attempted`() =
+        test {
+            val error = WPComGsonNetworkError(BaseNetworkError(GenericErrorType.INVALID_RESPONSE, "origin failed"))
+
+            val result = fetchConnectSiteInfoWithError(error, discoverWPAPIOnFailure = false)
+
+            assertThat(result.error!!.wpApiDiscovery).isNull()
+            verifyNoInteractions(discoveryWPAPIRestClient)
         }
 
     @Test
@@ -634,14 +721,15 @@ class SiteRestClientTest {
     }
 
     private suspend fun fetchConnectSiteInfoWithError(
-        error: WPComGsonNetworkError
+        error: WPComGsonNetworkError,
+        discoverWPAPIOnFailure: Boolean = false
     ): ConnectSiteInfoPayload {
         val urlUtilsMock = mockStatic(UrlUtils::class.java)
         try {
             whenever(UrlUtils.addUrlSchemeIfNeeded(any(), any())).thenAnswer { it.arguments[0] as String }
             initGetResponse(ConnectSiteInfoResponse::class.java, null, error)
 
-            return restClient.fetchConnectSiteInfoSync("test.com")
+            return restClient.fetchConnectSiteInfoSync("test.com", discoverWPAPIOnFailure)
         } finally {
             urlUtilsMock.close()
         }

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
@@ -39,7 +39,6 @@ import org.wordpress.android.fluxc.store.SiteStore.SiteFilter.WPCOM
 import org.wordpress.android.fluxc.test
 import org.wordpress.android.fluxc.tools.initCoroutineEngine
 import org.wordpress.android.util.UrlUtils
-import java.net.UnknownHostException
 import java.security.cert.CertificateException
 import java.security.cert.CertificateExpiredException
 import java.security.cert.CertificateNotYetValidException
@@ -520,57 +519,39 @@ class SiteRestClientTest {
         }
 
     @Test
-    fun `given WordPress com no connection error, when fetching site info, then return connectivity error`() =
+    fun `given opted-in no connection site info error, when fetching site info, then discovery state is attached`() =
         test {
-            val error = WPComGsonNetworkError(
-                BaseNetworkError(
-                    GenericErrorType.NO_CONNECTION,
-                    VolleyError(UnknownHostException("public-api.wordpress.com"))
-                )
-            )
-
-            val result = fetchConnectSiteInfoWithError(error, discoverWPAPIOnFailure = true)
-
-            assertThat(result.error).isNotNull
-            assertThat(result.error!!.type).isEqualTo(SiteErrorType.WORDPRESS_COM_CONNECTIVITY_ERROR)
-            assertThat(result.error!!.wpApiDiscovery).isNull()
-            verifyNoInteractions(discoveryWPAPIRestClient)
+            assertOptedInConnectivityErrorDiscoversWPAPI(GenericErrorType.NO_CONNECTION)
         }
 
     @Test
-    fun `given WordPress com network error, when fetching site info, then return connectivity error`() =
+    fun `given opted-in network site info error, when fetching site info, then discovery state is attached`() =
         test {
-            val error = WPComGsonNetworkError(
-                BaseNetworkError(
-                    GenericErrorType.NETWORK_ERROR,
-                    VolleyError("Failed to connect to public-api.wordpress.com")
-                )
-            )
-
-            val result = fetchConnectSiteInfoWithError(error, discoverWPAPIOnFailure = true)
-
-            assertThat(result.error).isNotNull
-            assertThat(result.error!!.type).isEqualTo(SiteErrorType.WORDPRESS_COM_CONNECTIVITY_ERROR)
-            assertThat(result.error!!.wpApiDiscovery).isNull()
-            verifyNoInteractions(discoveryWPAPIRestClient)
+            assertOptedInConnectivityErrorDiscoversWPAPI(GenericErrorType.NETWORK_ERROR)
         }
 
     @Test
-    fun `given WordPress com timeout error, when fetching site info, then return connectivity error`() =
+    fun `given opted-in timeout site info error, when fetching site info, then discovery state is attached`() =
         test {
-            val error = WPComGsonNetworkError(
-                BaseNetworkError(
-                    GenericErrorType.TIMEOUT,
-                    VolleyError("Timed out connecting to public-api.wordpress.com")
-                )
-            )
+            assertOptedInConnectivityErrorDiscoversWPAPI(GenericErrorType.TIMEOUT)
+        }
 
-            val result = fetchConnectSiteInfoWithError(error, discoverWPAPIOnFailure = true)
+    @Test
+    fun `given default no connection site info error, when fetching site info, then discovery is not attempted`() =
+        test {
+            assertDefaultConnectivityErrorSkipsWPAPIDiscovery(GenericErrorType.NO_CONNECTION)
+        }
 
-            assertThat(result.error).isNotNull
-            assertThat(result.error!!.type).isEqualTo(SiteErrorType.WORDPRESS_COM_CONNECTIVITY_ERROR)
-            assertThat(result.error!!.wpApiDiscovery).isNull()
-            verifyNoInteractions(discoveryWPAPIRestClient)
+    @Test
+    fun `given default network site info error, when fetching site info, then discovery is not attempted`() =
+        test {
+            assertDefaultConnectivityErrorSkipsWPAPIDiscovery(GenericErrorType.NETWORK_ERROR)
+        }
+
+    @Test
+    fun `given default timeout site info error, when fetching site info, then discovery is not attempted`() =
+        test {
+            assertDefaultConnectivityErrorSkipsWPAPIDiscovery(GenericErrorType.TIMEOUT)
         }
 
     @Test
@@ -807,5 +788,33 @@ class SiteRestClientTest {
         } finally {
             urlUtilsMock.close()
         }
+    }
+
+    private suspend fun assertOptedInConnectivityErrorDiscoversWPAPI(type: GenericErrorType) {
+        val error = WPComGsonNetworkError(BaseNetworkError(type, VolleyError("Android connectivity failure")))
+        whenever(discoveryWPAPIRestClient.discoverWPAPIBaseURL("test.com")).thenReturn("https://test.com/wp-json/")
+        whenever(discoveryWPAPIRestClient.verifyWPAPIV2Support("https://test.com/wp-json/"))
+            .thenReturn("https://test.com/wp-json/")
+
+        val result = fetchConnectSiteInfoWithError(error, discoverWPAPIOnFailure = true)
+
+        assertThat(result.error).isNotNull
+        assertThat(result.error!!.type).isEqualTo(SiteErrorType.WORDPRESS_COM_CONNECTIVITY_ERROR)
+        assertThat(result.error!!.wpApiDiscovery).isNotNull
+        assertThat(result.error!!.wpApiDiscovery!!.connectSiteInfoApiError).isEqualTo(error.apiError)
+        assertThat(result.error!!.wpApiDiscovery!!.wpApiBaseUrl).isEqualTo("https://test.com/wp-json/")
+        verify(discoveryWPAPIRestClient).discoverWPAPIBaseURL("test.com")
+        verify(discoveryWPAPIRestClient).verifyWPAPIV2Support("https://test.com/wp-json/")
+    }
+
+    private suspend fun assertDefaultConnectivityErrorSkipsWPAPIDiscovery(type: GenericErrorType) {
+        val error = WPComGsonNetworkError(BaseNetworkError(type, VolleyError("Android connectivity failure")))
+
+        val result = fetchConnectSiteInfoWithError(error)
+
+        assertThat(result.error).isNotNull
+        assertThat(result.error!!.type).isEqualTo(SiteErrorType.WORDPRESS_COM_CONNECTIVITY_ERROR)
+        assertThat(result.error!!.wpApiDiscovery).isNull()
+        verifyNoInteractions(discoveryWPAPIRestClient)
     }
 }

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
@@ -39,6 +39,7 @@ import org.wordpress.android.fluxc.store.SiteStore.SiteFilter.WPCOM
 import org.wordpress.android.fluxc.test
 import org.wordpress.android.fluxc.tools.initCoroutineEngine
 import org.wordpress.android.util.UrlUtils
+import java.net.UnknownHostException
 import java.security.cert.CertificateException
 import java.security.cert.CertificateExpiredException
 import java.security.cert.CertificateNotYetValidException
@@ -231,10 +232,13 @@ class SiteRestClientTest {
             }
             initGetResponse(ConnectSiteInfoResponse::class.java, null, error)
 
-            val result = restClient.fetchConnectSiteInfoSync("test.com")
+            val result = restClient.fetchConnectSiteInfoSync("test.com", discoverWPAPIOnFailure = true)
 
             assertThat(result.error).isNotNull
             assertThat(result.error!!.type).isEqualTo(SiteErrorType.WPCOM_SITE_SUSPENDED)
+            assertThat(result.error!!.message).isNotNull
+            assertThat(result.error!!.wpApiDiscovery).isNull()
+            verifyNoInteractions(discoveryWPAPIRestClient)
         } finally {
             urlUtilsMock.close()
         }
@@ -250,6 +254,8 @@ class SiteRestClientTest {
 
             assertThat(result.error).isNotNull
             assertThat(result.error!!.type).isEqualTo(SiteErrorType.INVALID_SITE)
+            assertThat(result.error!!.wpApiDiscovery).isNull()
+            verifyNoInteractions(discoveryWPAPIRestClient)
         } finally {
             urlUtilsMock.close()
         }
@@ -289,10 +295,12 @@ class SiteRestClientTest {
                 apiError = "follow_redirects_failed"
             }
 
-            val result = fetchConnectSiteInfoWithError(error)
+            val result = fetchConnectSiteInfoWithError(error, discoverWPAPIOnFailure = true)
 
             assertThat(result.error).isNotNull
             assertThat(result.error!!.type).isEqualTo(SiteErrorType.REMOTE_SITE_CERTIFICATE_ERROR)
+            assertThat(result.error!!.wpApiDiscovery).isNull()
+            verifyNoInteractions(discoveryWPAPIRestClient)
         }
 
     @Test
@@ -405,7 +413,7 @@ class SiteRestClientTest {
             )
             initGetResponse(ConnectSiteInfoResponse::class.java, null, error)
 
-            val result = restClient.fetchConnectSiteInfoSync("test.com")
+            val result = restClient.fetchConnectSiteInfoSync("test.com", discoverWPAPIOnFailure = true)
 
             assertThat(result.error).isNotNull
             assertThat(result.error!!.type).isEqualTo(SiteErrorType.INVALID_SITE)
@@ -421,10 +429,12 @@ class SiteRestClientTest {
                 initCause(CertificateExpiredException("expired"))
             }
 
-            val result = fetchConnectSiteInfoWithInvalidSslError(sslException)
+            val result = fetchConnectSiteInfoWithInvalidSslError(sslException, discoverWPAPIOnFailure = true)
 
             assertThat(result.error).isNotNull
             assertThat(result.error!!.type).isEqualTo(SiteErrorType.TLS_CERTIFICATE_VALIDITY_ERROR)
+            assertThat(result.error!!.wpApiDiscovery).isNull()
+            verifyNoInteractions(discoveryWPAPIRestClient)
         }
 
     @Test
@@ -434,21 +444,26 @@ class SiteRestClientTest {
                 initCause(CertificateNotYetValidException("not yet valid"))
             }
 
-            val result = fetchConnectSiteInfoWithInvalidSslError(sslException)
+            val result = fetchConnectSiteInfoWithInvalidSslError(sslException, discoverWPAPIOnFailure = true)
 
             assertThat(result.error).isNotNull
             assertThat(result.error!!.type).isEqualTo(SiteErrorType.TLS_CERTIFICATE_VALIDITY_ERROR)
+            assertThat(result.error!!.wpApiDiscovery).isNull()
+            verifyNoInteractions(discoveryWPAPIRestClient)
         }
 
     @Test
     fun `given message-only SSL certificate validity site info error, when fetching site info, then return certificate validity error`() =
         test {
             val result = fetchConnectSiteInfoWithInvalidSslError(
-                SSLHandshakeException("certificate has expired")
+                SSLHandshakeException("certificate has expired"),
+                discoverWPAPIOnFailure = true
             )
 
             assertThat(result.error).isNotNull
             assertThat(result.error!!.type).isEqualTo(SiteErrorType.TLS_CERTIFICATE_VALIDITY_ERROR)
+            assertThat(result.error!!.wpApiDiscovery).isNull()
+            verifyNoInteractions(discoveryWPAPIRestClient)
         }
 
     @Test
@@ -464,10 +479,12 @@ class SiteRestClientTest {
                 )
             )
 
-            val result = fetchConnectSiteInfoWithError(error)
+            val result = fetchConnectSiteInfoWithError(error, discoverWPAPIOnFailure = true)
 
             assertThat(result.error).isNotNull
             assertThat(result.error!!.type).isEqualTo(SiteErrorType.TLS_CERTIFICATE_VALIDITY_ERROR)
+            assertThat(result.error!!.wpApiDiscovery).isNull()
+            verifyNoInteractions(discoveryWPAPIRestClient)
         }
 
     @Test
@@ -494,10 +511,66 @@ class SiteRestClientTest {
                 )
             )
 
-            val result = fetchConnectSiteInfoWithError(error)
+            val result = fetchConnectSiteInfoWithError(error, discoverWPAPIOnFailure = true)
 
             assertThat(result.error).isNotNull
             assertThat(result.error!!.type).isEqualTo(SiteErrorType.TLS_CERTIFICATE_VALIDITY_ERROR)
+            assertThat(result.error!!.wpApiDiscovery).isNull()
+            verifyNoInteractions(discoveryWPAPIRestClient)
+        }
+
+    @Test
+    fun `given WordPress com no connection error, when fetching site info, then return connectivity error`() =
+        test {
+            val error = WPComGsonNetworkError(
+                BaseNetworkError(
+                    GenericErrorType.NO_CONNECTION,
+                    VolleyError(UnknownHostException("public-api.wordpress.com"))
+                )
+            )
+
+            val result = fetchConnectSiteInfoWithError(error, discoverWPAPIOnFailure = true)
+
+            assertThat(result.error).isNotNull
+            assertThat(result.error!!.type).isEqualTo(SiteErrorType.WORDPRESS_COM_CONNECTIVITY_ERROR)
+            assertThat(result.error!!.wpApiDiscovery).isNull()
+            verifyNoInteractions(discoveryWPAPIRestClient)
+        }
+
+    @Test
+    fun `given WordPress com network error, when fetching site info, then return connectivity error`() =
+        test {
+            val error = WPComGsonNetworkError(
+                BaseNetworkError(
+                    GenericErrorType.NETWORK_ERROR,
+                    VolleyError("Failed to connect to public-api.wordpress.com")
+                )
+            )
+
+            val result = fetchConnectSiteInfoWithError(error, discoverWPAPIOnFailure = true)
+
+            assertThat(result.error).isNotNull
+            assertThat(result.error!!.type).isEqualTo(SiteErrorType.WORDPRESS_COM_CONNECTIVITY_ERROR)
+            assertThat(result.error!!.wpApiDiscovery).isNull()
+            verifyNoInteractions(discoveryWPAPIRestClient)
+        }
+
+    @Test
+    fun `given WordPress com timeout error, when fetching site info, then return connectivity error`() =
+        test {
+            val error = WPComGsonNetworkError(
+                BaseNetworkError(
+                    GenericErrorType.TIMEOUT,
+                    VolleyError("Timed out connecting to public-api.wordpress.com")
+                )
+            )
+
+            val result = fetchConnectSiteInfoWithError(error, discoverWPAPIOnFailure = true)
+
+            assertThat(result.error).isNotNull
+            assertThat(result.error!!.type).isEqualTo(SiteErrorType.WORDPRESS_COM_CONNECTIVITY_ERROR)
+            assertThat(result.error!!.wpApiDiscovery).isNull()
+            verifyNoInteractions(discoveryWPAPIRestClient)
         }
 
     @Test
@@ -709,7 +782,8 @@ class SiteRestClientTest {
     }
 
     private suspend fun fetchConnectSiteInfoWithInvalidSslError(
-        sslException: SSLHandshakeException
+        sslException: SSLHandshakeException,
+        discoverWPAPIOnFailure: Boolean = false
     ): ConnectSiteInfoPayload {
         val error = WPComGsonNetworkError(
             BaseNetworkError(
@@ -717,7 +791,7 @@ class SiteRestClientTest {
                 VolleyError(sslException)
             )
         )
-        return fetchConnectSiteInfoWithError(error)
+        return fetchConnectSiteInfoWithError(error, discoverWPAPIOnFailure)
     }
 
     private suspend fun fetchConnectSiteInfoWithError(

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/store/SiteStoreTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/store/SiteStoreTest.kt
@@ -11,6 +11,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.SiteActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.SitesModel
 import org.wordpress.android.fluxc.model.asDomainModel
@@ -29,6 +30,7 @@ import org.wordpress.android.fluxc.persistence.SiteSqlUtils
 import org.wordpress.android.fluxc.persistence.SiteStorePersistence
 import org.wordpress.android.fluxc.persistence.domains.DomainDao
 import org.wordpress.android.fluxc.store.SiteStore.FetchSitesPayload
+import org.wordpress.android.fluxc.store.SiteStore.FetchConnectSiteInfoPayload
 import org.wordpress.android.fluxc.store.SiteStore.FetchedDomainsPayload
 import org.wordpress.android.fluxc.store.SiteStore.FetchedPlansPayload
 import org.wordpress.android.fluxc.store.SiteStore.PlansError
@@ -246,5 +248,23 @@ class SiteStoreTest {
         val onSitePlansFetched = siteStore.fetchSitePlans(site)
 
         assertThat(onSitePlansFetched.error.type).isEqualTo(PlansError(PlansErrorType.GENERIC_ERROR, null).type)
+    }
+
+    @Test
+    fun `given default connect site info payload, when action handled, then discovery opt-out is forwarded`() {
+        val action = SiteActionBuilder.newFetchConnectSiteInfoAction(FetchConnectSiteInfoPayload("example.com"))
+
+        siteStore.onAction(action)
+
+        verify(siteRestClient).fetchConnectSiteInfo("example.com", false)
+    }
+
+    @Test
+    fun `given discovery connect site info payload, when action handled, then discovery opt-in is forwarded`() {
+        val action = SiteActionBuilder.newFetchConnectSiteInfoAction(FetchConnectSiteInfoPayload("example.com", true))
+
+        siteStore.onAction(action)
+
+        verify(siteRestClient).fetchConnectSiteInfo("example.com", true)
     }
 }

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/store/SiteStoreTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/store/SiteStoreTest.kt
@@ -29,8 +29,8 @@ import org.wordpress.android.fluxc.network.xmlrpc.site.SiteXMLRPCClient
 import org.wordpress.android.fluxc.persistence.SiteSqlUtils
 import org.wordpress.android.fluxc.persistence.SiteStorePersistence
 import org.wordpress.android.fluxc.persistence.domains.DomainDao
-import org.wordpress.android.fluxc.store.SiteStore.FetchSitesPayload
 import org.wordpress.android.fluxc.store.SiteStore.FetchConnectSiteInfoPayload
+import org.wordpress.android.fluxc.store.SiteStore.FetchSitesPayload
 import org.wordpress.android.fluxc.store.SiteStore.FetchedDomainsPayload
 import org.wordpress.android.fluxc.store.SiteStore.FetchedPlansPayload
 import org.wordpress.android.fluxc.store.SiteStore.PlansError

--- a/libs/login/src/main/java/org/wordpress/android/login/ConnectSiteInfoFallbackDecision.kt
+++ b/libs/login/src/main/java/org/wordpress/android/login/ConnectSiteInfoFallbackDecision.kt
@@ -4,7 +4,7 @@ import org.wordpress.android.fluxc.store.SiteStore.SiteError
 
 enum class ConnectSiteInfoFallbackDecision {
     OFFER_SITE_CREDENTIALS,
-    SHOW_CONNECTION_ERROR,
+    SHOW_ORIGINAL_ERROR,
     NOT_APPLICABLE;
 
     companion object {
@@ -12,7 +12,7 @@ enum class ConnectSiteInfoFallbackDecision {
         fun from(error: SiteError?, loginMode: LoginMode?): ConnectSiteInfoFallbackDecision {
             val discovery = error?.wpApiDiscovery ?: return NOT_APPLICABLE
             if (loginMode != LoginMode.WOO_LOGIN_MODE) return NOT_APPLICABLE
-            return if (discovery.wpApiBaseUrl != null) OFFER_SITE_CREDENTIALS else SHOW_CONNECTION_ERROR
+            return if (discovery.wpApiBaseUrl != null) OFFER_SITE_CREDENTIALS else SHOW_ORIGINAL_ERROR
         }
     }
 }

--- a/libs/login/src/main/java/org/wordpress/android/login/ConnectSiteInfoFallbackDecision.kt
+++ b/libs/login/src/main/java/org/wordpress/android/login/ConnectSiteInfoFallbackDecision.kt
@@ -1,0 +1,18 @@
+package org.wordpress.android.login
+
+import org.wordpress.android.fluxc.store.SiteStore.SiteError
+
+enum class ConnectSiteInfoFallbackDecision {
+    OFFER_SITE_CREDENTIALS,
+    SHOW_CONNECTION_ERROR,
+    NOT_APPLICABLE;
+
+    companion object {
+        @JvmStatic
+        fun from(error: SiteError?, loginMode: LoginMode?): ConnectSiteInfoFallbackDecision {
+            val discovery = error?.wpApiDiscovery ?: return NOT_APPLICABLE
+            if (loginMode != LoginMode.WOO_LOGIN_MODE) return NOT_APPLICABLE
+            return if (discovery.wpApiBaseUrl != null) OFFER_SITE_CREDENTIALS else SHOW_CONNECTION_ERROR
+        }
+    }
+}

--- a/libs/login/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
+++ b/libs/login/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
@@ -34,6 +34,7 @@ import org.wordpress.android.fluxc.store.SiteStore.ConnectSiteInfoPayload;
 import org.wordpress.android.fluxc.store.SiteStore.FetchConnectSiteInfoPayload;
 import org.wordpress.android.fluxc.store.SiteStore.OnConnectSiteInfoChecked;
 import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType;
+import org.wordpress.android.fluxc.store.SiteStore.WPAPIDiscoveryResult;
 import org.wordpress.android.login.util.SiteUtils;
 import org.wordpress.android.login.widgets.WPLoginInputRow;
 import org.wordpress.android.login.widgets.WPLoginInputRow.OnEditorCommitListener;
@@ -409,11 +410,20 @@ public class LoginSiteAddressFragment extends LoginBaseDiscoveryFragment impleme
                 ConnectSiteInfoFallbackDecision decision = ConnectSiteInfoFallbackDecision.from(
                         event.error,
                         mLoginListener.getLoginMode());
+                WPAPIDiscoveryResult discovery = event.error.wpApiDiscovery;
                 switch (decision) {
                     case OFFER_SITE_CREDENTIALS:
+                        AppLog.i(T.API, "connect/site-info fallback offered. errorType=" + event.error.type.name()
+                                + ", apiError=" + discovery.connectSiteInfoApiError
+                                + ", message=" + event.error.message
+                                + ", wpApiBaseUrl=" + discovery.wpApiBaseUrl);
                         mLoginListener.handleSiteAddressError(event.info);
                         break;
                     case SHOW_CONNECTION_ERROR:
+                        AppLog.i(T.API, "connect/site-info fallback discovery failed. errorType="
+                                + event.error.type.name()
+                                + ", apiError=" + discovery.connectSiteInfoApiError
+                                + ", message=" + event.error.message);
                         showError(R.string.error_generic_network);
                         break;
                     case NOT_APPLICABLE:

--- a/libs/login/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
+++ b/libs/login/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
@@ -31,6 +31,7 @@ import org.wordpress.android.fluxc.network.discovery.DiscoveryUtils;
 import org.wordpress.android.fluxc.network.discovery.SelfHostedEndpointFinder.DiscoveryError;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.SiteStore.ConnectSiteInfoPayload;
+import org.wordpress.android.fluxc.store.SiteStore.FetchConnectSiteInfoPayload;
 import org.wordpress.android.fluxc.store.SiteStore.OnConnectSiteInfoChecked;
 import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType;
 import org.wordpress.android.login.util.SiteUtils;
@@ -223,7 +224,8 @@ public class LoginSiteAddressFragment extends LoginBaseDiscoveryFragment impleme
         String cleanedUrl = stripKnownPaths(mRequestedSiteAddress);
 
         mAnalyticsListener.trackConnectedSiteInfoRequested(cleanedUrl);
-        mDispatcher.dispatch(SiteActionBuilder.newFetchConnectSiteInfoAction(cleanedUrl));
+        mDispatcher.dispatch(SiteActionBuilder.newFetchConnectSiteInfoAction(
+                new FetchConnectSiteInfoPayload(cleanedUrl, true)));
 
         startProgress();
     }
@@ -404,10 +406,24 @@ public class LoginSiteAddressFragment extends LoginBaseDiscoveryFragment impleme
                         )
                 );
             } else {
-                AppLog.e(T.API, "onFetchedConnectSiteInfo has error: " + event.error.message);
-                showError(mSiteAddressErrorMapper.getSiteInfoErrorResId(
+                ConnectSiteInfoFallbackDecision decision = ConnectSiteInfoFallbackDecision.from(
                         event.error,
-                        NetworkUtils.isNetworkAvailable(requireContext())));
+                        mLoginListener.getLoginMode());
+                switch (decision) {
+                    case OFFER_SITE_CREDENTIALS:
+                        mLoginListener.handleSiteAddressError(event.info);
+                        break;
+                    case SHOW_CONNECTION_ERROR:
+                        showError(R.string.error_generic_network);
+                        break;
+                    case NOT_APPLICABLE:
+                    default:
+                        AppLog.e(T.API, "onFetchedConnectSiteInfo has error: " + event.error.message);
+                        showError(mSiteAddressErrorMapper.getSiteInfoErrorResId(
+                                event.error,
+                                NetworkUtils.isNetworkAvailable(requireContext())));
+                        break;
+                }
             }
             endProgressIfNeeded();
         } else {

--- a/libs/login/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
+++ b/libs/login/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
@@ -419,12 +419,14 @@ public class LoginSiteAddressFragment extends LoginBaseDiscoveryFragment impleme
                                 + ", wpApiBaseUrl=" + discovery.wpApiBaseUrl);
                         mLoginListener.handleSiteAddressError(event.info);
                         break;
-                    case SHOW_CONNECTION_ERROR:
+                    case SHOW_ORIGINAL_ERROR:
                         AppLog.i(T.API, "connect/site-info fallback discovery failed. errorType="
                                 + event.error.type.name()
                                 + ", apiError=" + discovery.connectSiteInfoApiError
                                 + ", message=" + event.error.message);
-                        showError(R.string.error_generic_network);
+                        showError(mSiteAddressErrorMapper.getSiteInfoErrorResId(
+                                event.error,
+                                NetworkUtils.isNetworkAvailable(requireContext())));
                         break;
                     case NOT_APPLICABLE:
                     default:

--- a/libs/login/src/test/java/org/wordpress/android/login/ConnectSiteInfoFallbackDecisionTest.kt
+++ b/libs/login/src/test/java/org/wordpress/android/login/ConnectSiteInfoFallbackDecisionTest.kt
@@ -4,6 +4,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.wordpress.android.fluxc.store.SiteStore.SiteError
 import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType.INVALID_SITE
+import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType.WORDPRESS_COM_CONNECTIVITY_ERROR
 import org.wordpress.android.fluxc.store.SiteStore.WPAPIDiscoveryResult
 
 class ConnectSiteInfoFallbackDecisionTest {
@@ -36,6 +37,18 @@ class ConnectSiteInfoFallbackDecisionTest {
     fun `given discovered WP API base URL in Woo login mode, when creating fallback decision, then offer site credentials`() {
         val error = SiteError(
             INVALID_SITE,
+            wpApiDiscovery = WPAPIDiscoveryResult(wpApiBaseUrl = "https://example.com/wp-json/")
+        )
+
+        val decision = ConnectSiteInfoFallbackDecision.from(error, LoginMode.WOO_LOGIN_MODE)
+
+        assertThat(decision).isEqualTo(ConnectSiteInfoFallbackDecision.OFFER_SITE_CREDENTIALS)
+    }
+
+    @Test
+    fun `given discovered connectivity error in Woo login mode, when creating fallback decision, then offer site credentials`() {
+        val error = SiteError(
+            WORDPRESS_COM_CONNECTIVITY_ERROR,
             wpApiDiscovery = WPAPIDiscoveryResult(wpApiBaseUrl = "https://example.com/wp-json/")
         )
 

--- a/libs/login/src/test/java/org/wordpress/android/login/ConnectSiteInfoFallbackDecisionTest.kt
+++ b/libs/login/src/test/java/org/wordpress/android/login/ConnectSiteInfoFallbackDecisionTest.kt
@@ -58,11 +58,20 @@ class ConnectSiteInfoFallbackDecisionTest {
     }
 
     @Test
-    fun `given discovery state without WP API base URL in Woo login mode, when creating fallback decision, then show error`() {
+    fun `given invalid site discovery without WP API base URL in Woo login mode, when creating decision, then show original error`() {
         val error = SiteError(INVALID_SITE, wpApiDiscovery = WPAPIDiscoveryResult())
 
         val decision = ConnectSiteInfoFallbackDecision.from(error, LoginMode.WOO_LOGIN_MODE)
 
-        assertThat(decision).isEqualTo(ConnectSiteInfoFallbackDecision.SHOW_CONNECTION_ERROR)
+        assertThat(decision).isEqualTo(ConnectSiteInfoFallbackDecision.SHOW_ORIGINAL_ERROR)
+    }
+
+    @Test
+    fun `given connectivity discovery without WP API base URL in Woo login mode, when creating decision, then show original error`() {
+        val error = SiteError(WORDPRESS_COM_CONNECTIVITY_ERROR, wpApiDiscovery = WPAPIDiscoveryResult())
+
+        val decision = ConnectSiteInfoFallbackDecision.from(error, LoginMode.WOO_LOGIN_MODE)
+
+        assertThat(decision).isEqualTo(ConnectSiteInfoFallbackDecision.SHOW_ORIGINAL_ERROR)
     }
 }

--- a/libs/login/src/test/java/org/wordpress/android/login/ConnectSiteInfoFallbackDecisionTest.kt
+++ b/libs/login/src/test/java/org/wordpress/android/login/ConnectSiteInfoFallbackDecisionTest.kt
@@ -1,0 +1,55 @@
+package org.wordpress.android.login
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.wordpress.android.fluxc.store.SiteStore.SiteError
+import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType.INVALID_SITE
+import org.wordpress.android.fluxc.store.SiteStore.WPAPIDiscoveryResult
+
+class ConnectSiteInfoFallbackDecisionTest {
+    @Test
+    fun `given null error, when creating fallback decision, then not applicable`() {
+        val decision = ConnectSiteInfoFallbackDecision.from(null, LoginMode.WOO_LOGIN_MODE)
+
+        assertThat(decision).isEqualTo(ConnectSiteInfoFallbackDecision.NOT_APPLICABLE)
+    }
+
+    @Test
+    fun `given error without discovery state, when creating fallback decision, then not applicable`() {
+        val error = SiteError(INVALID_SITE)
+
+        val decision = ConnectSiteInfoFallbackDecision.from(error, LoginMode.WOO_LOGIN_MODE)
+
+        assertThat(decision).isEqualTo(ConnectSiteInfoFallbackDecision.NOT_APPLICABLE)
+    }
+
+    @Test
+    fun `given discovery state and non-Woo login mode, when creating fallback decision, then not applicable`() {
+        val error = SiteError(INVALID_SITE, wpApiDiscovery = WPAPIDiscoveryResult())
+
+        val decision = ConnectSiteInfoFallbackDecision.from(error, LoginMode.FULL)
+
+        assertThat(decision).isEqualTo(ConnectSiteInfoFallbackDecision.NOT_APPLICABLE)
+    }
+
+    @Test
+    fun `given discovered WP API base URL in Woo login mode, when creating fallback decision, then offer site credentials`() {
+        val error = SiteError(
+            INVALID_SITE,
+            wpApiDiscovery = WPAPIDiscoveryResult(wpApiBaseUrl = "https://example.com/wp-json/")
+        )
+
+        val decision = ConnectSiteInfoFallbackDecision.from(error, LoginMode.WOO_LOGIN_MODE)
+
+        assertThat(decision).isEqualTo(ConnectSiteInfoFallbackDecision.OFFER_SITE_CREDENTIALS)
+    }
+
+    @Test
+    fun `given discovery state without WP API base URL in Woo login mode, when creating fallback decision, then show error`() {
+        val error = SiteError(INVALID_SITE, wpApiDiscovery = WPAPIDiscoveryResult())
+
+        val decision = ConnectSiteInfoFallbackDecision.from(error, LoginMode.WOO_LOGIN_MODE)
+
+        assertThat(decision).isEqualTo(ConnectSiteInfoFallbackDecision.SHOW_CONNECTION_ERROR)
+    }
+}


### PR DESCRIPTION
### Description
Fixes WOOMOB-2501

When Woo login enters a site address, Android currently relies on WordPress.com `/connect/site-info` to classify the site before continuing. That blocks login when `/site-info` cannot verify a site even though the device can still reach the site directly through the WordPress REST API.

This PR adds an explicit, opt-in fallback path for the Woo site-address preflight:

- eligible `/connect/site-info` failures run device-side WordPress REST API discovery before blocking login;
- successful discovery shows a `Connection Issue` dialog that lets the user continue with site credentials;
- failed discovery keeps the user on the site-address step with the existing connection-style error;
- existing explicit non-fallback paths are preserved for malformed local URLs, HTTP 200 non-WordPress/not-found payloads, suspended WordPress.com sites, remote cURL 60 certificate failures, and Android TLS certificate validity failures.

A few details are intentional:

- The discovery path is opt-in via `FetchConnectSiteInfoPayload(discoverWPAPIOnFailure = true)`, and only the Woo site-address flow opts in. No-Jetpack checks, site picker, and other default callers keep their existing no-discovery behavior.
- WordPress.com network/DNS/timeout failures from the opted-in `/connect/site-info` request are also discovery-gated. Remote site timeouts are now returned by WordPress.com as structured `follow_redirects_failed` / cURL 28 responses, so local Volley `NO_CONNECTION`, `NETWORK_ERROR`, and `TIMEOUT` mean Android failed reaching WordPress.com. Direct REST discovery is a safe recovery gate for those cases.
- The login/app layer owns the fallback decision and prompt. FluxC only carries mechanism-level discovery state (`WPAPIDiscoveryResult`) plus the original error context.
- No fallback-specific Tracks funnel is added. The existing site-info failure event remains in place, and fallback attempts add targeted `AppLog` context for support/debugging.

### Test Steps
1. Install and open a debug build on an emulator or device.
2. Configure ApiFaker to make WordPress.com `/connect/site-info` return the same fallback-eligible error used in manual verification:

```bash
cat > /tmp/woomob2501-site-info-error.json <<'JSON'
{"error":"origin_failed","message":"origin failed"}
JSON

adb push /tmp/woomob2501-site-info-error.json /data/local/tmp/woomob2501-site-info-error.json

adb shell am broadcast \
  -p com.woocommerce.android.dev \
  -a com.woocommerce.android.apifaker.CLEAR_ENDPOINTS

adb shell am broadcast \
  -p com.woocommerce.android.dev \
  -a com.woocommerce.android.apifaker.ADD_ENDPOINT \
  --es api_type wp-com \
  --es path /rest/v1.1/connect/site-info \
  --es http_method GET \
  --ei response_status_code 400 \
  --es response_body_file /data/local/tmp/woomob2501-site-info-error.json

adb shell am broadcast \
  -p com.woocommerce.android.dev \
  -a com.woocommerce.android.apifaker.SET_STATUS \
  --ez enabled true
```

3. Launch the Woo app and start the Woo login flow.
4. On the site-address screen, enter `wordpress.org` and tap Continue. This keeps `/connect/site-info` mocked while allowing live REST discovery at `https://wordpress.org/wp-json/`.
5. Verify the `Connection Issue` dialog appears with the message `We couldn't verify your site details. You can try logging in with your site credentials instead.` and the `Log In with Site Credentials` CTA.
6. Tap Cancel and verify the dialog closes, the app remains on the site-address screen, and `wordpress.org` is still present.
7. Tap Continue again, then tap `Log In with Site Credentials` and verify the site-credentials login screen opens for `wordpress.org`.
8. Optional logcat confirmation:

```bash
adb logcat -d | rg -i 'WCApiFaker|connect/site-info|Found valid WP-API endpoint|site-info fallback offered'
```

9. Cleanup ApiFaker after testing:

```bash
adb shell am broadcast \
  -p com.woocommerce.android.dev \
  -a com.woocommerce.android.apifaker.SET_STATUS \
  --ez enabled false

adb shell am broadcast \
  -p com.woocommerce.android.dev \
  -a com.woocommerce.android.apifaker.CLEAR_ENDPOINTS
```

10. As a preserved exclusion check, use a malformed local URL or a non-WordPress/not-found `/connect/site-info` success response and verify the fallback dialog is not shown.

### Images/gif
<img width="360" alt="image" src="https://github.com/user-attachments/assets/c1a62ba4-a374-4783-b5ab-8f73aa22d87b" />

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

