### PR TITLE
[WOOMOB-3293] Constrain OrderNotificationWorker to network + fix app-password order sync

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/background/OrderNotificationWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/background/OrderNotificationWorker.kt
@@ -2,8 +2,10 @@ package com.woocommerce.android.background
 
 import android.content.Context
 import androidx.hilt.work.HiltWorker
+import androidx.work.Constraints
 import androidx.work.CoroutineWorker
 import androidx.work.Data
+import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequest
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
@@ -29,8 +31,13 @@ class OrderNotificationWorker @AssistedInject constructor(
             dataBuilder.putLong(ORDER_ID, remoteOrderId)
             val data = dataBuilder.build()
 
+            val constraints = Constraints.Builder()
+                .setRequiredNetworkType(NetworkType.CONNECTED)
+                .build()
+
             val workRequest = OneTimeWorkRequest.Builder(OrderNotificationWorker::class.java)
                 .setInputData(data)
+                .setConstraints(constraints)
                 .build()
 
             WorkManager.getInstance(context).enqueue(workRequest)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/background/UpdateOrderAndOrderList.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/background/UpdateOrderAndOrderList.kt
@@ -1,20 +1,20 @@
 package com.woocommerce.android.background
 
+import com.woocommerce.android.tools.ResolveSiteBySiteId
 import org.wordpress.android.fluxc.network.BaseRequest
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
-import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.WCOrderStore
 import javax.inject.Inject
 
 class UpdateOrderAndOrderList @Inject constructor(
     private val updateOrdersListByStoreId: UpdateOrdersListByStoreId,
     private val orderStore: WCOrderStore,
-    private val siteStore: SiteStore
+    private val resolveSiteBySiteId: ResolveSiteBySiteId
 ) {
     suspend operator fun invoke(siteId: Long, remoteOrderId: Long): Result<Unit> {
-        val orderFetchedSuccess = siteStore.getSiteBySiteId(siteId)?.let { site ->
+        val orderFetchedSuccess = resolveSiteBySiteId(siteId)?.let { site ->
             orderStore.fetchSingleOrderSync(site, remoteOrderId)
         } ?: WooResult(
             WooError(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationAnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationAnalyticsTracker.kt
@@ -5,24 +5,24 @@ import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.notifications.NotificationSource
+import com.woocommerce.android.tools.ResolveSiteBySiteId
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.tools.SiteConnectionType
 import com.woocommerce.android.tools.connectionType
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.utils.extensions.putIfNotNull
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class NotificationAnalyticsTracker @Inject constructor(
-    private val siteStore: SiteStore,
+    private val resolveSiteBySiteId: ResolveSiteBySiteId,
     private val selectedSite: SelectedSite,
     private val appPrefsWrapper: AppPrefsWrapper,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper
 ) {
     fun track(stat: AnalyticsEvent, siteId: Long) {
-        val site = resolveNotificationSite(siteId) ?: return
+        val site = resolveSiteBySiteId(siteId) ?: return
         val properties = mutableMapOf<String, Any>().addCommonSiteProperties(site)
         analyticsTrackerWrapper.track(stat, properties)
     }
@@ -34,7 +34,7 @@ class NotificationAnalyticsTracker @Inject constructor(
         noteTypeTrackingValue: String,
         source: NotificationSource?
     ) {
-        val site = resolveNotificationSite(siteId) ?: return
+        val site = resolveSiteBySiteId(siteId) ?: return
         val properties = mutableMapOf<String, Any>(
             "notification_type" to noteTypeTrackingValue,
             "push_notification_token" to appPrefsWrapper.getFCMToken(),
@@ -54,23 +54,13 @@ class NotificationAnalyticsTracker @Inject constructor(
         errorType: String?,
         errorCode: String? = null
     ) {
-        val site = resolveNotificationSite(siteId) ?: return
+        val site = resolveSiteBySiteId(siteId) ?: return
         val properties = mutableMapOf<String, Any>().apply {
             errorDescription?.let { this[AnalyticsTracker.KEY_ERROR_DESC] = it }
             errorType?.let { this[AnalyticsTracker.KEY_ERROR_TYPE] = it }
             errorCode?.let { this[AnalyticsTracker.KEY_ERROR_CODE] = it }
         }.addCommonSiteProperties(site)
         analyticsTrackerWrapper.track(stat, properties)
-    }
-
-    // Application-password sites have no wpcom site id, so the payload siteId is unreliable;
-    // fall back to the selected site we don't support multi-sites with app passwords.
-    private fun resolveNotificationSite(siteId: Long): SiteModel? {
-        return if (selectedSite.connectionType == SiteConnectionType.ApplicationPasswords) {
-            selectedSite.getOrNull()
-        } else {
-            siteStore.getSiteBySiteId(siteId)
-        }
     }
 
     // App-password sites don't have a reliable wpcom siteId to compare against, but multi-site

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/tools/ResolveSiteBySiteId.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/tools/ResolveSiteBySiteId.kt
@@ -1,0 +1,20 @@
+package com.woocommerce.android.tools
+
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.SiteStore
+import javax.inject.Inject
+
+// Drop-in replacement for SiteStore.getSiteBySiteId that also supports application-password logins.
+// App-password sites have no wpcom site id, so the payload siteId is unreliable; fall back to the
+// selected site since multi-site isn't supported with app passwords.
+class ResolveSiteBySiteId @Inject constructor(
+    private val selectedSite: SelectedSite,
+    private val siteStore: SiteStore
+) {
+    operator fun invoke(siteId: Long): SiteModel? =
+        if (selectedSite.connectionType == SiteConnectionType.ApplicationPasswords) {
+            selectedSite.getOrNull()
+        } else {
+            siteStore.getSiteBySiteId(siteId)
+        }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/GetWCOrderListDescriptorWithFiltersBySiteId.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/GetWCOrderListDescriptorWithFiltersBySiteId.kt
@@ -1,19 +1,19 @@
 package com.woocommerce.android.ui.orders.list
 
 import com.woocommerce.android.ciab.CIABOrderStatusMapper
+import com.woocommerce.android.tools.ResolveSiteBySiteId
 import com.woocommerce.android.ui.orders.filters.data.DateRange
 import com.woocommerce.android.ui.orders.filters.data.OrderFiltersRepository
 import com.woocommerce.android.ui.orders.filters.data.OrderListFilterCategory
 import com.woocommerce.android.ui.orders.filters.domain.getBeforeAndAfterFrom
 import com.woocommerce.android.util.DateUtils
 import org.wordpress.android.fluxc.model.WCOrderListDescriptor
-import org.wordpress.android.fluxc.store.SiteStore
 import javax.inject.Inject
 
 class GetWCOrderListDescriptorWithFiltersBySiteId @Inject constructor(
     private val orderFiltersRepository: OrderFiltersRepository,
     private val dateUtils: DateUtils,
-    private val siteStore: SiteStore,
+    private val resolveSiteBySiteId: ResolveSiteBySiteId,
     private val ciabOrderStatusMapper: CIABOrderStatusMapper
 ) {
     operator fun invoke(siteId: Long): WCOrderListDescriptor? {
@@ -26,7 +26,7 @@ class GetWCOrderListDescriptorWithFiltersBySiteId @Inject constructor(
             orderFiltersRepository.getCurrentFilterSelection(OrderListFilterCategory.ORDER_STATUS)
         ).joinToString(separator = ",")
 
-        val site = siteStore.getSiteBySiteId(siteId) ?: return null
+        val site = resolveSiteBySiteId(siteId) ?: return null
 
         return WCOrderListDescriptor(
             site = site,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/background/UpdateOrderAndOrderListTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/background/UpdateOrderAndOrderListTest.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.background
 
+import com.woocommerce.android.tools.ResolveSiteBySiteId
 import com.woocommerce.android.ui.orders.OrderTestUtils
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -14,7 +15,6 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.persistence.entity.OrderEntity
-import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.WCOrderStore
 import kotlin.test.Test
 
@@ -22,19 +22,19 @@ import kotlin.test.Test
 class UpdateOrderAndOrderListTest : BaseUnitTest() {
     private val updateOrdersListByStoreId: UpdateOrdersListByStoreId = mock()
     private val orderStore: WCOrderStore = mock()
-    private val siteStore: SiteStore = mock()
+    private val resolveSiteBySiteId: ResolveSiteBySiteId = mock()
 
     private val sut = UpdateOrderAndOrderList(
         updateOrdersListByStoreId = updateOrdersListByStoreId,
         orderStore = orderStore,
-        siteStore = siteStore
+        resolveSiteBySiteId = resolveSiteBySiteId
     )
 
     @Test
     fun `when selected site is null then return false`() = testBlocking {
         val defaultSiteId = 2L
         val defaultOrderId = 5L
-        whenever(siteStore.getSiteBySiteId(defaultSiteId)).thenReturn(null)
+        whenever(resolveSiteBySiteId(defaultSiteId)).thenReturn(null)
         whenever(updateOrdersListByStoreId.invoke(any(), any())).thenReturn(Result.success(Unit))
 
         val result = sut(defaultSiteId, defaultOrderId)
@@ -53,7 +53,7 @@ class UpdateOrderAndOrderListTest : BaseUnitTest() {
             WooError(WooErrorType.INVALID_RESPONSE, BaseRequest.GenericErrorType.INVALID_RESPONSE)
         )
 
-        whenever(siteStore.getSiteBySiteId(defaultSiteId)).thenReturn(defaultSite)
+        whenever(resolveSiteBySiteId(defaultSiteId)).thenReturn(defaultSite)
         whenever(orderStore.fetchSingleOrderSync(eq(defaultSite), eq(defaultOrderId))).thenReturn(fetchOrderError)
         whenever(updateOrdersListByStoreId.invoke(any(), any())).thenReturn(Result.success(Unit))
 
@@ -71,7 +71,7 @@ class UpdateOrderAndOrderListTest : BaseUnitTest() {
         val defaultSite = SiteModel().apply { id = 3 }
         val fetchOrderResult = WooResult(OrderTestUtils.generateOrder())
 
-        whenever(siteStore.getSiteBySiteId(defaultSiteId)).thenReturn(defaultSite)
+        whenever(resolveSiteBySiteId(defaultSiteId)).thenReturn(defaultSite)
         whenever(orderStore.fetchSingleOrderSync(eq(defaultSite), eq(defaultOrderId))).thenReturn(fetchOrderResult)
         whenever(updateOrdersListByStoreId.invoke(any(), any()))
             .thenReturn(Result.failure(Exception("Unhandled error")))
@@ -90,8 +90,25 @@ class UpdateOrderAndOrderListTest : BaseUnitTest() {
         val defaultSite = SiteModel().apply { id = 3 }
         val fetchOrderResult = WooResult(OrderTestUtils.generateOrder())
 
-        whenever(siteStore.getSiteBySiteId(defaultSiteId)).thenReturn(defaultSite)
+        whenever(resolveSiteBySiteId(defaultSiteId)).thenReturn(defaultSite)
         whenever(orderStore.fetchSingleOrderSync(eq(defaultSite), eq(defaultOrderId))).thenReturn(fetchOrderResult)
+        whenever(updateOrdersListByStoreId.invoke(any(), any())).thenReturn(Result.success(Unit))
+
+        val result = sut(defaultSiteId, defaultOrderId)
+
+        // Assertions
+        Assert.assertTrue(result.isSuccess)
+    }
+
+    @Test
+    fun `given app-password site, when site resolved via selected site, then fetch succeeds`() = testBlocking {
+        val defaultSiteId = 0L
+        val defaultOrderId = 5L
+        val selectedSite = SiteModel().apply { id = 3 }
+        val fetchOrderResult = WooResult(OrderTestUtils.generateOrder())
+
+        whenever(resolveSiteBySiteId(defaultSiteId)).thenReturn(selectedSite)
+        whenever(orderStore.fetchSingleOrderSync(eq(selectedSite), eq(defaultOrderId))).thenReturn(fetchOrderResult)
         whenever(updateOrdersListByStoreId.invoke(any(), any())).thenReturn(Result.success(Unit))
 
         val result = sut(defaultSiteId, defaultOrderId)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/NotificationAnalyticsTrackerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/NotificationAnalyticsTrackerTest.kt
@@ -4,6 +4,7 @@ import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.notifications.NotificationSource
+import com.woocommerce.android.tools.ResolveSiteBySiteId
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.tools.SiteConnectionType
 import org.assertj.core.api.Assertions.assertThat
@@ -15,16 +16,14 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
-import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.store.SiteStore
 
 class NotificationAnalyticsTrackerTest {
     private val siteId = 12345L
     private val site: SiteModel = mock()
-    private val siteStore: SiteStore = mock {
-        on { getSiteBySiteId(siteId) } doReturn site
+    private val resolveSiteBySiteId: ResolveSiteBySiteId = mock {
+        on { invoke(siteId) } doReturn site
     }
     private val selectedSite: SelectedSite = mock()
     private val appPrefsWrapper: AppPrefsWrapper = mock {
@@ -33,7 +32,7 @@ class NotificationAnalyticsTrackerTest {
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper = mock()
 
     private val tracker = NotificationAnalyticsTracker(
-        siteStore = siteStore,
+        resolveSiteBySiteId = resolveSiteBySiteId,
         selectedSite = selectedSite,
         appPrefsWrapper = appPrefsWrapper,
         analyticsTrackerWrapper = analyticsTrackerWrapper
@@ -105,7 +104,7 @@ class NotificationAnalyticsTrackerTest {
     fun `given app-password site, when tracking, then resolve via selected site and flag as selected`() {
         val appPasswordSite: SiteModel = mock()
         whenever(selectedSite.connectionType).thenReturn(SiteConnectionType.ApplicationPasswords)
-        whenever(selectedSite.getOrNull()).thenReturn(appPasswordSite)
+        whenever(resolveSiteBySiteId(7777L)).thenReturn(appPasswordSite)
 
         // App-password notifications carry a non-zero payload siteId that doesn't match any
         // wpcom site in the store — resolution must fall back to the selected site.
@@ -117,7 +116,6 @@ class NotificationAnalyticsTrackerTest {
             source = NotificationSource.WOO_DRIVEN
         )
 
-        verifyNoInteractions(siteStore)
         val captor = argumentCaptor<Map<String, Any>>()
         verify(analyticsTrackerWrapper).track(eq(AnalyticsEvent.PUSH_NOTIFICATION_RECEIVED), captor.capture())
         assertThat(captor.firstValue).containsEntry("is_from_selected_site", true)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/tools/ResolveSiteBySiteIdTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/tools/ResolveSiteBySiteIdTest.kt
@@ -1,0 +1,45 @@
+package com.woocommerce.android.tools
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.SiteStore
+
+class ResolveSiteBySiteIdTest {
+    private val selectedSite: SelectedSite = mock()
+    private val siteStore: SiteStore = mock()
+
+    private val sut = ResolveSiteBySiteId(
+        selectedSite = selectedSite,
+        siteStore = siteStore
+    )
+
+    @Test
+    fun `given app-password connection, when resolving, then return selected site without hitting site store`() {
+        val payloadSiteId = 7777L
+        val selected: SiteModel = mock()
+        whenever(selectedSite.connectionType).thenReturn(SiteConnectionType.ApplicationPasswords)
+        whenever(selectedSite.getOrNull()).thenReturn(selected)
+
+        val result = sut(payloadSiteId)
+
+        assertThat(result).isEqualTo(selected)
+        verify(siteStore, never()).getSiteBySiteId(payloadSiteId)
+    }
+
+    @Test
+    fun `given wpcom connection, when resolving, then look the site up by its wpcom id`() {
+        val payloadSiteId = 12345L
+        val wpcomSite: SiteModel = mock()
+        whenever(selectedSite.connectionType).thenReturn(SiteConnectionType.Jetpack)
+        whenever(siteStore.getSiteBySiteId(payloadSiteId)).thenReturn(wpcomSite)
+
+        val result = sut(payloadSiteId)
+
+        assertThat(result).isEqualTo(wpcomSite)
+    }
+}


### PR DESCRIPTION
Fixes WOOMOB-3293

### Description

`OrderNotificationWorker` runs when an order push notification arrives and syncs the affected order (and the order list) in the background. The main goal of this PR was to add a constraint to the worker, but I found a bug that would make the worker fail every time in a specific scenario. More about that below.

**1. Add a `NetworkType.CONNECTED` constraint to the worker (WOOMOB-3293)**

The worker was enqueued as a `OneTimeWorkRequest` with no constraints, so WorkManager could run it while the device had no connectivity. Its work is entirely network-bound (fetch single order + refresh order list), so without a network it fails immediately and we emit a spurious `PUSH_NOTIFICATION_ORDER_BACKGROUND_SYNC_ERROR`. The fix attaches a `Constraints` with `setRequiredNetworkType(NetworkType.CONNECTED)`, so WorkManager defers the work until the device is online.

**2. Fix background order sync failing for site-credentials (application-password) logins**

While testing the constraint, the worker was still reaching a FAILED state with the network ON. Root cause: the worker resolved its target site **only** by the WordPress.com blog id, via `SiteStore.getSiteBySiteId(siteId)` — once for the single-order fetch (`UpdateOrderAndOrderList`) and once for the order-list refresh (`GetWCOrderListDescriptorWithFiltersBySiteId`). For a login done with **site credentials / application password**, the stored `SiteModel.siteId` (the wpcom blog id) is `0`, so the lookup returns null, the worker short-circuits to a "Site not found" error, and returns `Result.failure()`.

The codebase already solved this exact problem for analytics in `NotificationAnalyticsTracker`: for `SiteConnectionType.ApplicationPasswords` it falls back to the selected site (multi-site is unsupported with app passwords, so the single selected site is the target). This PR extracts that logic into a reusable, app-password-aware resolver and uses it for the worker's two site lookups:

- New `ResolveSiteBySiteId` in `com.woocommerce.android.tools` — a drop-in replacement for `SiteStore.getSiteBySiteId` that falls back to the selected site for app-password connections. It lives in `tools` (next to `SelectedSite`/connectivity helpers) rather than in `notifications` because it is a general site-resolution utility, not notification-specific.
- `UpdateOrderAndOrderList` and `GetWCOrderListDescriptorWithFiltersBySiteId` now use it (the latter's only caller is the worker path, so the blast radius is contained).
- `NotificationAnalyticsTracker` now reuses the shared resolver, removing its private duplicate.

Unit tests added/updated for the resolver and both consumers.

### Test Steps

This is background behavior, so the cleanest way to observe it is Android Studio's **Background Task Inspector** (App Inspection).

Setup:

In Android Studio open **View → Tool Windows → App Inspection**, select the app process, and open the **Background Task Inspector** tab.

Part A — network constraint:
1. Log into a store (any login type) and make sure order push notifications are enabled.
2. Put the device/emulator in **airplane mode** (or `adb shell svc wifi disable && adb shell svc data disable`).
3. Trigger an order notification (place/update an order on the store so a push is delivered).
4. In the inspector, find the `OrderNotificationWorker` entry and open it — confirm its **Constraints** list shows `NetworkType: CONNECTED`, and that the work stays **ENQUEUED** rather than running while offline.
5. Re-enable the network → the worker transitions to **RUNNING** → **SUCCEEDED**.

Part B — site-credentials (application-password) login:
1. Log in using **site credentials / application password** (a site that authenticates via app password rather than a WordPress.com account).
2. With the network ON, trigger an order notification for that store.
3. In the inspector, confirm `OrderNotificationWorker` reaches **SUCCEEDED** (before this change it ended in **FAILED** with a "Site not found" error), and that the order/order list is updated in the app.

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.