### PR TITLE
[WOOMOB-3304] Fix dialog CTA spacing

### DIFF
--- a/WooCommerce/src/main/res/values/themes.xml
+++ b/WooCommerce/src/main/res/values/themes.xml
@@ -124,6 +124,8 @@
         <!-- Colors -->
         <item name="buttonBarStyle">@style/Woo.Dialog.ButtonBar</item>
         <item name="android:buttonBarStyle">@style/Woo.Dialog.ButtonBar</item>
+        <item name="buttonBarPositiveButtonStyle">@style/Woo.Dialog.Button</item>
+        <item name="buttonBarNegativeButtonStyle">@style/Woo.Dialog.Button</item>
     </style>
 
     <style name="Theme.Woo.Dialog.RoundedCorners" parent="Theme.Woo.Dialog">
@@ -139,6 +141,11 @@
     <style name="Woo.Dialog.ButtonBar">
         <item name="android:paddingStart">@dimen/minor_100</item>
         <item name="android:paddingEnd">@dimen/minor_100</item>
+    </style>
+
+    <style name="Woo.Dialog.Button" parent="@style/Widget.MaterialComponents.Button.TextButton.Dialog">
+        <item name="android:layout_marginStart">@dimen/minor_100</item>
+        <item name="android:layout_marginLeft">@dimen/minor_100</item>
     </style>
 
     <style name="Theme.Woo.NumberPicker" parent="Theme.Woo.DayNight">


### PR DESCRIPTION
### Description
Fixes WOOMOB-3304

The affected product-detail confirmation dialogs are view-system dialogs shown through `WooDialog` / `MaterialAlertDialogBuilder`, using `Theme.Woo.Dialog`.

`Theme.Woo.Dialog` customizes the button bar, but the resolved positive/negative dialog button styles were not applying a start margin between adjacent actions. That allowed buttons such as `CANCEL` and `MOVE TO TRASH` (see Linear issue) to render flush against each other.

<img width="300" alt="Screenshot_20260618_154756" src="https://github.com/user-attachments/assets/c6260b78-cfd4-4198-b75a-9503ebe21b7d" />



This keeps the fix scoped to `Theme.Woo.Dialog` by explicitly applying a Woo dialog button style for positive and negative actions. The style inherits the Material dialog text-button style and restores the 8dp start margin used between adjacent dialog actions.

### Test Steps
1. Open the Products tab.
2. Open a product.
3. Tap the overflow menu.
4. Tap **Trash product**.
5. Verify the confirmation dialog shows visible spacing between `CANCEL` and `MOVE TO TRASH`.

### Images/gif
<img width="300" alt="image" src="https://github.com/user-attachments/assets/dc293fdc-4cdd-4cd8-b21d-6615d7bdbdd7" />


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
