### PR TITLE
Skip blocking POS catalog sync wait when the host blocks the catalog file

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosIsCatalogFileBlocked.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosIsCatalogFileBlocked.kt
@@ -1,0 +1,16 @@
+package com.woocommerce.android.ui.woopos.localcatalog
+
+import com.woocommerce.android.ui.woopos.util.datastore.WooPosSyncTimestampManager
+import javax.inject.Inject
+
+/**
+ * Reads the persisted "catalog file blocked by the host" flag. The flag is set when a full sync fails
+ * because the host blocks the generated catalog file (HTTP 403 / HTML body) and cleared on the first
+ * successful full sync. POS entry uses it to skip the blocking download wait that would otherwise
+ * repeat every time, while the background worker keeps retrying.
+ */
+class WooPosIsCatalogFileBlocked @Inject constructor(
+    private val syncTimestampManager: WooPosSyncTimestampManager,
+) {
+    suspend operator fun invoke(): Boolean = syncTimestampManager.isCatalogFileBlocked()
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncRepository.kt
@@ -49,7 +49,12 @@ class WooPosLocalCatalogSyncRepository @Inject constructor(
             when (result) {
                 is PosLocalCatalogSyncResult.Success -> {
                     syncTimestampManager.storeFullSyncLastCompletedTimestamp(dateTimeProvider.now())
+                    syncTimestampManager.setCatalogFileBlocked(false)
                     trackSyncCompleted(site, SyncType.FULL, result)
+                }
+                is PosLocalCatalogSyncResult.Failure.CatalogFileBlocked -> {
+                    syncTimestampManager.setCatalogFileBlocked(true)
+                    trackSyncFailed(SyncType.FULL, result)
                 }
                 is PosLocalCatalogSyncResult.Failure -> {
                     trackSyncFailed(SyncType.FULL, result)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosPerformInstantCatalogFullSync.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosPerformInstantCatalogFullSync.kt
@@ -14,9 +14,19 @@ class WooPosPerformInstantCatalogFullSync @Inject constructor(
     private val syncTimestampManager: WooPosSyncTimestampManager,
     private val syncScheduler: WooPosLocalCatalogSyncScheduler,
     private val selectedSite: SelectedSite,
+    private val isCatalogFileBlocked: WooPosIsCatalogFileBlocked,
     private val wooPosLogWrapper: WooPosLogWrapper
 ) {
     suspend operator fun invoke(): Result<Unit> {
+        if (isCatalogFileBlocked()) {
+            // The host blocked the catalog file on a previous attempt and a full sync has never
+            // completed. Fail fast instead of waiting on catalog generation/download again (which would
+            // repeat on every POS entry). The caller falls back to remote sync, while the background
+            // worker keeps retrying and clears the flag on the first successful sync.
+            wooPosLogWrapper.d("Catalog file is blocked by the host; skipping the blocking sync wait")
+            return Result.failure(WooPosCatalogFileBlockedException())
+        }
+
         val isOneTimeRunning = syncScheduler.observeOneTimeWorkStatus().first()
         val isPeriodicRunning = syncScheduler.observePeriodicWorkStatus().first()
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncRepositoryTest.kt
@@ -19,6 +19,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argThat
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
@@ -269,6 +270,48 @@ class WooPosLocalCatalogSyncRepositoryTest : BaseUnitTest() {
                 }
             )
         }
+
+    @Test
+    fun `when full sync succeeds, then clears catalog file blocked flag`() = testBlocking {
+        // GIVEN
+        givenFileBasedFullSyncSucceeds()
+
+        // WHEN
+        sut.syncLocalCatalogFull(site)
+
+        // THEN
+        verify(syncTimestampManager).setCatalogFileBlocked(false)
+    }
+
+    @Test
+    fun `when full sync fails with catalog file blocked, then sets catalog file blocked flag`() = testBlocking {
+        // GIVEN
+        givenFileBasedFullSyncFails(
+            PosLocalCatalogSyncResult.Failure.CatalogFileBlocked(
+                error = "Catalog file blocked by the host"
+            )
+        )
+
+        // WHEN
+        sut.syncLocalCatalogFull(site)
+
+        // THEN
+        verify(syncTimestampManager).setCatalogFileBlocked(true)
+    }
+
+    @Test
+    fun `when full sync fails with non-blocked error, then does not change catalog file blocked flag`() = testBlocking {
+        // GIVEN
+        givenFileBasedFullSyncFails(
+            PosLocalCatalogSyncResult.Failure.NetworkError("Network timeout")
+        )
+
+        // WHEN
+        sut.syncLocalCatalogFull(site)
+
+        // THEN
+        verify(syncTimestampManager, never()).setCatalogFileBlocked(any())
+    }
 
     @Test
     fun `when incremental sync starts, then tracks sync started event`() = testBlocking {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosPerformInstantCatalogFullSyncTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosPerformInstantCatalogFullSyncTest.kt
@@ -8,8 +8,12 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
 import org.junit.Test
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
 
@@ -19,6 +23,7 @@ class WooPosPerformInstantCatalogFullSyncTest {
     private val syncTimestampManager: WooPosSyncTimestampManager = mock()
     private val selectedSite: SelectedSite = mock()
     private val syncScheduler: WooPosLocalCatalogSyncScheduler = mock()
+    private val isCatalogFileBlocked: WooPosIsCatalogFileBlocked = mock()
     private val wooPosLogWrapper: WooPosLogWrapper = mock()
 
     private val sut = WooPosPerformInstantCatalogFullSync(
@@ -26,8 +31,28 @@ class WooPosPerformInstantCatalogFullSyncTest {
         syncTimestampManager = syncTimestampManager,
         syncScheduler = syncScheduler,
         selectedSite = selectedSite,
+        isCatalogFileBlocked = isCatalogFileBlocked,
         wooPosLogWrapper = wooPosLogWrapper
     )
+
+    @Before
+    fun setup() = runTest {
+        whenever(isCatalogFileBlocked()).thenReturn(false)
+    }
+
+    @Test
+    fun `given catalog file blocked, when invoke called, then returns failure without syncing`() = runTest {
+        // GIVEN
+        whenever(isCatalogFileBlocked()).thenReturn(true)
+
+        // WHEN
+        val result = sut()
+
+        // THEN
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull()).isInstanceOf(WooPosCatalogFileBlockedException::class.java)
+        verify(syncRepository, never()).syncLocalCatalogFull(any())
+    }
 
     @Test
     fun `given no site selected, when invoke called, then returns failure `() = runTest {

--- a/libs/pos/src/main/java/com/woocommerce/android/ui/woopos/util/datastore/WooPosSyncTimestampManager.kt
+++ b/libs/pos/src/main/java/com/woocommerce/android/ui/woopos/util/datastore/WooPosSyncTimestampManager.kt
@@ -41,6 +41,12 @@ class WooPosSyncTimestampManager @Inject constructor(
 
     suspend fun getFullSyncLastCompletedTimestamp(): Long? = timestampRepository.getFullSyncLastCompletedTimestamp()
 
+    suspend fun setCatalogFileBlocked(blocked: Boolean) {
+        timestampRepository.setCatalogFileBlocked(blocked)
+    }
+
+    suspend fun isCatalogFileBlocked(): Boolean = timestampRepository.isCatalogFileBlocked()
+
     fun formatTimestampForApi(timestamp: Long): String {
         return defaultApiDateFormatter.format(Instant.ofEpochMilli(timestamp))
     }

--- a/libs/pos/src/main/java/com/woocommerce/android/ui/woopos/util/datastore/WooPosSyncTimestampRepository.kt
+++ b/libs/pos/src/main/java/com/woocommerce/android/ui/woopos/util/datastore/WooPosSyncTimestampRepository.kt
@@ -72,15 +72,16 @@ class WooPosSyncTimestampRepository @Inject constructor(
     }
 
     suspend fun clearAllSyncTimestamps() {
-        val productsKey = buildSiteSpecificKey(PRODUCTS_TIMESTAMP_KEY)
-        val variationsKey = buildSiteSpecificKey(VARIATIONS_TIMESTAMP_KEY)
-        val fullSyncKey = buildSiteSpecificKey(FULL_SYNC_TIMESTAMP_KEY)
+        val keys = listOfNotNull(
+            buildSiteSpecificKey(PRODUCTS_TIMESTAMP_KEY),
+            buildSiteSpecificKey(VARIATIONS_TIMESTAMP_KEY),
+            buildSiteSpecificKey(FULL_SYNC_TIMESTAMP_KEY),
+            buildSiteSpecificKey(CATALOG_FILE_BLOCKED_KEY),
+        )
 
-        if (productsKey != null && variationsKey != null && fullSyncKey != null) {
+        if (keys.isNotEmpty()) {
             dataStore.edit { preferences ->
-                preferences.remove(productsKey)
-                preferences.remove(variationsKey)
-                preferences.remove(fullSyncKey)
+                keys.forEach { preferences.remove(it) }
             }
         }
     }
@@ -103,6 +104,28 @@ class WooPosSyncTimestampRepository @Inject constructor(
         }
     }
 
+    suspend fun setCatalogFileBlocked(blocked: Boolean) {
+        val key = buildSiteSpecificKey(CATALOG_FILE_BLOCKED_KEY)
+        if (key != null) {
+            dataStore.edit { preferences ->
+                if (blocked) {
+                    preferences[key] = true.toString()
+                } else {
+                    preferences.remove(key)
+                }
+            }
+        }
+    }
+
+    suspend fun isCatalogFileBlocked(): Boolean {
+        val key = buildSiteSpecificKey(CATALOG_FILE_BLOCKED_KEY)
+        return if (key != null) {
+            dataStore.data.first()[key]?.toBoolean() == true
+        } else {
+            false
+        }
+    }
+
     private fun buildSiteSpecificKey(key: String): Preferences.Key<String>? {
         val site = selectedSite.getOrNull()
         return if (site != null) {
@@ -117,5 +140,6 @@ class WooPosSyncTimestampRepository @Inject constructor(
         const val PRODUCTS_TIMESTAMP_KEY = "pos_products_sync_timestamp"
         const val VARIATIONS_TIMESTAMP_KEY = "pos_variations_sync_timestamp"
         const val FULL_SYNC_TIMESTAMP_KEY = "pos_full_sync_completed_timestamp"
+        const val CATALOG_FILE_BLOCKED_KEY = "pos_catalog_file_blocked"
     }
 }

--- a/libs/pos/src/test/java/com/woocommerce/android/ui/woopos/util/datastore/WooPosSyncTimestampManagerTest.kt
+++ b/libs/pos/src/test/java/com/woocommerce/android/ui/woopos/util/datastore/WooPosSyncTimestampManagerTest.kt
@@ -44,6 +44,31 @@ class WooPosSyncTimestampManagerTest {
     }
 
     @Test
+    fun `given blocked flag value, when setting catalog file blocked, then delegates to repository`() {
+        runTest {
+            // WHEN
+            manager.setCatalogFileBlocked(true)
+
+            // THEN
+            verify(repository).setCatalogFileBlocked(true)
+        }
+    }
+
+    @Test
+    fun `given repository reports blocked, when checking catalog file blocked, then returns true`() {
+        runTest {
+            // GIVEN
+            whenever(repository.isCatalogFileBlocked()).thenReturn(true)
+
+            // WHEN
+            val result = manager.isCatalogFileBlocked()
+
+            // THEN
+            assertThat(result).isTrue()
+        }
+    }
+
+    @Test
     fun `given valid timestamp in repository, when getting products timestamp, then timestamp is returned`() {
         runTest {
             // GIVEN


### PR DESCRIPTION
### Description

<!-- No linked Linear issue yet — add `Fixes WOOMOB-XYZ` here when available. -->

When a store uses the POS **local catalog**, the catalog is generated server-side and downloaded as a file. Some hosts block that file (HTTP 403, or an HTML error/login page served instead of JSON). When that happens we surface a "contact your hosting provider" notice (Woo 11+) and fall back to remote sync so POS keeps working.

The problem: a blocked catalog **never completes a full sync**, so `checkSyncRequirement()` keeps returning `BlockingRequired` on every POS launch. Each launch then re-runs the full generate → poll → download flow, which can take **minutes**, only to hit the same 403 and fall back to remote anyway. Merchants on a blocking host were forced to wait every single time they opened POS, for a catalog they'd never actually get.


### Test Steps

Reproducing the block requires a host that 403s / serves HTML for the catalog file. The simplest way to simulate it is to make `WooPosCatalogFileDownloader.downloadCatalogFile()` return `Result.failure(WooPosCatalogFileBlockedException())` (e.g. gated on a marker file), then on a POS-local-catalog store:

1. Clear the POS sync state so a full sync is required (fresh install, or clear the `woo_pos_data_store` datastore), with the simulated block active.
2. Open POS. It should attempt the full sync, fail on the (simulated) block, and enter POS via remote fallback — showing the "contact your hosting provider" notice on Woo 11+. Logcat: `Blocking full sync failed (catalog file blocked)`.
3. Close and re-open POS. It should load **immediately** with **no** "Syncing Catalog…" wait and no generation/download attempt. Logcat: `Catalog file is blocked by the host; skipping the blocking sync wait`.

- [X] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.