### PR TITLE
Surface non-JSON order responses through the orders error banner

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 25.1
 -----
 - [*] Fixed QR login retrying an expired number challenge re-showing the old number with "Expires in 0s"; it now returns you to the QR scanner to scan a fresh code [https://github.com/woocommerce/woocommerce-android/pull/16094]
+- [*] Show the orders troubleshooting banner (instead of a generic error) when your store returns an unexpected non-JSON response, and open the in-app Troubleshoot Connection screen from it [https://github.com/woocommerce/woocommerce-android/pull/16108]
 - [*] Renamed the empty Orders "test order" prompt to "Place your first order" and clarified that processing fees aren't refundable [https://github.com/woocommerce/woocommerce-android/pull/16086]
 - [*] Improved login error messages for site security certificate issues [https://github.com/woocommerce/woocommerce-android/pull/16042]
 - [Internal] Fixed a screen flash when navigating from the login prologue to the (feature-flagged) QR login screen [https://github.com/woocommerce/woocommerce-android/pull/16095]

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
@@ -32,9 +32,6 @@ object AppUrls {
         "https://jetpack.com/support/getting-started-with-jetpack/troubleshooting-tips/"
     const val PRODUCT_IMAGE_UPLOADS_TROUBLESHOOTING =
         "https://woocommerce.com/document/troubleshooting-image-upload-issues-in-the-woo-mobile-apps/"
-    const val ORDERS_TROUBLESHOOTING =
-        "https://woocommerce.com/document/android-ios-apps-troubleshooting-error-fetching-orders/"
-
     const val CROWDSIGNAL_MAIN_SURVEY = "https://automattic.survey.fm/woo-app-general-feedback-user-survey"
     const val CROWDSIGNAL_PRODUCT_SURVEY = "https://automattic.survey.fm/woo-app-feature-feedback-products"
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -1179,7 +1179,7 @@ class OrderListFragment :
             show = show,
             title = getString(R.string.orderlist_parsing_error_title),
             message = getString(R.string.orderlist_parsing_error_message),
-            troubleshootingClick = { ChromeCustomTabUtils.launchUrl(requireContext(), AppUrls.ORDERS_TROUBLESHOOTING) },
+            troubleshootingClick = { openTroubleshootConnection() },
             supportContactClick = { openSupportRequestScreen() }
         )
     }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -52,6 +52,7 @@ import org.wordpress.android.fluxc.store.WCOrderStore.OrderErrorType.TIMEOUT_ERR
 import org.wordpress.android.fluxc.store.WCOrderStore.RemoteOrderPayload
 import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.fluxc.utils.DateUtils
+import org.wordpress.android.fluxc.utils.ErrorUtils.OnUnexpectedError
 import org.wordpress.android.fluxc.utils.putIfNotEmpty
 import org.wordpress.android.fluxc.utils.toWooPayload
 import org.wordpress.android.util.AppLog
@@ -1174,11 +1175,39 @@ class OrderRestClient @Inject constructor(
             wpAPINetworkError.errorCode == "rest_invalid_param" -> OrderErrorType.INVALID_PARAM
             wpAPINetworkError.errorCode == "woocommerce_rest_shop_order_invalid_id" -> OrderErrorType.INVALID_ID
             wpAPINetworkError.errorCode == "rest_no_route" -> OrderErrorType.PLUGIN_NOT_ACTIVE
+            isSiteReturnedNonJsonResponse(wpAPINetworkError) -> {
+                reportNonJsonResponse(wpAPINetworkError)
+                OrderErrorType.PARSE_ERROR
+            }
             wpAPINetworkError.type == BaseRequest.GenericErrorType.PARSE_ERROR -> OrderErrorType.PARSE_ERROR
             wpAPINetworkError.type == BaseRequest.GenericErrorType.TIMEOUT -> TIMEOUT_ERROR
             else -> OrderErrorType.fromString(wpAPINetworkError.errorCode.orEmpty())
         }
         return OrderError(orderErrorType, wpAPINetworkError.combinedErrorMessage, wpAPINetworkError)
+    }
+
+    /**
+     * Detects when the merchant's site returned a non-JSON body through the Jetpack proxy: the proxy
+     * (see CONNECT-38) wraps the upstream bytes as `no_response_body` with the raw payload carried in
+     * `data.raw_body`. This usually means a plugin error or a maintenance page on the merchant's site.
+     */
+    private fun isSiteReturnedNonJsonResponse(wpAPINetworkError: WPAPINetworkError): Boolean {
+        return wpAPINetworkError.errorCode == "no_response_body" &&
+            wpAPINetworkError.errorData?.has("raw_body") == true
+    }
+
+    /**
+     * Reports the non-JSON proxy response through the existing FluxC parse-error reporting path so the
+     * occurrence is visible in crash/error reporting (and its impact measurable). The raw body itself
+     * is intentionally not attached as it may contain the merchant's page content.
+     */
+    private fun reportNonJsonResponse(wpAPINetworkError: WPAPINetworkError) {
+        val report = OnUnexpectedError(
+            Exception("Order API returned a non-JSON response through the Jetpack proxy"),
+            ORDER_RESPONSE_PARSE_ERROR_DESCRIPTION
+        )
+        wpAPINetworkError.errorCode?.let { report.addExtra("error_code", it) }
+        dispatcher.emitChange(report)
     }
 
     private fun orderShipmentTrackingResponseToModel(
@@ -1249,6 +1278,8 @@ class OrderRestClient @Inject constructor(
     }
 
     companion object {
+        private const val ORDER_RESPONSE_PARSE_ERROR_DESCRIPTION = "Order API response parse error"
+
         private val ORDER_FIELDS = arrayOf(
             "billing",
             "coupon_lines",

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClientTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClientTest.kt
@@ -4,25 +4,34 @@ import com.google.gson.Gson
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
+import org.json.JSONObject
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.UnitTestUtils
+import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCOrderFulfillmentModel
 import org.wordpress.android.fluxc.model.WCOrderListDescriptor
+import org.wordpress.android.fluxc.network.BaseRequest
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetworkError
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
+import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderListResponsePayload
+import org.wordpress.android.fluxc.store.WCOrderStore.OrderErrorType
 import org.wordpress.android.fluxc.tools.CoroutineEngine
+import org.wordpress.android.fluxc.utils.ErrorUtils.OnUnexpectedError
 import org.wordpress.android.fluxc.utils.initCoroutineEngine
 import kotlin.collections.emptyList
 
@@ -446,6 +455,81 @@ class OrderRestClientTest {
         assertThat(bodyCaptor.firstValue).isEqualTo(expectedBody)
         assertThat(bodyCaptor.firstValue).doesNotContainKey("template_id")
     }
+
+    @Test
+    fun `given the proxy returns no_response_body with raw_body, when fetching summaries fails, then error is PARSE_ERROR`() =
+        runTest {
+            // Given
+            val errorData = mock<JSONObject> {
+                on { has("raw_body") } doReturn true
+            }
+            val error = WPAPINetworkError(
+                baseError = BaseRequest.BaseNetworkError(BaseRequest.GenericErrorType.UNKNOWN),
+                errorCode = "no_response_body",
+                errorData = errorData
+            )
+            whenever(
+                wooNetwork.executeGetGsonRequest(
+                    site = any(),
+                    path = any(),
+                    clazz = eq(Array<OrderSummaryApiResponse>::class.java),
+                    params = any(),
+                    enableCaching = any(),
+                    cacheTimeToLive = any(),
+                    forced = any(),
+                    requestTimeout = any(),
+                    retries = any()
+                )
+            ).thenReturn(WPAPIResponse.Error(error))
+
+            // When
+            orderRestClient.fetchOrderListSummaries(WCOrderListDescriptor(site = testSite), 0)
+
+            // Then
+            val actionCaptor = argumentCaptor<Action<FetchOrderListResponsePayload>>()
+            verify(dispatcher).dispatch(actionCaptor.capture())
+            assertThat(actionCaptor.firstValue.payload.error?.type).isEqualTo(OrderErrorType.PARSE_ERROR)
+
+            val reportCaptor = argumentCaptor<OnUnexpectedError>()
+            verify(dispatcher).emitChange(reportCaptor.capture())
+            assertThat(reportCaptor.firstValue.description).isEqualTo("Order API response parse error")
+        }
+
+    @Test
+    fun `given proxy returns no_response_body without raw_body, when fetching fails, then error is GENERIC and not reported`() =
+        runTest {
+            // Given
+            val errorData = mock<JSONObject> {
+                on { has("raw_body") } doReturn false
+            }
+            val error = WPAPINetworkError(
+                baseError = BaseRequest.BaseNetworkError(BaseRequest.GenericErrorType.UNKNOWN),
+                errorCode = "no_response_body",
+                errorData = errorData
+            )
+            whenever(
+                wooNetwork.executeGetGsonRequest(
+                    site = any(),
+                    path = any(),
+                    clazz = eq(Array<OrderSummaryApiResponse>::class.java),
+                    params = any(),
+                    enableCaching = any(),
+                    cacheTimeToLive = any(),
+                    forced = any(),
+                    requestTimeout = any(),
+                    retries = any()
+                )
+            ).thenReturn(WPAPIResponse.Error(error))
+
+            // When
+            orderRestClient.fetchOrderListSummaries(WCOrderListDescriptor(site = testSite), 0)
+
+            // Then
+            val actionCaptor = argumentCaptor<Action<FetchOrderListResponsePayload>>()
+            verify(dispatcher).dispatch(actionCaptor.capture())
+            assertThat(actionCaptor.firstValue.payload.error?.type).isEqualTo(OrderErrorType.GENERIC_ERROR)
+            verify(dispatcher, never()).emitChange(any<OnUnexpectedError>())
+        }
 
     /* HELPER */
 


### PR DESCRIPTION
### Description

Closes [WOOMOB-3298](https://linear.app/a8c/issue/WOOMOB-3298/surface-html-raw-body-response-failures-to-the-user).

When a merchant's store returns a non-JSON body while loading orders — a WAF/maintenance page, a PHP fatal/warning, or markup injected by a caching plugin — the app couldn't load the order list. How that surfaces depends on the networking path:

- **Direct REST / Application Passwords:** the corrupted body fails JSON parsing, which FluxC already maps to `OrderErrorType.PARSE_ERROR` → `ListErrorType.PARSE_ERROR`. The order list already shows the **"We couldn't load your data"** troubleshooting banner for this. ✅ (no change needed)
- **Jetpack tunnel proxy:** the WordPress.com proxy (see CONNECT-38) wraps the upstream bytes as a JSON error with code `no_response_body` and the raw payload in `data.raw_body`. The app mapped this to `GENERIC_ERROR` → the generic *"Error fetching orders"* snackbar, which gives the merchant no diagnosis. ❌

This PR closes that gap and improves the banner's action.

#### Changes

1. **Error parsing** — `OrderRestClient.wpAPINetworkErrorToOrderError` now maps a proxy error of `no_response_body` **with** `data.raw_body` present to `OrderErrorType.PARSE_ERROR`, so it reaches the existing banner. The occurrence is also reported through the existing FluxC parse-error reporting path (`OnUnexpectedError`, matching #16102) so the impact is measurable in error reporting. The raw body is intentionally not attached to the report as it may contain the merchant's page content. A proxy `no_response_body` *without* `raw_body` keeps its previous `GENERIC_ERROR` behavior.
2. **Troubleshooting navigation** — the parse-error banner's *Troubleshooting* button now opens the in-app **Troubleshoot Connection** screen (the same one reachable from Settings and already used by the timeout banner) instead of launching a web view. The now-unused `AppUrls.ORDERS_TROUBLESHOOTING` constant is removed.

### Testing

A small WordPress plugin reproduces the corrupted responses: **WC REST API Parse Error Simulator** - 
[wc-rest-api-parse-error-simulator.zip](https://github.com/user-attachments/files/29138155/wc-rest-api-parse-error-simulator.zip). It keeps the HTTP status `200` and `Content-Type: application/json` but prepends non-JSON content to the body, in two modes:
- **Mode 1 — PHP warning injection** (mirrors WC Cost of Goods v2.8.3). Hooks the REST *dispatch* path, so it also corrupts requests proxied through the Jetpack tunnel.
- **Mode 2 — HTML/script injection** (mirrors a caching plugin).

Install the zip via **wp-admin → Plugins → Add New → Upload Plugin**, activate it, then enable a mode from its settings screen. Use two Jurassic Ninja (JN) sites so you can cover both networking paths:

#### Scenario A — Application Passwords (direct REST)
1. On JN site nr 1 (not Jetpack connected, Application Passwords working), log into the app with site credentials.
2. Install + activate the simulator plugin and enable **Mode 1** (or Mode 2).
3. Pull to refresh the **Orders** list.
4. **Expected:** the **"We couldn't load your data"** troubleshooting banner appears (not the generic "Error fetching orders" snackbar). Tapping **Troubleshooting** opens the in-app **Troubleshoot Connection** screen; tapping **Contact support** opens the support form.

#### Scenario B — Jetpack tunnel proxy
1. On JN site nr 2, **disable Application Passwords** so the app falls back to the Jetpack tunnel — install a "Disable Application Passwords" plugin (or otherwise turn the feature off). This is required, otherwise the app uses the direct REST path (Scenario A).
2. Log into the app with this site selected and confirm requests go through the Jetpack tunnel.
3. Install + activate the simulator plugin and enable **Mode 1** (its dispatch-path hook is what corrupts the proxied response).
4. Pull to refresh the **Orders** list.
5. **Expected:** same as Scenario A — the troubleshooting banner appears instead of the generic snackbar, and the corrupted-response event is reported via `OnUnexpectedError("Order API response parse error")`.

After testing, deactivate/remove the simulator plugin (and re-enable Application Passwords on site #2).

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
