### PR TITLE
[WOOMOB-2720] Surface POS order-detail refresh failures

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.wrapContentHeight
@@ -28,6 +29,8 @@ import androidx.compose.material.pullrefresh.PullRefreshIndicator
 import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -105,6 +108,14 @@ fun WooPosOrdersScreen(
 
     val listState by listViewModel.state.collectAsState()
     val detailState by detailViewModel.state.collectAsState()
+
+    val snackbarHostState = remember { SnackbarHostState() }
+    val refreshErrorMessage = stringResource(R.string.woopos_orders_details_refresh_error)
+    LaunchedEffect(Unit) {
+        detailViewModel.refreshFailedEvent.collect {
+            snackbarHostState.showSnackbar(refreshErrorMessage)
+        }
+    }
 
     val emailReceiptSent = backStackEntry.savedStateHandle
         .getStateFlow(EMAIL_RECEIPT_SENT, false)
@@ -201,6 +212,7 @@ fun WooPosOrdersScreen(
         detailState = detailState,
         isSingleOrderMode = detailViewModel.isSingleOrderMode,
         isPhoneLayout = isPhoneLayout,
+        snackbarHostState = snackbarHostState,
         scrollToTopEvent = listViewModel.scrollToTopEvent,
         onBackClicked = { onNavigationEvent(WooPosNavigationEvent.GoBack) },
         onRefresh = listViewModel::onRefresh,
@@ -239,6 +251,7 @@ private fun WooPosOrdersScreen(
     detailState: WooPosOrderDetailsState,
     isSingleOrderMode: Boolean = false,
     isPhoneLayout: Boolean = false,
+    snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
     scrollToTopEvent: SharedFlow<Unit>,
     onBackClicked: () -> Unit,
     onRefresh: () -> Unit,
@@ -339,6 +352,14 @@ private fun WooPosOrdersScreen(
             isVisible = pendingOrderSelectionConfirmation != null,
             onDismissRequest = onPendingOrderSelectionConfirmationDismissed,
             onDiscardChanges = onPendingOrderSelectionConfirmed,
+        )
+
+        SnackbarHost(
+            hostState = snackbarHostState,
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .navigationBarsPadding()
+                .padding(bottom = WooPosSpacing.Medium.value)
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsViewModel.kt
@@ -23,8 +23,11 @@ import com.woocommerce.android.viewmodel.ResourceProvider
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
@@ -54,6 +57,9 @@ class WooPosOrderDetailsViewModel @Inject constructor(
         if (singleOrderId != null) WooPosOrderDetailsState.Loading else WooPosOrderDetailsState.Idle
     )
     val state: StateFlow<WooPosOrderDetailsState> = _state.asStateFlow()
+
+    private val _refreshFailedEvent = MutableSharedFlow<Unit>()
+    val refreshFailedEvent: SharedFlow<Unit> = _refreshFailedEvent.asSharedFlow()
 
     private var loadOrderJob: Job? = null
     private var sideLoadJob: Job? = null
@@ -246,11 +252,15 @@ class WooPosOrderDetailsViewModel @Inject constructor(
             // Fetch + notify run atomically so the list row is always refreshed when the cache
             // is updated, even if the user has already selected a different order. Only the
             // detail-pane work below is cancellable and skipped on selection change.
-            val updated = withContext(NonCancellable) {
-                ordersDataSource.refreshOrderById(selectedOrderId).getOrNull()?.also {
+            val refreshResult = withContext(NonCancellable) {
+                ordersDataSource.refreshOrderById(selectedOrderId).onSuccess {
                     coordinator.notifyOrderRefreshed(it.id)
                 }
-            } ?: return@launch
+            }
+            val updated = refreshResult.getOrElse {
+                _refreshFailedEvent.emit(Unit)
+                return@launch
+            }
             if ((_state.value as? WooPosOrderDetailsState.Loaded)?.details?.id == updated.id) {
                 applyOrderUpdate(updated)
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsViewModel.kt
@@ -18,6 +18,7 @@ import com.woocommerce.android.ui.woopos.orders.WooPosOrdersState.OrderDetailsVi
 import com.woocommerce.android.ui.woopos.orders.WooPosOrdersUIEvent
 import com.woocommerce.android.ui.woopos.orders.details.refund.RefundRowData
 import com.woocommerce.android.ui.woopos.orders.details.refund.WooPosRefundInfoBuilder
+import com.woocommerce.android.ui.woopos.util.WooPosNetworkStatus
 import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
 import com.woocommerce.android.viewmodel.ResourceProvider
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -47,6 +48,7 @@ class WooPosOrderDetailsViewModel @Inject constructor(
     private val refundInfoBuilder: WooPosRefundInfoBuilder,
     private val formatPrice: WooPosFormatPrice,
     private val coordinator: WooPosOrdersCoordinator,
+    private val networkStatus: WooPosNetworkStatus,
 ) : ViewModel() {
 
     private val singleOrderId: Long? = savedStateHandle.get<Long>(ORDERS_ROUTE_ORDER_ID_KEY)
@@ -249,6 +251,10 @@ class WooPosOrderDetailsViewModel @Inject constructor(
         }
         refreshOrderJob?.cancel()
         refreshOrderJob = viewModelScope.launch {
+            if (!networkStatus.isConnected()) {
+                _refreshFailedEvent.emit(Unit)
+                return@launch
+            }
             // Fetch + notify run atomically so the list row is always refreshed when the cache
             // is updated, even if the user has already selected a different order. Only the
             // detail-pane work below is cancellable and skipped on selection change.

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4167,6 +4167,7 @@
     <string name="woopos_refund_back_to_order_button">Back to order</string>
     <string name="woopos_orders_refund_complete">Refund complete</string>
     <string name="woopos_orders_refund_success_message">You refunded %1$s via %2$s.</string>
+    <string name="woopos_orders_details_refresh_error">Couldn\'t refresh the order. Please check your connection and try again.</string>
     <string name="woopos_orders_details_placeholder_title">Select an order</string>
     <string name="woopos_orders_details_placeholder_message">Choose an order from the list to view details.</string>
     <string name="woopos_orders_details_products_title">Products</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsViewModelTest.kt
@@ -17,6 +17,7 @@ import com.woocommerce.android.ui.woopos.orders.WooPosOrdersState.OrderAction
 import com.woocommerce.android.ui.woopos.orders.WooPosOrdersUIEvent
 import com.woocommerce.android.ui.woopos.orders.details.refund.WooPosRefundInfoBuilder
 import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
+import com.woocommerce.android.ui.woopos.util.WooPosNetworkStatus
 import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
 import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -53,6 +54,7 @@ class WooPosOrderDetailsViewModelTest {
     private val ordersAnalyticsTracker: WooPosOrdersAnalyticsTracker = mock()
     private val getProductById: WooPosGetProductById = mock()
     private val coordinator = WooPosOrdersCoordinator()
+    private val networkStatus: WooPosNetworkStatus = mock()
     private lateinit var orderDetailsMapper: WooPosOrderDetailsMapper
     private lateinit var refundInfoBuilder: WooPosRefundInfoBuilder
     private lateinit var orderActionsProvider: WooPosOrderActionsProvider
@@ -417,6 +419,7 @@ class WooPosOrderDetailsViewModelTest {
             refundInfoBuilder = refundInfoBuilder,
             formatPrice = formatPrice,
             coordinator = coordinator,
+            networkStatus = networkStatus,
         )
     }
 
@@ -479,6 +482,7 @@ class WooPosOrderDetailsViewModelTest {
     private suspend fun setupDataSourceMocks() {
         doReturn(Result.success(order(1L))).whenever(dataSource).getOrderById(any())
         doReturn(Result.success(order(1L))).whenever(dataSource).refreshOrderById(any())
+        whenever(networkStatus.isConnected()).thenReturn(true)
     }
 
     // region Refresh
@@ -545,6 +549,29 @@ class WooPosOrderDetailsViewModelTest {
 
         // THEN
         assertThat(events).hasSize(1)
+
+        collectorJob.cancel()
+    }
+
+    @Test
+    fun `given no connection, when back from issue refund, then event emitted without fetching order`() = runTest {
+        // GIVEN
+        whenever(networkStatus.isConnected()).thenReturn(false)
+        viewModel = createViewModel()
+        advanceUntilIdle()
+        coordinator.selectOrder(1L)
+        advanceUntilIdle()
+        val events = mutableListOf<Unit>()
+        val collectorJob = launch { viewModel.refreshFailedEvent.collect { events.add(it) } }
+        advanceUntilIdle()
+
+        // WHEN
+        viewModel.onBackFromIssueRefund()
+        advanceUntilIdle()
+
+        // THEN
+        assertThat(events).hasSize(1)
+        verify(dataSource, never()).refreshOrderById(any())
 
         collectorJob.cancel()
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsViewModelTest.kt
@@ -526,6 +526,50 @@ class WooPosOrderDetailsViewModelTest {
             collectorJob.cancel()
         }
 
+    @Test
+    fun `given refresh fails, when back from issue refund, then refresh failed event emitted`() = runTest {
+        // GIVEN
+        viewModel = createViewModel()
+        advanceUntilIdle()
+        coordinator.selectOrder(1L)
+        advanceUntilIdle()
+        val events = mutableListOf<Unit>()
+        val collectorJob = launch { viewModel.refreshFailedEvent.collect { events.add(it) } }
+        advanceUntilIdle()
+        doReturn(Result.failure<Order>(RuntimeException("network error")))
+            .whenever(dataSource).refreshOrderById(1L)
+
+        // WHEN
+        viewModel.onBackFromIssueRefund()
+        advanceUntilIdle()
+
+        // THEN
+        assertThat(events).hasSize(1)
+
+        collectorJob.cancel()
+    }
+
+    @Test
+    fun `given refresh succeeds, when back from issue refund, then refresh failed event not emitted`() = runTest {
+        // GIVEN
+        viewModel = createViewModel()
+        advanceUntilIdle()
+        coordinator.selectOrder(1L)
+        advanceUntilIdle()
+        val events = mutableListOf<Unit>()
+        val collectorJob = launch { viewModel.refreshFailedEvent.collect { events.add(it) } }
+        advanceUntilIdle()
+
+        // WHEN
+        viewModel.onBackFromSuccessfullySendingEmailReceipt()
+        advanceUntilIdle()
+
+        // THEN
+        assertThat(events).isEmpty()
+
+        collectorJob.cancel()
+    }
+
     // endregion
 
     // region Retry


### PR DESCRIPTION
### Description

Fixes WOOMOB-2720

In POS, the order-detail refresh that runs after issuing a refund / sending an email receipt silently swallowed network failures, leaving stale data on screen with no feedback. This shows a snackbar when that refresh fails (and fails fast when offline). Uses an in-Compose snackbar because system `Toast`s don't render in the POS activity.

### Test Steps

1. POS → **Orders**, select a **Completed** order so it loads in the detail pane.
2. Tap **Issue refund** and complete a refund (any item).
3. On the **"Refund complete"** screen, **before** tapping Done, enable **Airplane mode** (or turn off Wi-Fi + mobile data).
4. Tap **Done**.
5. Expect: a snackbar at the bottom — *"Couldn't refresh the order. Please check your connection and try again."* — appears (near-)immediately, and the detail pane keeps showing the existing data instead of going blank/erroring.
6. Turn connectivity back on, refund another Completed order, and tap Done → no snackbar, and the detail pane updates to reflect the refund.

### Images/gif
<img width="2560" height="1600" alt="Screenshot_1781616221" src="https://github.com/user-attachments/assets/1d7571a8-7c22-481d-a8c0-a2c97de3a494" />



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
