### PR TITLE
[POS][New refunds API] Part 2. POS: v4 refund detection, preview & simplified-create integration

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosBuildRefundV4LineItems.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosBuildRefundV4LineItems.kt
@@ -10,11 +10,11 @@ class WooPosBuildRefundV4LineItems @Inject constructor() {
         val productLineItems = productItems
             .groupBy { it.orderItemId }
             .map { (orderItemId, rows) ->
-                RefundV4LineItem(lineItemId = orderItemId, quantity = rows.size)
+                RefundV4LineItem.quantityBased(lineItemId = orderItemId, quantity = rows.size)
             }
 
         val feeLineItems = feeItems.map { fee ->
-            RefundV4LineItem(
+            RefundV4LineItem.amountBased(
                 lineItemId = fee.orderItemId,
                 refundTotal = fee.unitPrice + fee.unitTax,
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosBuildRefundV4LineItems.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosBuildRefundV4LineItems.kt
@@ -1,0 +1,25 @@
+package com.woocommerce.android.ui.woopos.orders.details.refund
+
+import org.wordpress.android.fluxc.model.refunds.RefundV4LineItem
+import javax.inject.Inject
+
+class WooPosBuildRefundV4LineItems @Inject constructor() {
+    operator fun invoke(selectedItems: List<WooPosRefundableItem>): List<RefundV4LineItem> {
+        val (feeItems, productItems) = selectedItems.partition { it.isLumpSum }
+
+        val productLineItems = productItems
+            .groupBy { it.orderItemId }
+            .map { (orderItemId, rows) ->
+                RefundV4LineItem(lineItemId = orderItemId, quantity = rows.size)
+            }
+
+        val feeLineItems = feeItems.map { fee ->
+            RefundV4LineItem(
+                lineItemId = fee.orderItemId,
+                refundTotal = fee.unitPrice + fee.unitTax,
+            )
+        }
+
+        return productLineItems + feeLineItems
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosIssueRefundScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosIssueRefundScreen.kt
@@ -652,7 +652,7 @@ private fun RefundScreenButtons(
     ) {
         when (state) {
             is WooPosRefundState.Loading -> ContinueToReviewButton(
-                enabled = false,
+                state = WooPosButtonState.DISABLED,
                 onClick = {},
             )
             is WooPosRefundState.Content -> RefundContentStepButtons(
@@ -693,10 +693,25 @@ private fun RefundContentStepButtons(
     disablePartialRefund: Boolean,
 ) {
     when (state.step) {
-        WooPosRefundState.Content.RefundStep.SelectItems -> ContinueToReviewButton(
-            enabled = state.selectedItemIds.isNotEmpty(),
-            onClick = { onEvent(WooPosRefundUIEvent.ContinueToReviewClicked) },
-        )
+        WooPosRefundState.Content.RefundStep.SelectItems -> {
+            if (state.previewFailed) {
+                WooPosText(
+                    text = stringResource(R.string.woopos_refund_preview_error),
+                    style = WooPosTypography.BodyMedium,
+                    color = MaterialTheme.colorScheme.error,
+                    modifier = Modifier.fillMaxWidth()
+                )
+                WooPosOutlinedButton(
+                    text = stringResource(R.string.retry),
+                    onClick = { onEvent(WooPosRefundUIEvent.RetryPreview) },
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+            ContinueToReviewButton(
+                state = continueToReviewButtonState(state),
+                onClick = { onEvent(WooPosRefundUIEvent.ContinueToReviewClicked) },
+            )
+        }
         WooPosRefundState.Content.RefundStep.ReviewRefund -> {
             WooPosButton(
                 text = stringResource(R.string.continue_button),
@@ -843,15 +858,21 @@ private fun RefundSuccessButtons(
 
 @Composable
 private fun ContinueToReviewButton(
-    enabled: Boolean,
+    state: WooPosButtonState,
     onClick: () -> Unit,
 ) {
     WooPosButton(
         text = stringResource(R.string.continue_button),
         onClick = onClick,
-        state = if (enabled) WooPosButtonState.ENABLED else WooPosButtonState.DISABLED,
+        state = state,
         modifier = Modifier.fillMaxWidth()
     )
+}
+
+private fun continueToReviewButtonState(state: WooPosRefundState.Content): WooPosButtonState = when {
+    state.isPreviewLoading -> WooPosButtonState.LOADING
+    state.selectedItemIds.isEmpty() || state.previewFailed -> WooPosButtonState.DISABLED
+    else -> WooPosButtonState.ENABLED
 }
 
 @Composable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundPreview.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundPreview.kt
@@ -1,0 +1,79 @@
+package com.woocommerce.android.ui.woopos.orders.details.refund
+
+import com.woocommerce.android.extensions.semverCompareTo
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.util.GetWooCorePluginCachedVersion
+import com.woocommerce.android.util.WooLog
+import org.wordpress.android.fluxc.model.refunds.RefundV4LineItem
+import org.wordpress.android.fluxc.model.refunds.WCRefundPreview
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
+import org.wordpress.android.fluxc.store.WCRefundStore
+import javax.inject.Inject
+
+class WooPosRefundPreview @Inject constructor(
+    private val refundStore: WCRefundStore,
+    private val selectedSite: SelectedSite,
+    private val availabilityCache: WooPosV4RefundAvailabilityCache,
+    private val getWooCoreVersion: GetWooCorePluginCachedVersion,
+) {
+    suspend operator fun invoke(
+        orderId: Long,
+        lineItems: List<RefundV4LineItem>,
+    ): Result {
+        val site = selectedSite.get()
+
+        if (availabilityCache.isV4Available(site.siteId) == false) {
+            return Result.FallbackToLocal
+        }
+
+        if (isWooVersionBelowV4Support()) {
+            WooLog.i(WooLog.T.POS, "WooPosRefund: WooCommerce older than $MIN_WC_VERSION_FOR_V4; using v3")
+            availabilityCache.markV4Unavailable(site.siteId)
+            return Result.FallbackToLocal
+        }
+
+        if (lineItems.isEmpty()) {
+            return Result.FallbackToLocal
+        }
+
+        val response = refundStore.previewRefund(site, orderId, lineItems)
+        return when {
+            response.isError -> {
+                if (response.error.type == WooErrorType.API_NOT_FOUND) {
+                    WooLog.i(WooLog.T.POS, "WooPosRefund: v4 preview not available; falling back to v3")
+                    availabilityCache.markV4Unavailable(site.siteId)
+                    Result.FallbackToLocal
+                } else {
+                    WooLog.e(
+                        WooLog.T.POS,
+                        "WooPosRefund: v4 preview failed orderId=$orderId, type=${response.error.type}, " +
+                            "message=${response.error.message}"
+                    )
+                    Result.Error
+                }
+            }
+
+            response.model != null -> {
+                availabilityCache.markV4Available(site.siteId)
+                Result.ServerCalculated(response.model!!)
+            }
+
+            else -> Result.Error
+        }
+    }
+
+    private fun isWooVersionBelowV4Support(): Boolean {
+        val version = getWooCoreVersion() ?: return false
+        return version.semverCompareTo(MIN_WC_VERSION_FOR_V4) < 0
+    }
+
+    sealed interface Result {
+        data class ServerCalculated(val preview: WCRefundPreview) : Result
+        data object FallbackToLocal : Result
+        data object Error : Result
+    }
+
+    private companion object {
+        private const val MIN_WC_VERSION_FOR_V4 = "10.9.0"
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundPreview.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundPreview.kt
@@ -21,14 +21,15 @@ class WooPosRefundPreview @Inject constructor(
         lineItems: List<RefundV4LineItem>,
     ): Result {
         val site = selectedSite.get()
+        val localSiteId = site.localId().value
 
-        if (availabilityCache.isV4Available(site.siteId) == false) {
+        if (availabilityCache.isV4Available(localSiteId) == false) {
             return Result.FallbackToLocal
         }
 
         if (isWooVersionBelowV4Support()) {
             WooLog.i(WooLog.T.POS, "WooPosRefund: WooCommerce older than $MIN_WC_VERSION_FOR_V4; using v3")
-            availabilityCache.markV4Unavailable(site.siteId)
+            availabilityCache.markV4Unavailable(localSiteId)
             return Result.FallbackToLocal
         }
 
@@ -37,11 +38,12 @@ class WooPosRefundPreview @Inject constructor(
         }
 
         val response = refundStore.previewRefund(site, orderId, lineItems)
+        val preview = response.model
         return when {
             response.isError -> {
                 if (response.error.type == WooErrorType.API_NOT_FOUND) {
                     WooLog.i(WooLog.T.POS, "WooPosRefund: v4 preview not available; falling back to v3")
-                    availabilityCache.markV4Unavailable(site.siteId)
+                    availabilityCache.markV4Unavailable(localSiteId)
                     Result.FallbackToLocal
                 } else {
                     WooLog.e(
@@ -53,9 +55,9 @@ class WooPosRefundPreview @Inject constructor(
                 }
             }
 
-            response.model != null -> {
-                availabilityCache.markV4Available(site.siteId)
-                Result.ServerCalculated(response.model!!)
+            preview != null -> {
+                availabilityCache.markV4Available(localSiteId)
+                Result.ServerCalculated(preview)
             }
 
             else -> Result.Error

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundPreview.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundPreview.kt
@@ -2,6 +2,8 @@ package com.woocommerce.android.ui.woopos.orders.details.refund
 
 import com.woocommerce.android.extensions.semverCompareTo
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.util.FeatureFlag
+import com.woocommerce.android.util.FeatureFlagRepository
 import com.woocommerce.android.util.GetWooCorePluginCachedVersion
 import com.woocommerce.android.util.WooLog
 import org.wordpress.android.fluxc.model.refunds.RefundV4LineItem
@@ -15,12 +17,19 @@ class WooPosRefundPreview @Inject constructor(
     private val selectedSite: SelectedSite,
     private val availabilityCache: WooPosV4RefundAvailabilityCache,
     private val getWooCoreVersion: GetWooCorePluginCachedVersion,
+    private val featureFlagRepository: FeatureFlagRepository,
 ) {
     suspend operator fun invoke(
         orderId: Long,
         lineItems: List<RefundV4LineItem>,
     ): Result {
         val site = selectedSite.get()
+
+        // v4 refunds are gated off in release builds (debug-only local flag). When disabled we never
+        // probe v4 nor mark availability, so the whole flow stays on the v3 local-calculation path.
+        if (!featureFlagRepository.isEnabled(FeatureFlag.WOO_POS_REFUND_V4)) {
+            return Result.FallbackToLocal
+        }
 
         if (availabilityCache.isV4Available(site.siteId) == false) {
             return Result.FallbackToLocal

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundState.kt
@@ -27,7 +27,12 @@ sealed class WooPosRefundState {
         val formattedTotal: String,
         val paymentMethod: String,
         val refundReason: String = "",
-        val step: RefundStep
+        val step: RefundStep,
+        // Server-calculated preview status (v4). When v4 is unavailable the store falls back to the
+        // local calculation and these stay at their defaults (no loading/no failure).
+        val isPreviewLoading: Boolean = false,
+        val previewFailed: Boolean = false,
+        val maxRefundable: BigDecimal? = null,
     ) : WooPosRefundState() {
 
         @Immutable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSubmissionProcessor.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSubmissionProcessor.kt
@@ -228,9 +228,29 @@ class WooPosRefundSubmissionProcessor @Inject constructor(
         shouldAutoRefund: Boolean,
         retryBackendNotificationOnly: Boolean,
     ): WooResult<WCRefundModel> {
+        val v4LineItems = request.v4LineItems
+        if (v4LineItems != null) {
+            WooLog.i(
+                WooLog.T.POS,
+                "WooPosRefund: creating simplified v4 backend refund " +
+                    "orderId=${request.orderId}, " +
+                    "itemCount=${v4LineItems.size}, " +
+                    "autoRefund=$shouldAutoRefund, " +
+                    "backendOnlyRetry=$retryBackendNotificationOnly"
+            )
+            return refundStore.createSimplifiedItemsRefund(
+                site = selectedSite.get(),
+                orderId = request.orderId,
+                reason = request.refundReason,
+                autoRefund = shouldAutoRefund,
+                restockItems = true,
+                items = v4LineItems,
+            )
+        }
+
         WooLog.i(
             WooLog.T.POS,
-            "WooPosRefund: creating backend refund " +
+            "WooPosRefund: creating v3 backend refund " +
                 "orderId=${request.orderId}, " +
                 "amount=${request.refundAmount}, " +
                 "itemCount=${request.refundItems.size}, " +

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSubmissionRequest.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSubmissionRequest.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.woopos.orders.details.refund
 
 import com.woocommerce.android.model.Order
 import org.wordpress.android.fluxc.model.refunds.RefundRequestItem
+import org.wordpress.android.fluxc.model.refunds.RefundV4LineItem
 import java.math.BigDecimal
 
 data class WooPosRefundSubmissionRequest(
@@ -9,6 +10,7 @@ data class WooPosRefundSubmissionRequest(
     val refundAmount: BigDecimal,
     val refundReason: String,
     val refundItems: List<RefundRequestItem>,
+    val v4LineItems: List<RefundV4LineItem>? = null,
     val cardRefundAlreadySucceeded: Boolean = false,
 ) {
     val orderId: Long = order.id

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundUIEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundUIEvent.kt
@@ -4,6 +4,7 @@ sealed class WooPosRefundUIEvent {
     data object RefundFlowOpened : WooPosRefundUIEvent()
     data class ItemSelectionToggled(val uniqueId: String) : WooPosRefundUIEvent()
     data object SelectAllToggled : WooPosRefundUIEvent()
+    data object RetryPreview : WooPosRefundUIEvent()
     data object ContinueToReviewClicked : WooPosRefundUIEvent()
     data object BackToSelectItemsClicked : WooPosRefundUIEvent()
     data class OnRefundReasonChanged(val reason: String) : WooPosRefundUIEvent()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundViewModel.kt
@@ -390,11 +390,17 @@ class WooPosRefundViewModel @AssistedInject constructor(
     private fun recalculateRefundState(currentState: WooPosRefundState.Content, newSelectedIds: Set<String>) {
         // Toggling selection only updates which items are selected — totals are not shown on the
         // selection step and are resolved on "Continue", so no calculation happens here.
+        // A preview in flight for the previous selection is now stale: cancel it and clear the
+        // loading/failed flags, otherwise its result is dropped by the stale-selection guard and
+        // the Continue button would stay stuck in the loading state.
+        cancelPreview()
         val allItemIds = currentState.refundableItems.map { it.uniqueId }.toSet()
         _state.value = currentState.copy(
             selectedItemIds = newSelectedIds,
             allItemsSelected = newSelectedIds.containsAll(allItemIds),
             itemsCount = currentState.refundableItems.count { it.uniqueId in newSelectedIds },
+            isPreviewLoading = false,
+            previewFailed = false,
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundViewModel.kt
@@ -26,7 +26,9 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import org.wordpress.android.fluxc.model.refunds.WCRefundPreview
 import org.wordpress.android.fluxc.store.WooCommerceStore
+import java.math.BigDecimal
 import java.math.RoundingMode
 
 @Suppress("LongParameterList")
@@ -37,6 +39,9 @@ class WooPosRefundViewModel @AssistedInject constructor(
     private val retrieveOrderRefunds: WooPosRetrieveOrderRefunds,
     private val getRefundableItems: WooPosGetRefundableItems,
     private val groupRefundItems: WooPosGroupRefundItems,
+    private val buildRefundV4LineItems: WooPosBuildRefundV4LineItems,
+    private val refundPreview: WooPosRefundPreview,
+    private val v4RefundAvailabilityCache: WooPosV4RefundAvailabilityCache,
     private val calculateRefundSubtotal: WooPosCalculateRefundSubtotal,
     private val calculateRefundTax: WooPosCalculateRefundTax,
     private val resourceProvider: ResourceProvider,
@@ -63,6 +68,7 @@ class WooPosRefundViewModel @AssistedInject constructor(
     private var cachedTaxRoundAtSubtotal: Boolean? = null
     private var contentStateBeforeRefund: WooPosRefundState.Content? = null
     private var refundJob: Job? = null
+    private var previewJob: Job? = null
     private var pendingReaderConnectionRefund: PendingReaderConnectionRefund? = null
 
     init {
@@ -120,22 +126,10 @@ class WooPosRefundViewModel @AssistedInject constructor(
         loadingJob = viewModelScope.launch {
             _state.value = WooPosRefundState.Loading
 
-            if (fetchSiteSettings().isFailure) {
-                _state.value = WooPosRefundState.Error(
-                    message = resourceProvider.getString(R.string.error_generic),
-                    errorType = WooPosRefundState.Error.ErrorType.Loading
-                )
-                return@launch
-            }
-
-            if (fetchTaxRoundAtSubtotal().isFailure) {
-                _state.value = WooPosRefundState.Error(
-                    message = resourceProvider.getString(R.string.error_generic),
-                    errorType = WooPosRefundState.Error.ErrorType.Loading
-                )
-                return@launch
-            }
-
+            // Store settings (currency decimals, tax rounding mode) are only needed to calculate
+            // refund totals locally for the v3 fallback. When v4 is available the server returns the
+            // totals via the preview/create endpoints, so we defer fetching these settings until the
+            // moment we actually fall back to local calculation (see [ensureLocalCalculationSettings]).
             val orderAndRefundsResult = fetchOrderAndRefunds()
             if (orderAndRefundsResult.isFailure) {
                 _state.value = WooPosRefundState.Error(
@@ -166,34 +160,37 @@ class WooPosRefundViewModel @AssistedInject constructor(
                 return@launch
             }
 
-            _state.value = buildContentState(
-                order = order,
-                refundableItems = refundableItems,
-                numberOfDecimalPoints = checkNotNull(cachedNumberOfDecimalPoints) {
-                    "cachedNumberOfDecimalPoints should not be null when building content state"
-                },
-                taxRoundAtSubtotal = checkNotNull(cachedTaxRoundAtSubtotal) {
-                    "cachedTaxRoundAtSubtotal should not be null when building content state"
-                },
-                paymentMethod = paymentMethodResult.getOrThrow()
-            )
+            showRefundableItems(order, refundableItems, paymentMethodResult.getOrThrow())
+        }
+    }
+
+    private fun showRefundableItems(
+        order: Order,
+        refundableItems: List<WooPosRefundableItem>,
+        paymentMethod: String,
+    ) {
+        // The item-selection step does not display aggregate totals, so we build the content without
+        // computing them. Totals are resolved on "Continue": from the server (v4 preview) or, on a
+        // v4-unavailable store, calculated locally at that point (see [continueToReview]).
+        _state.value = buildContentShell(
+            order = order,
+            refundableItems = refundableItems,
+            paymentMethod = paymentMethod,
+        )
+        viewModelScope.launch {
             analyticsTracker.track(WooPosAnalyticsEvent.Event.RefundFlowStarted)
         }
     }
 
-    private fun buildContentState(
+    private fun buildContentShell(
         order: Order,
         refundableItems: List<WooPosRefundableItem>,
-        numberOfDecimalPoints: Int,
-        taxRoundAtSubtotal: Boolean,
         paymentMethod: String,
         selectedItemIds: Set<String> = refundableItems.map { it.uniqueId }.toSet()
     ): WooPosRefundState.Content {
         val selectedItems = refundableItems.filter { it.uniqueId in selectedItemIds }
         val allItemIds = refundableItems.map { it.uniqueId }.toSet()
-        val subtotal = calculateRefundSubtotal(selectedItems, numberOfDecimalPoints)
-        val taxes = calculateRefundTax(selectedItems, order, numberOfDecimalPoints, taxRoundAtSubtotal)
-        val total = (subtotal + taxes).setScale(numberOfDecimalPoints, RoundingMode.HALF_UP)
+        val zero = PriceUtils.formatCurrency(BigDecimal.ZERO, order.currency, currencyFormatter)
 
         return WooPosRefundState.Content(
             orderId = order.id,
@@ -203,14 +200,43 @@ class WooPosRefundViewModel @AssistedInject constructor(
             selectedItemIds = selectedItemIds,
             allItemsSelected = selectedItemIds.containsAll(allItemIds),
             itemsCount = selectedItems.size,
+            subtotal = BigDecimal.ZERO,
+            taxes = BigDecimal.ZERO,
+            total = BigDecimal.ZERO,
+            formattedSubtotal = zero,
+            formattedTaxes = zero,
+            formattedTotal = zero,
+            paymentMethod = paymentMethod,
+            step = WooPosRefundState.Content.RefundStep.SelectItems
+        )
+    }
+
+    /**
+     * Fetches the store settings required for local refund calculation (currency decimals and tax
+     * rounding mode) unless already cached. Only the v3 fallback path needs these.
+     */
+    private suspend fun ensureLocalCalculationSettings(): Boolean {
+        if (cachedNumberOfDecimalPoints == null && fetchSiteSettings().isFailure) return false
+        if (cachedTaxRoundAtSubtotal == null && fetchTaxRoundAtSubtotal().isFailure) return false
+        return true
+    }
+
+    private fun WooPosRefundState.Content.withLocalTotals(
+        order: Order,
+        selectedItems: List<WooPosRefundableItem>,
+        numberOfDecimalPoints: Int,
+        taxRoundAtSubtotal: Boolean,
+    ): WooPosRefundState.Content {
+        val subtotal = calculateRefundSubtotal(selectedItems, numberOfDecimalPoints)
+        val taxes = calculateRefundTax(selectedItems, order, numberOfDecimalPoints, taxRoundAtSubtotal)
+        val total = (subtotal + taxes).setScale(numberOfDecimalPoints, RoundingMode.HALF_UP)
+        return copy(
             subtotal = subtotal,
             taxes = taxes,
             total = total,
-            formattedSubtotal = PriceUtils.formatCurrency(subtotal, order.currency, currencyFormatter),
-            formattedTaxes = PriceUtils.formatCurrency(taxes, order.currency, currencyFormatter),
-            formattedTotal = PriceUtils.formatCurrency(total, order.currency, currencyFormatter),
-            paymentMethod = paymentMethod,
-            step = WooPosRefundState.Content.RefundStep.SelectItems
+            formattedSubtotal = PriceUtils.formatCurrency(subtotal, currency, currencyFormatter),
+            formattedTaxes = PriceUtils.formatCurrency(taxes, currency, currencyFormatter),
+            formattedTotal = PriceUtils.formatCurrency(total, currency, currencyFormatter),
         )
     }
 
@@ -272,6 +298,7 @@ class WooPosRefundViewModel @AssistedInject constructor(
         }
 
         cancelRefundSubmission()
+        cancelPreview()
         _state.value = WooPosRefundState.Loading
         loadingJob?.cancel()
     }
@@ -280,11 +307,8 @@ class WooPosRefundViewModel @AssistedInject constructor(
         when (event) {
             is WooPosRefundUIEvent.ItemSelectionToggled -> handleItemSelection(currentState, event.uniqueId)
             WooPosRefundUIEvent.SelectAllToggled -> handleSelectAllToggled(currentState)
-            WooPosRefundUIEvent.ContinueToReviewClicked -> {
-                if (currentState.selectedItemIds.isNotEmpty()) {
-                    _state.value = currentState.copy(step = WooPosRefundState.Content.RefundStep.ReviewRefund)
-                }
-            }
+            WooPosRefundUIEvent.RetryPreview -> continueToReview(currentState)
+            WooPosRefundUIEvent.ContinueToReviewClicked -> continueToReview(currentState)
             WooPosRefundUIEvent.BackToSelectItemsClicked ->
                 _state.value = currentState.copy(step = WooPosRefundState.Content.RefundStep.SelectItems)
             is WooPosRefundUIEvent.OnRefundReasonChanged ->
@@ -306,6 +330,11 @@ class WooPosRefundViewModel @AssistedInject constructor(
             WooPosRefundUIEvent.RetryCreateRefund,
             WooPosRefundUIEvent.CancelRefund -> Unit
         }
+    }
+
+    private fun cancelPreview() {
+        previewJob?.cancel()
+        previewJob = null
     }
 
     private fun handleConnectReaderClicked() {
@@ -359,24 +388,115 @@ class WooPosRefundViewModel @AssistedInject constructor(
     }
 
     private fun recalculateRefundState(currentState: WooPosRefundState.Content, newSelectedIds: Set<String>) {
-        val order = checkNotNull(currentOrder) {
-            "currentOrder should not be null when recalculating refund state"
-        }
-        val numberOfDecimalPoints = checkNotNull(cachedNumberOfDecimalPoints) {
-            "cachedNumberOfDecimalPoints should not be null when recalculating refund state"
-        }
-        val taxRoundAtSubtotal = checkNotNull(cachedTaxRoundAtSubtotal) {
-            "cachedTaxRoundAtSubtotal should not be null when recalculating refund state"
+        // Toggling selection only updates which items are selected — totals are not shown on the
+        // selection step and are resolved on "Continue", so no calculation happens here.
+        val allItemIds = currentState.refundableItems.map { it.uniqueId }.toSet()
+        _state.value = currentState.copy(
+            selectedItemIds = newSelectedIds,
+            allItemsSelected = newSelectedIds.containsAll(allItemIds),
+            itemsCount = currentState.refundableItems.count { it.uniqueId in newSelectedIds },
+        )
+    }
+
+    /**
+     * Triggered when the user commits their selection by tapping "Continue". Fetches the
+     * server-calculated totals (v4) and, on success, advances to the review step showing those
+     * authoritative totals. On a v4-unavailable store the locally-calculated totals already in
+     * [currentState] stand and we advance immediately. On a preview error the user stays on the
+     * selection step with a retry affordance.
+     */
+    private fun continueToReview(currentState: WooPosRefundState.Content) {
+        if (currentState.selectedItemIds.isEmpty()) return
+        previewJob?.cancel()
+
+        val siteId = selectedSite.get().siteId
+        val selectedItems = currentState.refundableItems.filter { it.uniqueId in currentState.selectedItemIds }
+
+        if (v4RefundAvailabilityCache.isV4Available(siteId) == false) {
+            // v4 is known unavailable for this store: skip the probe and resolve totals locally.
+            _state.value = currentState.copy(isPreviewLoading = true, previewFailed = false)
+            previewJob = viewModelScope.launch {
+                advanceToReviewWithLocalTotals(currentState, selectedItems)
+            }
+            return
         }
 
-        _state.value = buildContentState(
-            order = order,
-            refundableItems = currentState.refundableItems,
-            numberOfDecimalPoints = numberOfDecimalPoints,
-            taxRoundAtSubtotal = taxRoundAtSubtotal,
-            paymentMethod = currentState.paymentMethod,
-            selectedItemIds = newSelectedIds
-        ).copy(step = currentState.step)
+        _state.value = currentState.copy(isPreviewLoading = true, previewFailed = false)
+
+        previewJob = viewModelScope.launch {
+            val lineItems = buildRefundV4LineItems(selectedItems)
+            when (val result = refundPreview(currentState.orderId, lineItems)) {
+                is WooPosRefundPreview.Result.ServerCalculated ->
+                    setContentIfMatchingSelection(currentState.selectedItemIds) {
+                        it.applyServerPreview(result.preview)
+                            .copy(step = WooPosRefundState.Content.RefundStep.ReviewRefund)
+                    }
+
+                WooPosRefundPreview.Result.FallbackToLocal ->
+                    advanceToReviewWithLocalTotals(currentState, selectedItems)
+
+                WooPosRefundPreview.Result.Error ->
+                    setContentIfMatchingSelection(currentState.selectedItemIds) {
+                        it.copy(isPreviewLoading = false, previewFailed = true)
+                    }
+            }
+        }
+    }
+
+    /**
+     * Resolves refund totals locally (the v3 path), fetching the required store settings on demand,
+     * then advances to the review step. Surfaces a preview failure if the settings can't be fetched.
+     */
+    private suspend fun advanceToReviewWithLocalTotals(
+        currentState: WooPosRefundState.Content,
+        selectedItems: List<WooPosRefundableItem>,
+    ) {
+        val order = currentOrder
+        if (order == null || !ensureLocalCalculationSettings()) {
+            setContentIfMatchingSelection(currentState.selectedItemIds) {
+                it.copy(isPreviewLoading = false, previewFailed = true)
+            }
+            return
+        }
+        val numberOfDecimalPoints = checkNotNull(cachedNumberOfDecimalPoints)
+        val taxRoundAtSubtotal = checkNotNull(cachedTaxRoundAtSubtotal)
+        setContentIfMatchingSelection(currentState.selectedItemIds) {
+            it.withLocalTotals(order, selectedItems, numberOfDecimalPoints, taxRoundAtSubtotal)
+                .copy(
+                    step = WooPosRefundState.Content.RefundStep.ReviewRefund,
+                    isPreviewLoading = false,
+                    previewFailed = false,
+                )
+        }
+    }
+
+    /**
+     * Applies [transform] to the current Content state only if the selection still matches — guards
+     * against a stale preview result landing after the user changed the selection.
+     */
+    private fun setContentIfMatchingSelection(
+        expectedSelection: Set<String>,
+        transform: (WooPosRefundState.Content) -> WooPosRefundState.Content,
+    ) {
+        val current = _state.value as? WooPosRefundState.Content ?: return
+        if (current.selectedItemIds != expectedSelection) return
+        _state.value = transform(current)
+    }
+
+    private fun WooPosRefundState.Content.applyServerPreview(
+        preview: WCRefundPreview
+    ): WooPosRefundState.Content {
+        return copy(
+            subtotal = preview.subtotal,
+            taxes = preview.tax,
+            total = preview.total,
+            maxRefundable = preview.maxRefundable,
+            formattedSubtotal = PriceUtils.formatCurrency(preview.subtotal, currency, currencyFormatter),
+            formattedTaxes = PriceUtils.formatCurrency(preview.tax, currency, currencyFormatter),
+            formattedTotal = PriceUtils.formatCurrency(preview.total, currency, currencyFormatter),
+            isPreviewLoading = false,
+            previewFailed = false,
+        )
     }
 
     private fun processRefund(contentState: WooPosRefundState.Content) {
@@ -385,6 +505,7 @@ class WooPosRefundViewModel @AssistedInject constructor(
                 return@launch
             }
 
+            cancelPreview()
             contentStateBeforeRefund = contentState
             _state.value = contentState.copy(step = WooPosRefundState.Content.RefundStep.Processing)
 
@@ -402,31 +523,52 @@ class WooPosRefundViewModel @AssistedInject constructor(
                 return@launch
             }
 
-            val numberOfDecimalPoints =
-                wooCommerceStore.getSiteSettings(selectedSite.get())?.currencyDecimalNumber ?: run {
-                    WooLog.e(
-                        WooLog.T.POS,
-                        "WooPosRefund: failed to read site settings currencyDecimalNumber from DB"
-                    )
-                    _state.value = WooPosRefundState.Error(
-                        message = resourceProvider.getString(R.string.error_generic),
-                        errorType = WooPosRefundState.Error.ErrorType.Processing
-                    )
-                    return@launch
-                }
             val selectedItems = contentState.refundableItems.filter { it.uniqueId in contentState.selectedItemIds }
-            val refundItems = groupRefundItems(selectedItems, order, numberOfDecimalPoints)
-
-            submitRefund(
-                contentState = contentState,
-                request = WooPosRefundSubmissionRequest(
-                    order = order,
-                    refundAmount = contentState.total,
-                    refundReason = contentState.refundReason,
-                    refundItems = refundItems,
+            val request = buildSubmissionRequest(order, contentState, selectedItems) ?: run {
+                _state.value = WooPosRefundState.Error(
+                    message = resourceProvider.getString(R.string.error_generic),
+                    errorType = WooPosRefundState.Error.ErrorType.Processing
                 )
+                return@launch
+            }
+
+            submitRefund(contentState = contentState, request = request)
+        }
+    }
+
+    /**
+     * Builds the submission request. When v4 is available the server computes monetary values, so we
+     * send only the simplified line items — no client-calculated amount and no local item grouping
+     * (which would require the store's currency settings). Otherwise the v3 request is built from the
+     * locally-grouped items, reusing the currency decimals already fetched for the local calculation.
+     */
+    private fun buildSubmissionRequest(
+        order: Order,
+        contentState: WooPosRefundState.Content,
+        selectedItems: List<WooPosRefundableItem>,
+    ): WooPosRefundSubmissionRequest? {
+        if (v4RefundAvailabilityCache.isV4Available(selectedSite.get().siteId) == true) {
+            return WooPosRefundSubmissionRequest(
+                order = order,
+                refundAmount = contentState.total,
+                refundReason = contentState.refundReason,
+                refundItems = emptyList(),
+                v4LineItems = buildRefundV4LineItems(selectedItems),
             )
         }
+
+        val numberOfDecimalPoints = cachedNumberOfDecimalPoints
+            ?: wooCommerceStore.getSiteSettings(selectedSite.get())?.currencyDecimalNumber
+            ?: run {
+                WooLog.e(WooLog.T.POS, "WooPosRefund: failed to read currencyDecimalNumber for v3 refund")
+                return null
+            }
+        return WooPosRefundSubmissionRequest(
+            order = order,
+            refundAmount = contentState.total,
+            refundReason = contentState.refundReason,
+            refundItems = groupRefundItems(selectedItems, order, numberOfDecimalPoints),
+        )
     }
 
     private fun submitRefund(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosV4RefundAvailabilityCache.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosV4RefundAvailabilityCache.kt
@@ -1,0 +1,20 @@
+package com.woocommerce.android.ui.woopos.orders.details.refund
+
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class WooPosV4RefundAvailabilityCache @Inject constructor() {
+    private val availabilityBySiteId = ConcurrentHashMap<Long, Boolean>()
+
+    fun isV4Available(siteId: Long): Boolean? = availabilityBySiteId[siteId]
+
+    fun markV4Available(siteId: Long) {
+        availabilityBySiteId[siteId] = true
+    }
+
+    fun markV4Unavailable(siteId: Long) {
+        availabilityBySiteId[siteId] = false
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosV4RefundAvailabilityCache.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosV4RefundAvailabilityCache.kt
@@ -4,17 +4,23 @@ import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import javax.inject.Singleton
 
+/**
+ * Caches per-store v4 refund availability for the lifetime of the process.
+ *
+ * Keyed by the *local* site id (unique per stored site), not the remote WP.com site id, which is
+ * `0` for self-hosted/WPAPI stores and would collide across them.
+ */
 @Singleton
 class WooPosV4RefundAvailabilityCache @Inject constructor() {
-    private val availabilityBySiteId = ConcurrentHashMap<Long, Boolean>()
+    private val availabilityByLocalSiteId = ConcurrentHashMap<Int, Boolean>()
 
-    fun isV4Available(siteId: Long): Boolean? = availabilityBySiteId[siteId]
+    fun isV4Available(localSiteId: Int): Boolean? = availabilityByLocalSiteId[localSiteId]
 
-    fun markV4Available(siteId: Long) {
-        availabilityBySiteId[siteId] = true
+    fun markV4Available(localSiteId: Int) {
+        availabilityByLocalSiteId[localSiteId] = true
     }
 
-    fun markV4Unavailable(siteId: Long) {
-        availabilityBySiteId[siteId] = false
+    fun markV4Unavailable(localSiteId: Int) {
+        availabilityByLocalSiteId[localSiteId] = false
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -23,6 +23,7 @@ enum class FeatureFlag(
     WOO_POS_TAP_TO_PAY("woo_pos_tap_to_pay", localValue = PackageUtils.isDebugBuild()),
     WOO_POS_SCAN_TO_PAY("woo_pos_scan_to_pay", localValue = PackageUtils.isDebugBuild()),
     WOO_POS_MARK_ORDER_AS_PAID("woo_pos_mark_order_as_complete", localValue = PackageUtils.isDebugBuild()),
+    WOO_POS_REFUND_V4("woo_pos_refund_v4", localValue = PackageUtils.isDebugBuild()),
     APP_PASSWORDS_FOR_JETPACK_SITES("woo_app_passwords_for_jetpack_sites"),
     WOO_POS_LOCAL_CATALOG_M1("woo_pos_local_catalog_m1"),
     WOO_POS_TABLET_PROMO_BANNER("woo_pos_tablet_promo_banner"),

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4196,6 +4196,7 @@
     <string name="woopos_orders_details_refunded_label">Refunded</string>
     <string name="woopos_orders_details_refund_error">Unable to load refund</string>
     <string name="woopos_refund_error_gateway_not_found">Unable to process refund.</string>
+    <string name="woopos_refund_preview_error">Couldn\'t calculate the refund total. Please try again.</string>
     <string name="woopos_orders_details_net_payment_label">Total Net</string>
     <string name="woopos_orders_details_products_list_content_description">Order products list</string>
     <string name="woopos_orders_details_totals_card_content_description">Order totals breakdown</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosBuildRefundV4LineItemsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosBuildRefundV4LineItemsTest.kt
@@ -1,0 +1,90 @@
+package com.woocommerce.android.ui.woopos.orders.details.refund
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import java.math.BigDecimal
+
+class WooPosBuildRefundV4LineItemsTest {
+
+    private val sut = WooPosBuildRefundV4LineItems()
+
+    @Test
+    fun `given product rows, when invoked, then groups by order item id with quantity and no amount`() {
+        // GIVEN — two units of the same product
+        val items = listOf(
+            productRow(orderItemId = 1L, rowIndex = 0),
+            productRow(orderItemId = 1L, rowIndex = 1),
+        )
+
+        // WHEN
+        val result = sut(items)
+
+        // THEN
+        assertThat(result).hasSize(1)
+        val lineItem = result.first()
+        assertThat(lineItem.lineItemId).isEqualTo(1L)
+        assertThat(lineItem.quantity).isEqualTo(2)
+        assertThat(lineItem.refundTotal).isNull()
+    }
+
+    @Test
+    fun `given a fee row, when invoked, then sends tax-inclusive amount and no quantity`() {
+        // GIVEN
+        val items = listOf(
+            feeRow(orderItemId = 99L, unitPrice = BigDecimal("10.00"), unitTax = BigDecimal("1.50")),
+        )
+
+        // WHEN
+        val result = sut(items)
+
+        // THEN
+        assertThat(result).hasSize(1)
+        val lineItem = result.first()
+        assertThat(lineItem.lineItemId).isEqualTo(99L)
+        assertThat(lineItem.quantity).isNull()
+        assertThat(lineItem.refundTotal).isEqualByComparingTo(BigDecimal("11.50"))
+    }
+
+    @Test
+    fun `given mixed products and fees, when invoked, then builds both forms`() {
+        // GIVEN
+        val items = listOf(
+            productRow(orderItemId = 1L, rowIndex = 0),
+            feeRow(orderItemId = 99L, unitPrice = BigDecimal("5.00"), unitTax = BigDecimal.ZERO),
+        )
+
+        // WHEN
+        val result = sut(items)
+
+        // THEN
+        assertThat(result).hasSize(2)
+        assertThat(result.any { it.lineItemId == 1L && it.quantity == 1 && it.refundTotal == null }).isTrue()
+        assertThat(result.any { it.lineItemId == 99L && it.quantity == null }).isTrue()
+    }
+
+    private fun productRow(orderItemId: Long, rowIndex: Int) = WooPosRefundableItem(
+        orderItemId = orderItemId,
+        productId = 10L,
+        variationId = 0L,
+        name = "Product",
+        unitPrice = BigDecimal("20.00"),
+        unitTax = BigDecimal("2.00"),
+        formattedUnitPrice = "$20.00",
+        formattedUnitTax = "$2.00",
+        rowIndex = rowIndex,
+        isLumpSum = false,
+    )
+
+    private fun feeRow(orderItemId: Long, unitPrice: BigDecimal, unitTax: BigDecimal) = WooPosRefundableItem(
+        orderItemId = orderItemId,
+        productId = 0L,
+        variationId = 0L,
+        name = "Fee",
+        unitPrice = unitPrice,
+        unitTax = unitTax,
+        formattedUnitPrice = "",
+        formattedUnitTax = "",
+        rowIndex = 0,
+        isLumpSum = true,
+    )
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundPreviewTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundPreviewTest.kt
@@ -1,11 +1,14 @@
 package com.woocommerce.android.ui.woopos.orders.details.refund
 
+import com.woocommerce.android.util.FeatureFlag
+import com.woocommerce.android.util.FeatureFlagRepository
 import com.woocommerce.android.util.GetWooCorePluginCachedVersion
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -28,6 +31,9 @@ class WooPosRefundPreviewTest {
     private val selectedSite: com.woocommerce.android.tools.SelectedSite = mock()
     private val availabilityCache = WooPosV4RefundAvailabilityCache()
     private val getWooCoreVersion: GetWooCorePluginCachedVersion = mock()
+    private val featureFlagRepository: FeatureFlagRepository = mock {
+        on { isEnabled(FeatureFlag.WOO_POS_REFUND_V4) } doReturn true
+    }
 
     private val site = SiteModel().apply { siteId = SITE_ID }
     private val lineItems = listOf(RefundV4LineItem(lineItemId = 1L, quantity = 1))
@@ -36,7 +42,21 @@ class WooPosRefundPreviewTest {
         whenever(selectedSite.get()).thenReturn(site)
         // The version mock defaults to null (unknown) → not below support → cases probe the network,
         // unless a test stubs a specific version.
-        WooPosRefundPreview(refundStore, selectedSite, availabilityCache, getWooCoreVersion)
+        WooPosRefundPreview(refundStore, selectedSite, availabilityCache, getWooCoreVersion, featureFlagRepository)
+    }
+
+    @Test
+    fun `given v4 flag disabled, when invoked, then falls back without probing or marking availability`() = runTest {
+        // GIVEN
+        whenever(featureFlagRepository.isEnabled(FeatureFlag.WOO_POS_REFUND_V4)).thenReturn(false)
+
+        // WHEN
+        val result = sut(ORDER_ID, lineItems)
+
+        // THEN
+        assertThat(result).isEqualTo(WooPosRefundPreview.Result.FallbackToLocal)
+        assertThat(availabilityCache.isV4Available(SITE_ID)).isNull()
+        verify(refundStore, never()).previewRefund(any(), any(), any())
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundPreviewTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundPreviewTest.kt
@@ -29,7 +29,10 @@ class WooPosRefundPreviewTest {
     private val availabilityCache = WooPosV4RefundAvailabilityCache()
     private val getWooCoreVersion: GetWooCorePluginCachedVersion = mock()
 
-    private val site = SiteModel().apply { siteId = SITE_ID }
+    private val site = SiteModel().apply {
+        id = LOCAL_SITE_ID
+        siteId = SITE_ID
+    }
     private val lineItems = listOf(RefundV4LineItem(lineItemId = 1L, quantity = 1))
 
     private val sut by lazy {
@@ -50,7 +53,7 @@ class WooPosRefundPreviewTest {
 
         // THEN
         assertThat(result).isInstanceOf(WooPosRefundPreview.Result.ServerCalculated::class.java)
-        assertThat(availabilityCache.isV4Available(SITE_ID)).isTrue()
+        assertThat(availabilityCache.isV4Available(LOCAL_SITE_ID)).isTrue()
     }
 
     @Test
@@ -64,7 +67,7 @@ class WooPosRefundPreviewTest {
 
         // THEN
         assertThat(result).isEqualTo(WooPosRefundPreview.Result.FallbackToLocal)
-        assertThat(availabilityCache.isV4Available(SITE_ID)).isFalse()
+        assertThat(availabilityCache.isV4Available(LOCAL_SITE_ID)).isFalse()
     }
 
     @Test
@@ -90,7 +93,7 @@ class WooPosRefundPreviewTest {
 
         // THEN
         assertThat(result).isEqualTo(WooPosRefundPreview.Result.FallbackToLocal)
-        assertThat(availabilityCache.isV4Available(SITE_ID)).isFalse()
+        assertThat(availabilityCache.isV4Available(LOCAL_SITE_ID)).isFalse()
         verify(refundStore, never()).previewRefund(any(), any(), any())
     }
 
@@ -126,7 +129,7 @@ class WooPosRefundPreviewTest {
     @Test
     fun `given v4 known unavailable, when invoked, then falls back without probing`() = runTest {
         // GIVEN
-        availabilityCache.markV4Unavailable(SITE_ID)
+        availabilityCache.markV4Unavailable(LOCAL_SITE_ID)
 
         // WHEN
         val result = sut(ORDER_ID, lineItems)
@@ -145,6 +148,35 @@ class WooPosRefundPreviewTest {
         assertThat(result).isEqualTo(WooPosRefundPreview.Result.FallbackToLocal)
         verify(refundStore, never()).previewRefund(any(), any(), any())
     }
+
+    @Test
+    fun `given two self-hosted sites share remote siteId 0, when one is unavailable, then other still probes`() =
+        runTest {
+            // GIVEN two distinct local sites that both report remote siteId 0 (self-hosted/WPAPI).
+            val siteA = SiteModel().apply {
+                id = 101
+                siteId = 0L
+            }
+            val siteB = SiteModel().apply {
+                id = 102
+                siteId = 0L
+            }
+            availabilityCache.markV4Unavailable(siteA.localId().value)
+
+            val selectedSiteB: com.woocommerce.android.tools.SelectedSite = mock()
+            whenever(selectedSiteB.get()).thenReturn(siteB)
+            whenever(refundStore.previewRefund(eq(siteB), eq(ORDER_ID), eq(lineItems)))
+                .thenReturn(WooResult(preview()))
+            val sutForB = WooPosRefundPreview(refundStore, selectedSiteB, availabilityCache, getWooCoreVersion)
+
+            // WHEN siteB requests a preview
+            val result = sutForB(ORDER_ID, lineItems)
+
+            // THEN siteA's verdict does not poison siteB — it probes v4 and is marked available.
+            assertThat(result).isInstanceOf(WooPosRefundPreview.Result.ServerCalculated::class.java)
+            assertThat(availabilityCache.isV4Available(siteB.localId().value)).isTrue()
+            verify(refundStore).previewRefund(eq(siteB), eq(ORDER_ID), eq(lineItems))
+        }
 
     private fun preview() = WCRefundPreview(
         subtotal = BigDecimal("100.00"),
@@ -166,6 +198,7 @@ class WooPosRefundPreviewTest {
     )
 
     private companion object {
+        private const val LOCAL_SITE_ID = 11
         private const val SITE_ID = 7L
         private const val ORDER_ID = 123L
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundPreviewTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundPreviewTest.kt
@@ -36,7 +36,7 @@ class WooPosRefundPreviewTest {
     }
 
     private val site = SiteModel().apply { siteId = SITE_ID }
-    private val lineItems = listOf(RefundV4LineItem(lineItemId = 1L, quantity = 1))
+    private val lineItems = listOf(RefundV4LineItem.quantityBased(lineItemId = 1L, quantity = 1))
 
     private val sut by lazy {
         whenever(selectedSite.get()).thenReturn(site)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundPreviewTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundPreviewTest.kt
@@ -1,0 +1,172 @@
+package com.woocommerce.android.ui.woopos.orders.details.refund
+
+import com.woocommerce.android.util.GetWooCorePluginCachedVersion
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.refunds.RefundV4LineItem
+import org.wordpress.android.fluxc.model.refunds.WCRefundPreview
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+import org.wordpress.android.fluxc.store.WCRefundStore
+import java.math.BigDecimal
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class WooPosRefundPreviewTest {
+
+    private val refundStore: WCRefundStore = mock()
+    private val selectedSite: com.woocommerce.android.tools.SelectedSite = mock()
+    private val availabilityCache = WooPosV4RefundAvailabilityCache()
+    private val getWooCoreVersion: GetWooCorePluginCachedVersion = mock()
+
+    private val site = SiteModel().apply { siteId = SITE_ID }
+    private val lineItems = listOf(RefundV4LineItem(lineItemId = 1L, quantity = 1))
+
+    private val sut by lazy {
+        whenever(selectedSite.get()).thenReturn(site)
+        // The version mock defaults to null (unknown) → not below support → cases probe the network,
+        // unless a test stubs a specific version.
+        WooPosRefundPreview(refundStore, selectedSite, availabilityCache, getWooCoreVersion)
+    }
+
+    @Test
+    fun `given v4 available, when preview succeeds, then returns server-calculated and marks available`() = runTest {
+        // GIVEN
+        whenever(refundStore.previewRefund(eq(site), eq(ORDER_ID), eq(lineItems)))
+            .thenReturn(WooResult(preview()))
+
+        // WHEN
+        val result = sut(ORDER_ID, lineItems)
+
+        // THEN
+        assertThat(result).isInstanceOf(WooPosRefundPreview.Result.ServerCalculated::class.java)
+        assertThat(availabilityCache.isV4Available(SITE_ID)).isTrue()
+    }
+
+    @Test
+    fun `given preview returns 404, when invoked, then falls back to local and marks unavailable`() = runTest {
+        // GIVEN
+        whenever(refundStore.previewRefund(eq(site), eq(ORDER_ID), eq(lineItems)))
+            .thenReturn(WooResult(WooError(WooErrorType.API_NOT_FOUND, GenericErrorType.NOT_FOUND)))
+
+        // WHEN
+        val result = sut(ORDER_ID, lineItems)
+
+        // THEN
+        assertThat(result).isEqualTo(WooPosRefundPreview.Result.FallbackToLocal)
+        assertThat(availabilityCache.isV4Available(SITE_ID)).isFalse()
+    }
+
+    @Test
+    fun `given non-404 error, when invoked, then returns Error`() = runTest {
+        // GIVEN
+        whenever(refundStore.previewRefund(eq(site), eq(ORDER_ID), eq(lineItems)))
+            .thenReturn(WooResult(WooError(WooErrorType.GENERIC_ERROR, GenericErrorType.NETWORK_ERROR)))
+
+        // WHEN
+        val result = sut(ORDER_ID, lineItems)
+
+        // THEN
+        assertThat(result).isEqualTo(WooPosRefundPreview.Result.Error)
+    }
+
+    @Test
+    fun `given WC older than 10_9_0, when invoked, then falls back without probing and marks unavailable`() = runTest {
+        // GIVEN
+        whenever(getWooCoreVersion.invoke()).thenReturn("10.8.0")
+
+        // WHEN
+        val result = sut(ORDER_ID, lineItems)
+
+        // THEN
+        assertThat(result).isEqualTo(WooPosRefundPreview.Result.FallbackToLocal)
+        assertThat(availabilityCache.isV4Available(SITE_ID)).isFalse()
+        verify(refundStore, never()).previewRefund(any(), any(), any())
+    }
+
+    @Test
+    fun `given WC at 10_9_0, when invoked, then probes v4`() = runTest {
+        // GIVEN
+        whenever(getWooCoreVersion.invoke()).thenReturn("10.9.0")
+        whenever(refundStore.previewRefund(eq(site), eq(ORDER_ID), eq(lineItems)))
+            .thenReturn(WooResult(preview()))
+
+        // WHEN
+        val result = sut(ORDER_ID, lineItems)
+
+        // THEN
+        assertThat(result).isInstanceOf(WooPosRefundPreview.Result.ServerCalculated::class.java)
+        verify(refundStore).previewRefund(eq(site), eq(ORDER_ID), eq(lineItems))
+    }
+
+    @Test
+    fun `given WC version unknown, when invoked, then still probes v4`() = runTest {
+        // GIVEN
+        whenever(getWooCoreVersion.invoke()).thenReturn(null)
+        whenever(refundStore.previewRefund(eq(site), eq(ORDER_ID), eq(lineItems)))
+            .thenReturn(WooResult(preview()))
+
+        // WHEN
+        sut(ORDER_ID, lineItems)
+
+        // THEN
+        verify(refundStore).previewRefund(eq(site), eq(ORDER_ID), eq(lineItems))
+    }
+
+    @Test
+    fun `given v4 known unavailable, when invoked, then falls back without probing`() = runTest {
+        // GIVEN
+        availabilityCache.markV4Unavailable(SITE_ID)
+
+        // WHEN
+        val result = sut(ORDER_ID, lineItems)
+
+        // THEN
+        assertThat(result).isEqualTo(WooPosRefundPreview.Result.FallbackToLocal)
+        verify(refundStore, never()).previewRefund(any(), any(), any())
+    }
+
+    @Test
+    fun `given empty selection, when invoked, then falls back without probing`() = runTest {
+        // WHEN
+        val result = sut(ORDER_ID, emptyList())
+
+        // THEN
+        assertThat(result).isEqualTo(WooPosRefundPreview.Result.FallbackToLocal)
+        verify(refundStore, never()).previewRefund(any(), any(), any())
+    }
+
+    private fun preview() = WCRefundPreview(
+        subtotal = BigDecimal("100.00"),
+        tax = BigDecimal("10.00"),
+        total = BigDecimal("110.00"),
+        maxRefundable = BigDecimal("200.00"),
+        breakdown = WCRefundPreview.Breakdown(
+            products = emptySection(),
+            shipping = emptySection(),
+            fees = emptySection(),
+        ),
+    )
+
+    private fun emptySection() = WCRefundPreview.Section(
+        items = emptyList(),
+        subtotal = BigDecimal.ZERO,
+        tax = BigDecimal.ZERO,
+        total = BigDecimal.ZERO,
+    )
+
+    private companion object {
+        private const val SITE_ID = 7L
+        private const val ORDER_ID = 123L
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundPreviewTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundPreviewTest.kt
@@ -33,7 +33,7 @@ class WooPosRefundPreviewTest {
         id = LOCAL_SITE_ID
         siteId = SITE_ID
     }
-    private val lineItems = listOf(RefundV4LineItem(lineItemId = 1L, quantity = 1))
+    private val lineItems = listOf(RefundV4LineItem.quantityBased(lineItemId = 1L, quantity = 1))
 
     private val sut by lazy {
         whenever(selectedSite.get()).thenReturn(site)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSubmissionProcessorTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSubmissionProcessorTest.kt
@@ -38,6 +38,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.refunds.RefundRequestItem
+import org.wordpress.android.fluxc.model.refunds.RefundV4LineItem
 import org.wordpress.android.fluxc.model.refunds.WCRefundModel
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
@@ -131,7 +132,7 @@ class WooPosRefundSubmissionProcessorTest {
             loadPaymentGateway = loadPaymentGateway,
             cardReaderPaymentControllerFactory = cardReaderPaymentControllerFactory,
             resourceProvider = resourceProvider,
-            uiStringParser = uiStringParser
+            uiStringParser = uiStringParser,
         )
     }
 
@@ -160,6 +161,55 @@ class WooPosRefundSubmissionProcessorTest {
             restockItems = eq(true),
             autoRefund = eq(true),
             items = eq(refundItems)
+        )
+    }
+
+    @Test
+    fun `given v4 line items, when submitted, then simplified v4 refund is created and v3 not called`() = runTest {
+        // GIVEN
+        whenever(paymentChargeRepository.fetchCardDataUsedForOrderPayment("ch_123")).thenReturn(
+            PaymentChargeRepository.CardDataUsedForOrderPaymentResult.Success(
+                cardBrand = "visa",
+                cardLast4 = "1234",
+                paymentMethodType = CARD_PRESENT
+            )
+        )
+        val v4LineItems = listOf(RefundV4LineItem(lineItemId = 1L, quantity = 1))
+        whenever(
+            refundStore.createSimplifiedItemsRefund(
+                site = eq(site),
+                orderId = eq(order.id),
+                reason = eq("Customer request"),
+                autoRefund = eq(true),
+                restockItems = eq(true),
+                items = eq(v4LineItems),
+            )
+        ).thenReturn(WooResult(refundModel))
+
+        // WHEN
+        processor.submit(request.copy(v4LineItems = v4LineItems)).test {
+            assertThat(awaitItem()).isEqualTo(WooPosRefundSubmissionState.Processing)
+            assertThat(awaitItem()).isEqualTo(WooPosRefundSubmissionState.Success)
+            awaitComplete()
+        }
+
+        // THEN
+        verify(refundStore).createSimplifiedItemsRefund(
+            site = eq(site),
+            orderId = eq(order.id),
+            reason = eq("Customer request"),
+            autoRefund = eq(true),
+            restockItems = eq(true),
+            items = eq(v4LineItems),
+        )
+        verify(refundStore, never()).createItemsRefund(
+            site = any(),
+            orderId = any(),
+            amount = any(),
+            reason = any(),
+            restockItems = any(),
+            autoRefund = any(),
+            items = any()
         )
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSubmissionProcessorTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSubmissionProcessorTest.kt
@@ -174,7 +174,7 @@ class WooPosRefundSubmissionProcessorTest {
                 paymentMethodType = CARD_PRESENT
             )
         )
-        val v4LineItems = listOf(RefundV4LineItem(lineItemId = 1L, quantity = 1))
+        val v4LineItems = listOf(RefundV4LineItem.quantityBased(lineItemId = 1L, quantity = 1))
         whenever(
             refundStore.createSimplifiedItemsRefund(
                 site = eq(site),

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundViewModelTest.kt
@@ -32,11 +32,13 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.argThat
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.refunds.RefundRequestItem
+import org.wordpress.android.fluxc.model.refunds.WCRefundPreview
 import org.wordpress.android.fluxc.model.settings.CurrencyPosition
 import org.wordpress.android.fluxc.model.settings.Settings
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
@@ -55,6 +57,9 @@ class WooPosRefundViewModelTest {
     private val retrieveOrderRefunds: WooPosRetrieveOrderRefunds = mock()
     private val getRefundableItems: WooPosGetRefundableItems = mock()
     private val groupRefundItems: WooPosGroupRefundItems = mock()
+    private val buildRefundV4LineItems = WooPosBuildRefundV4LineItems()
+    private val refundPreview: WooPosRefundPreview = mock()
+    private val v4RefundAvailabilityCache = WooPosV4RefundAvailabilityCache()
     private val calculateRefundSubtotal = WooPosCalculateRefundSubtotal()
     private val calculateRefundTax = WooPosCalculateRefundTax()
     private val resourceProvider: ResourceProvider = mock()
@@ -134,6 +139,9 @@ class WooPosRefundViewModelTest {
         whenever(cardReaderFacade.readerStatus).thenReturn(readerStatus)
 
         whenever(loadPaymentMethod.invoke(any())).thenReturn(Result.success("Manual refund"))
+        // Default to the v3 fallback so existing assertions exercise the local-calculation path;
+        // v4-specific tests override this.
+        whenever(refundPreview.invoke(any(), any())).thenReturn(WooPosRefundPreview.Result.FallbackToLocal)
         whenever(refundSubmissionProcessor.submit(any())).thenReturn(
             flowOf(
                 WooPosRefundSubmissionState.Processing,
@@ -157,6 +165,9 @@ class WooPosRefundViewModelTest {
             retrieveOrderRefunds = retrieveOrderRefunds,
             getRefundableItems = getRefundableItems,
             groupRefundItems = groupRefundItems,
+            buildRefundV4LineItems = buildRefundV4LineItems,
+            refundPreview = refundPreview,
+            v4RefundAvailabilityCache = v4RefundAvailabilityCache,
             calculateRefundSubtotal = calculateRefundSubtotal,
             calculateRefundTax = calculateRefundTax,
             resourceProvider = resourceProvider,
@@ -175,6 +186,30 @@ class WooPosRefundViewModelTest {
      * Note: Items with the same orderItemId but different rowIndex represent
      * expanded units from an order item with quantity > 1.
      */
+    private fun refundPreview(
+        subtotal: String,
+        tax: String,
+        total: String,
+        maxRefundable: String,
+    ) = WCRefundPreview(
+        subtotal = BigDecimal(subtotal),
+        tax = BigDecimal(tax),
+        total = BigDecimal(total),
+        maxRefundable = BigDecimal(maxRefundable),
+        breakdown = WCRefundPreview.Breakdown(
+            products = emptyPreviewSection(),
+            shipping = emptyPreviewSection(),
+            fees = emptyPreviewSection(),
+        ),
+    )
+
+    private fun emptyPreviewSection() = WCRefundPreview.Section(
+        items = emptyList(),
+        subtotal = BigDecimal.ZERO,
+        tax = BigDecimal.ZERO,
+        total = BigDecimal.ZERO,
+    )
+
     private fun createRefundableItem(
         orderItemId: Long,
         productId: Long = 10L,
@@ -259,9 +294,138 @@ class WooPosRefundViewModelTest {
             assertThat(contentState.currency).isEqualTo("USD")
             assertThat(contentState.refundableItems).hasSize(2)
             assertThat(contentState.itemsCount).isEqualTo(2)
-            assertThat(contentState.subtotal).isEqualByComparingTo(BigDecimal("40.00"))
-            assertThat(contentState.taxes).isEqualByComparingTo(BigDecimal("4.00"))
-            assertThat(contentState.total).isEqualByComparingTo(BigDecimal("44.00"))
+            assertThat(contentState.step).isEqualTo(WooPosRefundState.Content.RefundStep.SelectItems)
+            // Totals are not computed on the selection step; they are resolved on Continue.
+            assertThat(contentState.subtotal).isEqualByComparingTo(BigDecimal.ZERO)
+            assertThat(contentState.taxes).isEqualByComparingTo(BigDecimal.ZERO)
+            assertThat(contentState.total).isEqualByComparingTo(BigDecimal.ZERO)
+        }
+
+    @Test
+    fun `given v4 unavailable, when continue clicked, then store settings fetched and totals calculated locally`() =
+        runTest {
+            // GIVEN — v4 is known unavailable for the site, so the local (v3) path is used.
+            v4RefundAvailabilityCache.markV4Unavailable(testSite.siteId)
+            val refundableItems = listOf(
+                testRefundableItem.copy(rowIndex = 0),
+                testRefundableItem.copy(rowIndex = 1)
+            )
+            whenever(ordersDataSource.refreshOrderById(testOrderId)).thenReturn(Result.success(testOrder))
+            whenever(retrieveOrderRefunds.invoke(eq(testOrder), any())).thenReturn(Result.success(emptyList()))
+            whenever(getRefundableItems.invoke(any(), any())).thenReturn(refundableItems)
+            viewModel = createViewModel()
+            viewModel.onUIEvent(WooPosRefundUIEvent.RefundFlowOpened)
+            advanceUntilIdle()
+
+            // WHEN
+            viewModel.onUIEvent(WooPosRefundUIEvent.ContinueToReviewClicked)
+            advanceUntilIdle()
+
+            // THEN — settings were fetched lazily and the totals computed locally.
+            verify(wooCommerceStore).fetchSiteSettingsTaxRoundAtSubtotal(testSite)
+            verify(refundPreview, never()).invoke(any(), any())
+            val content = viewModel.state.value as WooPosRefundState.Content
+            assertThat(content.step).isEqualTo(WooPosRefundState.Content.RefundStep.ReviewRefund)
+            assertThat(content.subtotal).isEqualByComparingTo(BigDecimal("40.00"))
+            assertThat(content.taxes).isEqualByComparingTo(BigDecimal("4.00"))
+            assertThat(content.total).isEqualByComparingTo(BigDecimal("44.00"))
+        }
+
+    @Test
+    fun `given v4 available, when continue clicked, then store settings are not fetched`() = runTest {
+        // GIVEN
+        whenever(ordersDataSource.refreshOrderById(testOrderId)).thenReturn(Result.success(testOrder))
+        whenever(retrieveOrderRefunds.invoke(eq(testOrder), any())).thenReturn(Result.success(emptyList()))
+        whenever(getRefundableItems.invoke(any(), any())).thenReturn(listOf(testRefundableItem))
+        whenever(refundPreview.invoke(any(), any())).thenReturn(
+            WooPosRefundPreview.Result.ServerCalculated(
+                refundPreview(subtotal = "55.00", tax = "5.00", total = "60.00", maxRefundable = "60.00")
+            )
+        )
+        viewModel = createViewModel()
+        viewModel.onUIEvent(WooPosRefundUIEvent.RefundFlowOpened)
+        advanceUntilIdle()
+
+        // WHEN
+        viewModel.onUIEvent(WooPosRefundUIEvent.ContinueToReviewClicked)
+        advanceUntilIdle()
+
+        // THEN — no redundant settings calls when the server provides the totals.
+        verify(wooCommerceStore, never()).fetchSiteSettingsTaxRoundAtSubtotal(any())
+        verify(wooCommerceStore, never()).fetchSiteGeneralSettings(any())
+    }
+
+    @Test
+    fun `given v4 available, when continue clicked, then review shows server-calculated totals`() = runTest {
+        // GIVEN
+        val refundableItems = listOf(testRefundableItem.copy(rowIndex = 0), testRefundableItem.copy(rowIndex = 1))
+        whenever(ordersDataSource.refreshOrderById(testOrderId)).thenReturn(Result.success(testOrder))
+        whenever(retrieveOrderRefunds.invoke(eq(testOrder), any())).thenReturn(Result.success(emptyList()))
+        whenever(getRefundableItems.invoke(any(), any())).thenReturn(refundableItems)
+        whenever(refundPreview.invoke(any(), any())).thenReturn(
+            WooPosRefundPreview.Result.ServerCalculated(
+                refundPreview(subtotal = "55.00", tax = "5.00", total = "60.00", maxRefundable = "60.00")
+            )
+        )
+        viewModel = createViewModel()
+        viewModel.onUIEvent(WooPosRefundUIEvent.RefundFlowOpened)
+        advanceUntilIdle()
+
+        // WHEN
+        viewModel.onUIEvent(WooPosRefundUIEvent.ContinueToReviewClicked)
+        advanceUntilIdle()
+
+        // THEN
+        val content = viewModel.state.value as WooPosRefundState.Content
+        assertThat(content.step).isEqualTo(WooPosRefundState.Content.RefundStep.ReviewRefund)
+        assertThat(content.subtotal).isEqualByComparingTo(BigDecimal("55.00"))
+        assertThat(content.taxes).isEqualByComparingTo(BigDecimal("5.00"))
+        assertThat(content.total).isEqualByComparingTo(BigDecimal("60.00"))
+        assertThat(content.maxRefundable).isEqualByComparingTo(BigDecimal("60.00"))
+        assertThat(content.isPreviewLoading).isFalse()
+        assertThat(content.previewFailed).isFalse()
+    }
+
+    @Test
+    fun `given preview is not triggered, when items toggled, then preview is not called`() = runTest {
+        // GIVEN
+        val refundableItems = listOf(testRefundableItem.copy(rowIndex = 0), testRefundableItem.copy(rowIndex = 1))
+        whenever(ordersDataSource.refreshOrderById(testOrderId)).thenReturn(Result.success(testOrder))
+        whenever(retrieveOrderRefunds.invoke(eq(testOrder), any())).thenReturn(Result.success(emptyList()))
+        whenever(getRefundableItems.invoke(any(), any())).thenReturn(refundableItems)
+        viewModel = createViewModel()
+        viewModel.onUIEvent(WooPosRefundUIEvent.RefundFlowOpened)
+        advanceUntilIdle()
+
+        // WHEN
+        viewModel.onUIEvent(WooPosRefundUIEvent.ItemSelectionToggled(refundableItems.first().uniqueId))
+        advanceUntilIdle()
+
+        // THEN
+        verify(refundPreview, never()).invoke(any(), any())
+    }
+
+    @Test
+    fun `given v4 preview errors, when continue clicked, then content marks preview failed and stays on select`() =
+        runTest {
+            // GIVEN
+            whenever(ordersDataSource.refreshOrderById(testOrderId)).thenReturn(Result.success(testOrder))
+            whenever(retrieveOrderRefunds.invoke(eq(testOrder), any())).thenReturn(Result.success(emptyList()))
+            whenever(getRefundableItems.invoke(any(), any())).thenReturn(listOf(testRefundableItem))
+            whenever(refundPreview.invoke(any(), any())).thenReturn(WooPosRefundPreview.Result.Error)
+            viewModel = createViewModel()
+            viewModel.onUIEvent(WooPosRefundUIEvent.RefundFlowOpened)
+            advanceUntilIdle()
+
+            // WHEN
+            viewModel.onUIEvent(WooPosRefundUIEvent.ContinueToReviewClicked)
+            advanceUntilIdle()
+
+            // THEN
+            val content = viewModel.state.value as WooPosRefundState.Content
+            assertThat(content.step).isEqualTo(WooPosRefundState.Content.RefundStep.SelectItems)
+            assertThat(content.previewFailed).isTrue()
+            assertThat(content.isPreviewLoading).isFalse()
         }
 
     @Test
@@ -437,6 +601,8 @@ class WooPosRefundViewModelTest {
                 )
             )
 
+            // v4 unavailable so totals are calculated locally on Continue.
+            v4RefundAvailabilityCache.markV4Unavailable(testSite.siteId)
             whenever(ordersDataSource.refreshOrderById(testOrderId)).thenReturn(Result.success(orderWithMultipleItems))
             whenever(
                 retrieveOrderRefunds.invoke(eq(orderWithMultipleItems), any())
@@ -446,6 +612,8 @@ class WooPosRefundViewModelTest {
             // WHEN
             viewModel = createViewModel()
             viewModel.onUIEvent(WooPosRefundUIEvent.RefundFlowOpened)
+            advanceUntilIdle()
+            viewModel.onUIEvent(WooPosRefundUIEvent.ContinueToReviewClicked)
             advanceUntilIdle()
 
             // THEN
@@ -924,7 +1092,9 @@ class WooPosRefundViewModelTest {
             viewModel.onUIEvent(WooPosRefundUIEvent.RefundFlowOpened)
             advanceUntilIdle()
 
-            // WHEN
+            // WHEN — Continue resolves the totals (locally, via the v3 fallback) before confirming.
+            viewModel.onUIEvent(WooPosRefundUIEvent.ContinueToReviewClicked)
+            advanceUntilIdle()
             viewModel.onUIEvent(WooPosRefundUIEvent.OnRefundConfirmed)
             advanceUntilIdle()
 
@@ -964,6 +1134,8 @@ class WooPosRefundViewModelTest {
 
             // WHEN
             viewModel.onUIEvent(WooPosRefundUIEvent.OnRefundReasonChanged(testReason))
+            viewModel.onUIEvent(WooPosRefundUIEvent.ContinueToReviewClicked)
+            advanceUntilIdle()
             viewModel.onUIEvent(WooPosRefundUIEvent.OnRefundConfirmed)
             advanceUntilIdle()
 
@@ -1034,7 +1206,7 @@ class WooPosRefundViewModelTest {
         }
 
     @Test
-    fun `given all items selected initially, when item deselected, then selectedItemIds updated and totals recalculated`() =
+    fun `given all items selected initially, when item deselected, then selectedItemIds and count updated`() =
         runTest {
             // GIVEN
             val orderWithTwoItems = testOrder.copy(
@@ -1075,9 +1247,7 @@ class WooPosRefundViewModelTest {
 
             val initialState = viewModel.state.value as WooPosRefundState.Content
             assertThat(initialState.selectedItemIds).containsExactlyInAnyOrder(item1.uniqueId, item2.uniqueId)
-            assertThat(initialState.subtotal).isEqualByComparingTo(BigDecimal("30.00"))
-            assertThat(initialState.taxes).isEqualByComparingTo(BigDecimal("3.00"))
-            assertThat(initialState.total).isEqualByComparingTo(BigDecimal("33.00"))
+            assertThat(initialState.itemsCount).isEqualTo(2)
 
             // WHEN
             viewModel.onUIEvent(WooPosRefundUIEvent.ItemSelectionToggled(item1.uniqueId))
@@ -1085,13 +1255,12 @@ class WooPosRefundViewModelTest {
             // THEN
             val updatedState = viewModel.state.value as WooPosRefundState.Content
             assertThat(updatedState.selectedItemIds).containsExactly(item2.uniqueId)
-            assertThat(updatedState.subtotal).isEqualByComparingTo(BigDecimal("20.00"))
-            assertThat(updatedState.taxes).isEqualByComparingTo(BigDecimal("2.00"))
-            assertThat(updatedState.total).isEqualByComparingTo(BigDecimal("22.00"))
+            assertThat(updatedState.itemsCount).isEqualTo(1)
+            assertThat(updatedState.allItemsSelected).isFalse()
         }
 
     @Test
-    fun `given item not selected, when item selected, then selectedItemIds updated and totals recalculated`() =
+    fun `given item not selected, when item selected, then selectedItemIds and count updated`() =
         runTest {
             // GIVEN
             val orderWithTwoItems = testOrder.copy(
@@ -1134,7 +1303,7 @@ class WooPosRefundViewModelTest {
 
             val stateBeforeSelect = viewModel.state.value as WooPosRefundState.Content
             assertThat(stateBeforeSelect.selectedItemIds).containsExactly(item2.uniqueId)
-            assertThat(stateBeforeSelect.subtotal).isEqualByComparingTo(BigDecimal("20.00"))
+            assertThat(stateBeforeSelect.itemsCount).isEqualTo(1)
 
             // WHEN
             viewModel.onUIEvent(WooPosRefundUIEvent.ItemSelectionToggled(item1.uniqueId))
@@ -1142,9 +1311,8 @@ class WooPosRefundViewModelTest {
             // THEN
             val updatedState = viewModel.state.value as WooPosRefundState.Content
             assertThat(updatedState.selectedItemIds).containsExactlyInAnyOrder(item1.uniqueId, item2.uniqueId)
-            assertThat(updatedState.subtotal).isEqualByComparingTo(BigDecimal("30.00"))
-            assertThat(updatedState.taxes).isEqualByComparingTo(BigDecimal("3.00"))
-            assertThat(updatedState.total).isEqualByComparingTo(BigDecimal("33.00"))
+            assertThat(updatedState.itemsCount).isEqualTo(2)
+            assertThat(updatedState.allItemsSelected).isTrue()
         }
 
     @Test
@@ -1203,7 +1371,7 @@ class WooPosRefundViewModelTest {
         }
 
     @Test
-    fun `given no items selected, when select all toggled, then all items selected and totals recalculated`() =
+    fun `given no items selected, when select all toggled, then all items selected`() =
         runTest {
             // GIVEN
             val orderWithTwoItems = testOrder.copy(
@@ -1254,9 +1422,7 @@ class WooPosRefundViewModelTest {
             val updatedState = viewModel.state.value as WooPosRefundState.Content
             assertThat(updatedState.selectedItemIds).containsExactlyInAnyOrder(item1.uniqueId, item2.uniqueId)
             assertThat(updatedState.itemsCount).isEqualTo(2)
-            assertThat(updatedState.subtotal).isEqualByComparingTo(BigDecimal("30.00"))
-            assertThat(updatedState.taxes).isEqualByComparingTo(BigDecimal("3.00"))
-            assertThat(updatedState.total).isEqualByComparingTo(BigDecimal("33.00"))
+            assertThat(updatedState.allItemsSelected).isTrue()
         }
 
     @Test
@@ -1471,7 +1637,6 @@ class WooPosRefundViewModelTest {
 
             val initialState = viewModel.state.value as WooPosRefundState.Content
             assertThat(initialState.selectedItemIds).hasSize(3)
-            assertThat(initialState.subtotal).isEqualByComparingTo(BigDecimal("30.00"))
 
             // WHEN
             viewModel.onUIEvent(WooPosRefundUIEvent.ItemSelectionToggled(item1Unit2.uniqueId))
@@ -1483,9 +1648,6 @@ class WooPosRefundViewModelTest {
                 item1Unit3.uniqueId
             )
             assertThat(updatedState.itemsCount).isEqualTo(2)
-            assertThat(updatedState.subtotal).isEqualByComparingTo(BigDecimal("20.00"))
-            assertThat(updatedState.taxes).isEqualByComparingTo(BigDecimal("2.00"))
-            assertThat(updatedState.total).isEqualByComparingTo(BigDecimal("22.00"))
         }
 
     @Suppress("LongMethod")
@@ -1567,7 +1729,9 @@ class WooPosRefundViewModelTest {
             val stateBeforeConfirm = viewModel.state.value as WooPosRefundState.Content
             assertThat(stateBeforeConfirm.selectedItemIds).containsExactlyInAnyOrder(item1.uniqueId, item3.uniqueId)
 
-            // WHEN
+            // WHEN — Continue resolves the totals (locally, via the v3 fallback) before confirming.
+            viewModel.onUIEvent(WooPosRefundUIEvent.ContinueToReviewClicked)
+            advanceUntilIdle()
             viewModel.onUIEvent(WooPosRefundUIEvent.OnRefundConfirmed)
             advanceUntilIdle()
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundViewModelTest.kt
@@ -17,6 +17,7 @@ import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.viewmodel.ResourceProvider
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -30,6 +31,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argThat
+import org.mockito.kotlin.doSuspendableAnswer
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -426,6 +428,79 @@ class WooPosRefundViewModelTest {
             assertThat(content.step).isEqualTo(WooPosRefundState.Content.RefundStep.SelectItems)
             assertThat(content.previewFailed).isTrue()
             assertThat(content.isPreviewLoading).isFalse()
+        }
+
+    @Test
+    fun `given v4 available and preview succeeded, when refund confirmed, then processor receives v4 line items`() =
+        runTest {
+            // GIVEN — v4 is available, so the preview returns server-calculated totals.
+            v4RefundAvailabilityCache.markV4Available(testSite.siteId)
+            val refundableItems = listOf(testRefundableItem)
+            whenever(ordersDataSource.refreshOrderById(testOrderId)).thenReturn(Result.success(testOrder))
+            whenever(retrieveOrderRefunds.invoke(eq(testOrder), any())).thenReturn(Result.success(emptyList()))
+            whenever(getRefundableItems.invoke(any(), any())).thenReturn(refundableItems)
+            whenever(refundPreview.invoke(any(), any())).thenReturn(
+                WooPosRefundPreview.Result.ServerCalculated(
+                    refundPreview(subtotal = "20.00", tax = "2.00", total = "22.00", maxRefundable = "22.00")
+                )
+            )
+            viewModel = createViewModel()
+            viewModel.onUIEvent(WooPosRefundUIEvent.RefundFlowOpened)
+            advanceUntilIdle()
+
+            // WHEN — Continue fetches the server preview, then the refund is confirmed.
+            viewModel.onUIEvent(WooPosRefundUIEvent.ContinueToReviewClicked)
+            advanceUntilIdle()
+            viewModel.onUIEvent(WooPosRefundUIEvent.OnRefundConfirmed)
+            advanceUntilIdle()
+
+            // THEN — the submission carries the simplified v4 line items and no v3 grouped items.
+            verify(refundSubmissionProcessor).submit(
+                argThat {
+                    val lineItem = v4LineItems?.singleOrNull()
+                    orderId == testOrderId &&
+                        refundItems.isEmpty() &&
+                        lineItem?.lineItemId == 1L &&
+                        lineItem.quantity == 1 &&
+                        refundAmount.compareTo(BigDecimal("22.00")) == 0
+                }
+            )
+            // v3 grouping must not run on the v4 path.
+            verify(groupRefundItems, never()).invoke(any(), any(), any())
+        }
+
+    @Test
+    fun `given preview loading, when selection toggled, then loading is cleared and stale preview dropped`() =
+        runTest {
+            // GIVEN — v4 is available; the preview is held open to simulate a request still in flight.
+            v4RefundAvailabilityCache.markV4Available(testSite.siteId)
+            val refundableItems = listOf(testRefundableItem.copy(rowIndex = 0), testRefundableItem.copy(rowIndex = 1))
+            whenever(ordersDataSource.refreshOrderById(testOrderId)).thenReturn(Result.success(testOrder))
+            whenever(retrieveOrderRefunds.invoke(eq(testOrder), any())).thenReturn(Result.success(emptyList()))
+            whenever(getRefundableItems.invoke(any(), any())).thenReturn(refundableItems)
+            val previewGate = CompletableDeferred<WooPosRefundPreview.Result>()
+            whenever(refundPreview.invoke(any(), any())).doSuspendableAnswer { previewGate.await() }
+            viewModel = createViewModel()
+            viewModel.onUIEvent(WooPosRefundUIEvent.RefundFlowOpened)
+            advanceUntilIdle()
+
+            // WHEN — Continue starts the preview (now suspended), then the selection changes.
+            viewModel.onUIEvent(WooPosRefundUIEvent.ContinueToReviewClicked)
+            assertThat((viewModel.state.value as WooPosRefundState.Content).isPreviewLoading).isTrue()
+            viewModel.onUIEvent(WooPosRefundUIEvent.ItemSelectionToggled(refundableItems.first().uniqueId))
+            // Releasing the gate now would feed a stale result; the cancelled preview must ignore it.
+            previewGate.complete(
+                WooPosRefundPreview.Result.ServerCalculated(
+                    refundPreview(subtotal = "20.00", tax = "2.00", total = "22.00", maxRefundable = "22.00")
+                )
+            )
+            advanceUntilIdle()
+
+            // THEN — the loading flag is cleared and the stale preview did not advance the flow.
+            val content = viewModel.state.value as WooPosRefundState.Content
+            assertThat(content.isPreviewLoading).isFalse()
+            assertThat(content.previewFailed).isFalse()
+            assertThat(content.step).isEqualTo(WooPosRefundState.Content.RefundStep.SelectItems)
         }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundViewModelTest.kt
@@ -334,6 +334,33 @@ class WooPosRefundViewModelTest {
         }
 
     @Test
+    fun `given another local store lacks v4, when continue clicked, then this store still probes v4`() = runTest {
+        // GIVEN — a DIFFERENT local site is known to lack v4. The cache is keyed by local site id, so
+        // that verdict must not bleed into testSite (local id 1) — important for self-hosted/WPAPI
+        // stores that all share remote siteId 0.
+        val otherLocalSiteId = testSite.localId().value + 1
+        v4RefundAvailabilityCache.markV4Unavailable(otherLocalSiteId)
+        whenever(ordersDataSource.refreshOrderById(testOrderId)).thenReturn(Result.success(testOrder))
+        whenever(retrieveOrderRefunds.invoke(eq(testOrder), any())).thenReturn(Result.success(emptyList()))
+        whenever(getRefundableItems.invoke(any(), any())).thenReturn(listOf(testRefundableItem))
+        whenever(refundPreview.invoke(any(), any())).thenReturn(
+            WooPosRefundPreview.Result.ServerCalculated(
+                refundPreview(subtotal = "55.00", tax = "5.00", total = "60.00", maxRefundable = "60.00")
+            )
+        )
+        viewModel = createViewModel()
+        viewModel.onUIEvent(WooPosRefundUIEvent.RefundFlowOpened)
+        advanceUntilIdle()
+
+        // WHEN
+        viewModel.onUIEvent(WooPosRefundUIEvent.ContinueToReviewClicked)
+        advanceUntilIdle()
+
+        // THEN — testSite's availability is still unknown, so it probes v4 rather than skipping to v3.
+        verify(refundPreview).invoke(any(), any())
+    }
+
+    @Test
     fun `given v4 available, when continue clicked, then store settings are not fetched`() = runTest {
         // GIVEN
         whenever(ordersDataSource.refreshOrderById(testOrderId)).thenReturn(Result.success(testOrder))

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosV4RefundAvailabilityCacheTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosV4RefundAvailabilityCacheTest.kt
@@ -1,0 +1,46 @@
+package com.woocommerce.android.ui.woopos.orders.details.refund
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class WooPosV4RefundAvailabilityCacheTest {
+
+    private val cache = WooPosV4RefundAvailabilityCache()
+
+    @Test
+    fun `given site not probed, when isV4Available, then returns null`() {
+        assertThat(cache.isV4Available(SITE_ID)).isNull()
+    }
+
+    @Test
+    fun `given site marked available, when isV4Available, then returns true`() {
+        // WHEN
+        cache.markV4Available(SITE_ID)
+
+        // THEN
+        assertThat(cache.isV4Available(SITE_ID)).isTrue()
+    }
+
+    @Test
+    fun `given site marked unavailable, when isV4Available, then returns false`() {
+        // WHEN
+        cache.markV4Unavailable(SITE_ID)
+
+        // THEN
+        assertThat(cache.isV4Available(SITE_ID)).isFalse()
+    }
+
+    @Test
+    fun `given one site unavailable, when querying another site, then it is independent`() {
+        // GIVEN
+        cache.markV4Unavailable(SITE_ID)
+
+        // THEN
+        assertThat(cache.isV4Available(OTHER_SITE_ID)).isNull()
+    }
+
+    private companion object {
+        private const val SITE_ID = 1L
+        private const val OTHER_SITE_ID = 2L
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosV4RefundAvailabilityCacheTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosV4RefundAvailabilityCacheTest.kt
@@ -40,7 +40,7 @@ class WooPosV4RefundAvailabilityCacheTest {
     }
 
     private companion object {
-        private const val SITE_ID = 1L
-        private const val OTHER_SITE_ID = 2L
+        private const val SITE_ID = 1
+        private const val OTHER_SITE_ID = 2
     }
 }


### PR DESCRIPTION
### Part of a 3-PR stack — review & merge in order

1. #16122 — FluxC: v4 refund preview + simplified-create APIs
2. **#16123 — POS: v4 refund detection, preview & simplified-create plumbing ← you are here**
3. #16124 — POS: wire v4 refund preview, detection & creation into the flow

Each part is stacked on the previous, so its diff only shows that part's changes. **Stacked on #16122 — review/merge that first.** Split from #16109.

### Description

Part of WOOMOB-2693, WOOMOB-2689 and WOOMOB-2687 — these issues are closed by Part 3 (#16124), once the whole stack lands.

Part 2 of 3 of the v4 refunds integration for Woo POS. This adds the POS **domain layer** — the units that Part 3 wires into the ViewModel and UI. On their own they are inert: nothing in the refund flow calls them yet, so the app still behaves exactly as before (v3). No user-facing change in this PR.

- **`WooPosV4RefundAvailabilityCache`** — caches, per site for the app session, whether the store exposes the v4 refund endpoints (keyed by remote site id, so switching stores never reuses a stale result).
- **`WooPosRefundPreview`** — the detection + preview use case:
  - The v4 endpoints ship in WooCommerce 10.9.0. If the **cached** WooCommerce version is older, v4 cannot be available, so it skips the probe entirely (no network call) and falls back to v3.
  - On 10.9.0+ the endpoints may still be behind the `rest-api-v4` flag, so it probes `POST /wc/v4/refunds/preview`. A `404 rest_no_route` marks the site unavailable and falls back; a success caches availability and returns the server totals.
- **`WooPosBuildRefundV4LineItems`** — maps the selected refundable rows to the simplified v4 line items (products → quantity; fees → tax-inclusive `refund_total`).
- **`WooPosRefundSubmissionRequest`** — adds an optional `v4LineItems` (null = v3 path; defaulted, so existing callers are unchanged).
- **`WooPosRefundSubmissionProcessor`** — sends the simplified v4 create when `v4LineItems` is present, otherwise the v3 create.

### Test Steps

No user-facing change (the new units aren't wired into the flow until Part 3). Covered by unit tests: `WooPosRefundPreviewTest`, `WooPosBuildRefundV4LineItemsTest`, `WooPosV4RefundAvailabilityCacheTest`, `WooPosRefundSubmissionProcessorTest`.

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
