### PR TITLE
[WOOMOB-3214] Fix refund notice icon appearing after rotation on Issue Refund screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundDetailFragment.kt
@@ -121,10 +121,12 @@ class RefundDetailFragment : BaseFragment(R.layout.fragment_refund_detail) {
                     binding.refundDetailDetailsCard.show()
                     binding.refundDetailReasonCard.show()
                     productsBinding.issueRefundTotalsGroup.show()
+                    productsBinding.issueRefundDividerBelowList.show()
                 } else {
                     binding.refundDetailDetailsCard.hide()
                     binding.refundDetailReasonCard.hide()
                     productsBinding.issueRefundTotalsGroup.hide()
+                    productsBinding.issueRefundDividerBelowList.hide()
                 }
             }
 

--- a/WooCommerce/src/main/res/layout/refund_by_items_products.xml
+++ b/WooCommerce/src/main/res/layout/refund_by_items_products.xml
@@ -22,9 +22,11 @@
         style="@style/Woo.Divider"
         android:layout_marginStart="@dimen/major_100"
         android:layout_marginEnd="@dimen/minor_00"
+        android:visibility="gone"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/issueRefund_products"
-        app:layout_constraintBottom_toTopOf="@id/issueRefund_lblSubtotal"/>
+        app:layout_constraintBottom_toTopOf="@id/issueRefund_lblSubtotal"
+        tools:visibility="visible"/>
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/issueRefund_lblSubtotal"
@@ -121,7 +123,7 @@
         android:id="@+id/issueRefund_totalsGroup"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        app:constraint_referenced_ids="issueRefund_dividerBelowList,issueRefund_dividerBelowTaxes,issueRefund_taxesTotal,issueRefund_subtotal,issueRefund_productsTotal,issueRefund_lblProductsTotal,issueRefund_lblTaxes,issueRefund_lblSubtotal" />
+        app:constraint_referenced_ids="issueRefund_dividerBelowTaxes,issueRefund_taxesTotal,issueRefund_subtotal,issueRefund_productsTotal,issueRefund_lblProductsTotal,issueRefund_lblTaxes,issueRefund_lblSubtotal" />
 
     <androidx.constraintlayout.widget.Group
         android:id="@+id/issueRefundSubtotalTaxesGroup"

--- a/WooCommerce/src/main/res/layout/refund_by_items_products.xml
+++ b/WooCommerce/src/main/res/layout/refund_by_items_products.xml
@@ -74,10 +74,12 @@
         android:layout_marginTop="@dimen/major_100"
         android:drawableStart="@drawable/ic_deprecated_info_outline_24dp"
         android:drawablePadding="@dimen/major_100"
+        android:visibility="gone"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/issueRefund_taxesTotal"
-        tools:text="@string/order_refunds_shipping_refund_variable_notice" />
+        tools:text="@string/order_refunds_shipping_refund_variable_notice"
+        tools:visibility="visible" />
 
     <View
         android:id="@+id/issueRefund_dividerBelowTaxes"
@@ -119,7 +121,7 @@
         android:id="@+id/issueRefund_totalsGroup"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        app:constraint_referenced_ids="issueRefund_refundNotice,issueRefund_dividerBelowList,issueRefund_dividerBelowTaxes,issueRefund_taxesTotal,issueRefund_subtotal,issueRefund_productsTotal,issueRefund_lblProductsTotal,issueRefund_lblTaxes,issueRefund_lblSubtotal" />
+        app:constraint_referenced_ids="issueRefund_dividerBelowList,issueRefund_dividerBelowTaxes,issueRefund_taxesTotal,issueRefund_subtotal,issueRefund_productsTotal,issueRefund_lblProductsTotal,issueRefund_lblTaxes,issueRefund_lblSubtotal" />
 
     <androidx.constraintlayout.widget.Group
         android:id="@+id/issueRefundSubtotalTaxesGroup"


### PR DESCRIPTION
### Description

Fixes WOOMOB-3214

On the Issue Refund screen, a stray refund-notice info icon (plus a duplicate divider) appeared after rotating the device. Both views were referenced by the `issueRefund_totalsGroup`, which re-forces its members visible on rotation and overrode the fragment's `hide()`. Removed them from the group and defaulted them to `gone` so the controlling fragment owns their visibility; `RefundDetailFragment` now toggles the divider explicitly to preserve its behavior.

### Test Steps

1. Open a completed, refundable single-shipping order → **Issue refund**.
2. Confirm no info `ⓘ` icon below Taxes and a single divider above "Products refund".
3. Rotate the device and confirm the icon stays hidden and there's still a single divider.

### Images/gif
<img width="1800" height="1921" alt="WOOMOB-3214_pr_overview" src="https://github.com/user-attachments/assets/edc98b23-756e-46b3-a5c5-74b376ed9bfc" />



<!-- Drag WOOMOB-3214_pr_overview.png here -->

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.