### PR TITLE
[WOOMOB-3209] Fix screen flash navigating from login prologue to QR login

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 25.1
 -----
 - [*] Improved login error messages for site security certificate issues [https://github.com/woocommerce/woocommerce-android/pull/16042]
+- [Internal] Fixed a screen flash when navigating from the login prologue to the (feature-flagged) QR login screen [https://github.com/woocommerce/woocommerce-android/pull/16095]
 - [Internal] Migrated media upload and media-list endpoints to Application Passwords [https://github.com/woocommerce/woocommerce-android/pull/15550]
 
 25.0

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -416,11 +416,16 @@ class LoginActivity :
     }
 
     override fun onPrimaryButtonClicked() {
-        disableDynamicEdgeToEdge()
         if (qrLoginAvailability.isAvailable()) {
+            // The QR login prologue is itself an edge-to-edge screen, so keep edge-to-edge enabled
+            // through the transition. Disabling it here would re-apply the system bar insets to the
+            // shared root while the prologue is still visible, briefly shifting the content and
+            // flashing the white window background before the QR prologue re-enables edge-to-edge.
             unifiedLoginTracker.trackClick(Click.LOGIN_WITH_QR)
             showQrLoginPrologueFragment()
         } else {
+            // The site address login screen is not edge-to-edge, so restore the default window insets.
+            disableDynamicEdgeToEdge()
             unifiedLoginTracker.trackClick(Click.LOGIN_WITH_SITE_ADDRESS)
             loginViaSiteAddress()
         }


### PR DESCRIPTION
### Description
Fixes WOOMOB-3209

When the merchant taps **Log In** on the Login Prologue and the QR login flow is enabled, the screen flashes briefly: the status-bar/toolbar area appears to disappear, the content jumps, and a white line flashes at the top and bottom edges before the new "Scan to log in" (QR login prologue) screen settles.

**Why it happens**

`LoginActivity` hosts every login screen in one shared root (`snack_root`). Some screens are edge-to-edge (full-bleed purple drawn under the system bars) and some are not, so the activity implements `DynamicEdgeToEdgeActivity`:

- `enableDynamicEdgeToEdge()` removes the system-bar inset padding from the shared root, letting content draw under the bars.
- `disableDynamicEdgeToEdge()` re-applies the system-bar insets as padding to the shared root, so content sits below the status bar / above the nav bar (used by the regular login screens, which are not edge-to-edge).

Both the **Login Prologue** and the new **QR login prologue** are edge-to-edge purple screens. But `onPrimaryButtonClicked()` called `disableDynamicEdgeToEdge()` *unconditionally*, before deciding where to navigate. That re-applied the system-bar insets to the still-visible prologue, momentarily shrinking it and exposing the white window background at the top and bottom edges — and then the incoming QR prologue's `onViewCreated()` immediately called `enableDynamicEdgeToEdge()` again, removing the padding. The result is a one-off toggle (edge-to-edge → insets → edge-to-edge) on the shared container during the transition, which is the visible flash.

### Test Steps
1. Enable Qr code login.
2. Make sure you are logged out.
3. On the **Login Prologue**, tap **Log In**.
4. Check the sliding transition is smooth like in the video below. 

### Images/gif

https://github.com/user-attachments/assets/96fce5d6-1f50-49c3-85b6-364560e03fb7



| Build | White-band frames during the transition |
|-------|------------------------------------------|
| Before fix | 14 frames (white status-bar strip, then a white line at the bottom) |
| After fix | 0 frames (clean purple → purple slide) |

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.