### PR TITLE
Fix site-address login fallback routing WP.com & Jetpack sites to site credentials

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -11,6 +11,7 @@
 - [*] Added age-eligibility verification to comply with Google Play age requirements [https://github.com/woocommerce/woocommerce-android/pull/16048]
 - [**] Woo POS is now available in Canada, and the POS refund flow is improved [https://github.com/woocommerce/woocommerce-android/pull/15996]
 - [*] Fixed Tap to Pay being offered on devices that don't support it, and replaced the generic "No reader connected" error with a clear "Tap to Pay is not available" message linking to the requirements [https://github.com/woocommerce/woocommerce-android/pull/16044]
+- [*] Fixed the "Log in with site address" fallback sending WordPress.com and Jetpack-connected sites to the site credentials screen instead of the WordPress.com email login
 
 24.9
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -11,7 +11,7 @@
 - [*] Added age-eligibility verification to comply with Google Play age requirements [https://github.com/woocommerce/woocommerce-android/pull/16048]
 - [**] Woo POS is now available in Canada, and the POS refund flow is improved [https://github.com/woocommerce/woocommerce-android/pull/15996]
 - [*] Fixed Tap to Pay being offered on devices that don't support it, and replaced the generic "No reader connected" error with a clear "Tap to Pay is not available" message linking to the requirements [https://github.com/woocommerce/woocommerce-android/pull/16044]
-- [*] Fixed the "Log in with site address" fallback sending WordPress.com and Jetpack-connected sites to the site credentials screen instead of the WordPress.com email login
+- [*] Fixed the "Log in with site address" fallback sending WordPress.com and Jetpack-connected sites to the site credentials screen instead of the WordPress.com email login [https://github.com/woocommerce/woocommerce-android/pull/16105]
 
 24.9
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -699,7 +699,12 @@ class LoginActivity :
         val protocolRegex = Regex("^(http[s]?://)", IGNORE_CASE)
         val siteAddressClean = inputSiteAddress.replaceFirst(protocolRegex, "")
         appPrefsWrapper.setLoginSiteAddress(siteAddressClean)
-        if (result.hasJetpack || connectSiteInfo?.shouldUseWPComAuth == true) {
+        // Decide the next screen from the site info carried by the result itself, so the routing
+        // doesn't depend on the separately-maintained connectSiteInfo field (which can be null when
+        // its subscriber races/clears). WordPress.com, Commerce-garden and Jetpack-connected sites
+        // use the WP.com email flow; only self-hosted sites without a Jetpack connection use site
+        // credentials. Mirrors iOS AuthenticationManager.shouldPresentUsernamePasswordController.
+        if (result.shouldUseWPComLogin) {
             showEmailLoginScreen(null)
         } else {
             appPrefsWrapper.isSiteWPComSuspended = result.isWPComSuspended

--- a/libs/login/src/main/java/org/wordpress/android/login/ConnectSiteInfoResult.kt
+++ b/libs/login/src/main/java/org/wordpress/android/login/ConnectSiteInfoResult.kt
@@ -8,4 +8,17 @@ data class ConnectSiteInfoResult @JvmOverloads constructor(
      * Whether the site is suspended on WordPress.com and can't be connected using Jetpack
      */
     val isWPComSuspended: Boolean = false,
-)
+    val isWPCom: Boolean = false,
+    val isCommerceGarden: Boolean = false,
+    val isJetpackConnected: Boolean = false,
+) {
+    /**
+     * Whether the site should authenticate through the WordPress.com login (email) flow rather than
+     * site credentials. Mirrors the iOS routing in
+     * `AuthenticationManager.shouldPresentUsernamePasswordController` so both platforms send
+     * WordPress.com, Commerce-garden and Jetpack-connected sites to the email screen, and only
+     * self-hosted sites without a Jetpack connection to the site-credentials screen.
+     */
+    val shouldUseWPComLogin: Boolean
+        get() = isWPCom || isCommerceGarden || isJetpackConnected
+}

--- a/libs/login/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
+++ b/libs/login/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
@@ -445,7 +445,11 @@ public class LoginSiteAddressFragment extends LoginBaseDiscoveryFragment impleme
                     new ConnectSiteInfoResult(
                             mConnectSiteInfoUrl,
                             mConnectSiteInfoUrlRedirect,
-                            mConnectSiteInfoCalculatedHasJetpack
+                            mConnectSiteInfoCalculatedHasJetpack,
+                            false,
+                            siteInfo.isWPCom,
+                            siteInfo.isCommerceGarden,
+                            siteInfo.isJetpackConnected
                     )
             );
         }

--- a/libs/login/src/test/java/org/wordpress/android/login/ConnectSiteInfoResultTest.kt
+++ b/libs/login/src/test/java/org/wordpress/android/login/ConnectSiteInfoResultTest.kt
@@ -1,0 +1,64 @@
+package org.wordpress.android.login
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class ConnectSiteInfoResultTest {
+    @Test
+    fun `given a WPCom site, when checking the login flow, then WPCom login is used`() {
+        val result = connectSiteInfoResult(isWPCom = true)
+
+        assertThat(result.shouldUseWPComLogin).isTrue
+    }
+
+    @Test
+    fun `given a Commerce-garden site, when checking the login flow, then WPCom login is used`() {
+        val result = connectSiteInfoResult(isCommerceGarden = true)
+
+        assertThat(result.shouldUseWPComLogin).isTrue
+    }
+
+    @Test
+    fun `given a self-hosted Jetpack-connected site, when checking the login flow, then WPCom login is used`() {
+        val result = connectSiteInfoResult(isJetpackConnected = true)
+
+        assertThat(result.shouldUseWPComLogin).isTrue
+    }
+
+    @Test
+    fun `given a self-hosted site with Jetpack installed but not connected, then site credentials are used`() {
+        val result = connectSiteInfoResult(hasJetpack = true, isJetpackConnected = false)
+
+        assertThat(result.shouldUseWPComLogin).isFalse
+    }
+
+    @Test
+    fun `given a self-hosted non-Jetpack site, when checking the login flow, then site credentials are used`() {
+        val result = connectSiteInfoResult()
+
+        assertThat(result.shouldUseWPComLogin).isFalse
+    }
+
+    @Test
+    fun `given a WPCom-suspended site, when checking the login flow, then site credentials are used`() {
+        val result = connectSiteInfoResult(isWPComSuspended = true)
+
+        assertThat(result.shouldUseWPComLogin).isFalse
+    }
+
+    private fun connectSiteInfoResult(
+        hasJetpack: Boolean = false,
+        isWPComSuspended: Boolean = false,
+        isWPCom: Boolean = false,
+        isCommerceGarden: Boolean = false,
+        isJetpackConnected: Boolean = false,
+    ) = ConnectSiteInfoResult(
+        url = "https://example.com",
+        urlAfterRedirects = null,
+        hasJetpack = hasJetpack,
+        isWPComSuspended = isWPComSuspended,
+        isWPCom = isWPCom,
+        isCommerceGarden = isCommerceGarden,
+        isJetpackConnected = isJetpackConnected,
+    )
+}


### PR DESCRIPTION
<!-- No Linear issue was linked for this fix; please attach the issue number if one exists. -->

### Description

In the QR-first login flow, the prologue offers a fallback CTA **"No computer? Log in with site address"** (`login_qr_prologue_fallback_link`). After the merchant enters a site URL, the app is supposed to send WordPress.com sites and Jetpack-connected sites to the **WordPress.com email** login screen, and only self-hosted sites without a Jetpack connection to the **site credentials** (admin username/password) screen.

Instead, WordPress.com sites (and Jetpack-connected sites) could land on the site-credentials screen.

**Root cause:** the screen decision in `LoginActivity.gotConnectSiteInfo()` was "split-brained" — it combined two independent sources for one decision:

```kotlin
if (result.hasJetpack || connectSiteInfo?.shouldUseWPComAuth == true) { … }
```

- `ConnectSiteInfoResult` (the value the login library hands to the callback) only carried `hasJetpack`. For a **WordPress.com simple** site `calculateHasJetpack` is `false`, so this operand doesn't help.
- The WordPress.com-ness therefore depended entirely on `connectSiteInfo`, a field maintained by a *separate* `@Subscribe` to the same `OnConnectSiteInfoChecked` event. That field is `null`ed on any error event and is not part of the data passed into the callback, so the routing was order-/state-dependent and could fall through to site credentials.

The condition also diverged from iOS, which routes purely on the site info itself in `AuthenticationManager.shouldPresentUsernamePasswordController`:

```swift
if site.isWPCom || site.isCommerceGarden || site.isJetpackConnected { … } // email
```

**Fix:** make the decision self-contained and identical to iOS.
- `ConnectSiteInfoResult` now also carries `isWPCom`, `isCommerceGarden`, `isJetpackConnected`, plus a derived `shouldUseWPComLogin = isWPCom || isCommerceGarden || isJetpackConnected`.
- `LoginSiteAddressFragment` populates those fields from the fetched site info.
- `LoginActivity.gotConnectSiteInfo()` now routes on `result.shouldUseWPComLogin`, so the decision no longer depends on the out-of-band `connectSiteInfo` field.

This is purely additive and behavior-preserving for correctly-classified cases (the new predicate is a superset of the old email condition): self-hosted non-Jetpack and Jetpack-installed-but-not-connected sites still go to site credentials; the suspended-site path is unchanged. The existing `connectSiteInfo.shouldUseWPComAuth` (used for the "log in with site credentials" fallback button on the email screen) is intentionally left unchanged, so the shipped Jetpack-site fallback-button behavior is preserved.

Targets `release/25.0` (where the QR login feature ships). No string or FluxC API changes.

### Test Steps

1. Launch the app logged out so the QR login prologue is shown (QR login enabled).
2. Tap **"No computer? Log in with site address"**.
3. Enter a **WordPress.com** site URL (e.g. a `*.wordpress.com` store) and submit.
   - Expected: the **WordPress.com email** login screen is shown (not site credentials).
4. Repeat with a **self-hosted, Jetpack-connected** site URL.
   - Expected: the **WordPress.com email** login screen is shown.
5. Repeat with a **self-hosted site that does NOT have Jetpack connected**.
   - Expected: the **site credentials** (admin username/password) screen is shown (unchanged).
6. On the email screen reached for a self-hosted Jetpack-connected site, confirm the "Log in with site credentials" fallback option is still offered (unchanged).

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.