### PR TITLE
[WOOMOB-3211] Fix white edge line on order creation screen in dark mode

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -246,6 +246,7 @@ class OrderCreateEditFormFragment :
 
     private fun FragmentOrderCreateEditFormBinding.adjustUIForScreenSize() {
         productSelectorNavContainer.isVisible = requireContext().isTwoPanesShouldBeUsed
+        divider.isVisible = requireContext().isTwoPanesShouldBeUsed
         when (requireContext().isTwoPanesShouldBeUsed) {
             false -> twoPaneLayoutGuideline.setGuidelinePercent(0.0f)
             true -> twoPaneLayoutGuideline.setGuidelinePercent(TABLET_PANES_WIDTH_RATIO)


### PR DESCRIPTION
### Description
Fixes WOOMOB-3211

In single-pane (phone) layout the two-pane separator `divider` collapsed to the screen's left edge, showing a thin light line in dark mode. It's now hidden when two-pane mode isn't used.

### Test Steps

IMO not worth testing manually.

1. Enable dark mode, use a phone / single-pane layout.
2. Orders → Create order.
3. Confirm the left edge of the New order screen has no light line.
4. On a tablet (two-pane), confirm the divider still separates the two panes.

### Images/gif
<img width="5144" height="1670" alt="compare_full" src="https://github.com/user-attachments/assets/16a44230-ca6c-4c59-91b8-f9e3942980ea" />
<img width="350" alt="compare_zoom_left_edge" src="https://github.com/user-attachments/assets/af2231ef-c5c0-4902-b803-7fd4e0bc8827" />


- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.