### PR TITLE
[WOOMOB-3182] Fix orders missing from the order list until a filter or refresh

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 -----
 - [*] Improved login error messages for site security certificate issues [https://github.com/woocommerce/woocommerce-android/pull/16042]
 - [Internal] Migrated media upload and media-list endpoints to Application Passwords [https://github.com/woocommerce/woocommerce-android/pull/15550]
+- [*] Fixed newest orders sometimes missing from the order list until a filter was applied or the list was refreshed [https://github.com/woocommerce/woocommerce-android/pull/16088]
 
 25.0
 -----

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -47,6 +47,7 @@ import org.wordpress.android.fluxc.persistence.entity.OrderNoteEntity
 import org.wordpress.android.fluxc.store.ListStore.FetchedListItemsPayload
 import org.wordpress.android.fluxc.store.ListStore.ListError
 import org.wordpress.android.fluxc.store.ListStore.ListErrorType
+import org.wordpress.android.fluxc.store.ListStore.MarkListsNeedRefreshPayload
 import org.wordpress.android.fluxc.store.ListStore.OnListDataFailure
 import org.wordpress.android.fluxc.store.WCOrderStore.OrderErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.store.WCOrderStore.OrderErrorType.PARSE_ERROR
@@ -935,43 +936,82 @@ class WCOrderStore @Inject internal constructor(
         // - WCOrderModel
         // - WCOrderNoteModel
         // - WCOrderShipmentTrackingModel
-        if (!payload.isError) {
-            // Save order summaries to the db
-            coroutineEngine.launch(API, this, "handleFetchOrderListCompleted") {
+        // The whole handler runs in a single coroutine so the summaries are persisted and the
+        // "mark other lists for refresh" step is dispatched BEFORE the completion events below. This
+        // way, by the time the UI reacts to FETCHED_LIST_ITEMS, the sibling lists have already been
+        // flagged for refresh and the summaries are available for hydration.
+        coroutineEngine.launch(API, this, "handleFetchOrderListCompleted") {
+            if (!payload.isError) {
+                // When this fetch reveals orders we have never seen before, mark every other cached
+                // order list for refresh so they self-heal on next view.
+                markOtherOrderListsForRefreshIfNewOrders(payload.listDescriptor, payload.orderSummaries)
+                // Save order summaries to the db
                 orderSummaryDao.upsertOrderSummaries(payload.orderSummaries)
+                // Fetch outdated or missing orders
+                fetchOutdatedOrMissingOrders(payload.listDescriptor.site, payload.orderSummaries)
             }
 
-            // Fetch outdated or missing orders
-            fetchOutdatedOrMissingOrders(payload.listDescriptor.site, payload.orderSummaries)
-        }
-
-        emitChange(
-            OnOrderSummariesFetched(
-                listDescriptor = payload.listDescriptor,
-                duration = payload.requestDurationMs,
-                networkingMode = payload.networkingMode,
-                error = payload.error
+            emitChange(
+                OnOrderSummariesFetched(
+                    listDescriptor = payload.listDescriptor,
+                    duration = payload.requestDurationMs,
+                    networkingMode = payload.networkingMode,
+                    error = payload.error
+                )
             )
-        )
+
+            mDispatcher.dispatch(
+                ListActionBuilder.newFetchedListItemsAction(
+                    FetchedListItemsPayload(
+                        listDescriptor = payload.listDescriptor,
+                        remoteItemIds = payload.orderSummaries.map { it.orderId.value },
+                        loadedMore = payload.loadedMore,
+                        canLoadMore = payload.canLoadMore,
+                        error = payload.error?.let { fetchError ->
+                            ListError(
+                                type = when (fetchError.type) {
+                                    PARSE_ERROR -> ListErrorType.PARSE_ERROR
+                                    TIMEOUT_ERROR -> ListErrorType.TIMEOUT_ERROR
+                                    else -> ListErrorType.GENERIC_ERROR
+                                },
+                                message = fetchError.message
+                            )
+                        }
+                    )
+                )
+            )
+        }
+    }
+
+    /**
+     * Each order list (All and every filter combination) is a server-defined, fetch-populated
+     * sequence of order ids, so an order can be in the local DB yet absent from a given list until
+     * that list is refetched. When a fetch reveals an order we have never seen before, every *other*
+     * cached order list may legitimately need it (e.g. it belongs in All, and in any matching
+     * filter), so mark them all for refresh. They refetch lazily on next view and the server decides
+     * membership, so an order only appears where it actually belongs. The just-fetched list already
+     * includes these orders, so it is excluded to avoid a redundant refetch.
+     *
+     * "New order" is detected against the order summary table (the global record of every order id we
+     * have seen), computed before the summaries are upserted, so re-fetching known orders is a no-op
+     * and cannot cause a refetch loop.
+     */
+    private suspend fun markOtherOrderListsForRefreshIfNewOrders(
+        fetchedDescriptor: WCOrderListDescriptor,
+        fetchedSummaries: List<WCOrderSummaryModel>
+    ) {
+        if (fetchedSummaries.isEmpty()) return
+        val knownOrderIds = orderSummaryDao
+            .getOrderSummaries(fetchedDescriptor.site.localId(), fetchedSummaries.map { it.orderId })
+            .mapTo(HashSet()) { it.orderId.value }
+        val hasNewOrders = fetchedSummaries.any { it.orderId.value !in knownOrderIds }
+        if (!hasNewOrders) return
 
         mDispatcher.dispatch(
-            ListActionBuilder.newFetchedListItemsAction(
-            FetchedListItemsPayload(
-            listDescriptor = payload.listDescriptor,
-            remoteItemIds = payload.orderSummaries.map { it.orderId.value },
-            loadedMore = payload.loadedMore,
-            canLoadMore = payload.canLoadMore,
-            error = payload.error?.let { fetchError ->
-                ListError(
-                    type = when (fetchError.type) {
-                        PARSE_ERROR -> ListErrorType.PARSE_ERROR
-                        TIMEOUT_ERROR -> ListErrorType.TIMEOUT_ERROR
-                        else -> ListErrorType.GENERIC_ERROR
-                    },
-                    message = fetchError.message
-                )
-            }
-        )))
+            ListActionBuilder.newMarkListsOfTypeNeedRefreshAction(
+                MarkListsNeedRefreshPayload(excludedDescriptor = fetchedDescriptor)
+            )
+        )
     }
 
     private fun fetchOutdatedOrMissingOrders(site: SiteModel, fetchedSummaries: List<WCOrderSummaryModel>) {

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderStoreTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderStoreTest.kt
@@ -16,16 +16,22 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.atLeastOnce
 import org.mockito.kotlin.check
+import org.mockito.kotlin.clearInvocations
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
+import org.mockito.kotlin.spy
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.UnitTestUtils
+import org.wordpress.android.fluxc.action.ListAction
+import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.generated.WCOrderActionBuilder.newFetchedOrderListAction
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
@@ -48,6 +54,7 @@ import org.wordpress.android.fluxc.persistence.dao.OrdersDaoDecorator
 import org.wordpress.android.fluxc.persistence.entity.OrderEntity
 import org.wordpress.android.fluxc.persistence.entity.OrderNoteEntity
 import org.wordpress.android.fluxc.store.InsertOrder
+import org.wordpress.android.fluxc.store.ListStore.MarkListsNeedRefreshPayload
 import org.wordpress.android.fluxc.store.WCOrderFetcher
 import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WCOrderStore.BulkUpdateOrderStatusResponsePayload
@@ -81,10 +88,11 @@ internal class WCOrderStoreTest {
     lateinit var metaDataDao: MetaDataDao
     lateinit var orderStore: WCOrderStore
     private val insertOrder: InsertOrder = mock()
+    private lateinit var dispatcher: Dispatcher
 
     @Before
     fun setUp() {
-        val dispatcher = Dispatcher()
+        dispatcher = spy(Dispatcher())
         ordersDaoDecorator = OrdersDaoDecorator(dispatcher, databaseRule.db.ordersDao)
         orderNotesDao = databaseRule.db.orderNotesDao
         metaDataDao = databaseRule.db.metaDataDao
@@ -403,6 +411,56 @@ internal class WCOrderStoreTest {
             })
         }
     }
+
+    @Test
+    fun `given fetch surfaces a new order, when fetch completes, then marks other lists of type for refresh`() =
+        runBlocking {
+            val site = SiteModel().apply { id = 8 }
+            val descriptor = WCOrderListDescriptor(site = site, statusFilter = "processing")
+            // Summaries not pre-inserted -> these orders are new to the device.
+            val summaries = listOf(
+                generateSampleOrderSummary(id = 8, remoteId = 1),
+                generateSampleOrderSummary(id = 8, remoteId = 2)
+            )
+            clearInvocations(dispatcher)
+
+            orderStore.onAction(
+                newFetchedOrderListAction(FetchOrderListResponsePayload(descriptor, orderSummaries = summaries))
+            )
+
+            val captor = argumentCaptor<Action<*>>()
+            verify(dispatcher, atLeastOnce()).dispatch(captor.capture())
+            val markPayloads = captor.allValues
+                .filter { it.type == ListAction.MARK_LISTS_OF_TYPE_NEED_REFRESH }
+                .map { it.payload as MarkListsNeedRefreshPayload }
+            assertThat(markPayloads).hasSize(1)
+            assertThat(markPayloads.first().excludedDescriptor.uniqueIdentifier)
+                .isEqualTo(descriptor.uniqueIdentifier)
+            Unit
+        }
+
+    @Test
+    fun `given fetch surfaces only known orders, when fetch completes, then does not mark lists for refresh`() =
+        runBlocking {
+            val site = SiteModel().apply { id = 8 }
+            val summaries = listOf(generateSampleOrderSummary(id = 8, remoteId = 1))
+            // Pre-insert the summary so the fetched order is already known.
+            databaseRule.db.orderSummaryDao.upsertOrderSummaries(summaries)
+            clearInvocations(dispatcher)
+
+            orderStore.onAction(
+                newFetchedOrderListAction(
+                    FetchOrderListResponsePayload(WCOrderListDescriptor(site = site), orderSummaries = summaries)
+                )
+            )
+
+            val captor = argumentCaptor<Action<*>>()
+            verify(dispatcher, atLeastOnce()).dispatch(captor.capture())
+            assertThat(
+                captor.allValues.none { it.type == ListAction.MARK_LISTS_OF_TYPE_NEED_REFRESH }
+            ).isTrue()
+            Unit
+        }
 
     @Test
     fun testUpdateOrderStatusRequestUpdatesLocalDatabase() = runBlocking {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/action/ListAction.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/action/ListAction.kt
@@ -5,6 +5,7 @@ import org.wordpress.android.fluxc.annotations.ActionEnum
 import org.wordpress.android.fluxc.annotations.action.IAction
 import org.wordpress.android.fluxc.model.list.ListDescriptorTypeIdentifier
 import org.wordpress.android.fluxc.store.ListStore.FetchedListItemsPayload
+import org.wordpress.android.fluxc.store.ListStore.MarkListsNeedRefreshPayload
 import org.wordpress.android.fluxc.store.ListStore.OnListDataFailure
 
 @ActionEnum
@@ -15,6 +16,8 @@ enum class ListAction : IAction {
     LIST_REQUIRES_REFRESH,
     @Action(payloadType = ListDescriptorTypeIdentifier::class)
     LIST_DATA_INVALIDATED,
+    @Action(payloadType = MarkListsNeedRefreshPayload::class)
+    MARK_LISTS_OF_TYPE_NEED_REFRESH,
     @Action(payloadType = OnListDataFailure::class)
     LIST_DATA_FAILURE,
 }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/dao/ListDao.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/dao/ListDao.kt
@@ -54,6 +54,33 @@ internal abstract class ListDao {
     @Insert
     protected abstract suspend fun insertList(list: ListModel): Long
 
+    /**
+     * Marks every cached list sharing [typeIdentifier] as [ListState.NEEDS_REFRESH], except the list
+     * with [excludedUniqueIdentifier], so they refetch the next time they are consumed. Each list's
+     * [ListModel.lastModified] is left untouched so it keeps reflecting when the list was actually
+     * fetched (marking a list stale is not a fetch).
+     */
+    suspend fun markListsOfTypeNeedRefresh(typeIdentifier: Int, excludedUniqueIdentifier: Int) =
+        updateListStatesOfTypeExcept(
+            typeIdentifier = typeIdentifier,
+            excludedUniqueIdentifier = excludedUniqueIdentifier,
+            stateDbValue = ListState.NEEDS_REFRESH.value
+        )
+
+    @Query(
+        """
+        UPDATE ListEntity
+        SET stateDbValue = :stateDbValue
+        WHERE descriptorTypeIdentifierDbValue = :typeIdentifier
+        AND descriptorUniqueIdentifierDbValue != :excludedUniqueIdentifier
+        """
+    )
+    protected abstract suspend fun updateListStatesOfTypeExcept(
+        typeIdentifier: Int,
+        excludedUniqueIdentifier: Int,
+        stateDbValue: Int
+    )
+
     @Query(
         """
         UPDATE ListEntity

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/ListStore.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/ListStore.kt
@@ -58,6 +58,10 @@ class ListStore @Inject internal constructor(
                 handleListRequiresRefresh(action.payload as ListDescriptorTypeIdentifier)
             ListAction.LIST_DATA_INVALIDATED ->
                 handleListDataInvalidated(action.payload as ListDescriptorTypeIdentifier)
+            ListAction.MARK_LISTS_OF_TYPE_NEED_REFRESH ->
+                coroutineEngine.launch(AppLog.T.API, this, "handleMarkListsOfTypeNeedRefresh") {
+                    handleMarkListsOfTypeNeedRefresh(action.payload as MarkListsNeedRefreshPayload)
+                }
             ListAction.LIST_DATA_FAILURE ->
                 handleDataFailure(action.payload as OnListDataFailure)
         }
@@ -262,6 +266,21 @@ class ListStore @Inject internal constructor(
         emitChange(OnListDataInvalidated(type = typeIdentifier))
     }
 
+    /**
+     * Handles the [ListAction.MARK_LISTS_OF_TYPE_NEED_REFRESH] action.
+     *
+     * Sets every cached list of [MarkListsNeedRefreshPayload.excludedDescriptor]'s type to
+     * [ListState.NEEDS_REFRESH] — except that descriptor itself — so each list refetches the next
+     * time it is consumed. No change event is emitted, so the new state is consumed lazily (via
+     * [getListState]) and this cannot trigger a refetch loop.
+     */
+    private suspend fun handleMarkListsOfTypeNeedRefresh(payload: MarkListsNeedRefreshPayload) {
+        listDao.markListsOfTypeNeedRefresh(
+            typeIdentifier = payload.excludedDescriptor.typeIdentifier.value,
+            excludedUniqueIdentifier = payload.excludedDescriptor.uniqueIdentifier.value
+        )
+    }
+
     private fun handleDataFailure(event: OnListDataFailure) {
         emitChange(event)
     }
@@ -362,6 +381,17 @@ class ListStore @Inject internal constructor(
             this.error = error
         }
     }
+
+    /**
+     * This is the payload for [ListAction.MARK_LISTS_OF_TYPE_NEED_REFRESH].
+     *
+     * @property excludedDescriptor All cached lists sharing this descriptor's type identifier are
+     * marked [ListState.NEEDS_REFRESH], except this descriptor itself (it is assumed to be freshly
+     * fetched).
+     */
+    class MarkListsNeedRefreshPayload(
+        val excludedDescriptor: ListDescriptor
+    ) : Payload<ListError>()
 
     class ListError(
         val type: ListErrorType,

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/store/ListStoreTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/store/ListStoreTest.kt
@@ -49,6 +49,13 @@ class ListStoreTest {
         override val config = ListConfig.default
     }
 
+    // Shares its type identifier with [testListDescriptor] but has a different unique identifier.
+    private val siblingListDescriptor = object : ListDescriptor {
+        override val uniqueIdentifier = ListDescriptorUniqueIdentifier(101)
+        override val typeIdentifier = ListDescriptorTypeIdentifier(200)
+        override val config = ListConfig.default
+    }
+
     @Before
     fun setUp() {
         store = ListStore(
@@ -287,6 +294,41 @@ class ListStoreTest {
         val event = captor.firstValue as ListStore.OnListDataFailure
         assertThat(event.type).isEqualTo(payload)
     }
+    // endregion
+
+    // region onAction - MARK_LISTS_OF_TYPE_NEED_REFRESH
+    @Test
+    fun `given sibling lists of same type, when mark lists of type need refresh, then siblings need refresh`() = runTest {
+        store.saveListFetched(testListDescriptor, listOf(1L), canLoadMore = false)
+        store.saveListFetched(siblingListDescriptor, listOf(2L), canLoadMore = false)
+
+        store.onAction(
+            ListActionBuilder.newMarkListsOfTypeNeedRefreshAction(
+                ListStore.MarkListsNeedRefreshPayload(excludedDescriptor = testListDescriptor)
+            )
+        )
+
+        // The excluded (just-fetched) list keeps its state; the sibling is marked for refresh.
+        assertThat(store.getListState(testListDescriptor)).isEqualTo(ListState.FETCHED)
+        assertThat(store.getListState(siblingListDescriptor)).isEqualTo(ListState.NEEDS_REFRESH)
+    }
+
+    @Test
+    fun `given lists of a different type, when mark lists of type need refresh, then other type is unaffected`() =
+        runTest {
+            store.saveListFetched(testListDescriptor, listOf(1L), canLoadMore = false) // type 200
+            store.saveListFetched(otherListDescriptor, listOf(2L), canLoadMore = false) // type 400
+
+            // Exclude a (non-existent) type-200 sibling so every type-200 list is marked.
+            store.onAction(
+                ListActionBuilder.newMarkListsOfTypeNeedRefreshAction(
+                    ListStore.MarkListsNeedRefreshPayload(excludedDescriptor = siblingListDescriptor)
+                )
+            )
+
+            assertThat(store.getListState(testListDescriptor)).isEqualTo(ListState.NEEDS_REFRESH)
+            assertThat(store.getListState(otherListDescriptor)).isEqualTo(ListState.FETCHED)
+        }
     // endregion
 
     /* HELPER */


### PR DESCRIPTION
### Description
Fixes WOOMOB-3182

The order list is backed by FluxC's `ListStore`: the unfiltered **All** list and every filter combination are each a *separately cached, server-defined sequence of order ids* (one `ListEntity` + `ListItemEntity` set per descriptor `uniqueIdentifier`), while order data lives in its own tables. Because of this split, an order can be present locally yet missing from a given list until that **specific** list is refetched — and each list is only refetched when its 30‑minute freshness window (`ShouldUpdateOrdersList` / `LastUpdateDataStore`) expires.

Visible symptom: a newly‑created order shows under a filter (e.g. *Processing* / *Last 30 days*) but not under **All** — and the reverse too (after pull‑to‑refresh on **All**, a previously‑cached filter still omits the order). Orders appear/disappear when switching filters until a manual pull‑to‑refresh.

This change makes the lists self‑heal. When an order‑list fetch reveals an order id we have **never seen before** (checked against the order summary table *before* the fetched summaries are upserted), every **other** cached order list of the same type is marked `ListState.NEEDS_REFRESH`, so each refetches the next time it is shown. The just‑fetched list is excluded (it already contains the order), and the server decides membership on refetch, so an order only appears where it actually belongs. When no new order arrives, nothing is invalidated, so existing caching is preserved.

Implementation:
- New FluxC `ListStore` action `MARK_LISTS_OF_TYPE_NEED_REFRESH` (+ `MarkListsNeedRefreshPayload`) and `ListDao.markListsOfTypeNeedRefresh(typeId, excludedUniqueId)` — a single `UPDATE` setting `NEEDS_REFRESH` on all lists of a type except the excluded one. **No change event is emitted**, so the new state is consumed lazily by the existing `ShouldUpdateOrdersList` gate — avoiding both refetch loops and UI flashes.
- `WCOrderStore.handleFetchOrderListCompleted` detects new orders (vs the summary table) and dispatches the action, excluding the just‑fetched descriptor.
- No app‑layer change was needed; `ShouldUpdateOrdersList` already treats `NEEDS_REFRESH` as "must refetch".

### Test Steps
Reproduce with a real store (orders created outside the app).
1. Open **Orders** → ensure no filter (**All**); let it load.
2. Make sure a new order exists on the store that isn't yet in **All**.
3. Apply a filter that includes it (Status = *Processing*, or Date = *Last 30 days*) → the new order appears.
4. Clear the filter back to **All** *(without pull‑to‑refresh)* → the order now also appears in **All** (previously it was missing).
5. Reverse direction: pull‑to‑refresh **All** to load a new order, then open a previously‑used filter the order matches → it appears there too (previously missing until a manual refresh).

### Images/gif

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/b218c58d-2366-41d2-920e-727eebf39e4a" /> | <video src="https://github.com/user-attachments/assets/f25e0153-a67a-4edf-bf51-0cac7d27ff3b" /> |

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.