### PR TITLE
[WOOMOB-3310] Fix push notifications setup crash and Dashboard card leak

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
@@ -25,6 +25,7 @@ import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.key
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -119,14 +120,16 @@ private fun DashboardWidgets(
         ) {
             Spacer(modifier = Modifier)
             widgetUiModels.forEach { widget ->
-                AnimatedVisibility(widget.isVisible) {
-                    DashboardWidgetCard(
-                        it = widget,
-                        mainActivityViewModel = mainActivityViewModel,
-                        dashboardViewModel = dashboardViewModel,
-                        blazeCampaignCreationDispatcher = blazeCampaignCreationDispatcher,
-                        modifier = Modifier.fillMaxWidth()
-                    )
+                key(widget.stableKey()) {
+                    AnimatedVisibility(widget.isVisible) {
+                        DashboardWidgetCard(
+                            it = widget,
+                            mainActivityViewModel = mainActivityViewModel,
+                            dashboardViewModel = dashboardViewModel,
+                            blazeCampaignCreationDispatcher = blazeCampaignCreationDispatcher,
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                    }
                 }
             }
             Spacer(modifier = Modifier)
@@ -190,6 +193,13 @@ private fun splitWidgetsIntoColumns(
         widgetColumns[index % numberOfColumns].add(item)
     }
     return widgetColumns
+}
+
+private fun DashboardWidgetUiModel.stableKey(): Any = when (this) {
+    is ConfigurableWidget -> widget.type
+    is ShareStoreWidget -> "share_store"
+    is FeedbackWidget -> "feedback"
+    is NewWidgetsCard -> "new_widgets"
 }
 
 @Composable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionViewModel.kt
@@ -19,6 +19,7 @@ import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
+import org.wordpress.android.fluxc.model.SiteModel
 import javax.inject.Inject
 
 @HiltViewModel
@@ -50,7 +51,13 @@ class WooPushNotificationsIntroductionViewModel @Inject constructor(
 
     private fun fetchStatus() {
         launch {
-            val viewState = checkIfJetpackIsConnected()
+            val site = selectedSite.get()
+            if (site.connectionType == SiteConnectionType.Jetpack) {
+                triggerEvent(Exit)
+                return@launch
+            }
+
+            val viewState = checkIfJetpackIsConnected(site)
                 .map { isConnected ->
                     if (!isConnected) {
                         return@map ViewState.NotConnected
@@ -83,8 +90,7 @@ class WooPushNotificationsIntroductionViewModel @Inject constructor(
         }
     }
 
-    private suspend fun checkIfJetpackIsConnected(): Result<Boolean> {
-        val site = selectedSite.get()
+    private suspend fun checkIfJetpackIsConnected(site: SiteModel): Result<Boolean> {
         return when (site.connectionType) {
             SiteConnectionType.ApplicationPasswords -> fetchJetpackStatus(
                 site = site,
@@ -101,10 +107,7 @@ class WooPushNotificationsIntroductionViewModel @Inject constructor(
                 Result.success(true)
             }
 
-            SiteConnectionType.Jetpack -> error(
-                "Invalid state: WooPushNotificationsIntroductionViewModel should not be instantiated for sites " +
-                    "with SiteConnectionType.Jetpack"
-            )
+            SiteConnectionType.Jetpack -> Result.success(false)
         }
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionViewModelTest.kt
@@ -11,6 +11,7 @@ import com.woocommerce.android.model.JetpackStatus
 import com.woocommerce.android.notifications.push.CheckWooPluginPushNotificationsSupport
 import com.woocommerce.android.support.help.HelpOrigin
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.tools.SiteConnectionType
 import com.woocommerce.android.ui.jetpack.FetchJetpackStatus
 import com.woocommerce.android.ui.jetpack.FetchJetpackStatus.JetpackStatusFetchResponse
 import com.woocommerce.android.ui.pushnotifications.introduction.WooPushNotificationsIntroductionViewModel.ViewState
@@ -53,16 +54,28 @@ class WooPushNotificationsIntroductionViewModelTest : BaseUnitTest() {
 
     private lateinit var viewModel: WooPushNotificationsIntroductionViewModel
 
-    private fun setup(isJetpackCPSite: Boolean = false) {
+    private fun setup(connectionType: SiteConnectionType = SiteConnectionType.ApplicationPasswords) {
         val site = SiteModel().apply {
             url = "https://example.com"
-            origin = if (isJetpackCPSite) {
-                SiteModel.ORIGIN_WPCOM_REST
-            } else {
-                SiteModel.ORIGIN_WPAPI
+            when (connectionType) {
+                SiteConnectionType.ApplicationPasswords -> {
+                    origin = SiteModel.ORIGIN_WPAPI
+                    setIsJetpackCPConnected(false)
+                    setIsJetpackConnected(false)
+                }
+
+                SiteConnectionType.JetpackConnectionPackage -> {
+                    origin = SiteModel.ORIGIN_WPCOM_REST
+                    setIsJetpackCPConnected(true)
+                    setIsJetpackConnected(false)
+                }
+
+                SiteConnectionType.Jetpack -> {
+                    origin = SiteModel.ORIGIN_WPCOM_REST
+                    setIsJetpackConnected(true)
+                    setIsJetpackCPConnected(false)
+                }
             }
-            setIsJetpackCPConnected(isJetpackCPSite)
-            setIsJetpackConnected(false)
         }
         whenever(selectedSite.get()).thenReturn(site)
 
@@ -74,6 +87,25 @@ class WooPushNotificationsIntroductionViewModelTest : BaseUnitTest() {
             analyticsTrackerWrapper = analyticsTrackerWrapper
         )
     }
+
+    @Test
+    fun `given a full Jetpack site, when screen opens, then Exit is triggered without checking setup status`() =
+        testBlocking {
+            setup(connectionType = SiteConnectionType.Jetpack)
+
+            val event = viewModel.event.value
+            assertThat(event).isEqualTo(Exit)
+            verify(fetchJetpackStatus, never()).invoke(any(), any(), anyOrNull())
+            verify(checkWCPluginSupport, never()).invoke(any())
+            verify(analyticsTrackerWrapper, never()).track(
+                eq(AnalyticsEvent.PUSH_NOTIFICATIONS_SETUP_INTRODUCTION_VIEW),
+                any()
+            )
+            verify(analyticsTrackerWrapper, never()).track(
+                eq(AnalyticsEvent.PUSH_NOTIFICATIONS_SETUP_INTRODUCTION_ERROR),
+                any()
+            )
+        }
 
     @Test
     fun `given site is not registered, when screen opens, then NotConnected state is shown`() =
@@ -403,7 +435,7 @@ class WooPushNotificationsIntroductionViewModelTest : BaseUnitTest() {
             whenever(checkWCPluginSupport(forceRefresh = true))
                 .thenReturn(CheckWooPluginPushNotificationsSupport.Result.UpdateRequired("9.0.0"))
 
-            setup(isJetpackCPSite = true)
+            setup(connectionType = SiteConnectionType.JetpackConnectionPackage)
 
             val viewState = viewModel.viewState.getOrAwaitValue()
             assertThat(viewState).isEqualTo(ViewState.UpdateRequired)
@@ -419,7 +451,7 @@ class WooPushNotificationsIntroductionViewModelTest : BaseUnitTest() {
             whenever(checkWCPluginSupport(forceRefresh = true))
                 .thenReturn(CheckWooPluginPushNotificationsSupport.Result.Compatible)
 
-            setup(isJetpackCPSite = true)
+            setup(connectionType = SiteConnectionType.JetpackConnectionPackage)
 
             val viewState = viewModel.viewState.getOrAwaitValue()
             assertThat(viewState).isEqualTo(ViewState.Connected)
@@ -435,7 +467,7 @@ class WooPushNotificationsIntroductionViewModelTest : BaseUnitTest() {
             whenever(checkWCPluginSupport(forceRefresh = true))
                 .thenReturn(CheckWooPluginPushNotificationsSupport.Result.Error)
 
-            setup(isJetpackCPSite = true)
+            setup(connectionType = SiteConnectionType.JetpackConnectionPackage)
 
             val viewState = viewModel.viewState.getOrAwaitValue()
             assertThat(viewState).isEqualTo(ViewState.GenericError)
@@ -451,7 +483,7 @@ class WooPushNotificationsIntroductionViewModelTest : BaseUnitTest() {
             whenever(checkWCPluginSupport(forceRefresh = true))
                 .thenReturn(CheckWooPluginPushNotificationsSupport.Result.Compatible)
 
-            setup(isJetpackCPSite = true)
+            setup(connectionType = SiteConnectionType.JetpackConnectionPackage)
 
             verify(fetchJetpackStatus, never()).invoke(any(), any(), anyOrNull())
         }
@@ -462,7 +494,7 @@ class WooPushNotificationsIntroductionViewModelTest : BaseUnitTest() {
             whenever(checkWCPluginSupport(forceRefresh = true))
                 .thenReturn(CheckWooPluginPushNotificationsSupport.Result.UpdateRequired("9.0.0"))
 
-            setup(isJetpackCPSite = true)
+            setup(connectionType = SiteConnectionType.JetpackConnectionPackage)
             viewModel.onContinueClick()
 
             val event = viewModel.event.value


### PR DESCRIPTION
### Description
Fixes WOOMOB-3310

Sentry reported a fatal `IllegalStateException` when `WooPushNotificationsIntroductionViewModel` was instantiated for a full Jetpack site. The push notifications introduction screen is only meant for non-Jetpack sites, so the ViewModel used to treat `SiteConnectionType.Jetpack` as an invalid state and crash.

The important finding from the investigation is that the Dashboard entry point could briefly appear even when the eligibility logic said it should be hidden. We reproduced the **Enable push notifications** card being composed, shown, and tappable while its computed status was `Hidden`, including with the remote feature flag off. In other words, the feature-flag/site gate was correct; the phone Dashboard rendering leaked the hidden card.

Why that could happen:

1. On phones, the single-column Dashboard rendered the full widget list with an unkeyed `forEach`, and each widget owned an `AnimatedVisibility(widget.isVisible)`.
2. Editing and saving Dashboard cards re-emits the widget list and can shift card positions around the hidden push notifications slot.
3. Because the list was unkeyed, Compose matched widgets by position and reused a slot whose `AnimatedVisibility` was already in a visible state for a different card.
4. That visible slot could then be reused for the hidden push notifications card, causing the card to flash on screen and become tappable even though its status was `Hidden`.
5. If the selected site was a full Jetpack site, tapping that leaked card navigated to the intro screen and the ViewModel crashed.

This PR fixes both parts of the path:

- The phone Dashboard single-column list now keys each widget around `AnimatedVisibility` using stable widget identity. Compose no longer reuses a visible animation slot across different widgets, so a hidden push notifications card cannot inherit another card's visible state.
- The push notifications intro ViewModel now reads the selected site once and exits immediately for `SiteConnectionType.Jetpack`, before setup checks or intro analytics. This is a defense-in-depth guard for stale taps, restored navigation, Settings entry points, or any future path that reaches the screen for a Jetpack site.

No release-note entry was added because this is a correction for the feature-flagged self-driven push notifications setup flow. Post-release Sentry monitoring for `WOOCOMMERCE-ANDROID-TWK` / `7405953501` is deferred until a build containing this fix ships.

### Test Steps
The visual flash is timing-dependent, so the specific before/after verification uses the local-only patch below. **Do not commit the patch.** Test on a phone emulator with existing logged-in app data and a full Jetpack-connected site selected.

1. **Check crash:** check out pre-fix ef52f0d0d19 and apply the patch below with `git apply --3way`.

<details>
<summary>Local-only reproduction patch (do not commit)</summary>

```diff
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
index 7740709ec3f..a4bcb85b350 100644
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
@@ -62,6 +62,10 @@ import com.woocommerce.android.ui.dashboard.stats.DashboardStatsCard
 import com.woocommerce.android.ui.dashboard.stock.DashboardProductStockCard
 import com.woocommerce.android.ui.dashboard.topperformers.DashboardTopPerformersWidgetCard
 import com.woocommerce.android.ui.main.MainActivityViewModel
+import com.woocommerce.android.util.WooLog
+import com.woocommerce.android.util.WooLog.T.DASHBOARD
+
+private const val WOOMOB_3310_TAG = "WOOMOB3310"
 
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
@@ -110,6 +114,13 @@ private fun DashboardWidgets(
 ) {
     val nestedScrollInterop = rememberNestedScrollInteropConnection()
 
+    LaunchedEffect(widgetUiModels) {
+        WooLog.i(
+            DASHBOARD,
+            "$WOOMOB_3310_TAG dashboard widgets " + widgetUiModels.joinToString(" | ") { it.debugLabel() }
+        )
+    }
+
     if (numberOfColumns == 1) {
         Column(
             modifier = modifier
@@ -192,6 +203,14 @@ private fun splitWidgetsIntoColumns(
     return widgetColumns
 }
 
+private fun DashboardWidgetUiModel.debugLabel(): String = when (this) {
+    is ConfigurableWidget ->
+        "${widget.type}:selected=${widget.isSelected},status=${widget.status},visible=$isVisible"
+    is ShareStoreWidget -> "share_store:visible=$isVisible"
+    is FeedbackWidget -> "feedback:visible=$isVisible"
+    is NewWidgetsCard -> "new_widgets:visible=$isVisible"
+}
+
 @Composable
 private fun DashboardWidgetCard(
     it: DashboardWidgetUiModel,
@@ -242,7 +261,25 @@ private fun ConfigurableWidgetCard(
     blazeCampaignCreationDispatcher: BlazeCampaignCreationDispatcher,
     modifier: Modifier
 ) {
-    when (widgetUiModel.widget.type) {
+    val widget = widgetUiModel.widget
+    if (widget.type == DashboardWidget.Type.PUSH_NOTIFICATIONS) {
+        LaunchedEffect(widget.isSelected, widget.status, widget.isVisible) {
+            WooLog.i(
+                DASHBOARD,
+                "$WOOMOB_3310_TAG push card composed selected=${widget.isSelected} " +
+                    "status=${widget.status} visible=${widget.isVisible}"
+            )
+            if (widget.status == DashboardWidget.Status.Hidden && !widget.isVisible) {
+                WooLog.i(DASHBOARD, "$WOOMOB_3310_TAG hidden push card leak composed; opening intro")
+                dashboardViewModel.trackCardInteracted(DashboardWidget.Type.PUSH_NOTIFICATIONS.trackingIdentifier)
+                dashboardViewModel.onDashboardWidgetEvent(
+                    DashboardViewModel.DashboardEvent.OpenWooPushNotificationsIntroduction
+                )
+            }
+        }
+    }
+
+    when (widget.type) {
         DashboardWidget.Type.AI_ASSISTANT -> DashboardAIAssistantCard(
             onClick = dashboardViewModel::onAiAssistantCardClicked,
             modifier = modifier
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/widgeteditor/DashboardWidgetEditorViewModel.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/widgeteditor/DashboardWidgetEditorViewModel.kt
index 0ccc34157da..7b9f615db95 100644
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/widgeteditor/DashboardWidgetEditorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/widgeteditor/DashboardWidgetEditorViewModel.kt
@@ -9,6 +9,8 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.model.DashboardWidget
 import com.woocommerce.android.ui.dashboard.data.DashboardRepository
+import com.woocommerce.android.util.WooLog
+import com.woocommerce.android.util.WooLog.T.DASHBOARD
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow
@@ -21,6 +23,8 @@ import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 
+private const val WOOMOB_3310_TAG = "WOOMOB3310"
+
 @HiltViewModel
 class DashboardWidgetEditorViewModel @Inject constructor(
     savedState: SavedStateHandle,
@@ -79,7 +83,13 @@ class DashboardWidgetEditorViewModel @Inject constructor(
     fun onSaveClicked() {
         viewModelScope.launch {
             trackSelectedCards()
-            dashboardRepository.updateWidgets(editedWidgets)
+            val widgetsToSave = editedWidgets.withWoomob3310ProbeReorder()
+            WooLog.i(
+                DASHBOARD,
+                "$WOOMOB_3310_TAG editor save widgets " +
+                    widgetsToSave.joinToString(" | ") { it.debugProbeLabel() }
+            )
+            dashboardRepository.updateWidgets(widgetsToSave)
             triggerEvent(Exit)
         }
     }
@@ -129,3 +139,18 @@ class DashboardWidgetEditorViewModel @Inject constructor(
             widgetList.filter { it.isAvailable } + widgetList.filter { it.status is DashboardWidget.Status.Unavailable }
     }
 }
+
+private fun List<DashboardWidget>.withWoomob3310ProbeReorder(): List<DashboardWidget> {
+    val pushIndex = indexOfFirst {
+        it.type == DashboardWidget.Type.PUSH_NOTIFICATIONS && it.status == DashboardWidget.Status.Hidden
+    }
+    if (pushIndex == -1 || none { it.isVisible }) return this
+
+    val pushWidget = get(pushIndex)
+    val withoutPush = toMutableList().apply { removeAt(pushIndex) }
+    val insertIndex = (withoutPush.indexOfFirst { it.isVisible } + 1).coerceIn(0, withoutPush.size)
+    return withoutPush.apply { add(insertIndex, pushWidget) }
+}
+
+private fun DashboardWidget.debugProbeLabel(): String =
+    "$type:selected=$isSelected,status=$status,visible=$isVisible"
```

</details>

2. Build and install `:WooCommerce:assembleWasabiDebug`. Preserve app data; do not uninstall or clear storage.
3. Start logcat and filter for `WOOMOB3310|push_notifications_card_view|dynamic_dashboard_card_interacted|FATAL EXCEPTION|SiteConnectionType.Jetpack`.
4. Open **My Store -> Customize/Edit layout -> toggle any card -> Save**. The verified path used **hide Store setup -> Save**.
5. Pre-fix expected result: logs show `PUSH_NOTIFICATIONS ... status=Hidden,visible=false`, then `push card composed`, then `hidden push card leak composed; opening intro`, then `dynamic_dashboard_card_interacted type=push_notifications`, `push_notifications_card_view`, and finally the Jetpack ViewModel crash.
6. **Verify fix:** In a clean disposable worktree, check out fixed HEAD 019048f82e9c73dd0545dc27c7d6a84172361c52, apply the same patch, build/install over the same app data, and repeat step 4.
7. Fixed-branch pass condition: logs still show the push model is `Hidden`, but there are **0** `push card composed`, **0** hidden-leak markers, **0** `push_notifications_card_view` events, **0** push-card interactions, and **0** intro dialog openings. No crash is expected, but do not accept on no-crash alone because the new ViewModel guard would also prevent the crash if the card still leaked.
8. **Supported-site smoke check:** with an eligible Application Passwords or Jetpack Connection Package site, open push setup from the Dashboard card and from **Settings > Enable push notifications**. The introduction screen should open normally.
9. Jetpack guard check: covered by unit test `given a full Jetpack site, when screen opens, then Exit is triggered without checking setup status`; there is no separate manual step.

### Images/gif
N/A - the production card flash is timing-dependent and was verified through the Dashboard customize/save churn described above.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.