### PR TITLE
Remove unused POS dependencies

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -136,6 +136,7 @@ androidx-compose-ui-text-google-fonts = { group = "androidx.compose.ui", name = 
 androidx-compose-ui-tooling-main = { group = "androidx.compose.ui", name = "ui-tooling" }
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3-android" }
 androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
+androidx-compose-ui-unit = { group = "androidx.compose.ui", name = "ui-unit" }
 androidx-constraintlayout-compose = { group = "androidx.constraintlayout", name = "constraintlayout-compose", version.ref = "androidx-constraintlayout-compose" }
 androidx-constraintlayout-main = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "androidx-constraintlayout-main" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "androidx-core-main" }

--- a/libs/pos/build.gradle
+++ b/libs/pos/build.gradle
@@ -29,16 +29,14 @@ android {
 }
 
 dependencies {
+    implementation(platform(libs.androidx.compose.bom))
     implementation(project(":libs:commons"))
     implementation(project(":libs:fluxc"))
     implementation(project(":libs:fluxc-plugin"))
     implementation(libs.google.dagger.hilt.android.main)
     implementation(libs.androidx.datastore.preferences)
-    implementation(libs.androidx.datastore.main)
     implementation(libs.androidx.core.ktx)
-    implementation(libs.androidx.compose.ui.main)
-    implementation(libs.google.gson)
-    implementation(libs.google.guava)
+    implementation(libs.androidx.compose.ui.unit)
 
     ksp(libs.google.dagger.hilt.compiler)
 


### PR DESCRIPTION
### Description
Cleans up the low-risk `:libs:pos` slice of the unused-dependency findings reported by the **Exception Catchers** dependency-analysis rotation. No Linear issue.

The scheduled dependency-analysis job (`./gradlew buildHealth`) flagged 14 unused dependencies across the repo. This PR addresses only the `:libs:pos` unused-dependency findings.

Source alert: p1781842271824519-slack-C8ZFBDQC9

### Changes
For `:libs:pos`, the report listed four unused direct dependencies and recommended declaring the narrower Compose unit artifact directly. This PR:

- Removes `libs.androidx.datastore.main`, `libs.google.gson`, and `libs.google.guava`.
- Replaces the broad `libs.androidx.compose.ui.main` with `libs.androidx.compose.ui.unit`.
- Adds the `androidx-compose-ui-unit` version-catalog alias.
- Adds the Compose BOM to `:libs:pos` so the new versionless Compose alias is versioned consistently with the rest of the project.

### Why this is safe
- `:libs:pos` does not directly reference Gson or Guava APIs.
- DataStore Preferences APIs are unaffected: `:libs:pos` still keeps `libs.androidx.datastore.preferences`, used by `WooPosPreferencesRepository`, `WooPosSyncTimestampRepository`, and the POS `preferencesDataStore` extension.
- The only direct Compose UI usage in `:libs:pos` is `androidx.compose.ui.unit.Dp` / `dp`, so `ui-unit` is sufficient and avoids declaring the full Compose UI artifact directly.
- After this PR, the refreshed report no longer lists any unused dependencies for `:libs:pos`.

<details>
<summary>Report finding removed by this PR</summary>

Before this PR, the `:libs:pos` section of `buildHealth` contained:

```text
Advice for :libs:pos
Unused dependencies which should be removed:
  implementation libs.androidx.compose.ui.main
  implementation libs.androidx.datastore.main
  implementation libs.google.gson
  implementation libs.google.guava
```

After this PR, the `Unused dependencies which should be removed` block is gone from the `:libs:pos` section. The remaining transitive/API-scope advice for `:libs:pos` is unchanged and intentionally left for separate PRs.

</details>

### Out of scope
- Remaining `:libs:pos` transitive/API-scope advice — no unused-dependency advice remains; left alone to keep this PR focused on the EC unused-dependency cleanup.
- Other modules' findings, including unused entries in `:libs:commons`, need separate verification because they touch broader shared dependencies.

### Validation run locally
- `ANDROID_HOME=/Users/hicham/Library/Android/sdk ./gradlew :libs:pos:compileDebugKotlin :libs:pos:testDebugUnitTest :libs:pos:projectHealth`
- `ANDROID_HOME=/Users/hicham/Library/Android/sdk ./gradlew buildHealth`
- `git diff --check`

### Test Steps
1. No manual app flow; this is a Gradle dependency cleanup only.
2. In the refreshed dependency-analysis report, confirm `:libs:pos` no longer has an `Unused dependencies which should be removed` section.
3. Confirm POS still builds and its debug unit tests pass in CI.

### Images/gif
N/A

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.