### PR TITLE
[WOOMOB-3292] Don't fire dashboard card data loading failed for visitor-unavailable state

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsViewModel.kt
@@ -332,10 +332,6 @@ class DashboardStatsViewModel @AssistedInject constructor(
                             showJetpackIcon = !appPrefsWrapper.isSiteWPComSuspended
                         )
                         parentViewModel.hideRefreshingIndicator()
-                        trackEventForStatsCard(
-                            AnalyticsEvent.DYNAMIC_DASHBOARD_CARD_DATA_LOADING_FAILED,
-                            properties = mapOf(AnalyticsTracker.KEY_ERROR to it.toString())
-                        )
                     }
                 }
                 dashboardTransactionLauncher.onStoreStatisticsFetched()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsViewModelTest.kt
@@ -501,6 +501,20 @@ class DashboardStatsViewModelTest : BaseUnitTest() {
         }
 
     @Test
+    fun `given visitor stats unavailable, when screen starts, then data loading failed is not tracked`() =
+        testBlocking {
+            setup {
+                whenever(getStats.invoke(any(), any(), anyOrNull()))
+                    .thenReturn(flowOf(GetStats.LoadStatsResult.VisitorStatUnavailable))
+            }
+
+            verify(analyticsTrackerWrapper, never()).track(
+                stat = eq(AnalyticsEvent.DYNAMIC_DASHBOARD_CARD_DATA_LOADING_FAILED),
+                properties = any()
+            )
+        }
+
+    @Test
     fun `when changing tabs, clear selected date`() = testBlocking {
         setup {
             whenever(dateRangeFormatter.formatSelectedDate(any(), argThat { selectionType == DEFAULT_SELECTION_TYPE }))


### PR DESCRIPTION
Fixes WOOMOB-3292

### Description

The Performance (Stats) dashboard card was reporting a ~27.9% "failure" rate in the `dynamic_dashboard_card_data_loading_failed` Tracks event, but most of that volume isn't a real failure — it's a *design state* the UI handles gracefully.

This PR drops the `DYNAMIC_DASHBOARD_CARD_DATA_LOADING_FAILED` tracking call from the `VisitorStatUnavailable` branch in `DashboardStatsViewModel.loadStoreStats()`.

`VisitorStatUnavailable` is emitted for non-Jetpack-connected sites. In the data layer (`GetStats.kt`) it is a **pure local check on `selectedSite.connectionType`** — no repository call, no network request is made. The visitor stream also never contributes a `COMPLETED` event, so reporting a `FAILED` here was doubly wrong: nothing was actually loaded, and the unavailable state is an expected, gracefully-rendered placeholder rather than an error.

The card's `Unavailable` UI state and the `hideRefreshingIndicator()` call are preserved — only the analytics call is removed.

### Test Steps

This is an analytics-only change with no user-visible behavior difference. To verify the tracking behavior:

1. Use a non-Jetpack-connected site (or a site where visitor stats are unavailable).
2. Open the My Store dashboard and let the Performance card load.
3. Confirm the card still shows its "visitor stats unavailable" placeholder state (with/without the Jetpack icon) exactly as before.
4. Confirm that no `dynamic_dashboard_card_data_loading_failed` event is logged for the visitor-stats path (e.g. via the Tracks/logcat output).

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.