### PR TITLE
[WOOMOB-3280] Remove "test" wording from order flow + add non-refundable fees note

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 
 25.1
 -----
+- [*] Renamed the empty Orders "test order" prompt to "Place your first order" and clarified that processing fees aren't refundable [https://github.com/woocommerce/woocommerce-android/pull/16086]
 - [*] Improved login error messages for site security certificate issues [https://github.com/woocommerce/woocommerce-android/pull/16042]
 - [Internal] Migrated media upload and media-list endpoints to Application Passwords [https://github.com/woocommerce/woocommerce-android/pull/15550]
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
@@ -79,6 +79,8 @@ object AppUrls {
         "https://stripe.com/docs/terminal/payments/setup-reader/tap-to-pay?platform=android#supported-devices"
     const val LEARN_MORE_ABOUT_TAP_TO_PAY =
         "https://woocommerce.com/document/woopayments/in-person-payments/tap-to-pay-android/"
+    const val WOOPAYMENTS_FEES_NOT_REFUNDABLE =
+        "https://woocommerce.com/document/woopayments/fees/why-arent-fees-refunded/"
 
     const val WOOCOMMERCE_LEARN_MORE_ABOUT_PAYMENTS_CASH_ON_DELIVERY =
         "https://woocommerce.com/document/cash-on-delivery/"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/CreateTestOrderDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/CreateTestOrderDialog.kt
@@ -21,16 +21,22 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.woocommerce.android.AppUrls
 import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.annotatedStringRes
+import com.woocommerce.android.ui.compose.clickableAnnotatedStringRes
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.util.ChromeCustomTabUtils
 import java.text.NumberFormat
 import java.util.Locale
 
@@ -72,10 +78,20 @@ fun CreateTestOrderDialog(
 
             Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_200)))
 
-            TestOrderStep(1, R.string.try_test_order_step_1)
-            TestOrderStep(2, R.string.try_test_order_step_2)
-            TestOrderStep(3, R.string.try_test_order_step_3)
-            TestOrderStep(4, R.string.try_test_order_step_4)
+            val context = LocalContext.current
+
+            TestOrderStep(1, annotatedStringRes(R.string.try_test_order_step_1))
+            TestOrderStep(2, annotatedStringRes(R.string.try_test_order_step_2))
+            TestOrderStep(3, annotatedStringRes(R.string.try_test_order_step_3))
+            TestOrderStep(
+                4,
+                clickableAnnotatedStringRes(
+                    stringResId = R.string.try_test_order_step_4,
+                    onUrlClick = {
+                        ChromeCustomTabUtils.launchUrl(context, AppUrls.WOOPAYMENTS_FEES_NOT_REFUNDABLE)
+                    }
+                )
+            )
 
             WCColoredButton(
                 modifier = Modifier
@@ -90,7 +106,7 @@ fun CreateTestOrderDialog(
 }
 
 @Composable
-fun TestOrderStep(stepNumber: Int, stepTextId: Int) {
+fun TestOrderStep(stepNumber: Int, stepText: AnnotatedString) {
     val format = NumberFormat.getInstance(Locale.getDefault())
     val formattedNumber = format.format(stepNumber)
     Column {
@@ -112,7 +128,7 @@ fun TestOrderStep(stepNumber: Int, stepTextId: Int) {
 
             Spacer(modifier = Modifier.width(dimensionResource(id = R.dimen.major_100)))
 
-            Text(text = stringResource(id = stepTextId))
+            Text(text = stepText)
         }
 
         Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/CreateTestOrderDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/CreateTestOrderDialog.kt
@@ -59,7 +59,7 @@ fun CreateTestOrderDialog(
         ) {
             Text(
                 modifier = Modifier.padding(top = dimensionResource(id = R.dimen.major_100)),
-                text = stringResource(id = R.string.try_test_order_heading),
+                text = stringResource(id = R.string.place_first_order_heading),
                 style = MaterialTheme.typography.h5,
                 textAlign = TextAlign.Center
             )
@@ -81,12 +81,12 @@ fun CreateTestOrderDialog(
             val context = LocalContext.current
 
             TestOrderStep(1, annotatedStringRes(R.string.try_test_order_step_1))
-            TestOrderStep(2, annotatedStringRes(R.string.try_test_order_step_2))
+            TestOrderStep(2, annotatedStringRes(R.string.place_first_order_step_2))
             TestOrderStep(3, annotatedStringRes(R.string.try_test_order_step_3))
             TestOrderStep(
                 4,
                 clickableAnnotatedStringRes(
-                    stringResId = R.string.try_test_order_step_4,
+                    stringResId = R.string.place_first_order_step_4,
                     onUrlClick = {
                         ChromeCustomTabUtils.launchUrl(context, AppUrls.WOOPAYMENTS_FEES_NOT_REFUNDABLE)
                     }
@@ -99,7 +99,7 @@ fun CreateTestOrderDialog(
                     .fillMaxWidth(),
                 onClick = onStartTestOrderButtonClick
             ) {
-                Text(stringResource(id = R.string.try_test_order_button))
+                Text(stringResource(id = R.string.place_first_order_button))
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCEmptyView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCEmptyView.kt
@@ -155,8 +155,8 @@ class WCEmptyView @JvmOverloads constructor(ctx: Context, attrs: AttributeSet? =
             ORDER_LIST_CREATE_TEST_ORDER -> {
                 isTitleBold = true
                 title = context.getString(R.string.empty_order_list_title)
-                message = context.getString(R.string.empty_order_test_order_message)
-                buttonText = context.getString(R.string.empty_order_test_order_button)
+                message = context.getString(R.string.empty_order_place_order_message)
+                buttonText = context.getString(R.string.empty_order_place_order_button)
                 drawableId = R.drawable.img_empty_orders_no_orders
             }
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2303,16 +2303,17 @@
     <string name="empty_message_with_search">We\'re sorry, we couldn\'t find results for \"%s\"</string>
     <string name="empty_message_with_filters">We\'re sorry, no products match the selected filters"</string>
 
-    <!-- Empty order: try a test order -->
-    <string name="empty_order_test_order_message">Run an order to ensure your WooCommerce process delivers a seamless customer experience</string>
-    <string name="empty_order_test_order_button">Place your first order</string>
+    <!-- Empty order: place your first order -->
+    <string name="empty_order_place_order_message">Run an order to ensure your WooCommerce process delivers a seamless customer experience</string>
+    <string name="empty_order_place_order_button">Place your first order</string>
 
-    <string name="try_test_order_heading">Place your first order</string>
+    <string name="place_first_order_heading">Place your first order</string>
+    <!-- Steps 1 and 3 keep their original keys: their copy is unchanged, so renaming would discard existing translations -->
     <string name="try_test_order_step_1">Tap the button below to be redirected to your online store via a web browser.</string>
-    <string name="try_test_order_step_2">Select your product, add to cart, and complete checkout on that web store as a real customer.</string>
+    <string name="place_first_order_step_2">Select your product, add to cart, and complete checkout on that web store as a real customer.</string>
     <string name="try_test_order_step_3">Complete the payment and await a push notification about the order on your WooCommerce app.</string>
-    <string name="try_test_order_step_4">Use the app to process the refund for the order. &lt;a href=\'processingFees\'&gt;&lt;u&gt;Processing fees aren\'t refundable&lt;/u&gt;&lt;/a&gt;.</string>
-    <string name="try_test_order_button">Place order</string>
+    <string name="place_first_order_step_4">Use the app to process the refund for the order. &lt;a href=\'processingFees\'&gt;&lt;u&gt;Processing fees aren\'t refundable&lt;/u&gt;&lt;/a&gt;.</string>
+    <string name="place_first_order_button">Place order</string>
     <!--
         Settings
     -->

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2304,15 +2304,15 @@
     <string name="empty_message_with_filters">We\'re sorry, no products match the selected filters"</string>
 
     <!-- Empty order: try a test order -->
-    <string name="empty_order_test_order_message">Run a test order to ensure your WooCommerce process delivers a seamless customer experience</string>
-    <string name="empty_order_test_order_button">Try a test order</string>
+    <string name="empty_order_test_order_message">Run an order to ensure your WooCommerce process delivers a seamless customer experience</string>
+    <string name="empty_order_test_order_button">Place your first order</string>
 
-    <string name="try_test_order_heading">Try a test order</string>
+    <string name="try_test_order_heading">Place your first order</string>
     <string name="try_test_order_step_1">Tap the button below to be redirected to your online store via a web browser.</string>
-    <string name="try_test_order_step_2">Select your test product, add to cart, and complete checkout on that web store as a real customer.</string>
+    <string name="try_test_order_step_2">Select your product, add to cart, and complete checkout on that web store as a real customer.</string>
     <string name="try_test_order_step_3">Complete the payment and await a push notification about the order on your WooCommerce app.</string>
-    <string name="try_test_order_step_4">Use the app to process the refund for the test order</string>
-    <string name="try_test_order_button">Start test order</string>
+    <string name="try_test_order_step_4">Use the app to process the refund for the order. &lt;a href=\'processingFees\'&gt;&lt;u&gt;Processing fees aren\'t refundable&lt;/u&gt;&lt;/a&gt;.</string>
+    <string name="try_test_order_button">Place order</string>
     <!--
         Settings
     -->


### PR DESCRIPTION
### Description

Fixes WOOMOB-3280

The empty Orders screen offered a "Try a Test Order" prompt. The word "test" implies a sandbox/no-charge order (as it does in Stripe, PayPal, Square, and WooPayments), but the flow sends the merchant to their live store and processes a real charge — including non-refundable processing fees. A merchant was charged real fees believing it was a test (parent issue WOOMOB-3167).

This PR removes the "test" wording from the flow entirely and adds an inline link clarifying that processing fees aren't refundable (per the discussion on the parent issue):

- Dialog title and empty-screen entry button → **"Place your first order"**
- Step 2 → "Select your product, …" (dropped "test")
- Step 4 → "Use the app to process the refund for the order. **Processing fees aren't refundable**." where the bold text links to the WooPayments fees doc
- CTA button → **"Place order"**
- Empty-screen message → "Run an order to ensure …" (dropped "test")

The step-4 link reuses the existing `clickableAnnotatedStringRes` helper (same pattern as the Blaze payment summary) and opens the doc in a Chrome custom tab via a new `AppUrls.WOOPAYMENTS_FEES_NOT_REFUNDABLE` constant. String-resource keys and analytics events are intentionally unchanged (copy-only change); only the English source strings were edited.

Parent issue: WOOMOB-3167. iOS counterpart: WOOMOB-3281.

### Test Steps

1. Use a store that is public, has at least one published product, has zero orders.
2. Open the **Orders** tab — the empty state shows a **"Place your first order"** button with the message "Run an order to ensure your WooCommerce process delivers a seamless customer experience." (no "test" wording).
3. Tap **"Place your first order"** to open the dialog.
4. Verify the dialog title is **"Place your first order"**, none of the four steps or the CTA contain the word "test", and the CTA reads **"Place order"**.
5. On step 4, tap **"Processing fees aren't refundable"** and verify it opens the WooPayments fees documentation (https://woocommerce.com/document/woopayments/fees/why-arent-fees-refunded/) in an in-app browser tab.

### Images/gif

https://github.com/user-attachments/assets/ee8cb2a8-7e0c-484a-bd37-d2cd4b12db64

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.