### PR TITLE
Document Store design system rollout direction

### DIFF
--- a/docs/design-system/android-adapter.md
+++ b/docs/design-system/android-adapter.md
@@ -18,9 +18,8 @@ doc defines the technical boundaries that support that rollout.
 - Figma is the design-intent source of truth. Android owns the runtime API contract.
 - Source references use public-repo shorthands: P2 `pe5sF9-5ox-p2`, Figma
   `50XIH5MmOf4xUYEkM6fAm6-fi`. Do not expand them into raw URLs in public repo docs.
-- Foundation source values come from `docs/design-system/figma-export.json` and the row-level audit
-  files under `docs/design-system/foundation-audit/`. This docs branch is allowed to lack runtime
-  foundation code; future implementation consumes these docs as the contract.
+- Foundation source values come from `docs/design-system/figma-export.json`. This docs branch is
+  allowed to lack runtime foundation code; future implementation consumes these docs as the contract.
 
 ## Package
 
@@ -30,7 +29,7 @@ New Compose APIs live under:
 com.woocommerce.android.ui.compose.designsystem
 ```
 
-Suggested subpackages:
+Subpackages:
 
 - `foundation`: theme, color, typography, spacing, shape, elevation, and token helpers.
 - `component`: production-ready Woo Mobile Design System components.
@@ -55,6 +54,9 @@ rollout wiring should stay outside the module.
 - The new `WooTheme` accessor lives under `com.woocommerce.android.ui.compose.designsystem`.
   The existing `com.woocommerce.android.ui.compose.theme.WooTheme` composable remains the legacy Store
   wrapper until deliberately removed; new design-system code should not import it.
+- The foundation implementation should add a detekt guardrail that reports files importing both legacy
+  `com.woocommerce.android.ui.compose.theme.*` and design-system
+  `com.woocommerce.android.ui.compose.designsystem.*` APIs.
 - Do not expose raw Figma variable names as public Android API.
 - Public APIs should expose only production-ready tokens and components.
 - In-progress i1 areas may be documented, tracked, or preview-only until signed off.
@@ -83,15 +85,8 @@ screens stay on the legacy root. Do not add root-selection indirection to arbitr
 `composeView {}` calls; a screen is migrated by changing its call site to the DS root builder.
 
 During migration work, introduce or use a DS-specific builder such as `designSystemComposeView {}`.
-That name is transitional: before the final merge of the migration branch, run a controlled rename
-boundary where the current legacy `composeView` becomes `legacyComposeView`, the current
-`WooThemeWithBackground` becomes `LegacyWooThemeWithBackground`, and the DS-specific builder becomes
-`composeView`.
-
-That final API shape should make the intended root obvious at call sites during migration and
-restore `composeView` as the DS default only after legacy call sites are renamed. Every remaining
-`composeView` call must be intentionally migrated, every non-migrated screen must use
-`legacyComposeView`, and the boundary must be verified with strict `rg` audits.
+The controlled root-API rename boundary is defined in [rollout-direction.md](rollout-direction.md);
+keep that file as the source for exact rename steps and audits.
 
 The Store design-system module still owns pure foundations/components and still does not import app
 `R`, Hilt, POS, or Store feature packages. Do not document a legacy-compatible design-system

--- a/docs/design-system/android-adapter.md
+++ b/docs/design-system/android-adapter.md
@@ -1,0 +1,229 @@
+# Store Design System Android Adapter
+
+This document defines how the Store Management App adopts the Woo Mobile Design System i1 with the least disruption.
+
+The current rollout scope is defined in [rollout-direction.md](rollout-direction.md). This adapter
+doc defines the technical boundaries that support that rollout.
+
+## Scope
+
+- Store Management App only.
+- POS is out of scope.
+- Design-system foundations and components live in the Store-only `:libs:store-design-system`
+  module, not `:libs:commons`.
+- The first rollout wave migrates Dashboard, Products, Orders, More, top Product Detail, and top Order Detail.
+- Product Detail and Order Detail launched child flows remain out of scope for the first wave.
+- Design-system components are adopted deliberately. Existing screens keep their current behavior and
+  styling until migrated or until the legacy theme convergence phase touches safe color/chrome tokens.
+- Figma is the design-intent source of truth. Android owns the runtime API contract.
+- Source references use public-repo shorthands: P2 `pe5sF9-5ox-p2`, Figma
+  `50XIH5MmOf4xUYEkM6fAm6-fi`. Do not expand them into raw URLs in public repo docs.
+- Foundation source values come from `docs/design-system/figma-export.json` and the row-level audit
+  files under `docs/design-system/foundation-audit/`. This docs branch is allowed to lack runtime
+  foundation code; future implementation consumes these docs as the contract.
+
+## Package
+
+New Compose APIs live under:
+
+```text
+com.woocommerce.android.ui.compose.designsystem
+```
+
+Suggested subpackages:
+
+- `foundation`: theme, color, typography, spacing, shape, elevation, and token helpers.
+- `component`: production-ready Woo Mobile Design System components.
+- `preview`: preview wrappers, sample data, and catalog-only helpers.
+
+The Gradle module boundary is stricter than the package boundary. `:libs:store-design-system` must
+not depend on app `R`, legacy app theme classes, Hilt, POS, or Store feature packages. App-layer
+rollout wiring should stay outside the module.
+
+## Public API Rules
+
+- Use the `Woo` prefix for new design-system components inside the design-system package.
+- Do not use `WooDs*` for new APIs.
+- Do not use `WC*` for new design-system APIs. `WC*` remains the legacy/shared component namespace.
+- Use `WooDesignSystemTheme` for the opt-in theme wrapper.
+- Treat `WooDesignSystemTheme` as the migration-era wrapper name while the legacy
+  `com.woocommerce.android.ui.compose.theme.WooTheme` wrapper still exists. Do not use temporal names
+  such as `WooNewTheme`; future consolidation can merge wrapper/accessor naming after the legacy
+  wrapper is removed.
+- Use `WooTheme` as the design-system foundation accessor object for theme-scoped values such as
+  colors, typography, spacing, padding, and radius.
+- The new `WooTheme` accessor lives under `com.woocommerce.android.ui.compose.designsystem`.
+  The existing `com.woocommerce.android.ui.compose.theme.WooTheme` composable remains the legacy Store
+  wrapper until deliberately removed; new design-system code should not import it.
+- Do not expose raw Figma variable names as public Android API.
+- Public APIs should expose only production-ready tokens and components.
+- In-progress i1 areas may be documented, tracked, or preview-only until signed off.
+- Preview-only components should not be exposed as reusable product-screen APIs.
+- Keep preview-only implementations private/internal to catalog or preview files under `designsystem.preview`.
+- The planned public foundation surface is:
+  - `WooTheme.colors` grouped as `core`, `container`, `surface`, `outline`, `status`, `alert`,
+    `background`, `overlay`, and `palette`.
+  - `WooTheme.text` with `regular`, `emphasized`, and `strong` variants.
+  - `WooTheme.spacing` and `WooTheme.padding` as separate APIs with identical value scales.
+  - `WooTheme.radius` including Woo-only `none` and `full` plus Material projection roles.
+  - `WooTheme.iconSize` scoped to glyph sizes only.
+- Expose primitive palette ramps intentionally through public `WooTheme.colors.palette.*` fields.
+- Treat `surfaceBright`, `surfaceDim`, and `surfaceContainerHighest` as source-backed Store roles,
+  not generated Material aliases.
+- Keep `WooStroke` internal or `preview_only` until production component usage requires public
+  authoring access.
+- Keep state layers internal-first until semantic names and mode behavior are approved. Do not create
+  public `WooTheme.stateAlpha` floats from mode-aware state-layer color tokens.
+- Do not create public `WooTheme.minimumTouchTarget` from legacy dimensions or screen-size variables.
+
+## Theme Root Strategy
+
+Screen migration is explicit: migrated screens opt into the design-system root, and non-migrated
+screens stay on the legacy root. Do not add root-selection indirection to arbitrary/default
+`composeView {}` calls; a screen is migrated by changing its call site to the DS root builder.
+
+During migration work, introduce or use a DS-specific builder such as `designSystemComposeView {}`.
+That name is transitional: before the final merge of the migration branch, run a controlled rename
+boundary where the current legacy `composeView` becomes `legacyComposeView`, the current
+`WooThemeWithBackground` becomes `LegacyWooThemeWithBackground`, and the DS-specific builder becomes
+`composeView`.
+
+That final API shape should make the intended root obvious at call sites during migration and
+restore `composeView` as the DS default only after legacy call sites are renamed. Every remaining
+`composeView` call must be intentionally migrated, every non-migrated screen must use
+`legacyComposeView`, and the boundary must be verified with strict `rg` audits.
+
+The Store design-system module still owns pure foundations/components and still does not import app
+`R`, Hilt, POS, or Store feature packages. Do not document a legacy-compatible design-system
+foundation bridge as required for this rollout path unless a future implementation explicitly
+chooses that bridge.
+
+Do not globally remap existing `Woo*`, `WC*`, XML styles, colors, typography, or app theme resources
+in the foundation PR. Later legacy convergence is intentionally narrower: safe color/chrome tokens only,
+as described in [rollout-direction.md](rollout-direction.md).
+
+## Rollout Strategy
+
+Migrate screens once to design-system components. Do not keep duplicate `LegacyScreen` and
+`DesignSystemScreen` implementations for ordinary migrations.
+
+- Use explicit root builders to make migrated and non-migrated call sites clear.
+- Screen code should not branch between legacy and design-system UI trees as a permanent structure.
+- The first-wave scope is fixed in [rollout-direction.md](rollout-direction.md).
+- Temporary full-screen fallbacks inside in-scope screens are allowed only for genuinely high-risk
+  migration gaps and must have an explicit expiry/removal plan.
+- Out-of-scope child flows may remain legacy for this wave without an expiry plan.
+- Do not add broad component variants unless there is a clear rollout need.
+
+No design-system component should depend on hardcoded light fallback defaults. Rendering a
+design-system component under the design-system root must receive valid `WooTheme.colors`,
+`WooTheme.text`, `WooTheme.spacing`, `WooTheme.padding`, `WooTheme.radius`, and `WooTheme.iconSize`
+values.
+
+## Chrome Component Compatibility
+
+Top app bar/chrome migration is not just a token change. Moving from the Activity toolbar to Compose
+`WooTopAppBar` changes chrome ownership and structure.
+
+The direction is a unified design-system visual look, not one mandatory implementation:
+
+- Compose-owned screens use `WooTopAppBar`.
+- Heavy XML screens may keep XML toolbar ownership if the toolbar matches the design-system look.
+- Migrated Compose-owned screens render `WooTopAppBar` under the design-system root.
+- Legacy-heavy screens can preserve existing toolbar ownership unless a scoped migration chooses a
+  DS-looking XML toolbar or an explicit Compose chrome migration.
+- Preserve `SearchView`, `ActionMode`, collapsing app bars, menu/action ownership, navigation
+  ownership, and insets.
+- A DS-looking XML toolbar is acceptable for legacy-heavy screens when changing toolbar ownership would
+  turn the UI migration into a broader app rewrite.
+
+## Token Strategy
+
+i1 uses manual Kotlin/Compose runtime token definitions first.
+
+- Use `docs/design-system/material3-reference.md` for official Material 3 role semantics, Compose
+  API pointers, and default scale references while mapping i1 foundations.
+- Keep adapter token names stable and screen-facing.
+- Use source-backed names and shallow intent groups for public Store authoring roles under `WooTheme`.
+- Product-screen and design-system component code should read approved foundations from `WooTheme`,
+  for example `WooTheme.colors.primary`, `WooTheme.text.titleMedium.emphasized`,
+  `WooTheme.spacing.space5`, `WooTheme.padding.padding5`, and `WooTheme.radius.medium`.
+- `MaterialTheme.colorScheme`, `MaterialTheme.typography`, and `MaterialTheme.shapes` are interop
+  projections for Material 3 components, defaults, and helpers. Use them when a Material API requires
+  them, not as the primary Store design-system authoring surface.
+- `WooTheme.colors` should expose source-backed Store authoring roles from `figma-export.json` /
+  `Woo theme`, grouped shallowly by source intent.
+- Do not limit `WooTheme.colors` to a small curated Material 3-like subset.
+- Parse Store runtime/public foundations from non-`Semantic` top-level sections in
+  `figma-export.json`.
+- Keep top-level `Semantic` in the export for traceability, but ignore it for Store runtime/public
+  mapping and Material projections unless a future component audit updates the contract.
+- Use normal `Light` / `Dark` values for runtime color modes. Keep high-contrast values out of
+  normal runtime mapping until accessibility-mode scope is decided.
+- Use Android typography mode values from `Typescale`; `Typescale/<Role>/Font` resolves through
+  `Font theme/Font/Plain`, whose Android value is `Roboto`. Android default font is the accepted
+  runtime equivalent.
+- Do not create `WooTheme.semanticColors`; supported status, alert, overlay, and palette colors live
+  as grouped fields under `WooTheme.colors`.
+- Keep Material 3-only projection aliases internal. Do not expose generated Material aliases such as
+  fixed roles or surface-container aliases unless those names are real source-backed tokens.
+- The runtime may intentionally leave unsupported Material 3 roles on builder defaults when a Store
+  token would be a guess. Project source-backed container and promoted surface roles from Store
+  fields, including `surfaceBright`.
+- `outline` and `outlineVariant` are source-backed tokens and public under `WooTheme.colors`.
+- Preserve source intent with shallow groups such as core, container, surface, outline, status,
+  alert, background, overlay, and palette.
+- Keep unresolved non-color Figma variables tracked in docs or internal mapping first, but
+  source-backed color tokens still belong in the public foundation surface.
+- `WooTheme.radius` and `WooTheme.iconSize` are public because both are source-backed
+  design-system foundations. `WooTheme.iconSize` is glyph-size only; it is not a generic layout-size
+  or touch-target API. `WooStroke` remains internal until a production component needs public access.
+  Unresolved foundation groups may stay documented-only.
+- Keep source token names in documentation and internal mapping metadata when useful, but do not
+  record raw Figma variable IDs in repo docs.
+- Structure token definitions so a future Figma generation pipeline can update adapter internals
+  without changing screen APIs.
+- Every token that reaches production APIs must be represented in `docs/design-system/token-map.md`.
+- Keep `WooTheme.colors` as the Store authoring API even when color primitives are resource-backed internally.
+- Store design-system color primitives are the XML-safe exception and may live in module-local
+  Android color resources so Compose and targeted XML/View usage share the same values.
+- Non-color foundations remain Kotlin/Compose-owned: typography, spacing, padding, radius, icon
+  size, and stroke do not move to Android resources as part of this adapter layer.
+- Do not keep parallel Kotlin/Compose and XML resource definitions for the same token primitive value.
+
+## Component Strategy
+
+- Implement the i1 catalog as Compose-first components with previews.
+- Wrap Material 3 components where the design intent maps cleanly.
+- Build custom components only when Material 3 behavior, shape, state, or layout is materially different.
+- Do not migrate a screen only to consume a component. Screen migration follows [rollout-direction.md](rollout-direction.md).
+- Production screens may import only production-ready components.
+- Preview-only components can be shown in the catalog, but must not expose public product-screen APIs for migration agents to consume.
+
+## Delivery Sequence
+
+Follow `docs/design-system/implementation-plan.md`.
+
+The current sequence is docs, foundation API gate resolution, foundations/theme,
+components/previews, first-wave screen migration, safe legacy theme convergence, and playbook updates
+from real migration findings.
+
+## View/XML Compatibility
+
+Fragment-hosted Compose layout migration is preferred for new and substantially redesigned Store
+surfaces, but it is not mandatory for every legacy flow.
+
+For first-wave heavy XML surfaces, use `ComposeView` for migrated sections, rows, or content areas
+while retaining the XML shell only where compatibility requires it. The retained shell is not the XML
+bridge strategy; it is a compatibility boundary around migrated design-system content.
+
+Some out-of-scope child flows should remain XML/View during this wave. Those screens can still receive
+targeted token/style updates during legacy convergence if doing so is low-risk and does not force a
+global theme replacement.
+
+When XML/View screens need design-system styling, consume only the required shared color resources
+and keep Compose reading those same resources through `WooTheme.colors`.
+
+Do not create XML resources for non-color primitives as the primary implementation. Typography,
+spacing, padding, radius, icon size, stroke, state layers, elevation, and minimum touch target remain
+Kotlin/Compose-owned or unresolved unless a later approved plan changes that boundary.

--- a/docs/design-system/component-catalog.md
+++ b/docs/design-system/component-catalog.md
@@ -33,8 +33,8 @@ Production components should read approved foundation values through `WooTheme.*
 inside wrappers when Material 3 components or defaults require interop projection values.
 
 Production components must render correctly under the design-system root and must not rely on static
-fallback defaults such as `LightWooColors`. Non-migrated screens stay on the legacy root and should
-not consume production design-system components until explicitly migrated.
+hardcoded light fallback defaults. Non-migrated screens stay on the legacy root and should not
+consume production design-system components until explicitly migrated.
 
 Do not add additional thin wrappers beyond this subset unless a later design-system decision
 explicitly expands the catalog. This prevents the adapter from becoming an unlimited Material 3
@@ -48,9 +48,8 @@ Older Store Compose screens may use the project `LightDarkThemePreviews` annotat
 design-system foundations, components, preview catalog entries, and first-wave screen updates should
 use `@PreviewLightDark`.
 
-Design-system component previews should wrap content in `WooDesignSystemTheme`, not
-`WooThemeWithBackground`. Migrated screen previews should cover the design-system root in light and
-dark mode.
+Design-system component previews should wrap content in `WooDesignSystemTheme`, not the legacy Store
+theme root. Migrated screen previews should cover the design-system root in light and dark mode.
 
 Preview coverage is required for every component. Screenshot verification is required for first-wave
 screens and high-risk components, but not for every small primitive component.

--- a/docs/design-system/component-catalog.md
+++ b/docs/design-system/component-catalog.md
@@ -1,0 +1,108 @@
+# Store Design System Component Catalog
+
+This catalog tracks Woo Mobile Design System i1 components for Android.
+
+The goal is to implement the i1 foundation and component catalog with previews, while only allowing
+production-ready APIs into migrated Store screens.
+
+Production design-system components live in the Store-only `:libs:store-design-system` module under
+`com.woocommerce.android.ui.compose.designsystem.*`.
+
+The component PR should provide visual coverage for the full i1 catalog, but it does not need to mark
+every component as production-ready. Components needed by the first-wave tab and top-detail surfaces
+plus low-risk primitives can become production APIs first; unsettled components should remain
+private/internal preview catalog implementations. Rollout scope is defined in
+[rollout-direction.md](rollout-direction.md).
+
+## Initial Production Subset
+
+Before first-wave screen migration begins, production-ready APIs should exist for:
+
+- Top/navigation bar.
+- Page title/body/link text styles or wrappers.
+- Primary button.
+- Settings cell/row.
+- Section header.
+- Switch.
+- Icon button.
+- Divider.
+- Progress indicator.
+- Spacing, radius, color, and typography tokens used by those components.
+
+Production components should read approved foundation values through `WooTheme.*`. `MaterialTheme` remains available
+inside wrappers when Material 3 components or defaults require interop projection values.
+
+Production components must render correctly under the design-system root and must not rely on static
+fallback defaults such as `LightWooColors`. Non-migrated screens stay on the legacy root and should
+not consume production design-system components until explicitly migrated.
+
+Do not add additional thin wrappers beyond this subset unless a later design-system decision
+explicitly expands the catalog. This prevents the adapter from becoming an unlimited Material 3
+wrapper library.
+
+## Preview Standard
+
+Use `androidx.compose.ui.tooling.preview.PreviewLightDark` for design-system component previews.
+
+Older Store Compose screens may use the project `LightDarkThemePreviews` annotation. New
+design-system foundations, components, preview catalog entries, and first-wave screen updates should
+use `@PreviewLightDark`.
+
+Design-system component previews should wrap content in `WooDesignSystemTheme`, not
+`WooThemeWithBackground`. Migrated screen previews should cover the design-system root in light and
+dark mode.
+
+Preview coverage is required for every component. Screenshot verification is required for first-wave
+screens and high-risk components, but not for every small primitive component.
+
+## Status Values
+
+- `production`: Stable API, visual states, accessibility behavior, and previews.
+- `preview_only`: Implemented for catalog or design review, but not exposed as a reusable production-screen API.
+- `needs_design`: Design intent or required states are not signed off.
+- `needs_android_mapping`: Android API or Material 3 mapping is not resolved.
+
+## Catalog
+
+| Component | Android API | Strategy | Status | Required previews | Notes |
+| --- | --- | --- | --- | --- | --- |
+| Badges | TBD | Material 3 wrapper or custom after review | needs_android_mapping | Light/dark, states | i1 component. |
+| Buttons | TBD | Material 3 wrapper first | needs_android_mapping | Light/dark, enabled/disabled/loading if supported | First-wave screens need primary actions. |
+| Cell | TBD | Material 3 wrapper or custom after review | needs_android_mapping | Light/dark, leading/trailing content | Common migration component. |
+| Cell Content | TBD | Custom composition if needed | needs_android_mapping | Light/dark, text density variants | Pair with Cell. |
+| Check Box | TBD | Material 3 wrapper first | needs_android_mapping | Light/dark, checked/unchecked/disabled | Form candidate. |
+| Chip | TBD | Material 3 wrapper first | needs_android_mapping | Light/dark, selected/unselected/disabled | Filter/search candidate. |
+| Divider | TBD | Material 3 wrapper first | needs_android_mapping | Light/dark | Low-risk early component. |
+| Icons | TBD | Existing icon assets plus token mapping | needs_android_mapping | Light/dark, sizing | Avoid new naming until icon policy is clear. |
+| Navigation Bar | TBD | Material 3 wrapper or app-specific custom | needs_android_mapping | Light/dark, navigation/action/search/collapse states | Unified visual spec across Compose `WooTopAppBar` and DS-looking XML toolbar. |
+| Page Header | TBD | Custom composition if needed | needs_android_mapping | Light/dark, title/subtitle variants | Useful for screen migrations. |
+| Radio Button | TBD | Material 3 wrapper first | needs_android_mapping | Light/dark, selected/unselected/disabled | Form candidate. |
+| Search | TBD | Material 3 wrapper or custom after review | needs_android_mapping | Light/dark, focused/unfocused/query states | Existing search components may inform behavior only. |
+| Segment Control | TBD | Preview-only until design signed off | preview_only | Light/dark, selected states | i1 marks this in progress. |
+| Sheets | TBD | Material 3 wrapper first | needs_android_mapping | Light/dark, content variants | Migration should preserve navigation/event ownership. |
+| Tab Bar | TBD | Material 3 wrapper first | needs_android_mapping | Light/dark, selected/unselected | Existing `WCPrimaryTabRow` remains legacy. |
+| Table | TBD | Custom after review | needs_android_mapping | Light/dark, row density variants | Likely high migration cost on real screens. |
+| Progress Indicator | TBD | Thin Material 3 wrapper | needs_android_mapping | Light/dark, indeterminate/determinate if supported | Not listed as an i1 Figma component. Candidate wrapper for the component PR. |
+
+## Production Checklist
+
+Before a component is marked `production`:
+
+- It uses `Woo` naming inside `com.woocommerce.android.ui.compose.designsystem`.
+- It is wrapped by `WooDesignSystemTheme` in design-system previews.
+- It reads production foundation values through `WooTheme.*`, except where a Material 3 API requires `MaterialTheme`
+  interop values.
+- It has light and dark previews through `@PreviewLightDark`.
+- Required states are covered in previews.
+- Screenshot verification is completed if the component is high-risk.
+- Accessibility is reviewed: semantic role where applicable, label/contentDescription rules, disabled
+  state behavior, minimum touch target, and font-scale resilience.
+- Its tokens are mapped in `docs/design-system/token-map.md`.
+- It does not depend on POS APIs or POS design-system concepts.
+
+## Preview-Only Boundary
+
+Preview-only components may exist only as private/internal catalog or preview implementations, preferably under `designsystem.preview`.
+
+Do not expose preview-only components as reusable public APIs. This keeps product-screen migrations
+and AI agents from importing components that are not signed off.

--- a/docs/design-system/figma-export.json
+++ b/docs/design-system/figma-export.json
@@ -1,0 +1,2062 @@
+{
+  "Woo theme": {
+    "Background": {
+      "Section-Background": {
+        "$value": {
+          "Light": "#f2f2f8",
+          "Dark": "#101517",
+          "Light High Contrast": "#f2f2f8",
+          "Dark High Contrast": "#101517"
+        },
+        "$type": "color"
+      },
+      "On-Section-Background": {
+        "$value": {
+          "Light": "#1e1e1e",
+          "Dark": "#ffffff",
+          "Light High Contrast": "#1e1e1e",
+          "Dark High Contrast": "#ffffff"
+        },
+        "$type": "color"
+      },
+      "Section-Background-Variant": {
+        "$value": {
+          "Light": "#f0f0f0",
+          "Dark": "#101517",
+          "Light High Contrast": "#f0f0f0",
+          "Dark High Contrast": "#101517"
+        },
+        "$type": "color"
+      },
+      "On-Section-Background-Variant": {
+        "$value": {
+          "Light": "#1c1c1e",
+          "Dark": "#8b8a8e",
+          "Light High Contrast": "#1c1c1e",
+          "Dark High Contrast": "#8b8a8e"
+        },
+        "$type": "color"
+      }
+    },
+    "Primary": {
+      "$value": {
+        "Light": "#873eff",
+        "Dark": "#873eff",
+        "Light High Contrast": "#873eff",
+        "Dark High Contrast": "#873eff"
+      },
+      "$type": "color"
+    },
+    "On-Primary": {
+      "$value": {
+        "Light": "#ffffff",
+        "Dark": "#ffffff",
+        "Light High Contrast": "#ffffff",
+        "Dark High Contrast": "#ffffff"
+      },
+      "$type": "color"
+    },
+    "Secondary": {
+      "$value": {
+        "Light": "#6108ce",
+        "Dark": "#383146",
+        "Light High Contrast": "#eae2fe",
+        "Dark High Contrast": "#383146"
+      },
+      "$type": "color"
+    },
+    "On-Secondary": {
+      "$value": {
+        "Light": "#ffffff",
+        "Dark": "#f1edfe",
+        "Light High Contrast": "#873eff",
+        "Dark High Contrast": "#f1edfe"
+      },
+      "$type": "color"
+    },
+    "Primary-Container": {
+      "$value": {
+        "Light": "#b999ff",
+        "Dark": "#ffffff",
+        "Light High Contrast": "#ffffff",
+        "Dark High Contrast": "#ffffff"
+      },
+      "$type": "color"
+    },
+    "On-Primary-Container": {
+      "$value": {
+        "Light": "#2c045d",
+        "Dark": "#ffffff",
+        "Light High Contrast": "#ffffff",
+        "Dark High Contrast": "#ffffff"
+      },
+      "$type": "color"
+    },
+    "Secondary-Container": {
+      "$value": {
+        "Light": "#f2edff",
+        "Dark": "#ffffff",
+        "Light High Contrast": "#ffffff",
+        "Dark High Contrast": "#ffffff"
+      },
+      "$type": "color"
+    },
+    "On-Secondary-Container": {
+      "$value": {
+        "Light": "#873eff",
+        "Dark": "#ffffff",
+        "Light High Contrast": "#ffffff",
+        "Dark High Contrast": "#ffffff"
+      },
+      "$type": "color"
+    },
+    "Alerts": {
+      "Error-Container": {
+        "$value": {
+          "Light": "#f6e6e3",
+          "Dark": "#f6e6e3",
+          "Light High Contrast": "#f6e6e3",
+          "Dark High Contrast": "rgba(246, 230, 227, 0.9)"
+        },
+        "$type": "color"
+      },
+      "On-Error-Container": {
+        "$value": {
+          "Light": "#470000",
+          "Dark": "#470000",
+          "Light High Contrast": "#470000",
+          "Dark High Contrast": "#470000"
+        },
+        "$type": "color"
+      },
+      "Warning-Container": {
+        "$value": {
+          "Light": "#fde6be",
+          "Dark": "#fde6be",
+          "Light High Contrast": "#fde6be",
+          "Dark High Contrast": "rgba(253, 230, 190, 0.9)"
+        },
+        "$type": "color"
+      },
+      "On-Warning-Container": {
+        "$value": {
+          "Light": "#2e1900",
+          "Dark": "#2e1900",
+          "Light High Contrast": "#2e1900",
+          "Dark High Contrast": "#2e1900"
+        },
+        "$type": "color"
+      },
+      "Caution-Container": {
+        "$value": {
+          "Light": "#fee995",
+          "Dark": "#fee995",
+          "Light High Contrast": "#fee995",
+          "Dark High Contrast": "rgba(254, 233, 149, 0.9)"
+        },
+        "$type": "color"
+      },
+      "On-Caution-Container": {
+        "$value": {
+          "Light": "#281d00",
+          "Dark": "#281d00",
+          "Light High Contrast": "#281d00",
+          "Dark High Contrast": "#281d00"
+        },
+        "$type": "color"
+      },
+      "Success-Container": {
+        "$value": {
+          "Light": "#c6f7cd",
+          "Dark": "#c6f7cd",
+          "Light High Contrast": "#c6f7cd",
+          "Dark High Contrast": "rgba(198, 247, 205, 0.9)"
+        },
+        "$type": "color"
+      },
+      "On-Success-Container": {
+        "$value": {
+          "Light": "#002900",
+          "Dark": "#002900",
+          "Light High Contrast": "#002900",
+          "Dark High Contrast": "#002900"
+        },
+        "$type": "color"
+      },
+      "Info-Container": {
+        "$value": {
+          "Light": "#deebfa",
+          "Dark": "#deebfa",
+          "Light High Contrast": "#deebfa",
+          "Dark High Contrast": "rgba(222, 235, 250, 0.9)"
+        },
+        "$type": "color"
+      },
+      "On-Info-Container": {
+        "$value": {
+          "Light": "#001b4f",
+          "Dark": "#001b4f",
+          "Light High Contrast": "#001b4f",
+          "Dark High Contrast": "#001b4f"
+        },
+        "$type": "color"
+      },
+      "Neutral-Container": {
+        "$value": {
+          "Light": "#f4f4f4",
+          "Dark": "#f4f4f4",
+          "Light High Contrast": "#f4f4f4",
+          "Dark High Contrast": "rgba(244, 244, 244, 0.9)"
+        },
+        "$type": "color"
+      },
+      "On-Neutral-Container": {
+        "$value": {
+          "Light": "#1e1e1e",
+          "Dark": "#1e1e1e",
+          "Light High Contrast": "#1e1e1e",
+          "Dark High Contrast": "#1e1e1e"
+        },
+        "$type": "color"
+      },
+      "Red": {
+        "$value": {
+          "Light": "#fc4a5b",
+          "Dark": "#dc3545",
+          "Light High Contrast": "#fc4a5b",
+          "Dark High Contrast": "#dc3545"
+        },
+        "$type": "color"
+      },
+      "On-Red": {
+        "$value": {
+          "Light": "#ffffff",
+          "Dark": "#dc3545",
+          "Light High Contrast": "#fc4a5b",
+          "Dark High Contrast": "#dc3545"
+        },
+        "$type": "color"
+      },
+      "Orange": {
+        "$value": {
+          "Light": "#ff9000",
+          "Dark": "#eaab2d",
+          "Light High Contrast": "#eaab2d",
+          "Dark High Contrast": "#eaab2d"
+        },
+        "$type": "color"
+      },
+      "On-Orange": {
+        "$value": {
+          "Light": "#ffffff",
+          "Dark": "#eaab2d",
+          "Light High Contrast": "#eaab2d",
+          "Dark High Contrast": "#eaab2d"
+        },
+        "$type": "color"
+      },
+      "Green": {
+        "$value": {
+          "Light": "#27ae32",
+          "Dark": "#69b66f",
+          "Light High Contrast": "#27ae32",
+          "Dark High Contrast": "#69b66f"
+        },
+        "$type": "color"
+      },
+      "On-Green": {
+        "$value": {
+          "Light": "#ffffff",
+          "Dark": "#69b66f",
+          "Light High Contrast": "#27ae32",
+          "Dark High Contrast": "#69b66f"
+        },
+        "$type": "color"
+      },
+      "Blue": {
+        "$value": {
+          "Light": "#1e94d0",
+          "Dark": "#1e94d0",
+          "Light High Contrast": "#1e94d0",
+          "Dark High Contrast": "#1e94d0"
+        },
+        "$type": "color"
+      },
+      "On-Blue": {
+        "$value": {
+          "Light": "#ffffff",
+          "Dark": "#1e94d0",
+          "Light High Contrast": "#1e94d0",
+          "Dark High Contrast": "#1e94d0"
+        },
+        "$type": "color"
+      }
+    },
+    "Outline": {
+      "Outline": {
+        "$value": {
+          "Light": "#787c82",
+          "Dark": "#454549",
+          "Light High Contrast": "#787c82",
+          "Dark High Contrast": "#454549"
+        },
+        "$type": "color"
+      },
+      "Outline-Variant": {
+        "$value": {
+          "Light": "#dcdcde",
+          "Dark": "#5e5e63",
+          "Light High Contrast": "#d2d2d8",
+          "Dark High Contrast": "#5e5e63"
+        },
+        "$type": "color"
+      }
+    },
+    "Surface": {
+      "Surface-Dim": {
+        "$value": {
+          "Light": "#f6f7f7",
+          "Dark": "#232529",
+          "Light High Contrast": "#ffffff",
+          "Dark High Contrast": "#232529"
+        },
+        "$type": "color"
+      },
+      "Surface-Bright": {
+        "$value": {
+          "Light": "#ffffff",
+          "Dark": "#232529",
+          "Light High Contrast": "#ffffff",
+          "Dark High Contrast": "#232529"
+        },
+        "$type": "color"
+      },
+      "Surface": {
+        "$value": {
+          "Light": "#ffffff",
+          "Dark": "#232529",
+          "Light High Contrast": "#ffffff",
+          "Dark High Contrast": "#232529"
+        },
+        "$type": "color"
+      },
+      "Surface-Container-Highest": {
+        "$value": {
+          "Light": "#dcdcde",
+          "Dark": "#232529",
+          "Light High Contrast": "#ffffff",
+          "Dark High Contrast": "#232529"
+        },
+        "$type": "color"
+      },
+      "On-Surface": {
+        "$value": {
+          "Light": "#000000",
+          "Dark": "#ffffff",
+          "Light High Contrast": "#1e1e1e",
+          "Dark High Contrast": "#ffffff"
+        },
+        "$type": "color"
+      },
+      "On-Surface-Variant": {
+        "$value": {
+          "Light": "#2c3338",
+          "Dark": "#626068",
+          "Light High Contrast": "#50575e",
+          "Dark High Contrast": "#626068"
+        },
+        "$type": "color"
+      },
+      "On-Surface-Variant-Lowest": {
+        "$value": {
+          "Light": "#50575e",
+          "Dark": "#626068",
+          "Light High Contrast": "#50575e",
+          "Dark High Contrast": "#626068"
+        },
+        "$type": "color"
+      },
+      "Inverse-Surface": {
+        "$value": {
+          "Light": "#000000",
+          "Dark": "#ffffff",
+          "Light High Contrast": "#1c1c1e",
+          "Dark High Contrast": "#ffffff"
+        },
+        "$type": "color"
+      },
+      "On-Inverse-Surface": {
+        "$value": {
+          "Light": "#ffffff",
+          "Dark": "#000000",
+          "Light High Contrast": "#ffffff",
+          "Dark High Contrast": "#1e1e1e"
+        },
+        "$type": "color"
+      }
+    },
+    "Overlay": {
+      "Opacity-20": {
+        "$value": {
+          "Light": "rgba(0, 0, 0, 0.2)",
+          "Dark": "rgba(0, 0, 0, 0.2)",
+          "Light High Contrast": "rgba(0, 0, 0, 0.2)",
+          "Dark High Contrast": "rgba(0, 0, 0, 0.2)"
+        },
+        "$type": "color"
+      },
+      "Opacity-50": {
+        "$value": {
+          "Light": "rgba(0, 0, 0, 0.5)",
+          "Dark": "rgba(0, 0, 0, 0.75)",
+          "Light High Contrast": "rgba(0, 0, 0, 0.5)",
+          "Dark High Contrast": "rgba(0, 0, 0, 0.75)"
+        },
+        "$type": "color"
+      }
+    },
+    "Add-On-Colors": {
+      "Woo-Blue": {
+        "20": {
+          "$value": {
+            "Light": "#75ffff",
+            "Dark": "#75ffff",
+            "Light High Contrast": "#75ffff",
+            "Dark High Contrast": "#75ffff"
+          },
+          "$type": "color"
+        },
+        "40": {
+          "$value": {
+            "Light": "#1ad0fd",
+            "Dark": "#1ad0fd",
+            "Light High Contrast": "#1ad0fd",
+            "Dark High Contrast": "#1ad0fd"
+          },
+          "$type": "color"
+        },
+        "60": {
+          "$value": {
+            "Light": "#05096c",
+            "Dark": "#05096c",
+            "Light High Contrast": "#05096c",
+            "Dark High Contrast": "#05096c"
+          },
+          "$type": "color"
+        }
+      },
+      "Woo-Green": {
+        "20": {
+          "$value": {
+            "Light": "#d5ff4a",
+            "Dark": "#d5ff4a",
+            "Light High Contrast": "#d5ff4a",
+            "Dark High Contrast": "#d5ff4a"
+          },
+          "$type": "color"
+        },
+        "40": {
+          "$value": {
+            "Light": "#06e782",
+            "Dark": "#06e782",
+            "Light High Contrast": "#06e782",
+            "Dark High Contrast": "#06e782"
+          },
+          "$type": "color"
+        },
+        "60": {
+          "$value": {
+            "Light": "#083d2d",
+            "Dark": "#083d2d",
+            "Light High Contrast": "#083d2d",
+            "Dark High Contrast": "#083d2d"
+          },
+          "$type": "color"
+        }
+      },
+      "Woo-Orange": {
+        "20": {
+          "$value": {
+            "Light": "#ffe500",
+            "Dark": "#ffe500",
+            "Light High Contrast": "#ffe500",
+            "Dark High Contrast": "#ffe500"
+          },
+          "$type": "color"
+        },
+        "40": {
+          "$value": {
+            "Light": "#ff9000",
+            "Dark": "#ff9000",
+            "Light High Contrast": "#ff9000",
+            "Dark High Contrast": "#ff9000"
+          },
+          "$type": "color"
+        },
+        "60": {
+          "$value": {
+            "Light": "#ff4800",
+            "Dark": "#ff4800",
+            "Light High Contrast": "#ff4800",
+            "Dark High Contrast": "#ff4800"
+          },
+          "$type": "color"
+        }
+      },
+      "Woo-Pink": {
+        "20": {
+          "$value": {
+            "Light": "#fca8ff",
+            "Dark": "#fca8ff",
+            "Light High Contrast": "#fca8ff",
+            "Dark High Contrast": "#fca8ff"
+          },
+          "$type": "color"
+        },
+        "40": {
+          "$value": {
+            "Light": "#ff45e3",
+            "Dark": "#ff45e3",
+            "Light High Contrast": "#ff45e3",
+            "Dark High Contrast": "#ff45e3"
+          },
+          "$type": "color"
+        },
+        "60": {
+          "$value": {
+            "Light": "#4e0061",
+            "Dark": "#4e0061",
+            "Light High Contrast": "#4e0061",
+            "Dark High Contrast": "#4e0061"
+          },
+          "$type": "color"
+        }
+      },
+      "Woo-Purple": {
+        "0": {
+          "$value": {
+            "Light": "#f2edff",
+            "Dark": "#f2edff",
+            "Light High Contrast": "#f2edff",
+            "Dark High Contrast": "#f2edff"
+          },
+          "$type": "color"
+        },
+        "5": {
+          "$value": {
+            "Light": "#e1d7ff",
+            "Dark": "#e1d7ff",
+            "Light High Contrast": "#e1d7ff",
+            "Dark High Contrast": "#e1d7ff"
+          },
+          "$type": "color"
+        },
+        "10": {
+          "$value": {
+            "Light": "#d1c1ff",
+            "Dark": "#d1c1ff",
+            "Light High Contrast": "#d1c1ff",
+            "Dark High Contrast": "#d1c1ff"
+          },
+          "$type": "color"
+        },
+        "20": {
+          "$value": {
+            "Light": "#b999ff",
+            "Dark": "#b999ff",
+            "Light High Contrast": "#b999ff",
+            "Dark High Contrast": "#b999ff"
+          },
+          "$type": "color"
+        },
+        "30": {
+          "$value": {
+            "Light": "#a77eff",
+            "Dark": "#a77eff",
+            "Light High Contrast": "#a77eff",
+            "Dark High Contrast": "#a77eff"
+          },
+          "$type": "color"
+        },
+        "40": {
+          "$value": {
+            "Light": "#873eff",
+            "Dark": "#873eff",
+            "Light High Contrast": "#873eff",
+            "Dark High Contrast": "#873eff"
+          },
+          "$type": "color"
+        },
+        "50": {
+          "$value": {
+            "Light": "#720eec",
+            "Dark": "#720eec",
+            "Light High Contrast": "#720eec",
+            "Dark High Contrast": "#720eec"
+          },
+          "$type": "color"
+        },
+        "60": {
+          "$value": {
+            "Light": "#6108ce",
+            "Dark": "#6108ce",
+            "Light High Contrast": "#6108ce",
+            "Dark High Contrast": "#6108ce"
+          },
+          "$type": "color"
+        },
+        "70": {
+          "$value": {
+            "Light": "#5007aa",
+            "Dark": "#5007aa",
+            "Light High Contrast": "#5007aa",
+            "Dark High Contrast": "#5007aa"
+          },
+          "$type": "color"
+        },
+        "80": {
+          "$value": {
+            "Light": "#3c087e",
+            "Dark": "#3c087e",
+            "Light High Contrast": "#3c087e",
+            "Dark High Contrast": "#3c087e"
+          },
+          "$type": "color"
+        },
+        "90": {
+          "$value": {
+            "Light": "#2c045d",
+            "Dark": "#2c045d",
+            "Light High Contrast": "#2c045d",
+            "Dark High Contrast": "#2c045d"
+          },
+          "$type": "color"
+        },
+        "100": {
+          "$value": {
+            "Light": "#1f0342",
+            "Dark": "#1f0342",
+            "Light High Contrast": "#1f0342",
+            "Dark High Contrast": "#1f0342"
+          },
+          "$type": "color"
+        }
+      },
+      "Woo-Sandstone": {
+        "5": {
+          "$value": {
+            "Light": "#fbf9f6",
+            "Dark": "#fbf9f6",
+            "Light High Contrast": "#fbf9f6",
+            "Dark High Contrast": "#fbf9f6"
+          },
+          "$type": "color"
+        },
+        "10": {
+          "$value": {
+            "Light": "#f1eeeb",
+            "Dark": "#f1eeeb",
+            "Light High Contrast": "#f1eeeb",
+            "Dark High Contrast": "#f1eeeb"
+          },
+          "$type": "color"
+        },
+        "20": {
+          "$value": {
+            "Light": "#e6e2de",
+            "Dark": "#e6e2de",
+            "Light High Contrast": "#e6e2de",
+            "Dark High Contrast": "#e6e2de"
+          },
+          "$type": "color"
+        },
+        "40": {
+          "$value": {
+            "Light": "#c5c2bf",
+            "Dark": "#c5c2bf",
+            "Light High Contrast": "#c5c2bf",
+            "Dark High Contrast": "#c5c2bf"
+          },
+          "$type": "color"
+        },
+        "60": {
+          "$value": {
+            "Light": "#8b8a89",
+            "Dark": "#8b8a89",
+            "Light High Contrast": "#8b8a89",
+            "Dark High Contrast": "#8b8a89"
+          },
+          "$type": "color"
+        }
+      },
+      "Gray": {
+        "0": {
+          "$value": {
+            "Light": "#f6f7f7",
+            "Dark": "#f6f7f7",
+            "Light High Contrast": "#f6f7f7",
+            "Dark High Contrast": "#f6f7f7"
+          },
+          "$type": "color"
+        },
+        "5": {
+          "$value": {
+            "Light": "#dcdcde",
+            "Dark": "#dcdcde",
+            "Light High Contrast": "#dcdcde",
+            "Dark High Contrast": "#dcdcde"
+          },
+          "$type": "color"
+        },
+        "10": {
+          "$value": {
+            "Light": "#c3c4c7",
+            "Dark": "#c3c4c7",
+            "Light High Contrast": "#c3c4c7",
+            "Dark High Contrast": "#c3c4c7"
+          },
+          "$type": "color"
+        },
+        "20": {
+          "$value": {
+            "Light": "#a7aaad",
+            "Dark": "#a7aaad",
+            "Light High Contrast": "#a7aaad",
+            "Dark High Contrast": "#a7aaad"
+          },
+          "$type": "color"
+        },
+        "30": {
+          "$value": {
+            "Light": "#8c8f94",
+            "Dark": "#8c8f94",
+            "Light High Contrast": "#8c8f94",
+            "Dark High Contrast": "#8c8f94"
+          },
+          "$type": "color"
+        },
+        "40": {
+          "$value": {
+            "Light": "#787c82",
+            "Dark": "#787c82",
+            "Light High Contrast": "#787c82",
+            "Dark High Contrast": "#787c82"
+          },
+          "$type": "color"
+        },
+        "50": {
+          "$value": {
+            "Light": "#646970",
+            "Dark": "#646970",
+            "Light High Contrast": "#646970",
+            "Dark High Contrast": "#646970"
+          },
+          "$type": "color"
+        },
+        "60": {
+          "$value": {
+            "Light": "#50575e",
+            "Dark": "#50575e",
+            "Light High Contrast": "#50575e",
+            "Dark High Contrast": "#50575e"
+          },
+          "$type": "color"
+        },
+        "70": {
+          "$value": {
+            "Light": "#3c434a",
+            "Dark": "#3c434a",
+            "Light High Contrast": "#3c434a",
+            "Dark High Contrast": "#3c434a"
+          },
+          "$type": "color"
+        },
+        "80": {
+          "$value": {
+            "Light": "#2c3338",
+            "Dark": "#2c3338",
+            "Light High Contrast": "#2c3338",
+            "Dark High Contrast": "#2c3338"
+          },
+          "$type": "color"
+        },
+        "90": {
+          "$value": {
+            "Light": "#1d2327",
+            "Dark": "#1d2327",
+            "Light High Contrast": "#1d2327",
+            "Dark High Contrast": "#1d2327"
+          },
+          "$type": "color"
+        },
+        "100": {
+          "$value": {
+            "Light": "#101517",
+            "Dark": "#101517",
+            "Light High Contrast": "#101517",
+            "Dark High Contrast": "#101517"
+          },
+          "$type": "color"
+        }
+      }
+    },
+    "State-Layers": {
+      "On-Surface": {
+        "Opacity-08": {
+          "$value": {
+            "Light": "rgba(30, 30, 30, 0.08)",
+            "Dark": "#1e1e1e",
+            "Light High Contrast": "#ffffff",
+            "Dark High Contrast": "#ffffff"
+          },
+          "$type": "color"
+        },
+        "Opacity-10": {
+          "$value": {
+            "Light": "rgba(30, 30, 30, 0.1)",
+            "Dark": "#ffffff",
+            "Light High Contrast": "#ffffff",
+            "Dark High Contrast": "#ffffff"
+          },
+          "$type": "color"
+        },
+        "Opacity-16": {
+          "$value": {
+            "Light": "rgba(30, 30, 30, 0.16)",
+            "Dark": "#ffffff",
+            "Light High Contrast": "#ffffff",
+            "Dark High Contrast": "#ffffff"
+          },
+          "$type": "color"
+        }
+      }
+    }
+  },
+  "Semantic": {
+    "interactive": {
+      "primary": {
+        "$value": {
+          "Light": "{Woo theme.Add-On Colors.Woo Purple.40}",
+          "Dark": "{Woo theme.Add-On Colors.Woo Purple.30}"
+        },
+        "$type": "color"
+      },
+      "destructive": {
+        "$value": {
+          "Light": "{Woo theme.Puprle.Sandstone.40}",
+          "Dark": "{Woo theme.Puprle.Sandstone.40}"
+        },
+        "$type": "color"
+      }
+    },
+    "primary": {
+      "pressed": {
+        "$value": {
+          "Light": "{Woo theme.Add-On Colors.Woo Purple.70}",
+          "Dark": "{Woo theme.Add-On Colors.Woo Purple.20}"
+        },
+        "$type": "color"
+      }
+    },
+    "text": {
+      "primary": {
+        "$value": {
+          "Light": "#000000",
+          "Dark": "#ffffff"
+        },
+        "$type": "color"
+      },
+      "secondary": {
+        "$value": {
+          "Light": "{Woo theme.Puprle.Gray.40}",
+          "Dark": "{Woo theme.Puprle.Gray.20}"
+        },
+        "$type": "color"
+      },
+      "tertiary": {
+        "$value": {
+          "Light": "{Woo theme.Puprle.Gray.20}",
+          "Dark": "{Woo theme.Puprle.Gray.40}"
+        },
+        "$type": "color"
+      },
+      "disabled": {
+        "$value": {
+          "Light": "{Woo theme.Puprle.Gray.60}",
+          "Dark": "{Woo theme.Puprle.Gray.60}"
+        },
+        "$type": "color"
+      },
+      "on-primary": {
+        "$value": {
+          "Light": "#ffffff",
+          "Dark": "#000000"
+        },
+        "$type": "color"
+      }
+    },
+    "icon": {
+      "primary": {
+        "$value": {
+          "Light": "#000000",
+          "Dark": "{Woo theme.Puprle.Gray.0}"
+        },
+        "$type": "color"
+      }
+    },
+    "surface": {
+      "primary": {
+        "$value": {
+          "Light": "#ffffff",
+          "Dark": "{Woo theme.Puprle.Gray.90}"
+        },
+        "$type": "color"
+      },
+      "secondary": {
+        "$value": {
+          "Light": "{Woo theme.Puprle.Gray.40}",
+          "Dark": "{Woo theme.Puprle.Gray.80}"
+        },
+        "$type": "color"
+      },
+      "overlay": {
+        "$value": {
+          "Light": "{Woo theme.ios.fill.secondary}",
+          "Dark": "{Woo theme.ios.fill.secondary}"
+        },
+        "$type": "color"
+      }
+    },
+    "border": {
+      "default": {
+        "$value": {
+          "Light": "{Woo theme.ios.separator}",
+          "Dark": "{Woo theme.ios.separator}"
+        },
+        "$type": "color"
+      },
+      "focused": {
+        "$value": {
+          "Light": "{Woo theme.Add-On Colors.Woo Purple.40}",
+          "Dark": "{Woo theme.Add-On Colors.Woo Purple.30}"
+        },
+        "$type": "color"
+      }
+    },
+    "status": {
+      "success": {
+        "$value": {
+          "Light": "{Woo theme.Puprle.Green.40}",
+          "Dark": "{Woo theme.Puprle.Green.60}"
+        },
+        "$type": "color"
+      },
+      "error": {
+        "$value": {
+          "Light": "{Woo theme.Puprle.Sandstone.40}",
+          "Dark": "{Woo theme.Puprle.Sandstone.60}"
+        },
+        "$type": "color"
+      },
+      "warning": {
+        "$value": {
+          "Light": "{Woo theme.Puprle.orange.40}",
+          "Dark": "{Woo theme.Puprle.orange.60}"
+        },
+        "$type": "color"
+      }
+    },
+    "label": {
+      "primary": {
+        "$value": {
+          "Light": "#000000",
+          "Dark": "#ffffff"
+        },
+        "$type": "color"
+      },
+      "secondary": {
+        "$value": {
+          "Light": "{Woo theme.Puprle.Gray.40}",
+          "Dark": "{Woo theme.Puprle.Gray.20}"
+        },
+        "$type": "color"
+      },
+      "tertiary": {
+        "$value": {
+          "Light": "{Woo theme.Puprle.Gray.20}",
+          "Dark": "{Woo theme.Puprle.Gray.40}"
+        },
+        "$type": "color"
+      },
+      "disabled": {
+        "$value": {
+          "Light": "{Woo theme.Puprle.Gray.60}",
+          "Dark": "{Woo theme.Puprle.Gray.60}"
+        },
+        "$type": "color"
+      },
+      "on-primary": {
+        "$value": {
+          "Light": "#ffffff",
+          "Dark": "#000000"
+        },
+        "$type": "color"
+      }
+    }
+  },
+  "Spacing": {
+    "Spacing": {
+      "0": {
+        "$value": 0,
+        "$type": "number"
+      },
+      "1": {
+        "$value": 2,
+        "$type": "number"
+      },
+      "2": {
+        "$value": 4,
+        "$type": "number"
+      },
+      "3": {
+        "$value": 8,
+        "$type": "number"
+      },
+      "4": {
+        "$value": 12,
+        "$type": "number"
+      },
+      "5": {
+        "$value": 16,
+        "$type": "number"
+      },
+      "6": {
+        "$value": 20,
+        "$type": "number"
+      },
+      "7": {
+        "$value": 24,
+        "$type": "number"
+      },
+      "8": {
+        "$value": 32,
+        "$type": "number"
+      },
+      "9": {
+        "$value": 40,
+        "$type": "number"
+      },
+      "10": {
+        "$value": 48,
+        "$type": "number"
+      },
+      "11": {
+        "$value": 56,
+        "$type": "number"
+      },
+      "12": {
+        "$value": 64,
+        "$type": "number"
+      }
+    },
+    "Padding": {
+      "0": {
+        "$value": 0,
+        "$type": "number"
+      },
+      "1": {
+        "$value": 2,
+        "$type": "number"
+      },
+      "2": {
+        "$value": 4,
+        "$type": "number"
+      },
+      "3": {
+        "$value": 8,
+        "$type": "number"
+      },
+      "4": {
+        "$value": 12,
+        "$type": "number"
+      },
+      "5": {
+        "$value": 16,
+        "$type": "number"
+      },
+      "6": {
+        "$value": 20,
+        "$type": "number"
+      },
+      "7": {
+        "$value": 24,
+        "$type": "number"
+      },
+      "8": {
+        "$value": 32,
+        "$type": "number"
+      },
+      "9": {
+        "$value": 40,
+        "$type": "number"
+      },
+      "10": {
+        "$value": 48,
+        "$type": "number"
+      },
+      "11": {
+        "$value": 56,
+        "$type": "number"
+      },
+      "12": {
+        "$value": 64,
+        "$type": "number"
+      }
+    }
+  },
+  "Shape": {
+    "Corner-Radius": {
+      "None": {
+        "$value": 0,
+        "$type": "number"
+      },
+      "Extra-small": {
+        "$value": 2,
+        "$type": "number"
+      },
+      "Small": {
+        "$value": 4,
+        "$type": "number"
+      },
+      "Medium": {
+        "$value": 8,
+        "$type": "number"
+      },
+      "Large": {
+        "$value": 12,
+        "$type": "number"
+      },
+      "Extra-large": {
+        "$value": 16,
+        "$type": "number"
+      },
+      "Full": {
+        "$value": 999,
+        "$type": "number"
+      }
+    },
+    "Stroke": {
+      "Weight": {
+        "None": {
+          "$value": 0,
+          "$type": "number"
+        },
+        "Extra-Thin": {
+          "$value": 0.5,
+          "$type": "number"
+        },
+        "Thin": {
+          "$value": 0.75,
+          "$type": "number"
+        },
+        "Regular": {
+          "$value": 1,
+          "$type": "number"
+        },
+        "Medium": {
+          "$value": 1.5,
+          "$type": "number"
+        },
+        "Medium-Increased": {
+          "$value": 2,
+          "$type": "number"
+        },
+        "Thick": {
+          "$value": 3,
+          "$type": "number"
+        },
+        "Extra-Thick": {
+          "$value": 4,
+          "$type": "number"
+        }
+      }
+    }
+  },
+  "Font theme": {
+    "Font": {
+      "Brand": {
+        "$value": {
+          "iOS": "SF Pro Text",
+          "iOS Extra bold": "SF Pro Text",
+          "Android": "Roboto"
+        },
+        "$type": "string"
+      },
+      "Plain": {
+        "$value": {
+          "iOS": "SF Pro Text",
+          "iOS Extra bold": "SF Pro Text",
+          "Android": "Roboto"
+        },
+        "$type": "string"
+      }
+    },
+    "Weight": {
+      "Regular": {
+        "$value": {
+          "iOS": "Regular",
+          "iOS Extra bold": "Regular",
+          "Android": "Regular"
+        },
+        "$type": "string"
+      },
+      "Medium": {
+        "$value": {
+          "iOS": "Medium",
+          "iOS Extra bold": "Semibold",
+          "Android": "Medium"
+        },
+        "$type": "string"
+      },
+      "Bold": {
+        "$value": {
+          "iOS": "Bold",
+          "iOS Extra bold": "Heavy",
+          "Android": "Bold"
+        },
+        "$type": "string"
+      }
+    },
+    "Tracking": {
+      "None": {
+        "$value": {
+          "iOS": 0,
+          "iOS Extra bold": 0,
+          "Android": 0
+        },
+        "$type": "number"
+      },
+      "Small": {
+        "$value": {
+          "iOS": -0.4099999964237213,
+          "iOS Extra bold": -0.4099999964237213,
+          "Android": 0
+        },
+        "$type": "number"
+      }
+    }
+  },
+  "Typescale": {
+    "Display-Large": {
+      "Font": {
+        "$value": {
+          "iOS": "{Font theme.Font.Plain}",
+          "Android": "{Font theme.Font.Plain}"
+        },
+        "$type": "string"
+      },
+      "Weight-Regular": {
+        "$value": {
+          "iOS": "{Font theme.Weight.Regular}",
+          "Android": "{Font theme.Weight.Regular}"
+        },
+        "$type": "string"
+      },
+      "Weight-Emphasized": {
+        "$value": {
+          "iOS": "{Font theme.Weight.Medium}",
+          "Android": "{Font theme.Weight.Medium}"
+        },
+        "$type": "string"
+      },
+      "Weight-Extra-Emphasized": {
+        "$value": {
+          "iOS": "{Font theme.Weight.Bold}",
+          "Android": "{Font theme.Weight.Bold}"
+        },
+        "$type": "string"
+      },
+      "Size": {
+        "$value": {
+          "iOS": 56,
+          "Android": 56
+        },
+        "$type": "number"
+      },
+      "Line-Height": {
+        "$value": {
+          "iOS": 64,
+          "Android": 64
+        },
+        "$type": "number"
+      },
+      "Tracking": {
+        "$value": {
+          "iOS": -2.5,
+          "Android": -0.4099999964237213
+        },
+        "$type": "number"
+      }
+    },
+    "Display-Medium": {
+      "Font": {
+        "$value": {
+          "iOS": "{Font theme.Font.Plain}",
+          "Android": "{Font theme.Font.Plain}"
+        },
+        "$type": "string"
+      },
+      "Weight": {
+        "$value": {
+          "iOS": "{Font theme.Weight.Regular}",
+          "Android": "{Font theme.Weight.Regular}"
+        },
+        "$type": "string"
+      },
+      "Weight-Emphasized": {
+        "$value": {
+          "iOS": "{Font theme.Weight.Medium}",
+          "Android": "{Font theme.Weight.Medium}"
+        },
+        "$type": "string"
+      },
+      "Weight-Strong": {
+        "$value": {
+          "iOS": "{Font theme.Weight.Bold}",
+          "Android": "{Font theme.Weight.Bold}"
+        },
+        "$type": "string"
+      },
+      "Size": {
+        "$value": {
+          "iOS": 48,
+          "Android": 48
+        },
+        "$type": "number"
+      },
+      "Line-Height": {
+        "$value": {
+          "iOS": 52,
+          "Android": 52
+        },
+        "$type": "number"
+      },
+      "Tracking": {
+        "$value": {
+          "iOS": -2.5,
+          "Android": -0.4099999964237213
+        },
+        "$type": "number"
+      }
+    },
+    "Display-Small": {
+      "Font": {
+        "$value": {
+          "iOS": "{Font theme.Font.Plain}",
+          "Android": "{Font theme.Font.Plain}"
+        },
+        "$type": "string"
+      },
+      "Weight": {
+        "$value": {
+          "iOS": "{Font theme.Weight.Regular}",
+          "Android": "{Font theme.Weight.Regular}"
+        },
+        "$type": "string"
+      },
+      "Weight-Emphasized": {
+        "$value": {
+          "iOS": "{Font theme.Weight.Medium}",
+          "Android": "{Font theme.Weight.Medium}"
+        },
+        "$type": "string"
+      },
+      "Weight-Strong": {
+        "$value": {
+          "iOS": "{Font theme.Weight.Bold}",
+          "Android": "{Font theme.Weight.Bold}"
+        },
+        "$type": "string"
+      },
+      "Size": {
+        "$value": {
+          "iOS": 36,
+          "Android": 36
+        },
+        "$type": "number"
+      },
+      "Line-Height": {
+        "$value": {
+          "iOS": 44,
+          "Android": 44
+        },
+        "$type": "number"
+      },
+      "Tracking": {
+        "$value": {
+          "iOS": -2.5,
+          "Android": -0.4099999964237213
+        },
+        "$type": "number"
+      }
+    },
+    "Headline-Large": {
+      "Font": {
+        "$value": {
+          "iOS": "{Font theme.Font.Plain}",
+          "Android": "{Font theme.Font.Plain}"
+        },
+        "$type": "string"
+      },
+      "Weight": {
+        "$value": {
+          "iOS": "{Font theme.Weight.Regular}",
+          "Android": "{Font theme.Weight.Regular}"
+        },
+        "$type": "string"
+      },
+      "Weight-Emphasized": {
+        "$value": {
+          "iOS": "{Font theme.Weight.Medium}",
+          "Android": "{Font theme.Weight.Medium}"
+        },
+        "$type": "string"
+      },
+      "Weight-Strong": {
+        "$value": {
+          "iOS": "{Font theme.Weight.Bold}",
+          "Android": "{Font theme.Weight.Bold}"
+        },
+        "$type": "string"
+      },
+      "Size": {
+        "$value": {
+          "iOS": 34,
+          "Android": 34
+        },
+        "$type": "number"
+      },
+      "Line-Height": {
+        "$value": {
+          "iOS": 40,
+          "Android": 40
+        },
+        "$type": "number"
+      },
+      "Tracking": {
+        "$value": {
+          "iOS": -1.5,
+          "Android": -1.399999976158142
+        },
+        "$type": "number"
+      }
+    },
+    "Headline-Medium": {
+      "Font": {
+        "$value": {
+          "iOS": "{Font theme.Font.Plain}",
+          "Android": "{Font theme.Font.Plain}"
+        },
+        "$type": "string"
+      },
+      "Weight": {
+        "$value": {
+          "iOS": "{Font theme.Weight.Regular}",
+          "Android": "{Font theme.Weight.Regular}"
+        },
+        "$type": "string"
+      },
+      "Weight-Emphasized": {
+        "$value": {
+          "iOS": "{Font theme.Weight.Medium}",
+          "Android": "{Font theme.Weight.Medium}"
+        },
+        "$type": "string"
+      },
+      "Weight-Strong": {
+        "$value": {
+          "iOS": "{Font theme.Weight.Bold}",
+          "Android": "{Font theme.Weight.Bold}"
+        },
+        "$type": "string"
+      },
+      "Size": {
+        "$value": {
+          "iOS": 28,
+          "Android": 28
+        },
+        "$type": "number"
+      },
+      "Line-Height": {
+        "$value": {
+          "iOS": 36,
+          "Android": 36
+        },
+        "$type": "number"
+      },
+      "Tracking": {
+        "$value": {
+          "iOS": -1,
+          "Android": -0.4099999964237213
+        },
+        "$type": "number"
+      }
+    },
+    "Headline-Small": {
+      "Font": {
+        "$value": {
+          "iOS": "{Font theme.Font.Plain}",
+          "Android": "{Font theme.Font.Plain}"
+        },
+        "$type": "string"
+      },
+      "Weight": {
+        "$value": {
+          "iOS": "{Font theme.Weight.Regular}",
+          "Android": "{Font theme.Weight.Regular}"
+        },
+        "$type": "string"
+      },
+      "Weight-Emphasized": {
+        "$value": {
+          "iOS": "{Font theme.Weight.Medium}",
+          "Android": "{Font theme.Weight.Medium}"
+        },
+        "$type": "string"
+      },
+      "Weight-Strong": {
+        "$value": {
+          "iOS": "{Font theme.Weight.Bold}",
+          "Android": "{Font theme.Weight.Bold}"
+        },
+        "$type": "string"
+      },
+      "Size": {
+        "$value": {
+          "iOS": 24,
+          "Android": 24
+        },
+        "$type": "number"
+      },
+      "Line-Height": {
+        "$value": {
+          "iOS": 32,
+          "Android": 32
+        },
+        "$type": "number"
+      },
+      "Tracking": {
+        "$value": {
+          "iOS": -0.75,
+          "Android": -1
+        },
+        "$type": "number"
+      }
+    },
+    "Title-Large": {
+      "Font": {
+        "$value": {
+          "iOS": "{Font theme.Font.Plain}",
+          "Android": "{Font theme.Font.Plain}"
+        },
+        "$type": "string"
+      },
+      "Weight": {
+        "$value": {
+          "iOS": "{Font theme.Weight.Regular}",
+          "Android": "{Font theme.Weight.Regular}"
+        },
+        "$type": "string"
+      },
+      "Weight-Emphasized": {
+        "$value": {
+          "iOS": "{Font theme.Weight.Medium}",
+          "Android": "{Font theme.Weight.Medium}"
+        },
+        "$type": "string"
+      },
+      "Weight-Strong": {
+        "$value": {
+          "iOS": "{Font theme.Weight.Bold}",
+          "Android": "{Font theme.Weight.Bold}"
+        },
+        "$type": "string"
+      },
+      "Size": {
+        "$value": {
+          "iOS": 20,
+          "Android": 20
+        },
+        "$type": "number"
+      },
+      "Line-Height": {
+        "$value": {
+          "iOS": 28,
+          "Android": 28
+        },
+        "$type": "number"
+      },
+      "Tracking": {
+        "$value": {
+          "iOS": -0.4099999964237213,
+          "Android": -0.4099999964237213
+        },
+        "$type": "number"
+      }
+    },
+    "Title-Medium": {
+      "Font": {
+        "$value": {
+          "iOS": "{Font theme.Font.Plain}",
+          "Android": "{Font theme.Font.Plain}"
+        },
+        "$type": "string"
+      },
+      "Weight": {
+        "$value": {
+          "iOS": "{Font theme.Weight.Regular}",
+          "Android": "{Font theme.Weight.Regular}"
+        },
+        "$type": "string"
+      },
+      "Weight-Emphasized": {
+        "$value": {
+          "iOS": "{Font theme.Weight.Medium}",
+          "Android": "{Font theme.Weight.Medium}"
+        },
+        "$type": "string"
+      },
+      "Weight-Strong": {
+        "$value": {
+          "iOS": "{Font theme.Weight.Bold}",
+          "Android": "{Font theme.Weight.Bold}"
+        },
+        "$type": "string"
+      },
+      "Size": {
+        "$value": {
+          "iOS": 17,
+          "Android": 17
+        },
+        "$type": "number"
+      },
+      "Line-Height": {
+        "$value": {
+          "iOS": 20,
+          "Android": 20
+        },
+        "$type": "number"
+      },
+      "Tracking": {
+        "$value": {
+          "iOS": -0.4099999964237213,
+          "Android": -0.4099999964237213
+        },
+        "$type": "number"
+      }
+    },
+    "Title-Small": {
+      "Font": {
+        "$value": {
+          "iOS": "{Font theme.Font.Plain}",
+          "Android": "{Font theme.Font.Plain}"
+        },
+        "$type": "string"
+      },
+      "Weight": {
+        "$value": {
+          "iOS": "{Font theme.Weight.Regular}",
+          "Android": "{Font theme.Weight.Regular}"
+        },
+        "$type": "string"
+      },
+      "Weight-Emphasized": {
+        "$value": {
+          "iOS": "{Font theme.Weight.Medium}",
+          "Android": "{Font theme.Weight.Medium}"
+        },
+        "$type": "string"
+      },
+      "Weight-Strong": {
+        "$value": {
+          "iOS": "{Font theme.Weight.Bold}",
+          "Android": "{Font theme.Weight.Bold}"
+        },
+        "$type": "string"
+      },
+      "Size": {
+        "$value": {
+          "iOS": 14,
+          "Android": 14
+        },
+        "$type": "number"
+      },
+      "Line-Height": {
+        "$value": {
+          "iOS": 16,
+          "Android": 16
+        },
+        "$type": "number"
+      },
+      "Tracking": {
+        "$value": {
+          "iOS": -0.4099999964237213,
+          "Android": -0.4099999964237213
+        },
+        "$type": "number"
+      }
+    },
+    "Label-Large": {
+      "Font": {
+        "$value": {
+          "iOS": "{Font theme.Font.Plain}",
+          "Android": "{Font theme.Font.Plain}"
+        },
+        "$type": "string"
+      },
+      "Weight": {
+        "$value": {
+          "iOS": "{Font theme.Weight.Regular}",
+          "Android": "{Font theme.Weight.Regular}"
+        },
+        "$type": "string"
+      },
+      "Weight-Emphasized": {
+        "$value": {
+          "iOS": "{Font theme.Weight.Medium}",
+          "Android": "{Font theme.Weight.Medium}"
+        },
+        "$type": "string"
+      },
+      "Weight-Strong": {
+        "$value": {
+          "iOS": "{Font theme.Weight.Bold}",
+          "Android": "{Font theme.Weight.Bold}"
+        },
+        "$type": "string"
+      },
+      "Size": {
+        "$value": {
+          "iOS": 17,
+          "Android": 16
+        },
+        "$type": "number"
+      },
+      "Line-Height": {
+        "$value": {
+          "iOS": 24,
+          "Android": 24
+        },
+        "$type": "number"
+      },
+      "Tracking": {
+        "$value": {
+          "iOS": -0.4099999964237213,
+          "Android": -0.4099999964237213
+        },
+        "$type": "number"
+      }
+    },
+    "Label-Medium": {
+      "Font": {
+        "$value": {
+          "iOS": "{Font theme.Font.Plain}",
+          "Android": "{Font theme.Font.Plain}"
+        },
+        "$type": "string"
+      },
+      "Weight": {
+        "$value": {
+          "iOS": "{Font theme.Weight.Regular}",
+          "Android": "{Font theme.Weight.Regular}"
+        },
+        "$type": "string"
+      },
+      "Weight-Emphasized": {
+        "$value": {
+          "iOS": "{Font theme.Weight.Medium}",
+          "Android": "{Font theme.Weight.Medium}"
+        },
+        "$type": "string"
+      },
+      "Weight-Strong": {
+        "$value": {
+          "iOS": "{Font theme.Weight.Bold}",
+          "Android": "{Font theme.Weight.Bold}"
+        },
+        "$type": "string"
+      },
+      "Size": {
+        "$value": {
+          "iOS": 14,
+          "Android": 14
+        },
+        "$type": "number"
+      },
+      "Line-Height": {
+        "$value": {
+          "iOS": 20,
+          "Android": 20
+        },
+        "$type": "number"
+      },
+      "Tracking": {
+        "$value": {
+          "iOS": -0.4099999964237213,
+          "Android": -0.4099999964237213
+        },
+        "$type": "number"
+      }
+    },
+    "Label-Small": {
+      "Font": {
+        "$value": {
+          "iOS": "{Font theme.Font.Plain}",
+          "Android": "{Font theme.Font.Plain}"
+        },
+        "$type": "string"
+      },
+      "Weight": {
+        "$value": {
+          "iOS": "{Font theme.Weight.Regular}",
+          "Android": "{Font theme.Weight.Regular}"
+        },
+        "$type": "string"
+      },
+      "Weight-Emphasized": {
+        "$value": {
+          "iOS": "{Font theme.Weight.Medium}",
+          "Android": "{Font theme.Weight.Medium}"
+        },
+        "$type": "string"
+      },
+      "Weight-Strong": {
+        "$value": {
+          "iOS": "{Font theme.Weight.Bold}",
+          "Android": "{Font theme.Weight.Bold}"
+        },
+        "$type": "string"
+      },
+      "Size": {
+        "$value": {
+          "iOS": 10,
+          "Android": 10
+        },
+        "$type": "number"
+      },
+      "Line-Height": {
+        "$value": {
+          "iOS": 14,
+          "Android": 14
+        },
+        "$type": "number"
+      },
+      "Tracking": {
+        "$value": {
+          "iOS": -0.07000000029802322,
+          "Android": -0.07000000029802322
+        },
+        "$type": "number"
+      }
+    },
+    "Body-Large": {
+      "Font": {
+        "$value": {
+          "iOS": "{Font theme.Font.Plain}",
+          "Android": "{Font theme.Font.Plain}"
+        },
+        "$type": "string"
+      },
+      "Weight": {
+        "$value": {
+          "iOS": "{Font theme.Weight.Regular}",
+          "Android": "{Font theme.Weight.Regular}"
+        },
+        "$type": "string"
+      },
+      "Weight-Emphasized": {
+        "$value": {
+          "iOS": "{Font theme.Weight.Medium}",
+          "Android": "{Font theme.Weight.Medium}"
+        },
+        "$type": "string"
+      },
+      "Weight-Strong": {
+        "$value": {
+          "iOS": "{Font theme.Weight.Bold}",
+          "Android": "{Font theme.Weight.Bold}"
+        },
+        "$type": "string"
+      },
+      "Size": {
+        "$value": {
+          "iOS": 17,
+          "Android": 17
+        },
+        "$type": "number"
+      },
+      "Line-Height": {
+        "$value": {
+          "iOS": 24,
+          "Android": 24
+        },
+        "$type": "number"
+      },
+      "Tracking": {
+        "$value": {
+          "iOS": -0.4099999964237213,
+          "Android": -0.4099999964237213
+        },
+        "$type": "number"
+      }
+    },
+    "Body-Medium": {
+      "Font": {
+        "$value": {
+          "iOS": "{Font theme.Font.Plain}",
+          "Android": "{Font theme.Font.Plain}"
+        },
+        "$type": "string"
+      },
+      "Weight": {
+        "$value": {
+          "iOS": "{Font theme.Weight.Regular}",
+          "Android": "{Font theme.Weight.Regular}"
+        },
+        "$type": "string"
+      },
+      "Weight-Emphasized": {
+        "$value": {
+          "iOS": "{Font theme.Weight.Medium}",
+          "Android": "{Font theme.Weight.Medium}"
+        },
+        "$type": "string"
+      },
+      "Weight-Strong": {
+        "$value": {
+          "iOS": "{Font theme.Weight.Bold}",
+          "Android": "{Font theme.Weight.Bold}"
+        },
+        "$type": "string"
+      },
+      "Size": {
+        "$value": {
+          "iOS": 14,
+          "Android": 15
+        },
+        "$type": "number"
+      },
+      "Line-Height": {
+        "$value": {
+          "iOS": 20,
+          "Android": 20
+        },
+        "$type": "number"
+      },
+      "Tracking": {
+        "$value": {
+          "iOS": -0.4099999964237213,
+          "Android": -0.4099999964237213
+        },
+        "$type": "number"
+      }
+    },
+    "Body-Small": {
+      "Font": {
+        "$value": {
+          "iOS": "{Font theme.Font.Plain}",
+          "Android": "{Font theme.Font.Plain}"
+        },
+        "$type": "string"
+      },
+      "Weight-Regular": {
+        "$value": {
+          "iOS": "{Font theme.Weight.Regular}",
+          "Android": "{Font theme.Weight.Regular}"
+        },
+        "$type": "string"
+      },
+      "Weight-Emphasized": {
+        "$value": {
+          "iOS": "{Font theme.Weight.Medium}",
+          "Android": "{Font theme.Weight.Medium}"
+        },
+        "$type": "string"
+      },
+      "Weight-Strong": {
+        "$value": {
+          "iOS": "{Font theme.Weight.Bold}",
+          "Android": "{Font theme.Weight.Bold}"
+        },
+        "$type": "string"
+      },
+      "Size": {
+        "$value": {
+          "iOS": 12,
+          "Android": 13
+        },
+        "$type": "number"
+      },
+      "Line-Height": {
+        "$value": {
+          "iOS": 16,
+          "Android": 16
+        },
+        "$type": "number"
+      },
+      "Tracking": {
+        "$value": {
+          "iOS": 0,
+          "Android": -0.4099999964237213
+        },
+        "$type": "number"
+      }
+    }
+  },
+  "Screen size": {
+    "Mobile": {
+      "Width": {
+        "$value": {
+          "iOS": 430,
+          "Android": 412
+        },
+        "$type": "number"
+      },
+      "Height": {
+        "$value": {
+          "iOS": 932,
+          "Android": 892
+        },
+        "$type": "number"
+      }
+    }
+  },
+  "Icon": {
+    "Size": {
+      "Extra-small": {
+        "$value": 14,
+        "$type": "number"
+      },
+      "Small": {
+        "$value": 16,
+        "$type": "number"
+      },
+      "Medium": {
+        "$value": 18,
+        "$type": "number"
+      },
+      "Large": {
+        "$value": 20,
+        "$type": "number"
+      },
+      "Large-Increased": {
+        "$value": 24,
+        "$type": "number"
+      },
+      "Extra-Large": {
+        "$value": 32,
+        "$type": "number"
+      }
+    }
+  }
+}

--- a/docs/design-system/implementation-plan.md
+++ b/docs/design-system/implementation-plan.md
@@ -26,8 +26,6 @@ consume:
 - [material3-reference.md](material3-reference.md) for Material 3 projection behavior.
 - [android-adapter.md](android-adapter.md) for public/internal Android API boundaries and
   parser/mode handling.
-- The per-foundation audit files under `docs/design-system/foundation-audit/` for row-level source
-  paths, values, and unresolved details.
 
 Foundation source data comes from `figma-export.json`. Runtime/public token parsing uses
 non-`Semantic` top-level sections. Top-level `Semantic` remains traceability-only. High-contrast
@@ -39,8 +37,6 @@ Expected output:
 - Decision checkpoint with source references and rejected alternatives.
 - Material 3 reference for token semantics and Compose interop.
 - Token map, component catalog, migration playbook, and rollout direction.
-- Foundation audit files for colors, typography, spacing, padding, radius, icon size, and
-  stroke/unresolved foundations.
 
 The rollout direction doc is the canonical source for in-scope and out-of-scope screens. Other docs
 should link to it instead of repeating the scope table.
@@ -64,16 +60,14 @@ Expected output:
   migrated or renamed to `legacyComposeView` at the controlled boundary.
 - No root-selection indirection inside shared/default `composeView {}` calls. The root should be
   obvious at the call site.
-- Before final merge of the migration branch, a controlled root-API rename: current legacy
-  `composeView` -> `legacyComposeView`, current `WooThemeWithBackground` ->
-  `LegacyWooThemeWithBackground`, and DS-specific builder -> `composeView`.
+- Follow [rollout-direction.md](rollout-direction.md) for the exact controlled root-API rename
+  boundary and audits.
 - Manual i1 runtime tokens, with colors as the XML-safe resource-backed exception and non-color
   foundations remaining Kotlin/Compose-owned.
 - Foundation groups for color, typography, spacing, padding, radius, icon size, and internal stroke
   previews.
 - Source-backed color tokens exposed through `WooTheme.colors`, grouped shallowly by Store authoring
-  intent: core, container, surface, outline, status, alert, background, overlay, and intentionally
-  handled palette tokens.
+  intent: core, container, surface, outline, status, alert, background, overlay, and palette.
 - Internal Material 3 projections for Material 3 component interop, with Material 3 treated as a
   projection rather than the source of Store foundations.
 - Full text roles through `WooTheme.text`.
@@ -90,6 +84,9 @@ Expected output:
 - Token map entries for implemented foundations.
 - Design-system module code does not import app resources, legacy app theme classes, Hilt, POS, or
   Store feature packages.
+- A detekt guardrail that reports files importing both legacy
+  `com.woocommerce.android.ui.compose.theme.*` and design-system
+  `com.woocommerce.android.ui.compose.designsystem.*` APIs.
 
 Implementation risks to verify when code work begins:
 
@@ -155,14 +152,8 @@ Expected output:
 - Previews and screenshot review for migrated surfaces under the design-system root in light and
   dark mode.
 
-Before final merge of the migration branch, perform the controlled root-API rename and verify it
-with strict `rg` audits:
-
-- Current legacy `composeView` becomes `legacyComposeView`.
-- Current `WooThemeWithBackground` becomes `LegacyWooThemeWithBackground`.
-- DS-specific builder becomes `composeView`.
-- Every remaining `composeView` call is intentionally migrated.
-- Every non-migrated screen uses `legacyComposeView`.
+Before final merge of the migration branch, follow the controlled root-API rename boundary defined
+in [rollout-direction.md](rollout-direction.md).
 
 The XML bridge explored in earlier branches is out of scope. A retained XML shell is allowed only as
 a compatibility boundary around migrated design-system content.
@@ -219,8 +210,8 @@ Add new example docs only when first-wave migrations produce reusable findings.
 - Temporary full-screen fallbacks inside in-scope migrated screens are allowed only for genuinely
   high-risk migration gaps and require an expiry/removal plan.
 - New design-system previews should use `androidx.compose.ui.tooling.preview.PreviewLightDark`.
-- Design-system component previews should wrap content in `WooDesignSystemTheme`, not
-  `WooThemeWithBackground`.
+- Design-system component previews should wrap content in `WooDesignSystemTheme`, not the legacy
+  Store theme root.
 - Migrated screen previews should cover the design-system root in light and dark mode.
 - Final root-API rename should be handled as a dedicated mechanical boundary and verified with
   strict `rg` audits before merge.

--- a/docs/design-system/implementation-plan.md
+++ b/docs/design-system/implementation-plan.md
@@ -1,0 +1,230 @@
+# Store Design System Implementation Plan
+
+This plan sequences the Woo Mobile Design System i1 adapter work for trunk-based delivery.
+
+The rollout direction is decided in [rollout-direction.md](rollout-direction.md). The short version is:
+
+- Build Store-only foundations and production-ready components.
+- Migrate the first coherent wave: Dashboard, Products, Orders, More, top Product Detail, and top
+  Order Detail.
+- Keep Product Detail and Order Detail launched child flows out of scope for this wave.
+- After the first wave, converge legacy XML and legacy Compose foundations toward the design-system
+  look for safe color/chrome tokens only.
+
+## PR Sequence
+
+### 1. Docs and Checkpoint
+
+Capture the integration model before implementation.
+
+This docs branch is the contract for the future Store Design System foundation build. The absence of
+runtime foundation code in this branch is expected and is not a defect. Future implementation should
+consume:
+
+- [token-map.md](token-map.md) for source-backed token rows, values, statuses, unresolved items, and
+  parser rules.
+- [material3-reference.md](material3-reference.md) for Material 3 projection behavior.
+- [android-adapter.md](android-adapter.md) for public/internal Android API boundaries and
+  parser/mode handling.
+- The per-foundation audit files under `docs/design-system/foundation-audit/` for row-level source
+  paths, values, and unresolved details.
+
+Foundation source data comes from `figma-export.json`. Runtime/public token parsing uses
+non-`Semantic` top-level sections. Top-level `Semantic` remains traceability-only. High-contrast
+color modes stay out of normal `Light` / `Dark` runtime mapping until separately scoped.
+
+Expected output:
+
+- Design-system docs skeleton.
+- Decision checkpoint with source references and rejected alternatives.
+- Material 3 reference for token semantics and Compose interop.
+- Token map, component catalog, migration playbook, and rollout direction.
+- Foundation audit files for colors, typography, spacing, padding, radius, icon size, and
+  stroke/unresolved foundations.
+
+The rollout direction doc is the canonical source for in-scope and out-of-scope screens. Other docs
+should link to it instead of repeating the scope table.
+
+### 2. Foundations and Theme
+
+Implement the design-system foundation layer without forcing adoption in product screens.
+
+Expected output:
+
+- Store-only Gradle module `:libs:store-design-system`, separate from `:libs:commons`.
+- Pure module-owned foundations and previews under
+  `com.woocommerce.android.ui.compose.designsystem.*`.
+- `WooDesignSystemTheme`.
+- Migration-era wrapper naming: use `WooDesignSystemTheme`, not `WooNewTheme`, while the legacy
+  `WooTheme` wrapper exists. Future consolidation can happen after the legacy wrapper is removed.
+- `WooTheme` foundation accessors for theme-scoped production APIs.
+- `WooDesignSystemThemeWithBackground` providing the real design-system foundation.
+- A DS-specific builder, such as `designSystemComposeView {}`, for explicitly migrated screens.
+- Existing legacy screens continue using the current legacy Compose root until they are intentionally
+  migrated or renamed to `legacyComposeView` at the controlled boundary.
+- No root-selection indirection inside shared/default `composeView {}` calls. The root should be
+  obvious at the call site.
+- Before final merge of the migration branch, a controlled root-API rename: current legacy
+  `composeView` -> `legacyComposeView`, current `WooThemeWithBackground` ->
+  `LegacyWooThemeWithBackground`, and DS-specific builder -> `composeView`.
+- Manual i1 runtime tokens, with colors as the XML-safe resource-backed exception and non-color
+  foundations remaining Kotlin/Compose-owned.
+- Foundation groups for color, typography, spacing, padding, radius, icon size, and internal stroke
+  previews.
+- Source-backed color tokens exposed through `WooTheme.colors`, grouped shallowly by Store authoring
+  intent: core, container, surface, outline, status, alert, background, overlay, and intentionally
+  handled palette tokens.
+- Internal Material 3 projections for Material 3 component interop, with Material 3 treated as a
+  projection rather than the source of Store foundations.
+- Full text roles through `WooTheme.text`.
+- Spacing, padding, radius, and icon size through `WooTheme.spacing`, `WooTheme.padding`,
+  `WooTheme.radius`, and `WooTheme.iconSize`.
+- Supported status, alert, overlay, and palette colors as grouped fields under `WooTheme.colors`;
+  no separate `WooTheme.semanticColors`.
+- `surfaceDim`, `surfaceBright`, and `surfaceContainerHighest` as source-backed Store roles.
+- State layers remain internal-first until semantic names and mode behavior are approved.
+- `WooTheme.iconSize` scoped to glyph sizes only.
+- Internal or `preview_only` stroke from `Shape/Stroke/Weight/*`; public stroke waits for production
+  component need.
+- Preview wrappers and light/dark previews using `@PreviewLightDark`.
+- Token map entries for implemented foundations.
+- Design-system module code does not import app resources, legacy app theme classes, Hilt, POS, or
+  Store feature packages.
+
+Implementation risks to verify when code work begins:
+
+- Radius projection visual changes: `large` moves from the current `8dp` projection to `12dp`, and
+  `extraLarge` moves from the current `8dp` projection to `16dp`.
+- Fractional stroke width rendering for `0.5dp`, `0.75dp`, and `1.5dp`.
+- State-layer mode behavior if internal defaults are implemented.
+
+Foundation work remains opt-in. Do not globally remap existing app theme resources in the foundation
+PR. Store design-system color primitives may be module-local Android resources so `WooTheme.colors`
+can serve both Compose and targeted XML/View convergence. Non-color foundations remain
+Kotlin/Compose-owned. Do not document an app-owned legacy-compatible design-system foundation bridge
+as required for this rollout path unless a future implementation explicitly chooses it.
+
+Do not add implementation work to recompute token-map color ratios. The docs intentionally remove
+stale manually maintained ratio and alpha-composition notes.
+
+### 3. Components and Preview Catalog
+
+Implement the i1 component catalog with previews, while exposing production APIs only for ready components.
+
+Expected output:
+
+- Compose-first, Material 3-only design-system components under
+  `com.woocommerce.android.ui.compose.designsystem`.
+- `Woo` component naming.
+- Material 3 wrappers where the mapping is close.
+- Custom components only where Material 3 is materially different.
+- Component catalog status updates.
+- Light and dark previews for every component using `@PreviewLightDark`.
+- Production APIs for the subset needed by the first-wave tab and top-detail surfaces plus low-risk
+  primitives.
+- Private/internal preview catalog implementations for unsettled components.
+
+Production screens should consume only production-ready components. In-progress components can remain preview-only.
+
+The initial production subset should cover top/navigation bar, page title/body/link text styles or
+wrappers, primary button, list/cell rows, section header, switch, icon button, divider, progress
+indicator, and the spacing/radius/color/typography tokens they depend on.
+
+Chrome components should follow [rollout-direction.md](rollout-direction.md): unified visual look,
+not one forced implementation. Compose-owned screens use `WooTopAppBar`; heavy XML screens may keep a
+DS-looking XML toolbar when needed for compatibility.
+
+### 4. First-Wave Screen Migration
+
+Migrate the first coherent product wave defined in [rollout-direction.md](rollout-direction.md).
+
+Expected output:
+
+- Dashboard tab surface migrated to design-system UI.
+- Products tab surface migrated to design-system UI.
+- Orders tab surface migrated to design-system UI.
+- More tab surface migrated to design-system UI.
+- Top Product Detail surface migrated, with launched child/edit flows left legacy.
+- Top Order Detail surface migrated, with launched child flows left legacy.
+- Existing Fragments, XML nav graphs, SafeArgs, ViewModels, analytics, strings, and product behavior
+  preserved unless there is an explicit product decision.
+- One design-system UI implementation per migrated screen. No permanent duplicate legacy/design-system screen trees.
+- Migrated screens use the design-system root explicitly. Non-migrated screens stay on the legacy
+  root.
+- `ComposeView` used for migrated content sections where heavy XML shells must remain for compatibility.
+- Previews and screenshot review for migrated surfaces under the design-system root in light and
+  dark mode.
+
+Before final merge of the migration branch, perform the controlled root-API rename and verify it
+with strict `rg` audits:
+
+- Current legacy `composeView` becomes `legacyComposeView`.
+- Current `WooThemeWithBackground` becomes `LegacyWooThemeWithBackground`.
+- DS-specific builder becomes `composeView`.
+- Every remaining `composeView` call is intentionally migrated.
+- Every non-migrated screen uses `legacyComposeView`.
+
+The XML bridge explored in earlier branches is out of scope. A retained XML shell is allowed only as
+a compatibility boundary around migrated design-system content.
+
+### 5. Legacy Theme Convergence
+
+After the first-wave screens, converge existing XML and legacy Compose foundations toward the design-system look.
+
+Expected output:
+
+- Shared module-local color resources where XML/View needs the same primitive values as Compose.
+- Background/surface, toolbar/chrome, divider/outline, and verified primary/accent color alignment.
+- DS-looking XML toolbar style for legacy-heavy screens that cannot move toolbar ownership to Compose.
+- Compose toolbar alignment through `WooTopAppBar` on Compose-owned screens.
+- No parallel Kotlin/Compose and XML resource definitions for the same color primitive values.
+
+Do not use this phase for global typography replacement, global spacing/padding replacement, global
+status/semantic color rewrites, app-wide card radius changes, or behavior/navigation rewrites.
+Typography, spacing, padding, radius, icon size, and stroke remain Kotlin/Compose-owned.
+
+### 6. Playbook Updates
+
+Keep the migration playbook aligned with real first-wave findings.
+
+Expected output:
+
+- Concrete examples from first-wave migrations once they exist.
+- Known pitfalls.
+- Component usage examples.
+- Verification checklist refinements.
+- Guidance for screens that remain XML/View because they are outside the first-wave scope.
+- Required candidate assessment output for unassigned future screens.
+
+Add new example docs only when first-wave migrations produce reusable findings.
+
+## Delivery Constraints
+
+- POS stays out of scope.
+- The rollout scope is defined by [rollout-direction.md](rollout-direction.md).
+- No mandatory migration of every screen.
+- No global app rewrite.
+- No raw Figma variable names in public Android API.
+- No raw private Figma node IDs in public docs.
+- `figma-export.json` remains an audit/source artifact; do not hand-edit it as part of foundation
+  implementation.
+- Runtime/public parser logic must ignore the top-level `Semantic` section unless the contract is
+  deliberately updated with approved evidence.
+- Normal runtime `Light` / `Dark` values must not use high-contrast modes.
+- No parallel Kotlin/Compose and XML resource definitions for the same token primitive values.
+- No production screen should consume preview-only components.
+- Preview-only components should not be exposed as reusable production-screen APIs.
+- Migrated screens should not keep permanent duplicate legacy/design-system implementations.
+- Out-of-scope child flows may remain legacy without an expiry plan for this wave.
+- Temporary full-screen fallbacks inside in-scope migrated screens are allowed only for genuinely
+  high-risk migration gaps and require an expiry/removal plan.
+- New design-system previews should use `androidx.compose.ui.tooling.preview.PreviewLightDark`.
+- Design-system component previews should wrap content in `WooDesignSystemTheme`, not
+  `WooThemeWithBackground`.
+- Migrated screen previews should cover the design-system root in light and dark mode.
+- Final root-API rename should be handled as a dedicated mechanical boundary and verified with
+  strict `rg` audits before merge.
+- Screenshot verification is required for first-wave screens and high-risk components, not for every
+  small primitive component.
+- Production components need accessibility review before product-screen adoption.
+- Each PR should be reviewable independently.

--- a/docs/design-system/integration-checkpoint.md
+++ b/docs/design-system/integration-checkpoint.md
@@ -1,0 +1,184 @@
+# Woo Mobile Design System Integration Checkpoint
+
+This checkpoint preserves the planning context for the Store Management App design-system integration.
+
+The current rollout direction is decided in [rollout-direction.md](rollout-direction.md). That file
+is the canonical source for first-wave scope and out-of-scope child flows.
+
+Root rollout update: [rollout-direction.md](rollout-direction.md) now supersedes the older
+root/foundation-selection notes preserved below. The current direction is explicit screen migration:
+migrated screens opt into the design-system root, non-migrated screens stay on the legacy root, and
+existing `composeView {}` calls do not get root-selection indirection.
+
+## Scope
+
+- Store Management App only.
+- POS is out of scope.
+- The goal is least-disruptive, trunk-based integration of the Woo Mobile Design System.
+- The first iteration uses the design system discussed in the May 27, 2026 P2: `Woo Mobile Design System, i1`.
+
+## Source References
+
+- P2: `Woo Mobile Design System, i1`, May 27, 2026 (`pe5sF9-5ox-p2`).
+- Figma: `Woo Mobile Design System` (`50XIH5MmOf4xUYEkM6fAm6-fi`).
+
+Do not expand these shorthands into raw P2 or Figma URLs in public repo docs.
+
+## Agreed Decisions
+
+- Use an Android Design System Adapter, not a global app rewrite.
+- Keep the adapter Store-only, with foundations and components in `:libs:store-design-system`.
+- The rollout strategy is decided. First-wave scope is Dashboard, Products, Orders, More,
+  top Product Detail, and top Order Detail.
+- Product Detail and Order Detail launched child flows are out of scope for the first wave.
+- Each migrated first-wave screen should have one design-system UI implementation.
+- Earlier root/foundation notes treated theme selection as the visual rollout boundary.
+- `ComposeTheme.LEGACY` uses `WooThemeWithBackground` with a legacy-compatible design-system
+  foundation.
+- `ComposeTheme.DESIGN_SYSTEM` uses `WooDesignSystemThemeWithBackground` with the real
+  design-system foundation.
+- The XML bridge explored in earlier branches is out of scope.
+- Heavy XML screens may retain an XML shell only where needed for compatibility, with `ComposeView`
+  hosting migrated sections, rows, or content areas.
+- Toolbar direction is a unified design-system visual look, not one mandatory implementation.
+- Compose-owned screens use `WooTopAppBar`.
+- Heavy XML screens may keep XML toolbar ownership if the toolbar matches the design-system look and
+  preserves `SearchView`, `ActionMode`, collapsing app bars, menu/action ownership, navigation
+  ownership, and insets.
+- After the first-wave screens, legacy XML and legacy Compose can converge toward the design-system
+  look for safe tokens only: colors, chrome, background/surfaces, dividers/outline, and toolbar look.
+- Global typography replacement, global spacing/padding replacement, and global status/semantic color
+  rewrites remain out of scope.
+- Add new design-system foundations and components as deliberately adopted APIs.
+- Do not globally remap existing `Woo*`, `WC*`, XML styles, or resource names in the foundation PR.
+- Figma is the design-intent source of truth; Android owns the runtime API contract.
+- Manually define stable i1 Kotlin/Compose runtime tokens first.
+- Structure tokens and docs so a future Figma generation pipeline can update adapter internals later.
+- Do not expose raw Figma variable names as public Android APIs.
+- Keep a strict token map with Android API/token name, source shorthand or source token name when
+  useful, light and dark values, Material 3 role mapping, status, and notes.
+- Public `WooTheme.colors` exposes source-backed color tokens used by the core foundation and
+  inspected i1 component nodes, grouped shallowly by source intent.
+- Do not limit `WooTheme.colors` to a small curated Material 3-like subset.
+- Material 3 color roles remain internal interop projection aliases, not the Store authoring surface.
+- Do not expose generated Material aliases such as fixed roles or surface-container aliases unless
+  they are real source-backed tokens.
+- Do not add `WooTheme.semanticColors`; supported status, alert, overlay, and palette colors live as
+  grouped fields under `WooTheme.colors`.
+- Do not expose top-level `Semantic` entries from `figma-export.json` unless a concrete Figma
+  component node is confirmed to bind to that token group.
+- `outline` and `outlineVariant` are source-backed and public under `WooTheme.colors`.
+- Store design-system color primitives are the XML-safe exception and may live in module-local
+  Android resources so Compose and targeted XML/View usage share the same values.
+- Non-color foundations remain Kotlin/Compose-owned unless a later approved plan says otherwise.
+- Do not keep parallel Kotlin/Compose and XML resource definitions for the same token primitive values.
+- Code should publicly expose only production-ready tokens/components.
+- In-progress i1 areas can be documented, tracked, or preview-only until stable.
+- Preview-only components should not be exposed as reusable product-screen APIs.
+- Preview-only implementations should stay private/internal to catalog or preview files under `designsystem.preview`.
+- New design-system components are Compose-first and Material 3-only.
+- Existing Material 2 usage can remain until touched.
+- Use Material 3 wrappers as the default implementation strategy; build custom components only when Material 3 is too different.
+- Component PR scope is full i1 catalog with previews, but production APIs only for first-wave needs and low-risk primitives.
+- Unsettled components stay private/internal preview catalog implementations.
+- Initial production subset covers top/navigation bar, page title/body/link text styles or wrappers,
+  primary button, list/cell rows, section header, switch, icon button, divider, progress indicator,
+  and the tokens they depend on.
+- Progress indicator is not listed as an i1 Figma component, but should still be wrapped as a thin
+  Material 3 adapter for future custom design replacement.
+- Do not add more thin Material 3 wrappers beyond the initial production subset unless a later
+  design-system decision explicitly expands the catalog.
+- Component names use the `Woo` prefix inside the design-system package.
+- Do not use `WooDs*` or `WC*` for new design-system components.
+- Module: `:libs:store-design-system`, separate from `:libs:commons`.
+- The module must not import app `R`, legacy app theme classes, Hilt, POS, or Store feature
+  packages. App-layer rollout wiring stays outside the module.
+- Package root: `com.woocommerce.android.ui.compose.designsystem`.
+- Suggested subpackages: `foundation`, `component`, and `preview`.
+- Use a separate opt-in `WooDesignSystemTheme`, Material 3-only.
+- `WooDesignSystemTheme` is the migration-era wrapper name while the legacy
+  `com.woocommerce.android.ui.compose.theme.WooTheme` wrapper exists. Do not introduce `WooNewTheme`.
+  Future consolidation can merge wrapper/accessor naming after the legacy wrapper is removed.
+- `WooDesignSystemTheme` installs the Store design-system runtime; `WooTheme.*` is the
+  component-facing accessor for theme-scoped foundation values.
+- `WooDesignSystemThemeWithBackground` uses the real design-system foundation.
+- `WooThemeWithBackground` remains app-owned in the earlier compatibility model and would provide
+  legacy-compatible design-system foundation locals.
+- The design-system module does not read app resources directly.
+- Migrated first-wave screens should cover legacy-compatible and real design-system foundations in
+  light and dark mode.
+- New design-system foundations, components, preview catalog entries, and first-wave screen updates
+  should use `androidx.compose.ui.tooling.preview.PreviewLightDark` for light/dark previews.
+- Design-system component previews should wrap content in `WooDesignSystemTheme`, not
+  `WooThemeWithBackground`.
+- Preview coverage is required for every component; screenshot verification is required for first-wave screens and high-risk components.
+- Production components need accessibility review before product-screen adoption.
+- Fragment-hosted Compose layout migration means replacing XML/View layout content with Compose while
+  keeping Fragments, XML nav graphs, SafeArgs, ViewModels, navigation, and Store app event ownership.
+- Compose layout migration is optional per screen, not required for all screens.
+- Some screens require substantial work and should stay XML/View while receiving targeted token/style updates when needed.
+- Agents may proceed on assigned first-wave screens, while documenting risk signals and preserved behavior.
+- Agents should assess and recommend before migrating unassigned heavy screens.
+- Agents must include a short candidate assessment in migration or adoption output.
+- Add example docs only when first-wave migrations produce reusable findings.
+
+## Considered Approaches
+
+These remain rejected for i1:
+
+- Global replacement of existing `Woo*`, `WC*`, XML styles, theme resources, and resource names.
+- A shared or cross-app design-system module, including putting Store foundations in `:libs:commons`.
+- A generated-token pipeline before manual i1 Android tokens exist.
+- Mandatory Compose layout migration for every Store screen.
+- A full app rewrite as part of the UI migration.
+- A single toolbar implementation forced across XML-heavy and Compose-owned screens.
+
+## Screen Migration Candidate Criteria
+
+For first-wave screens, use [rollout-direction.md](rollout-direction.md) as the assignment source.
+The criteria below apply to future unassigned screens.
+
+A good unassigned candidate:
+
+- Is a low-risk product surface.
+- Has visible design-system value such as toolbar, text hierarchy, cells, buttons, banners, empty/loading states, or forms.
+- Has bounded state and navigation.
+- Can be verified with previews and screenshots in light and dark mode.
+- Avoids RecyclerView behavior, selection tracking, `ActionMode`, complex custom Views, or major accessibility redesign.
+- Has a clear before/after baseline for AI agents.
+
+High-risk unassigned screens require explicit confirmation before editing. High-risk signals include:
+
+- RecyclerView, ListAdapter, PagingDataAdapter, or adapter-heavy migration.
+- Selection tracking or `ActionMode`.
+- Complex custom Views or compound widgets.
+- Shared element transitions or complicated animation behavior.
+- Embedded WebView, camera, barcode scanner, media picker, or payment/card-reader UI.
+- Product, order, payment editing, or fulfillment flows.
+- Many navigation branches or multiple child fragments.
+- No reliable preview or screenshot baseline.
+
+## AI-Agent Documentation
+
+Design-system docs:
+
+- `docs/design-system/rollout-direction.md`
+- `docs/design-system/android-adapter.md`
+- `docs/design-system/token-map.md`
+- `docs/design-system/component-catalog.md`
+- `docs/design-system/material3-reference.md`
+- `docs/design-system/screen-migration-playbook.md`
+- `docs/design-system/implementation-plan.md`
+
+Docs should point to `rollout-direction.md` for scope instead of duplicating the in/out table.
+
+## Resolved Open Question
+
+The earlier rejection of a standalone module is superseded by the accepted Store-only module
+boundary: `:libs:store-design-system` owns pure foundations/components.
+
+The earlier open migration strategy is resolved by [rollout-direction.md](rollout-direction.md).
+
+The earlier root/foundation-selection strategy is superseded by the explicit-root rollout direction
+in [rollout-direction.md](rollout-direction.md). Historical root-selection notes in this checkpoint
+should be read as preserved planning context, not the current rollout contract.

--- a/docs/design-system/integration-checkpoint.md
+++ b/docs/design-system/integration-checkpoint.md
@@ -32,11 +32,9 @@ Do not expand these shorthands into raw P2 or Figma URLs in public repo docs.
   top Product Detail, and top Order Detail.
 - Product Detail and Order Detail launched child flows are out of scope for the first wave.
 - Each migrated first-wave screen should have one design-system UI implementation.
-- Earlier root/foundation notes treated theme selection as the visual rollout boundary.
-- `ComposeTheme.LEGACY` uses `WooThemeWithBackground` with a legacy-compatible design-system
-  foundation.
-- `ComposeTheme.DESIGN_SYSTEM` uses `WooDesignSystemThemeWithBackground` with the real
-  design-system foundation.
+- Migrated screens use an explicit design-system root builder during migration.
+- Non-migrated screens stay on the legacy root until the controlled rename boundary in
+  [rollout-direction.md](rollout-direction.md).
 - The XML bridge explored in earlier branches is out of scope.
 - Heavy XML screens may retain an XML shell only where needed for compatibility, with `ComposeView`
   hosting migrated sections, rows, or content areas.
@@ -94,23 +92,23 @@ Do not expand these shorthands into raw P2 or Figma URLs in public repo docs.
 - The module must not import app `R`, legacy app theme classes, Hilt, POS, or Store feature
   packages. App-layer rollout wiring stays outside the module.
 - Package root: `com.woocommerce.android.ui.compose.designsystem`.
-- Suggested subpackages: `foundation`, `component`, and `preview`.
+- Subpackages: `foundation`, `component`, and `preview`.
 - Use a separate opt-in `WooDesignSystemTheme`, Material 3-only.
 - `WooDesignSystemTheme` is the migration-era wrapper name while the legacy
   `com.woocommerce.android.ui.compose.theme.WooTheme` wrapper exists. Do not introduce `WooNewTheme`.
   Future consolidation can merge wrapper/accessor naming after the legacy wrapper is removed.
 - `WooDesignSystemTheme` installs the Store design-system runtime; `WooTheme.*` is the
   component-facing accessor for theme-scoped foundation values.
-- `WooDesignSystemThemeWithBackground` uses the real design-system foundation.
-- `WooThemeWithBackground` remains app-owned in the earlier compatibility model and would provide
-  legacy-compatible design-system foundation locals.
+- `WooDesignSystemThemeWithBackground` uses the real design-system foundation for explicitly
+  migrated screens.
+- The legacy Store theme root remains app-owned until the controlled rename boundary in
+  [rollout-direction.md](rollout-direction.md).
 - The design-system module does not read app resources directly.
-- Migrated first-wave screens should cover legacy-compatible and real design-system foundations in
-  light and dark mode.
+- Migrated first-wave screens should cover the design-system root in light and dark mode.
 - New design-system foundations, components, preview catalog entries, and first-wave screen updates
   should use `androidx.compose.ui.tooling.preview.PreviewLightDark` for light/dark previews.
-- Design-system component previews should wrap content in `WooDesignSystemTheme`, not
-  `WooThemeWithBackground`.
+- Design-system component previews should wrap content in `WooDesignSystemTheme`, not the legacy
+  Store theme root.
 - Preview coverage is required for every component; screenshot verification is required for first-wave screens and high-risk components.
 - Production components need accessibility review before product-screen adoption.
 - Fragment-hosted Compose layout migration means replacing XML/View layout content with Compose while
@@ -136,27 +134,9 @@ These remain rejected for i1:
 ## Screen Migration Candidate Criteria
 
 For first-wave screens, use [rollout-direction.md](rollout-direction.md) as the assignment source.
-The criteria below apply to future unassigned screens.
-
-A good unassigned candidate:
-
-- Is a low-risk product surface.
-- Has visible design-system value such as toolbar, text hierarchy, cells, buttons, banners, empty/loading states, or forms.
-- Has bounded state and navigation.
-- Can be verified with previews and screenshots in light and dark mode.
-- Avoids RecyclerView behavior, selection tracking, `ActionMode`, complex custom Views, or major accessibility redesign.
-- Has a clear before/after baseline for AI agents.
-
-High-risk unassigned screens require explicit confirmation before editing. High-risk signals include:
-
-- RecyclerView, ListAdapter, PagingDataAdapter, or adapter-heavy migration.
-- Selection tracking or `ActionMode`.
-- Complex custom Views or compound widgets.
-- Shared element transitions or complicated animation behavior.
-- Embedded WebView, camera, barcode scanner, media picker, or payment/card-reader UI.
-- Product, order, payment editing, or fulfillment flows.
-- Many navigation branches or multiple child fragments.
-- No reliable preview or screenshot baseline.
+For future unassigned screens, use the
+[Candidate Assessment](screen-migration-playbook.md#candidate-assessment) section in the migration
+playbook.
 
 ## AI-Agent Documentation
 

--- a/docs/design-system/material3-reference.md
+++ b/docs/design-system/material3-reference.md
@@ -1,0 +1,259 @@
+# Material 3 Reference for Store Design System Agents
+
+This reference helps agents map Woo Mobile Design System i1 foundations and components to Material 3
+defaults and Compose semantics. It is for the Store Management App design-system adapter only. POS is
+out of scope.
+
+Use this as a semantic baseline, not as a public API mandate. The i1 adapter still owns stable
+`WooTheme` and component APIs under `com.woocommerce.android.ui.compose.designsystem`.
+
+Store design-system APIs should expose source-backed authoring roles through `WooTheme`.
+`MaterialTheme` is still populated from source values so Material 3 components, defaults, and
+helpers work normally. Product-screen and design-system component code should read Store foundations
+through `WooTheme` and use `MaterialTheme` when a Material API requires the interop projection.
+
+## Official Sources
+
+- [Material Design 3 color roles](https://m3.material.io/styles/color/roles)
+- [Material Design 3 typography](https://m3.material.io/styles/typography/type-scale-tokens)
+- [Material Design 3 shape](https://m3.material.io/styles/shape/overview)
+- [Material Design 3 elevation](https://m3.material.io/styles/elevation/overview)
+- [Material Design 3 states](https://m3.material.io/foundations/interaction/states/state-layers)
+- [Material Design 3 in Compose](https://developer.android.com/develop/ui/compose/designsystems/material3)
+- [Compose Material 3 API reference](https://developer.android.com/reference/kotlin/androidx/compose/material3/package-summary)
+- [AndroidX Material 3 source tokens](https://android.googlesource.com/platform/frameworks/support/+/androidx-main/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/tokens/)
+- [Compose accessibility API defaults](https://developer.android.com/develop/ui/compose/accessibility/api-defaults)
+- [Compose accessibility semantics](https://developer.android.com/develop/ui/compose/accessibility/semantics)
+
+Numeric defaults below are from the current public AndroidX Material 3 token source. Before
+implementation, confirm API availability against the repo's pinned Material 3 dependency.
+
+## Color Roles
+
+Use Material 3 color roles as interop semantics, not as the public Store color API. PR 2
+`WooTheme.colors` should expose source-backed Store authoring roles from normal `Light` / `Dark`
+values in non-`Semantic` `Woo theme` sources. `MaterialTheme.colorScheme` receives projections for
+Material 3 components, defaults, and helpers. Roles without approved Store semantics may
+intentionally use `lightColorScheme(...)` / `darkColorScheme(...)` builder defaults.
+
+Do not use top-level `Semantic` or high-contrast modes for normal Material color projections.
+Container roles are first-class Store roles and can project to Material container roles. The fuller
+surface role set is first-class Store data, including `surfaceDim`, `surfaceBright`,
+`surfaceContainerHighest`, `onVariantLowest`, `inverted`, and `onInverted`. These roles should
+project from their Store source-backed roles, not older internal aliases. Background, overlay, and
+palette roles remain export-backed even when they are not validated by the Color roles frame.
+
+Do not generate public `WooTheme.colors` entries for Material fixed roles or source-missing aliases.
+`outline` and `outlineVariant` are source-backed and public under `WooTheme.colors`.
+
+| Role group | Use for i1 mapping |
+| --- | --- |
+| `primary`, `onPrimary` | Highest-emphasis brand actions and selected interactive surfaces, such as primary buttons. |
+| `primaryContainer`, `onPrimaryContainer` | Prominent but less forceful brand containers, selected rows, or highlighted surfaces. |
+| `secondary`, `onSecondary` | Supporting accents and controls where primary would overstate hierarchy. |
+| `secondaryContainer`, `onSecondaryContainer` | Supporting selected or filled containers. |
+| `tertiary`, `onTertiary` | Complementary accent moments. Use sparingly and only when i1 has a distinct third accent meaning. |
+| `error`, `onError`, `errorContainer`, `onErrorContainer` | Destructive actions, validation errors, and error containers. |
+| `surface`, `onSurface` | Default app surfaces and primary text/icons on neutral surfaces. |
+| `surfaceVariant`, `onSurfaceVariant` | Lower-emphasis neutral containers, secondary text/icons, and content adjacent to dividers. |
+| `surfaceContainerLowest` through `surfaceContainerHighest` | Nested neutral containers for projection. `surfaceContainerHighest` is a promoted Store role; the rest stay internal unless source-backed names are promoted. |
+| `surfaceDim`, `surfaceBright` | Source-backed Store surface roles. |
+| `background`, `onBackground` | Root/background areas when distinct from `surface`. In M3, prefer `surface` for most containers. |
+| `outline`, `outlineVariant` | Borders, dividers, and low-emphasis strokes. |
+| `inverseSurface`, `inverseOnSurface`, `inversePrimary` | Inverse surfaces such as snackbar-like UI. |
+| `scrim` | Modal overlays and obscuring layers. |
+| `primaryFixed` and other fixed roles | Dynamic-color-stable accent roles. Keep internal unless source-backed names exist. |
+
+Always pair `on*` colors with their matching container/background role. Do not put
+`onPrimaryContainer` on `primary`, or `primaryContainer` on `tertiaryContainer`, unless the component
+intentionally owns that semantic mismatch.
+
+Public palette/ramp and alert tokens do not automatically approve foreground/background pairing. Treat
+them as source colors unless a component owns a specific semantic mapping.
+
+The Store source `Woo theme/Alerts/Error-Container` /
+`Woo theme/Alerts/On-Error-Container` pair is an error container/background pair. It should project
+to `errorContainer` / `onErrorContainer`, not to the foreground/control `error` role. Leave
+`error` / `onError` on Material defaults until a source-backed Store foreground error pair is
+approved.
+
+## Typography Scale
+
+Compose Material 3 exposes a 15-role type scale through `MaterialTheme.typography`. The Store
+design-system authoring surface is `WooTheme.text`, which keeps the regular, emphasized, and strong
+variants. `MaterialTheme.typography` receives the regular projection for Material 3 interop.
+
+All 15 Android Store roles are source-backed by `figma-export.json` / `Typescale`; use Android mode
+values. Export role names are hyphenated while Android doc/API names are camelCase. Source
+`Typescale/<Role>/Font` resolves through `Font theme/Font/Plain`, whose Android value is `Roboto`;
+Android default font is the accepted runtime equivalent.
+
+| Role | Default size/line | Weight | Typical use |
+| --- | --- | --- | --- |
+| `displayLarge` | 57sp/64sp | Regular | Rare, largest marketing-scale display. |
+| `displayMedium` | 45sp/52sp | Regular | Large display. |
+| `displaySmall` | 36sp/44sp | Regular | Smaller display. |
+| `headlineLarge` | 32sp/40sp | Regular | Screen-level headline. |
+| `headlineMedium` | 28sp/36sp | Regular | Major section headline. |
+| `headlineSmall` | 24sp/32sp | Regular | Section headline. |
+| `titleLarge` | 22sp/28sp | Regular | App bars, page titles, prominent titles. |
+| `titleMedium` | 16sp/24sp | Medium | Card/list titles and medium-emphasis labels. |
+| `titleSmall` | 14sp/20sp | Medium | Compact titles. |
+| `bodyLarge` | 16sp/24sp | Regular | Primary body copy. |
+| `bodyMedium` | 14sp/20sp | Regular | Default compact body copy. |
+| `bodySmall` | 12sp/16sp | Regular | Supporting copy. |
+| `labelLarge` | 14sp/20sp | Medium | Buttons and large labels. |
+| `labelMedium` | 12sp/16sp | Medium | Compact labels. |
+| `labelSmall` | 11sp/16sp | Medium | Small labels and metadata. |
+
+Material 3 currently also has emphasized token variants in AndroidX source. Treat those as Material
+implementation details; the Store design-system text variants are the ones exposed through
+`WooTheme.text`.
+
+## Shape Roles
+
+Compose Material 3 `Shapes` defaults are:
+
+| Role | Default | Common Material use |
+| --- | --- | --- |
+| `extraSmall` | 4dp | Menus, snackbars, text fields. |
+| `small` | 8dp | Chips. |
+| `medium` | 12dp | Cards, small FABs. |
+| `large` | 16dp | FABs, extended FABs, navigation drawers. |
+| `extraLarge` | 28dp | Large FABs. |
+| `largeIncreased` | 20dp | Expressive larger large role. |
+| `extraLargeIncreased` | 32dp | Expressive larger extra-large role. |
+| `extraExtraLarge` | 48dp | XXL containers. |
+| `RectangleShape` | 0dp | Square containers. |
+| `CircleShape` / full | Full | Pills, circular icon containers, full-round buttons. |
+
+Store radius tokens project to Material 3 shapes as:
+
+| Material role | Store source-backed radius |
+| --- | ---: |
+| `extraSmall` | `2dp` |
+| `small` | `4dp` |
+| `medium` | `8dp` |
+| `large` | `12dp` |
+| `extraLarge` | `16dp` |
+
+`WooTheme.radius.none = 0dp` and `WooTheme.radius.full = 999dp` are Woo-only tokens with no direct
+Material role. The `large` and `extraLarge` projection changes need visual review because the current
+legacy projection uses `8dp` for both roles.
+
+## Elevation And Surfaces
+
+Material 3 primarily differentiates surfaces with tonal elevation, backed by optional shadow
+elevation. Compose `Surface` supports both:
+
+- `tonalElevation`: changes the tonal surface color when the surface color is `ColorScheme.surface`.
+- `shadowElevation`: draws a physical shadow. Use only when i1 needs visual separation that tonal
+  surfaces cannot provide.
+- `ColorScheme.surfaceColorAtElevation(elevation)` computes elevated surface color.
+- AndroidX elevation token levels are `0dp`, `1dp`, `3dp`, `6dp`, `8dp`, and `12dp`.
+
+For Material 3 interop, `surfaceContainer*` roles can help model stable neutral container hierarchy.
+Keep aliases internal unless the source export has matching promoted Store roles. Product code should
+prefer the source-backed `WooTheme.colors` surface/background tokens.
+
+Elevation remains unresolved for Store foundations. No non-`Semantic` elevation, shadow, effect,
+z-depth, or tonal-elevation source exists in `figma-export.json`, so do not create a public Store
+elevation token or infer one from legacy Android resources.
+
+## State Layers And Interaction States
+
+Material state layers communicate interaction without changing component identity. AndroidX
+Material 3 state layer opacity tokens are:
+
+| State | Opacity |
+| --- | --- |
+| Hovered | `0.08f` |
+| Focused | `0.10f` |
+| Pressed | `0.10f` |
+| Dragged | `0.16f` |
+
+The Store export contains `Woo theme/State-Layers/On-Surface/Opacity-08`, `Opacity-10`, and
+`Opacity-16`. Treat them as mode-aware color tokens, not public raw alpha floats. Keep state-layer
+implementation internal-first until design confirms whether they map to hovered, focused/pressed,
+and dragged states, and whether the dark and high-contrast solid values are intentional.
+
+Material 3 `ripple()` is the default `LocalIndication` inside `MaterialTheme`. It draws ripple
+animations for press interactions and fixed state layers for other interactions. For custom Woo
+components, prefer Material components or `Surface`/`Modifier.clickable` with the default indication
+before building custom state drawing.
+
+Use `MutableInteractionSource` only when a component needs to expose or preview state. Keep disabled
+behavior aligned with Material defaults unless i1 explicitly defines different disabled opacity or
+color tokens.
+
+## Component Mapping Guidance
+
+- Start with Material 3 components when i1 intent, layout, state, accessibility, and shape are close.
+- Wrap them in `Woo` components so product screens consume adapter APIs, not raw Material defaults.
+- Use component defaults objects, such as `ButtonDefaults`, `CardDefaults`, `SwitchDefaults`, and
+  `ListItemDefaults`, to override colors, shapes, and elevation behind the Woo API.
+- Build custom Compose components only when i1 materially differs in layout, behavior, state model,
+  or semantics.
+- Use `ListItem` as a candidate for i1 cell/row semantics, but verify density, leading/trailing
+  content, dividers, and click/toggle semantics before marking a Woo cell production-ready.
+- Use Material emphasis variants intentionally: filled button for high emphasis, outlined/text for
+  lower emphasis, icon buttons for compact actions, and progress indicators as thin wrappers.
+- Do not expand the adapter into a general Material 3 wrapper library. Follow the production subset
+  and preview-only boundaries in `component-catalog.md`.
+
+## Accessibility Notes
+
+- Material components include many accessibility defaults, including semantics and minimum touch
+  target behavior for actionable controls. Custom components must provide equivalent semantics.
+- Actionable targets should preserve at least 48dp touch size unless there is a documented exception.
+- Icon-only actions need meaningful labels. Decorative icons should use `contentDescription = null`.
+- Use `heading()`, `stateDescription`, `error`, `progressBarRangeInfo`, `paneTitle`, or custom
+  accessibility actions when a custom component needs those semantics.
+- Do not communicate state by color alone. Include labels, icons, semantics, or layout affordances
+  where needed.
+- Use matching `on*` roles whenever i1 overrides Material color pairings. Document intentional role
+  mismatches in the component contract.
+- Add font-scale and RTL previews when the component or screen is sensitive to text growth or
+  directionality.
+
+## Compose API Pointers
+
+- Theme: `MaterialTheme(colorScheme, typography, shapes)`.
+- Color schemes: `lightColorScheme(...)`, `darkColorScheme(...)`, `ColorScheme`.
+- Color helpers: `contentColorFor(...)`, `ColorScheme.surfaceColorAtElevation(...)`.
+- Typography: `Typography(...)`, `MaterialTheme.typography.<role>`.
+- Shapes: `Shapes(...)`, `MaterialTheme.shapes.<role>`.
+- Surfaces: `Surface(color, contentColor, tonalElevation, shadowElevation, shape)`.
+- Interactions: `ripple()`, `MutableInteractionSource`, `collectIsPressedAsState()`,
+  `collectIsFocusedAsState()`, `collectIsHoveredAsState()`, `collectIsDraggedAsState()`.
+- Components: use `androidx.compose.material3` components and their `*Defaults` objects internally.
+- Previews: use `androidx.compose.ui.tooling.preview.PreviewLightDark` for design-system previews.
+
+## Token Ownership And XML/View Usage
+
+The current adapter decision is:
+
+- Store design-system APIs remain Compose-first at the component and authoring layer.
+- Store design-system color primitives are the XML-safe exception and may live in module-local
+  Android resources so Compose and targeted XML/View usage share the same values.
+- Non-color primitive foundations remain Kotlin/Compose-owned unless a later approved plan says
+  otherwise.
+- Material 3 `ColorScheme`, `Typography`, `Shapes`, and component defaults should be built from
+  `WooTheme` foundation values, whether those values originate from Kotlin/Compose primitives or
+  module-local color resources.
+- Do not create Android resources for every Material role just because `ColorScheme` has that role.
+- Expose source-backed Store authoring roles through `WooTheme.colors`, grouped shallowly by source
+  intent.
+- Do not create a parallel semantic-colors carrier in PR 2. Supported status, alert, overlay, and
+  palette colors live as grouped fields under `WooTheme.colors`.
+- Do not expose top-level `Semantic` groups in PR 2 unless a concrete Figma component audit approves
+  that token group.
+- Keep Material 3-only projection aliases internal unless the alias is itself a source-backed token.
+- Treat `surfaceDim`, `surfaceBright`, and `surfaceContainerHighest` as source-backed Store roles.
+- Keep high-contrast modes out of normal `Light` / `Dark` runtime mapping until accessibility-mode
+  scope is decided.
+- Do not create a public `WooTheme.stateAlpha` float API from mode-aware state-layer color tokens.
+- When XML/View needs a design-system color, consume the shared module-local color resource through
+  targeted style usage and keep Compose reading the same value through `WooTheme.colors`.
+- Do not keep parallel Kotlin and XML primitive definitions.
+- Record every production token and its closest Material 3 role in `token-map.md`.

--- a/docs/design-system/pilot-feedback-completed.md
+++ b/docs/design-system/pilot-feedback-completed.md
@@ -67,7 +67,7 @@ Before reusing this as a migration pattern:
 - Verify the inline help link.
 - Verify analytics are unchanged.
 - Verify the same screen implementation renders under the selected design-system root.
-- Verify DS components do not fall back to `LightWooColors`.
+- Verify DS components do not fall back to hardcoded light defaults.
 - Review light and dark previews/screenshots.
 - Confirm no POS APIs or patterns were introduced.
 

--- a/docs/design-system/pilot-feedback-completed.md
+++ b/docs/design-system/pilot-feedback-completed.md
@@ -1,0 +1,78 @@
+# Pilot: Feedback Completed
+
+Historical note: this doc records an XML/View-to-Compose validation pattern. It does not define
+current rollout scope; see [rollout-direction.md](rollout-direction.md).
+
+`FeedbackCompletedFragment` was the XML/View pilot for Store Management App design-system integration.
+
+The goal was to validate the adapter, the Fragment-hosted Compose migration workflow, and the documentation future AI agents should follow.
+
+## Target Files
+
+- `WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackCompletedFragment.kt`
+- `WooCommerce/src/main/res/layout/fragment_feedback_completed.xml`
+- `WooCommerce/src/main/res/navigation/nav_graph_main.xml`
+- `WooCommerce/src/main/res/navigation/nav_graph_settings.xml`
+
+## Why This Screen
+
+- It is visible but low-risk.
+- It is not a product, order, payment, fulfillment, or POS workflow.
+- It has bounded navigation and no ViewModel.
+- It exercises design-system basics: top bar, title text, body text, link text, image, primary button, spacing, and scroll behavior.
+- It can be reused as a concrete AI-agent migration example.
+
+## Behavior To Preserve
+
+- `activityAppBarStatus` remains hidden because the screen owns its top bar.
+- Close navigation uses `findNavController().navigateUp()`.
+- The "Back to store" button keeps the current back behavior.
+- The inline "contact us" text opens help with `HelpOrigin.FEEDBACK_SURVEY`.
+- `AnalyticsTracker.trackViewShown(this)` still runs on resume.
+- `AnalyticsEvent.SURVEY_SCREEN` still tracks `KEY_FEEDBACK_CONTEXT` and `VALUE_FEEDBACK_COMPLETED`.
+- Existing string resources and drawable assets remain unless a design decision changes them.
+- Existing nav graph destinations and SafeArgs remain.
+
+## Design-System Coverage Pattern
+
+The pattern consumes production-ready design-system APIs for:
+
+- `WooTheme.*` foundations under `WooDesignSystemThemeWithBackground`.
+- Top bar or navigation bar component.
+- Page title/body/link typography.
+- Primary button.
+- Spacing/padding tokens.
+- Radius/color tokens required by those components.
+- Image/content layout conventions.
+
+If a required component is not production-ready yet, either implement it first or document why the
+pattern temporarily uses a legacy component.
+
+## Preview Coverage
+
+Add previews for:
+
+- Design-system foundation in light and dark mode.
+- Long body/link text if layout can wrap.
+- Large font scale if text or button layout is sensitive.
+
+## Verification
+
+Before reusing this as a migration pattern:
+
+- Compare the migrated screen against the XML baseline.
+- Verify no accessibility regression from the XML baseline.
+- Verify close navigation.
+- Verify "Back to store" behavior.
+- Verify the inline help link.
+- Verify analytics are unchanged.
+- Verify the same screen implementation renders under the selected design-system root.
+- Verify DS components do not fall back to `LightWooColors`.
+- Review light and dark previews/screenshots.
+- Confirm no POS APIs or patterns were introduced.
+
+## Findings After Implementation
+
+Add findings here only when this pattern reveals something worth preserving for future migrations,
+such as a component gap, token mismatch, verification issue, or playbook change. Do not add trivial
+implementation notes.

--- a/docs/design-system/pilot-privacy-settings.md
+++ b/docs/design-system/pilot-privacy-settings.md
@@ -72,7 +72,7 @@ Before reusing this as an existing-Compose adoption pattern:
 - Verify policies navigation.
 - Verify snackbar behavior if touched.
 - Verify the same screen implementation renders under the selected design-system root.
-- Verify DS components do not fall back to `LightWooColors`.
+- Verify DS components do not fall back to hardcoded light defaults.
 - Review light and dark previews/screenshots.
 - Confirm no POS APIs or patterns were introduced.
 

--- a/docs/design-system/pilot-privacy-settings.md
+++ b/docs/design-system/pilot-privacy-settings.md
@@ -1,0 +1,83 @@
+# Pilot: Privacy Settings
+
+Historical note: this doc records an existing-Compose validation pattern. It does not define current
+rollout scope; see [rollout-direction.md](rollout-direction.md).
+
+`PrivacySettingsFragment` was the existing-Compose pilot for Store Management App design-system integration.
+
+The goal is to validate Compose Design System Adoption: an existing Store Compose screen adopts
+design-system components and foundations without changing its hosting model or product behavior.
+
+## Target Files
+
+- `WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsFragment.kt`
+- `WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsScreen.kt`
+- `WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsViewModel.kt`
+
+## Why This Screen
+
+- It is already Compose, so it tests design-system adoption without XML/View layout migration.
+- It is a visible Store app settings surface.
+- It is not a product, order, payment, fulfillment, or POS workflow.
+- It has useful design-system coverage: page text, section headers, cells/rows, switches, icon
+  buttons, dividers, progress indicator, scrolling, and snackbar-triggering behavior.
+- Existing preview coverage includes light, dark, RTL, and smaller-screen variants.
+
+## Behavior To Preserve
+
+- The Fragment remains the host.
+- XML nav graph and existing navigation remain.
+- `PrivacySettingsViewModel` remains the state and event owner.
+- Web option and usage tracker links still open via custom tabs.
+- Policies navigation still uses the existing SafeArgs direction.
+- Snackbar behavior remains in the Fragment through `UIMessageResolver`.
+- `AnalyticsTracker.trackViewShown(this)` still runs on resume.
+- Existing string resources remain unless a product copy decision changes them.
+
+## Design-System Coverage Pattern
+
+The pattern consumes production-ready design-system APIs for:
+
+- `WooTheme.*` foundations under `WooDesignSystemThemeWithBackground`.
+- Page title/body typography.
+- Section header.
+- Cell or settings row.
+- Switch.
+- Icon button.
+- Divider.
+- Spacing/padding tokens.
+- Radius/color tokens required by those components.
+- Progress indicator as a thin Material 3 wrapper, even though it is not listed as an i1 Figma component.
+
+If a required component is not production-ready yet, either implement it first or document why the
+pattern temporarily uses legacy/current Compose.
+
+## Preview Coverage
+
+Preserve or improve the current previews:
+
+- Design-system foundation in light and dark mode.
+- RTL mode.
+- Large font scale.
+- Smaller screen.
+
+## Verification
+
+Before reusing this as an existing-Compose adoption pattern:
+
+- Verify no accessibility regression from the current Compose screen.
+- Verify analytics are unchanged.
+- Verify switch interactions still call the existing ViewModel handlers.
+- Verify web option and usage tracker links.
+- Verify policies navigation.
+- Verify snackbar behavior if touched.
+- Verify the same screen implementation renders under the selected design-system root.
+- Verify DS components do not fall back to `LightWooColors`.
+- Review light and dark previews/screenshots.
+- Confirm no POS APIs or patterns were introduced.
+
+## Findings After Implementation
+
+Add findings here only when this pattern reveals something worth preserving for future migrations,
+such as a component gap, token mismatch, verification issue, or playbook change. Do not add trivial
+implementation notes.

--- a/docs/design-system/rollout-direction.md
+++ b/docs/design-system/rollout-direction.md
@@ -1,0 +1,148 @@
+# Store Design System Rollout Direction
+
+Status: current direction as of June 23, 2026.
+
+This document is the canonical source for Store Management App design-system rollout scope. It
+supersedes the earlier pilot-first and open-strategy framing in the design-system docs. Branches
+created before this direction predate the current plan and should not be treated as scope authority.
+
+## Direction
+
+The rollout is a UI migration, not a full app rewrite.
+
+The first coherent wave migrates:
+
+- Dashboard tab surface.
+- Products tab surface.
+- Orders tab surface.
+- More tab surface.
+- Top Product Detail surface.
+- Top Order Detail surface.
+
+Each migrated screen should have one design-system UI implementation. Do not keep permanent duplicate
+legacy and design-system screen trees, and do not use the XML bridge explored in earlier branches as
+the migration strategy.
+
+For heavy XML screens, full migration can still keep an XML shell when the shell is needed for
+existing app compatibility. In that case, use `ComposeView` for migrated sections, rows, or content
+areas, and keep XML only for compatibility ownership such as `SearchView`, `ActionMode`, collapsing
+toolbar behavior, or existing Fragment integration.
+
+## Theme Root Rollout
+
+Screen migration is explicit: migrated screens opt into the design-system root, and non-migrated
+screens stay on the legacy root. The current `composeView {}` implementation is legacy-rooted; no
+runtime root switching exists yet, so this is the root contract to build rather than a change to
+shipped behavior.
+
+- During migration work, design-system screens should use an explicit DS-specific builder, such as
+  `designSystemComposeView {}`.
+- Existing legacy screens continue using the current legacy Compose root.
+- Do not add root-selection indirection to existing `composeView {}` calls. A screen is migrated by
+  changing its call site to the DS root builder.
+
+Before the final merge of the migration branch, restore the ergonomic default API through a
+controlled rename boundary:
+
+- Rename the current legacy `composeView` to `legacyComposeView`.
+- Rename the current `WooThemeWithBackground` to `LegacyWooThemeWithBackground`.
+- Rename the DS-specific builder to `composeView`.
+- Audit every remaining `composeView` call as intentionally migrated.
+- Move every non-migrated screen to `legacyComposeView`.
+
+Verify the rename boundary with strict `rg` audits for legacy root usage, DS root usage, and
+remaining ambiguous `composeView` call sites. Do not document a legacy-compatible design-system
+foundation bridge as required for this rollout path unless a future implementation explicitly
+chooses that bridge.
+
+## Detail Scope
+
+### Product Detail
+
+Product Detail is expected to migrate most of its top surface because the scope is smaller than Order
+Detail. The top surface includes the entry detail screen, visible sections, loading/error states, and
+toolbar chrome.
+
+Launched child and edit flows are out of scope for this wave. Examples include product creation, AI
+product creation, image management, categories/tags/selectors, pricing, inventory, shipping,
+linked/grouped/bundle/composite editors, variations, downloads, add-ons, quantity rules, subscription
+editors, reviews, custom fields, and share/webview flows.
+
+### Order Detail
+
+Order Detail is larger. The top surface is in scope, including the initial rendered detail hub:
+status, product list, totals/custom amounts, shipping lines, refunds summary, shipping label
+summary/cards, payment summary, customer summary, subscriptions, gift cards, tracking summary,
+attribution, notes summary, trash action, loading/empty states, and toolbar chrome such as
+previous/next/edit actions.
+
+Launched child flows are out of scope for this wave. Examples include shipping label
+creation/refund/print/customs/Woo Shipping flows, refund creation, order editing/status/address
+flows, payment and card-reader flows, add note, shipment tracking add/provider/barcode flows,
+receipt/printing, fulfillment, custom fields, AI thank-you-note, and product detail launched from
+order items.
+
+## Legacy Theme Convergence
+
+After the first-wave screens, converge existing XML and legacy Compose foundations toward the
+design-system look for safe tokens only. This is broader visual convergence for screens that remain
+legacy; it is separate from explicit screen migration and does not require changing the root used by
+existing `composeView {}` calls.
+
+Allowed convergence areas:
+
+- Background and surface colors.
+- Toolbar and app chrome colors.
+- Primary/accent colors when contrast is verified.
+- Divider and outline colors.
+- Shallow radius only when centralized and low-risk.
+
+Explicitly out of scope for the convergence wave:
+
+- Global typography replacement.
+- Global spacing or padding replacement.
+- Global status, alert, or semantic color rewrites.
+- App-wide card radius changes.
+- Behavior, navigation, or state-model rewrites.
+
+Colors are now the approved XML-safe exception: Store design-system color primitives may live in
+module-local Android resources so Compose and targeted XML/View usage read the same values through
+`WooTheme.colors`.
+
+Non-color foundations remain Kotlin/Compose-owned. Do not promote typography, spacing, padding,
+radius, icon size, or stroke primitives to XML resources as part of this convergence direction.
+
+When XML/View needs a design-system color token, use the shared module-local color resource and keep
+Compose reading that same resource. Do not keep parallel Kotlin/Compose and XML primitive values.
+
+## Toolbar Direction
+
+The toolbar goal is a unified design-system visual look, not one mandatory implementation.
+
+- Compose-owned screens use `WooTopAppBar`.
+- Heavy XML screens may keep XML toolbar ownership if the toolbar matches the design-system look.
+- Existing behavior must be preserved for `SearchView`, `ActionMode`, collapsing app bars,
+  menu/action ownership, navigation ownership, and insets.
+- A DS-looking XML toolbar is an acceptable migration tool for legacy-heavy screens.
+
+This keeps the migration focused on UI consistency without forcing a full app rewrite.
+
+## Decision Table
+
+| Surface | Scope | Action |
+| --- | --- | --- |
+| Dashboard tab | In | Migrate the tab surface to design-system UI. |
+| Products tab | In | Migrate the tab surface to design-system UI. |
+| Orders tab | In | Migrate the tab surface to design-system UI. |
+| More tab | In | Migrate the tab surface to design-system UI. |
+| Product Detail top surface | In | Migrate the top detail surface and chrome. Keep launched child/edit flows out. |
+| Order Detail top surface | In | Migrate the top detail hub and chrome. Keep launched child flows out. |
+| Product creation and AI creation | Out | Leave legacy for this wave unless separately assigned later. |
+| Product editors and selectors | Out | Leave pricing, inventory, shipping, taxonomy, linked product, variation, add-on, subscription, review, and custom-field flows legacy for this wave. |
+| Order shipping label flows | Out | Leave creation, refund, print, customs, and Woo Shipping child flows legacy for this wave. |
+| Order refund creation | Out | Leave legacy for this wave. |
+| Order editing/status/address flows | Out | Leave legacy for this wave. |
+| Payment and card-reader flows | Out | Leave legacy for this wave. |
+| Shipment tracking add/provider/barcode flows | Out | Leave legacy for this wave. |
+| Receipt, printing, and fulfillment flows | Out | Leave legacy for this wave. |
+| Other unlisted screens | Unassigned | Assess separately. Do not infer migration scope from this wave. |

--- a/docs/design-system/screen-migration-playbook.md
+++ b/docs/design-system/screen-migration-playbook.md
@@ -1,0 +1,197 @@
+# Store Design System Screen Migration Playbook
+
+This playbook is for AI-assisted Store Management App screen migrations.
+
+Use [rollout-direction.md](rollout-direction.md) as the canonical source for first-wave scope. The
+assigned first-wave surfaces are Dashboard, Products, Orders, More, top Product Detail, and top Order
+Detail.
+
+## Supported Outcomes
+
+There are three supported outcomes:
+
+- XML/View layout to Fragment-hosted Compose layout migration.
+- Existing Compose screen adopting the design-system theme, tokens, and components.
+- Targeted XML/View visual convergence for screens that remain legacy but need safe color/chrome alignment.
+
+Migration is not mandatory for every screen. Do not infer scope for unlisted screens from the first wave.
+
+## Candidate Assessment
+
+Assess the screen before editing code.
+
+If the screen is named as in scope in [rollout-direction.md](rollout-direction.md), proceed with the
+appropriate migration outcome and record the risk signals found during exploration.
+
+A good unassigned candidate:
+
+- Is a low-risk product surface.
+- Has visible design-system value: toolbar, text hierarchy, cells, buttons, banners, empty/loading states, or forms.
+- Has bounded state and navigation.
+- Can be verified with previews and screenshots in light and dark mode.
+- Avoids RecyclerView behavior, selection tracking, `ActionMode`, complex custom Views, or major accessibility redesign.
+- Has a clear before/after baseline for AI agents.
+
+High-risk unassigned screens require explicit confirmation before editing. High-risk signals include:
+
+- RecyclerView, ListAdapter, PagingDataAdapter, or adapter-heavy migration.
+- Selection tracking or `ActionMode`.
+- Complex custom Views or compound widgets.
+- Shared element transitions or complicated animation behavior.
+- Embedded WebView, camera, barcode scanner, media picker, or payment/card-reader UI.
+- Product, order, payment editing, or fulfillment flows.
+- Many navigation branches or multiple child fragments.
+- No reliable preview or screenshot baseline.
+
+For assigned first-wave heavy screens, these risks shape the migration plan; they do not
+automatically block work. For unassigned screens, stop and ask whether the screen should be migrated,
+partially updated with View/XML styles, or deferred.
+
+## Migration Boundary
+
+Fragment-hosted Compose layout migration means:
+
+- Replace the screen layout/content with Compose.
+- Keep the Fragment.
+- Keep XML nav graphs and SafeArgs.
+- Keep existing ViewModels.
+- Keep navigation and Store app event handling in the Fragment.
+- Preserve analytics and product behavior.
+
+It does not mean:
+
+- Compose Navigation migration.
+- ViewModel rewrite.
+- Feature redesign.
+- POS migration.
+- Global app theme replacement.
+- Migrating launched child flows unless they are explicitly assigned.
+
+## Existing Compose Adoption Boundary
+
+Compose Design System Adoption means:
+
+- Keep the existing Fragment or dialog host.
+- Keep existing ViewModels, navigation, events, analytics, strings, and product behavior.
+- Replace legacy/current Compose styling with production-ready design-system components and
+  `WooTheme.*` foundations.
+- Import design-system APIs from `com.woocommerce.android.ui.compose.designsystem.*`; the
+  implementation is module-owned in `:libs:store-design-system` even though the package name stays
+  stable for Store screens.
+- Preserve or improve existing preview coverage.
+
+It does not mean:
+
+- Rewriting the screen's state model.
+- Moving navigation into Compose.
+- Migrating unrelated legacy components.
+- Changing product copy or behavior without an explicit product decision.
+
+## Targeted XML/View Visual Convergence Boundary
+
+Targeted XML/View visual convergence means:
+
+- Keep the existing XML/View screen implementation.
+- Apply design-system-aligned color or chrome styling only where the change is low-risk.
+- Consume shared module-local color resources through targeted XML/View styles when XML/View needs a
+  design-system color token. Keep Compose reading the same value through `WooTheme.colors`.
+- Use a DS-looking XML toolbar when toolbar ownership must remain in XML.
+
+It does not mean:
+
+- A global XML theme rewrite.
+- Global typography, spacing, or status/semantic color replacement.
+- A permanent XML bridge for an in-scope migrated screen.
+- Rewriting behavior, navigation, or state.
+
+## Rollout Boundary
+
+Migrated first-wave screens use one design-system component tree. Do not create permanent
+`LegacyScreen` and `DesignSystemScreen` implementations for ordinary migrations.
+
+- Screen migration is explicit: migrated screens opt into the design-system root; non-migrated
+  screens stay on the legacy root.
+- During migration work, use a DS-specific builder such as `designSystemComposeView {}` for migrated
+  screens.
+- Do not add root-selection indirection to existing `composeView {}` calls. A screen is migrated by
+  changing its call site to the DS root builder.
+- Temporary full-screen fallbacks inside in-scope screens are allowed only for genuinely high-risk
+  migration gaps and must include an expiry/removal plan.
+- Out-of-scope child flows may remain legacy for this wave without an expiry plan.
+
+Before the final merge of the migration branch, run a controlled root-API rename:
+
+- Rename the current legacy `composeView` to `legacyComposeView`.
+- Rename the current `WooThemeWithBackground` to `LegacyWooThemeWithBackground`.
+- Rename the DS-specific builder to `composeView`.
+- Audit every remaining `composeView` call as intentionally migrated.
+- Move every non-migrated screen to `legacyComposeView`.
+
+Verify the boundary with strict `rg` audits. A legacy-compatible design-system foundation bridge is
+not required by this rollout path unless a future implementation explicitly chooses it.
+
+## Chrome Components
+
+Top app bar/chrome migration is a component and rollout concern. Moving from the Activity toolbar to
+Compose `WooTopAppBar` changes ownership and structure, not only colors.
+
+The current toolbar direction is a unified design-system visual look, not one forced implementation:
+
+- Compose-owned screens use `WooTopAppBar`.
+- Heavy XML screens may keep XML toolbar ownership if the toolbar matches the design-system look.
+- For migrated Compose-owned screens, `WooTopAppBar` renders under the design-system root.
+- For legacy-heavy screens, preserve existing toolbar ownership unless a scoped migration chooses a
+  DS-looking XML toolbar or an explicit Compose chrome migration.
+- Preserve `SearchView`, `ActionMode`, collapsing app bars, menu/action ownership, navigation
+  ownership, and insets.
+- Do not add a duplicate screen implementation just to preserve legacy toolbar chrome.
+
+## Workflow
+
+1. Check [rollout-direction.md](rollout-direction.md) for scope before deciding what to migrate.
+2. Capture the baseline: current layout, Fragment/dialog host, navigation, analytics, strings,
+   images, and accessibility.
+3. Decide which adoption outcome applies.
+4. Keep the existing host. For XML/View migration, replace content with Compose or embed `ComposeView`
+   sections inside a compatibility XML shell. For existing Compose adoption, keep the current Compose
+   root.
+5. Keep one migrated screen implementation. Use an explicit DS root builder for migrated screens;
+   keep non-migrated screens on the legacy root.
+6. Build a stateless screen composable and a VM-aware overload only if the screen needs ViewModel state.
+7. Use design-system components and `WooTheme.*` foundations where they are production-ready.
+8. Do not use preview-only components in production screens. Preview-only implementations should not
+   have public APIs intended for product-screen imports.
+9. Preserve existing string resources and analytics event names unless the migration explicitly requires a product copy or tracking change.
+10. Add previews for the migrated screen under the design-system root in light and dark mode. Add
+    RTL and large-font coverage for row-heavy screens.
+11. Verify first-wave screens with screenshot review, targeted tests when behavior changes, and an
+    accessibility regression check against the original screen.
+12. Verify design-system components do not fall back to static `LightWooColors` or other hardcoded
+    light defaults under the design-system root.
+13. Before final merge, verify the controlled rename boundary with strict `rg` audits so every
+    remaining `composeView` call is intentionally migrated and every non-migrated screen uses
+    `legacyComposeView`.
+
+## Android Migration Skill
+
+When migrating XML/View layouts to Compose, use the Android skill as a workflow reference:
+
+`https://github.com/android/skills/tree/main/jetpack-compose/migration/migrate-xml-views-to-jetpack-compose`
+
+Use it as a per-screen checklist. It is not a mandate to migrate every screen.
+
+## Agent Output Requirements
+
+For each migrated, adopted, or visually converged screen, an agent must report a short assessment:
+
+- Whether the screen is in the first-wave scope.
+- Which adoption outcome was used.
+- Risk signals checked.
+- What behavior was intentionally preserved.
+- What design-system components and `WooTheme` foundations were used.
+- Whether the screen uses a single design-system component tree.
+- What stayed in XML/View or legacy Compose and why.
+- Preview coverage added, including light/dark DS-root coverage.
+- Verification performed.
+- Accessibility checks performed.
+- Any follow-up needed before broader migration.

--- a/docs/design-system/screen-migration-playbook.md
+++ b/docs/design-system/screen-migration-playbook.md
@@ -119,16 +119,10 @@ Migrated first-wave screens use one design-system component tree. Do not create 
   migration gaps and must include an expiry/removal plan.
 - Out-of-scope child flows may remain legacy for this wave without an expiry plan.
 
-Before the final merge of the migration branch, run a controlled root-API rename:
-
-- Rename the current legacy `composeView` to `legacyComposeView`.
-- Rename the current `WooThemeWithBackground` to `LegacyWooThemeWithBackground`.
-- Rename the DS-specific builder to `composeView`.
-- Audit every remaining `composeView` call as intentionally migrated.
-- Move every non-migrated screen to `legacyComposeView`.
-
-Verify the boundary with strict `rg` audits. A legacy-compatible design-system foundation bridge is
-not required by this rollout path unless a future implementation explicitly chooses it.
+Before the final merge of the migration branch, follow the controlled root-API rename boundary and
+audit steps defined in [rollout-direction.md](rollout-direction.md). A legacy-compatible
+design-system foundation bridge is not required by this rollout path unless a future implementation
+explicitly chooses it.
 
 ## Chrome Components
 
@@ -166,11 +160,10 @@ The current toolbar direction is a unified design-system visual look, not one fo
     RTL and large-font coverage for row-heavy screens.
 11. Verify first-wave screens with screenshot review, targeted tests when behavior changes, and an
     accessibility regression check against the original screen.
-12. Verify design-system components do not fall back to static `LightWooColors` or other hardcoded
-    light defaults under the design-system root.
-13. Before final merge, verify the controlled rename boundary with strict `rg` audits so every
-    remaining `composeView` call is intentionally migrated and every non-migrated screen uses
-    `legacyComposeView`.
+12. Verify design-system components do not fall back to hardcoded light defaults under the
+    design-system root.
+13. Before final merge, verify the controlled root-API rename boundary with the strict `rg` audits
+    defined in [rollout-direction.md](rollout-direction.md).
 
 ## Android Migration Skill
 

--- a/docs/design-system/token-map.md
+++ b/docs/design-system/token-map.md
@@ -1,0 +1,386 @@
+# Store Design System Token Map
+
+This file maps Woo Mobile Design System i1 design intent to Store runtime tokens.
+
+Figma remains the design-intent source of truth. Android owns the stable runtime API.
+Do not expose raw Figma variable names or variable IDs in public Android APIs. Do not include raw P2
+or Figma URLs or raw variable IDs in public repo docs.
+
+Source references use public-repo shorthands:
+
+- P2: `Woo Mobile Design System, i1`, May 27, 2026 (`pe5sF9-5ox-p2`).
+- Figma file: `Woo Mobile Design System` (`50XIH5MmOf4xUYEkM6fAm6-fi`).
+- Full Figma variable export: `figma-export.json`.
+
+Use source shorthands in the source-reference column. Do not use raw P2 or Figma URLs in public repo
+docs.
+
+Agent note: Figma references use the public GitHub shorthand `{fileKey}-fi`. When using Figma tools,
+strip the `-fi` suffix and pass only `{fileKey}` as the Figma `fileKey`.
+
+## Figma Export Parsing Rules
+
+`figma-export.json` is the committed full export of Figma variables used for foundation
+reconciliation. Refreshing the export should preserve this parser contract:
+
+- Parse Store runtime/public foundations from non-`Semantic` top-level export sections only.
+- Keep the top-level `Semantic` section in the export for traceability, but ignore it when generating
+  or updating Store runtime tokens, public token-map rows, `WooTheme.colors`,
+  `WooTheme.semanticColors`, or Material 3 projections.
+- Use normal `Light` / `Dark` values for runtime color modes. High-contrast modes remain
+  export-backed traceability data until an accessibility-mode foundation is separately scoped.
+- Use the Android mode for Android typography values.
+- If a future component audit proves a `Semantic` variable is the intended source, update this
+  token map with the component evidence and approved mapping before consuming that section.
+
+Use the committed full export plus the per-foundation audit files under
+`docs/design-system/foundation-audit/` for row-level source paths, values, and unresolved notes. Do
+not use older split token exports as current foundation sources.
+
+The Figma `Color roles` frame validates the role inventory and light-mode values for Primary and
+Secondary, Container, Surface, Outline, and Error/alert/success. Background, Overlay, and Palette are
+export-backed by `figma-export.json` but are not validated by that frame.
+
+## Status Values
+
+- `production`: Stable enough for Store screens to consume.
+- `preview_only`: Useful for previews or catalog work, but not ready for production screen adoption.
+- `needs_design`: Missing, inconsistent, or not signed off in design.
+- `needs_android_mapping`: Clear design intent exists, but the Android token/API still needs implementation work.
+
+## Public Foundation Surface
+
+Production Store screens and design-system components read approved foundations from `WooTheme.*`.
+`WooDesignSystemTheme` projects the same source values into `MaterialTheme` for Material 3 component
+interop.
+
+| Android API | Source reference | Light value | Dark value | Material 3 role mapping | Status | Notes |
+| --- | --- | --- | --- | --- | --- | --- |
+| `WooTheme.colors` | `figma-export.json` / `Woo theme` | See color reconciliation table | See color reconciliation table | Projection to `ColorScheme` | production | Grouped Store authoring roles; Material 3 is an interop projection. |
+| `WooTheme.text` | `figma-export.json` / `Typescale` and `Font theme` | See text table | Same values | Regular projection to `Typography` | production | Android mode values; Android default font is the runtime equivalent for source `Roboto`. |
+| `WooTheme.spacing` | `figma-export.json` / `Spacing/Spacing` | `0..64dp` | Same values | No Material role | production | Theme-scoped spacing accessor. |
+| `WooTheme.padding` | `figma-export.json` / `Spacing/Padding` | `0..64dp` | Same values | No Material role | production | Separate group from spacing even when values match. |
+| `WooTheme.radius` | `figma-export.json` / `Shape/Corner-Radius` | `0..999dp` | Same values | Partial projection to `Shapes` | production | Includes Woo-only `none` and `full` tokens. |
+| `WooTheme.iconSize` | `figma-export.json` / `Icon/Size` | `14..32dp` | Same values | No Material role | production | Glyph sizes only; not touch-target or layout sizing. |
+
+## PR 2 Public Color Surface
+
+`WooTheme.colors` exposes source-backed Store authoring roles from `figma-export.json` / `Woo theme`.
+Group the public API shallowly by source intent; do not collapse the source into a small Material
+3-like subset.
+
+| Public group | Source-backed coverage |
+| --- | --- |
+| Core | Primary, on-primary, secondary, and on-secondary roles from the Color roles frame's "Primary and Secondary" section. |
+| Container | Primary container, on-primary container, secondary container, and on-secondary container. These are accent containers; status containers stay under `status`. |
+| Surface | Surface, surface dim, surface bright, surface container highest, on-default, on-variant, on-variant-lowest, inverted, and on-inverted roles. |
+| Outline | `outline` and `outlineVariant`. |
+| Status | Error, warning, caution, success, info, and neutral containers plus their on-container colors. |
+| Alert | Red, orange, green, and blue alert ramp colors plus their on-colors. |
+| Background | Export-backed background roles; not validated by the Color roles frame. |
+| Overlay | Export-backed overlay roles; not validated by the Color roles frame. |
+| Palette | Export-backed primitive/ramp data exposed as public `WooTheme.colors.palette.*` tokens. |
+
+## Mapping Rules
+
+- Expose approved Store authoring roles through `WooTheme`, not directly through `MaterialTheme`.
+- Preserve source-backed color intent in `WooTheme.colors` instead of generating public Material 3
+  aliases.
+- Keep `MaterialTheme.colorScheme`, `MaterialTheme.typography`, and `MaterialTheme.shapes` populated
+  as interop projections for Material 3 components, defaults, and helpers.
+- Keep Material 3-only projection aliases internal. Do not expose generated fixed roles or
+  source-missing aliases as public Store roles.
+- `surfaceDim` and `surfaceContainerHighest` are promoted source-backed Store roles. Do not filter
+  them out as generated Material aliases.
+- `surfaceBright` is export-backed and public under `WooTheme.colors.surface`.
+- `outline` and `outlineVariant` are source-backed and public under `WooTheme.colors`.
+- Keep state layers internal-first until semantic names and mode behavior are approved. Do not create
+  public `WooTheme.stateAlpha` floats from mode-aware state-layer color tokens.
+- Do not expose the top-level `Semantic` section unless a concrete component audit updates this token
+  map with approved evidence.
+- Do not create a separate `WooTheme.semanticColors` group in PR 2.
+- If a non-color Figma variable has no clean Material 3 role, add it as an internal adapter token
+  first.
+- Expose a non-color token with no clean Material 3 role publicly only when a production component
+  or first-wave screen needs it.
+- Keep `WooTheme.colors` as the Store authoring API even when color primitives are resource-backed internally.
+- Store design-system color primitives are the XML-safe exception and may live in module-local
+  Android color resources so Compose and targeted XML/View usage share the same values.
+- Non-color foundations remain Kotlin/Compose-owned unless a later approved plan says otherwise.
+- Do not keep parallel Kotlin/Compose and XML resource definitions for the same token primitive value.
+- Keep source token names or page references in this document when useful, but do not record raw
+  Figma variable IDs in repo docs.
+- Include light and dark values before marking a token `production`.
+- Include the closest Material 3 role when the token maps to `ColorScheme`, typography, shape, or elevation.
+- Mark unsettled tokens `preview_only`, `needs_design`, or `needs_android_mapping`.
+- Do not wire design-system token resources into app-wide legacy styles by default. Product screens opt in through the design-system theme/components or targeted XML/View style usage.
+
+## Token Ownership And XML/View Usage
+
+The i1 adapter is Compose-first at the API/component layer. `WooTheme.colors` remains the stable
+authoring API, while Store color primitives may be resource-backed implementation details for safe
+XML/View convergence. Non-color primitive foundations remain Kotlin/Compose-owned implementation
+details.
+
+When defining tokens:
+
+- Keep `WooTheme.colors` as the consuming API for color access even when the underlying color
+  primitives are stored in module-local Android resources.
+- Define non-color primitive foundations such as spacing, radius, icon sizing, and typography in
+  Kotlin/Compose foundation code.
+- Compose APIs should expose stable `WooTheme` and design-system component surfaces, not raw `R.color`
+  or `R.dimen` usage to product screens.
+- If a non-migrated XML/View screen needs a design-system color token, use the shared module-local
+  color resource and keep Compose reading the same value through `WooTheme.colors`.
+- XML/View styles may consume shared color resources only through targeted, opt-in style usage.
+- Do not copy color token values into separate Kotlin/Compose constants and XML resources.
+- Keep `token-map.md` as the audit trail for the token value, source shorthand, Material 3 role
+  mapping, status, and notes.
+- The rollout direction now allows scoped legacy XML and legacy Compose convergence for safe
+  color/chrome tokens only; see [rollout-direction.md](rollout-direction.md). Global typography,
+  spacing, and status/semantic remapping remain out of scope.
+- Do not globally apply design-system XML/View styles in PR 2. Add targeted XML/View style usage only
+  when a non-migrated XML/View screen needs design-system styling.
+
+## Public Color Source Reconciliation
+
+Every production `WooTheme.colors` field below is backed by normal `Light` / `Dark` values from the
+non-`Semantic` `Woo theme` section in `figma-export.json`. The `Semantic` section and high-contrast
+modes are not runtime/public mapping sources. Source paths are public shorthands; keep raw variable
+IDs and raw Figma node IDs out of repo docs.
+
+| Android API | Source path | Export file | Light hex / alpha | Dark hex / alpha | M3 projection | Status | Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `WooTheme.colors.primary` | `Woo theme/Primary` | `figma-export.json` | `#873EFF` / 100% | `#873EFF` / 100% | `primary` | production | Core primary. |
+| `WooTheme.colors.onPrimary` | `Woo theme/On-Primary` | `figma-export.json` | `#FFFFFF` / 100% | `#FFFFFF` / 100% | `onPrimary` | production | Foreground for `primary`. |
+| `WooTheme.colors.secondary` | `Woo theme/Secondary` | `figma-export.json` | `#6108CE` / 100% | `#383146` / 100% | `secondary` | production | Core secondary. |
+| `WooTheme.colors.onSecondary` | `Woo theme/On-Secondary` | `figma-export.json` | `#FFFFFF` / 100% | `#F1EDFE` / 100% | `onSecondary` | production | Foreground for `secondary`. |
+| `WooTheme.colors.container.primaryContainer` | `Woo theme/Primary-Container` | `figma-export.json` | `#B999FF` / 100% | `#FFFFFF` / 100% | `primaryContainer` | production | Accent container role. |
+| `WooTheme.colors.container.onPrimaryContainer` | `Woo theme/On-Primary-Container` | `figma-export.json` | `#2C045D` / 100% | `#FFFFFF` / 100% | `onPrimaryContainer` | production | Foreground for `primaryContainer`. |
+| `WooTheme.colors.container.secondaryContainer` | `Woo theme/Secondary-Container` | `figma-export.json` | `#F2EDFF` / 100% | `#FFFFFF` / 100% | `secondaryContainer` | production | Accent container role. |
+| `WooTheme.colors.container.onSecondaryContainer` | `Woo theme/On-Secondary-Container` | `figma-export.json` | `#873EFF` / 100% | `#FFFFFF` / 100% | `onSecondaryContainer` | production | Foreground for `secondaryContainer`. |
+| `WooTheme.colors.outline` | `Woo theme/Outline/Outline` | `figma-export.json` | `#787C82` / 100% | `#454549` / 100% | `outline` | production | Boundary token. |
+| `WooTheme.colors.outlineVariant` | `Woo theme/Outline/Outline-Variant` | `figma-export.json` | `#DCDCDE` / 100% | `#5E5E63` / 100% | `outlineVariant` | production | Subtle boundary token. |
+| `WooTheme.colors.background.section` | `Woo theme/Background/Section-Background` | `figma-export.json` | `#F2F2F8` / 100% | `#101517` / 100% | `background` | production | Section background. |
+| `WooTheme.colors.background.onSection` | `Woo theme/Background/On-Section-Background` | `figma-export.json` | `#1E1E1E` / 100% | `#FFFFFF` / 100% | `onBackground` | production | Foreground for `section`. |
+| `WooTheme.colors.background.sectionVariant` | `Woo theme/Background/Section-Background-Variant` | `figma-export.json` | `#F0F0F0` / 100% | `#101517` / 100% | `surfaceVariant` | production | Variant section background. |
+| `WooTheme.colors.background.onSectionVariant` | `Woo theme/Background/On-Section-Background-Variant` | `figma-export.json` | `#1C1C1E` / 100% | `#8B8A8E` / 100% | No direct M3 role | production | Foreground for `sectionVariant`. |
+| `WooTheme.colors.surface.default` | `Woo theme/Surface/Surface` | `figma-export.json` | `#FFFFFF` / 100% | `#232529` / 100% | `surface` | production | Default surface. |
+| `WooTheme.colors.surface.surfaceDim` | `Woo theme/Surface/Surface-Dim` | `figma-export.json` | `#F6F7F7` / 100% | `#232529` / 100% | `surfaceDim` | production | Promoted source-backed surface role. |
+| `WooTheme.colors.surface.surfaceContainerHighest` | `Woo theme/Surface/Surface-Container-Highest` | `figma-export.json` | `#DCDCDE` / 100% | `#232529` / 100% | `surfaceContainerHighest` | production | Promoted source-backed surface role. |
+| `WooTheme.colors.surface.onDefault` | `Woo theme/Surface/On-Surface` | `figma-export.json` | `#000000` / 100% | `#FFFFFF` / 100% | `onSurface` | production | Foreground for default surface. |
+| `WooTheme.colors.surface.onVariant` | `Woo theme/Surface/On-Surface-Variant` | `figma-export.json` | `#2C3338` / 100% | `#626068` / 100% | `onSurfaceVariant` | production | Variant foreground. |
+| `WooTheme.colors.surface.onVariantLowest` | `Woo theme/Surface/On-Surface-Variant-Lowest` | `figma-export.json` | `#50575E` / 100% | `#626068` / 100% | No direct M3 role | production | Lowest variant foreground. |
+| `WooTheme.colors.surface.inverted` | `Woo theme/Surface/Inverse-Surface` | `figma-export.json` | `#000000` / 100% | `#FFFFFF` / 100% | `inverseSurface` | production | Inverse surface. |
+| `WooTheme.colors.surface.onInverted` | `Woo theme/Surface/On-Inverse-Surface` | `figma-export.json` | `#FFFFFF` / 100% | `#000000` / 100% | `inverseOnSurface` | production | Foreground for inverse surface. |
+| `WooTheme.colors.surface.surfaceBright` | `Woo theme/Surface/Surface-Bright` | `figma-export.json` | `#FFFFFF` / 100% | `#232529` / 100% | `surfaceBright` | production | Source-backed surface role. |
+| `WooTheme.colors.status.errorContainer` | `Woo theme/Alerts/Error-Container` | `figma-export.json` | `#F6E6E3` / 100% | `#F6E6E3` / 100% | `errorContainer` | production | Error container. |
+| `WooTheme.colors.status.onErrorContainer` | `Woo theme/Alerts/On-Error-Container` | `figma-export.json` | `#470000` / 100% | `#470000` / 100% | `onErrorContainer` | production | Foreground for `errorContainer`. |
+| `WooTheme.colors.status.warningContainer` | `Woo theme/Alerts/Warning-Container` | `figma-export.json` | `#FDE6BE` / 100% | `#FDE6BE` / 100% | No direct M3 role | production | Warning container. |
+| `WooTheme.colors.status.onWarningContainer` | `Woo theme/Alerts/On-Warning-Container` | `figma-export.json` | `#2E1900` / 100% | `#2E1900` / 100% | No direct M3 role | production | Foreground for `warningContainer`. |
+| `WooTheme.colors.status.cautionContainer` | `Woo theme/Alerts/Caution-Container` | `figma-export.json` | `#FEE995` / 100% | `#FEE995` / 100% | No direct M3 role | production | Caution container. |
+| `WooTheme.colors.status.onCautionContainer` | `Woo theme/Alerts/On-Caution-Container` | `figma-export.json` | `#281D00` / 100% | `#281D00` / 100% | No direct M3 role | production | Foreground for `cautionContainer`. |
+| `WooTheme.colors.status.successContainer` | `Woo theme/Alerts/Success-Container` | `figma-export.json` | `#C6F7CD` / 100% | `#C6F7CD` / 100% | No direct M3 role | production | Success container. |
+| `WooTheme.colors.status.onSuccessContainer` | `Woo theme/Alerts/On-Success-Container` | `figma-export.json` | `#002900` / 100% | `#002900` / 100% | No direct M3 role | production | Foreground for `successContainer`. |
+| `WooTheme.colors.status.infoContainer` | `Woo theme/Alerts/Info-Container` | `figma-export.json` | `#DEEBFA` / 100% | `#DEEBFA` / 100% | No direct M3 role | production | Info container. |
+| `WooTheme.colors.status.onInfoContainer` | `Woo theme/Alerts/On-Info-Container` | `figma-export.json` | `#001B4F` / 100% | `#001B4F` / 100% | No direct M3 role | production | Foreground for `infoContainer`. |
+| `WooTheme.colors.status.neutralContainer` | `Woo theme/Alerts/Neutral-Container` | `figma-export.json` | `#F4F4F4` / 100% | `#F4F4F4` / 100% | No direct M3 role | production | Neutral container. |
+| `WooTheme.colors.status.onNeutralContainer` | `Woo theme/Alerts/On-Neutral-Container` | `figma-export.json` | `#1E1E1E` / 100% | `#1E1E1E` / 100% | No direct M3 role | production | Foreground for `neutralContainer`. |
+| `WooTheme.colors.overlay.overlay20` | `Woo theme/Overlay/Opacity-20` | `figma-export.json` | `#000000` / 20% | `#000000` / 20% | No direct M3 role | production | Overlay color. |
+| `WooTheme.colors.overlay.overlay50` | `Woo theme/Overlay/Opacity-50` | `figma-export.json` | `#000000` / 50% | `#000000` / 75% | `scrim` | production | Overlay color. |
+| `WooTheme.colors.alert.red` | `Woo theme/Alerts/Red` | `figma-export.json` | `#FC4A5B` / 100% | `#DC3545` / 100% | No direct M3 role | production | Alert ramp color. |
+| `WooTheme.colors.alert.onRed` | `Woo theme/Alerts/On-Red` | `figma-export.json` | `#FFFFFF` / 100% | `#DC3545` / 100% | No direct M3 role | production | Foreground for `red`. |
+| `WooTheme.colors.alert.orange` | `Woo theme/Alerts/Orange` | `figma-export.json` | `#FF9000` / 100% | `#EAAB2D` / 100% | No direct M3 role | production | Alert ramp color. |
+| `WooTheme.colors.alert.onOrange` | `Woo theme/Alerts/On-Orange` | `figma-export.json` | `#FFFFFF` / 100% | `#EAAB2D` / 100% | No direct M3 role | production | Foreground for `orange`. |
+| `WooTheme.colors.alert.green` | `Woo theme/Alerts/Green` | `figma-export.json` | `#27AE32` / 100% | `#69B66F` / 100% | No direct M3 role | production | Alert ramp color. |
+| `WooTheme.colors.alert.onGreen` | `Woo theme/Alerts/On-Green` | `figma-export.json` | `#FFFFFF` / 100% | `#69B66F` / 100% | No direct M3 role | production | Foreground for `green`. |
+| `WooTheme.colors.alert.blue` | `Woo theme/Alerts/Blue` | `figma-export.json` | `#1E94D0` / 100% | `#1E94D0` / 100% | No direct M3 role | production | Alert ramp color. |
+| `WooTheme.colors.alert.onBlue` | `Woo theme/Alerts/On-Blue` | `figma-export.json` | `#FFFFFF` / 100% | `#1E94D0` / 100% | No direct M3 role | production | Foreground for `blue`. |
+| `WooTheme.colors.palette.sandstone.shade5` | `Woo theme/Add-On-Colors/Woo-Sandstone/5` | `figma-export.json` | `#FBF9F6` / 100% | `#FBF9F6` / 100% | No direct M3 role | production | Public palette ramp token. |
+| `WooTheme.colors.palette.sandstone.shade10` | `Woo theme/Add-On-Colors/Woo-Sandstone/10` | `figma-export.json` | `#F1EEEB` / 100% | `#F1EEEB` / 100% | No direct M3 role | production | Public palette ramp token. |
+| `WooTheme.colors.palette.sandstone.shade20` | `Woo theme/Add-On-Colors/Woo-Sandstone/20` | `figma-export.json` | `#E6E2DE` / 100% | `#E6E2DE` / 100% | No direct M3 role | production | Public palette ramp token. |
+| `WooTheme.colors.palette.sandstone.shade40` | `Woo theme/Add-On-Colors/Woo-Sandstone/40` | `figma-export.json` | `#C5C2BF` / 100% | `#C5C2BF` / 100% | No direct M3 role | production | Public palette ramp token. |
+| `WooTheme.colors.palette.sandstone.shade60` | `Woo theme/Add-On-Colors/Woo-Sandstone/60` | `figma-export.json` | `#8B8A89` / 100% | `#8B8A89` / 100% | No direct M3 role | production | Public palette ramp token. |
+| `WooTheme.colors.palette.wooBlue.shade20` | `Woo theme/Add-On-Colors/Woo-Blue/20` | `figma-export.json` | `#75FFFF` / 100% | `#75FFFF` / 100% | No direct M3 role | production | Public palette ramp token. |
+| `WooTheme.colors.palette.wooBlue.shade40` | `Woo theme/Add-On-Colors/Woo-Blue/40` | `figma-export.json` | `#1AD0FD` / 100% | `#1AD0FD` / 100% | No direct M3 role | production | Public palette ramp token. |
+| `WooTheme.colors.palette.wooBlue.shade60` | `Woo theme/Add-On-Colors/Woo-Blue/60` | `figma-export.json` | `#05096C` / 100% | `#05096C` / 100% | No direct M3 role | production | Public palette ramp token. |
+| `WooTheme.colors.palette.wooGreen.shade20` | `Woo theme/Add-On-Colors/Woo-Green/20` | `figma-export.json` | `#D5FF4A` / 100% | `#D5FF4A` / 100% | No direct M3 role | production | Public palette ramp token. |
+| `WooTheme.colors.palette.wooGreen.shade40` | `Woo theme/Add-On-Colors/Woo-Green/40` | `figma-export.json` | `#06E782` / 100% | `#06E782` / 100% | No direct M3 role | production | Public palette ramp token. |
+| `WooTheme.colors.palette.wooGreen.shade60` | `Woo theme/Add-On-Colors/Woo-Green/60` | `figma-export.json` | `#083D2D` / 100% | `#083D2D` / 100% | No direct M3 role | production | Public palette ramp token. |
+| `WooTheme.colors.palette.wooOrange.shade20` | `Woo theme/Add-On-Colors/Woo-Orange/20` | `figma-export.json` | `#FFE500` / 100% | `#FFE500` / 100% | No direct M3 role | production | Public palette ramp token. |
+| `WooTheme.colors.palette.wooOrange.shade40` | `Woo theme/Add-On-Colors/Woo-Orange/40` | `figma-export.json` | `#FF9000` / 100% | `#FF9000` / 100% | No direct M3 role | production | Public palette ramp token. |
+| `WooTheme.colors.palette.wooOrange.shade60` | `Woo theme/Add-On-Colors/Woo-Orange/60` | `figma-export.json` | `#FF4800` / 100% | `#FF4800` / 100% | No direct M3 role | production | Public palette ramp token. |
+| `WooTheme.colors.palette.wooPink.shade20` | `Woo theme/Add-On-Colors/Woo-Pink/20` | `figma-export.json` | `#FCA8FF` / 100% | `#FCA8FF` / 100% | No direct M3 role | production | Public palette ramp token. |
+| `WooTheme.colors.palette.wooPink.shade40` | `Woo theme/Add-On-Colors/Woo-Pink/40` | `figma-export.json` | `#FF45E3` / 100% | `#FF45E3` / 100% | No direct M3 role | production | Public palette ramp token. |
+| `WooTheme.colors.palette.wooPink.shade60` | `Woo theme/Add-On-Colors/Woo-Pink/60` | `figma-export.json` | `#4E0061` / 100% | `#4E0061` / 100% | No direct M3 role | production | Public palette ramp token. |
+| `WooTheme.colors.palette.wooPurple.shade0` | `Woo theme/Add-On-Colors/Woo-Purple/0` | `figma-export.json` | `#F2EDFF` / 100% | `#F2EDFF` / 100% | No direct M3 role | production | Public palette ramp token. |
+| `WooTheme.colors.palette.wooPurple.shade5` | `Woo theme/Add-On-Colors/Woo-Purple/5` | `figma-export.json` | `#E1D7FF` / 100% | `#E1D7FF` / 100% | No direct M3 role | production | Public palette ramp token. |
+| `WooTheme.colors.palette.wooPurple.shade10` | `Woo theme/Add-On-Colors/Woo-Purple/10` | `figma-export.json` | `#D1C1FF` / 100% | `#D1C1FF` / 100% | No direct M3 role | production | Public palette ramp token. |
+| `WooTheme.colors.palette.wooPurple.shade20` | `Woo theme/Add-On-Colors/Woo-Purple/20` | `figma-export.json` | `#B999FF` / 100% | `#B999FF` / 100% | No direct M3 role | production | Public palette ramp token. |
+| `WooTheme.colors.palette.wooPurple.shade30` | `Woo theme/Add-On-Colors/Woo-Purple/30` | `figma-export.json` | `#A77EFF` / 100% | `#A77EFF` / 100% | No direct M3 role | production | Public palette ramp token. |
+| `WooTheme.colors.palette.wooPurple.shade40` | `Woo theme/Add-On-Colors/Woo-Purple/40` | `figma-export.json` | `#873EFF` / 100% | `#873EFF` / 100% | No direct M3 role | production | Public palette ramp token. |
+| `WooTheme.colors.palette.wooPurple.shade50` | `Woo theme/Add-On-Colors/Woo-Purple/50` | `figma-export.json` | `#720EEC` / 100% | `#720EEC` / 100% | No direct M3 role | production | Public palette ramp token. |
+| `WooTheme.colors.palette.wooPurple.shade60` | `Woo theme/Add-On-Colors/Woo-Purple/60` | `figma-export.json` | `#6108CE` / 100% | `#6108CE` / 100% | No direct M3 role | production | Public palette ramp token. |
+| `WooTheme.colors.palette.wooPurple.shade70` | `Woo theme/Add-On-Colors/Woo-Purple/70` | `figma-export.json` | `#5007AA` / 100% | `#5007AA` / 100% | No direct M3 role | production | Public palette ramp token. |
+| `WooTheme.colors.palette.wooPurple.shade80` | `Woo theme/Add-On-Colors/Woo-Purple/80` | `figma-export.json` | `#3C087E` / 100% | `#3C087E` / 100% | No direct M3 role | production | Public palette ramp token. |
+| `WooTheme.colors.palette.wooPurple.shade90` | `Woo theme/Add-On-Colors/Woo-Purple/90` | `figma-export.json` | `#2C045D` / 100% | `#2C045D` / 100% | No direct M3 role | production | Public palette ramp token. |
+| `WooTheme.colors.palette.wooPurple.shade100` | `Woo theme/Add-On-Colors/Woo-Purple/100` | `figma-export.json` | `#1F0342` / 100% | `#1F0342` / 100% | No direct M3 role | production | Public palette ramp token. |
+| `WooTheme.colors.palette.gray.0..100` | `Woo theme/Add-On-Colors/Gray/0..100` | `figma-export.json` | Gray ramp / 100% | Gray ramp / 100% | No direct M3 role | production | Public gray palette ramp token. |
+
+## Material 3 Color Projection
+
+`WooDesignSystemTheme` builds a partial `ColorScheme` through Material 3 `1.4.0`
+`lightColorScheme(...)` / `darkColorScheme(...)` builders. Direct rows reuse public source fields.
+Alias rows are internal projection decisions only and are not additional public `WooTheme.colors`
+fields. Omitted rows intentionally use Material 3 defaults until a source-backed Store token is
+approved. Use normal `Light` / `Dark` values from non-`Semantic` `Woo theme` sources; do not fold
+high-contrast modes into the normal projection. In this projection table only, `defaulted` means
+omitted from the builder to use Material defaults, and `implicit` means resolved by the Material
+builder from another supplied source role.
+
+| Material role | Projection source | Status | Notes |
+| --- | --- | --- | --- |
+| `primary` | `WooTheme.colors.primary` | production | Direct source-backed projection. |
+| `onPrimary` | `WooTheme.colors.onPrimary` | production | Direct source-backed projection. |
+| `primaryContainer` | `WooTheme.colors.container.primaryContainer` | production | Source-backed accent container role. |
+| `onPrimaryContainer` | `WooTheme.colors.container.onPrimaryContainer` | production | Source-backed foreground for `primaryContainer`. |
+| `secondary` | `WooTheme.colors.secondary` | production | Direct source-backed projection. |
+| `onSecondary` | `WooTheme.colors.onSecondary` | production | Direct source-backed projection. |
+| `secondaryContainer` | `WooTheme.colors.container.secondaryContainer` | production | Source-backed accent container role. |
+| `onSecondaryContainer` | `WooTheme.colors.container.onSecondaryContainer` | production | Source-backed foreground for `secondaryContainer`. |
+| `tertiary` | `WooTheme.colors.secondary` | production | Internal alias to avoid baseline Material pink until a distinct tertiary source appears. |
+| `onTertiary` | `WooTheme.colors.onSecondary` | production | Internal alias to avoid baseline Material pink until a distinct tertiary source appears. |
+| `tertiaryContainer` | `WooTheme.colors.container.secondaryContainer` | production | Internal alias to avoid baseline Material pink until a distinct tertiary source appears. |
+| `onTertiaryContainer` | `WooTheme.colors.container.onSecondaryContainer` | production | Internal alias to avoid baseline Material pink until a distinct tertiary source appears. |
+| `background` | `WooTheme.colors.background.section` | production | Direct source-backed projection. |
+| `onBackground` | `WooTheme.colors.background.onSection` | production | Direct source-backed projection. |
+| `surface` | `WooTheme.colors.surface.default` | production | Direct source-backed projection. |
+| `onSurface` | `WooTheme.colors.surface.onDefault` | production | Direct source-backed projection. |
+| `surfaceVariant` | `WooTheme.colors.background.sectionVariant` | production | Source-backed projection, not a public Material mirror. |
+| `onSurfaceVariant` | `WooTheme.colors.surface.onVariant` | production | Direct source-backed projection. |
+| `inverseSurface` | `WooTheme.colors.surface.inverted` | production | Direct source-backed projection. |
+| `inverseOnSurface` | `WooTheme.colors.surface.onInverted` | production | Direct source-backed projection. |
+| `error` | Material 3 default | defaulted | Intentionally not projected. Source `Error` is a container/background; foreground/control error tokens are pending design. |
+| `onError` | Material 3 default | defaulted | Intentionally paired with Material 3 default `error`; do not use `alert.red` as a global control-error token without design approval. |
+| `errorContainer` | `WooTheme.colors.status.errorContainer` | production | Direct source-backed projection. |
+| `onErrorContainer` | `WooTheme.colors.status.onErrorContainer` | production | Direct source-backed projection. |
+| `outline` | `WooTheme.colors.outline` | production | Direct source-backed projection. |
+| `outlineVariant` | `WooTheme.colors.outlineVariant` | production | Direct source-backed projection. |
+| `scrim` | `WooTheme.colors.overlay.overlay50` | production | Source-backed projection; dark alpha is 75%. |
+| `surfaceBright` | `WooTheme.colors.surface.surfaceBright` | production | Direct source-backed projection. |
+| `surfaceDim` | `WooTheme.colors.surface.surfaceDim` | production | Promoted source-backed Store surface role. |
+| `surfaceContainer` | `WooTheme.colors.background.section` | production | Internal surface alias for navigation bars, menus, cards, and sheets. |
+| `surfaceContainerHigh` | `WooTheme.colors.surface.default` | production | Internal surface alias for Material container hierarchy. |
+| `surfaceContainerHighest` | `WooTheme.colors.surface.surfaceContainerHighest` | production | Promoted source-backed Store surface role. |
+| `surfaceContainerLow` | `WooTheme.colors.background.sectionVariant` | production | Internal surface alias for elevated cards and subtle containers. |
+| `surfaceContainerLowest` | `WooTheme.colors.surface.default` | production | Internal surface alias for Material container hierarchy. |
+| `surfaceTint` | Material 3 builder default | implicit | Builder default resolves to the passed Woo `primary`. |
+| `inversePrimary` | Material 3 default | defaulted | Keeps snackbar/action behavior on Material defaults until a source-backed inverse accent is approved. |
+| `primaryFixed*`, `secondaryFixed*`, `tertiaryFixed*` | Material 3 default | defaulted | Fixed roles are omitted until a source-backed Store fixed-role set or consuming component requires them. |
+
+## Public Text Tokens
+
+`WooTheme.text` exposes all 15 Android type roles from `figma-export.json` / `Typescale` and
+`Font theme`, with `regular`, `emphasized`, and `strong` variants. The regular variant is projected
+to `MaterialTheme.typography`. Android values must read the Android mode, and Android default font is
+the runtime equivalent for source `Roboto`. Export role names are hyphenated, while Android docs/API
+names are camelCase.
+
+`Typescale/<Role>/Font` resolves through `Font theme/Font/Plain`, whose Android value is `Roboto`.
+Android default font is the approved runtime equivalent. Most regular weights use `Weight`, but
+`Display-Large` and `Body-Small` use
+`Weight-Regular`. Most strong weights use `Weight-Strong`, but `Display-Large` uses
+`Weight-Extra-Emphasized`. Displayed tracking values may be rounded in docs; implementation should
+preserve source-backed values.
+
+| Android API | Size | Line height | Tracking | Weights | Material projection | Status | Notes |
+| --- | ---: | ---: | ---: | --- | --- | --- | --- |
+| `WooTheme.text.displayLarge` | `56sp` | `64sp` | `-0.41sp` | regular / medium / bold | `displayLarge.regular` | production | Source-backed role using the DS runtime font-family decision. |
+| `WooTheme.text.displayMedium` | `48sp` | `52sp` | `-0.41sp` | regular / medium / bold | `displayMedium.regular` | production | Source-backed role using the DS runtime font-family decision. |
+| `WooTheme.text.displaySmall` | `36sp` | `44sp` | `-0.41sp` | regular / medium / bold | `displaySmall.regular` | production | Source-backed role using the DS runtime font-family decision. |
+| `WooTheme.text.headlineLarge` | `34sp` | `40sp` | `-1.40sp` | regular / medium / bold | `headlineLarge.regular` | production | Source-backed role using the DS runtime font-family decision. |
+| `WooTheme.text.headlineMedium` | `28sp` | `36sp` | `-0.41sp` | regular / medium / bold | `headlineMedium.regular` | production | Source-backed role using the DS runtime font-family decision. |
+| `WooTheme.text.headlineSmall` | `24sp` | `32sp` | `-1.00sp` | regular / medium / bold | `headlineSmall.regular` | production | Source-backed role using the DS runtime font-family decision. |
+| `WooTheme.text.titleLarge` | `20sp` | `28sp` | `-0.41sp` | regular / medium / bold | `titleLarge.regular` | production | Source-backed role using the DS runtime font-family decision. |
+| `WooTheme.text.titleMedium` | `17sp` | `20sp` | `-0.41sp` | regular / medium / bold | `titleMedium.regular` | production | Source-backed role using the DS runtime font-family decision. |
+| `WooTheme.text.titleSmall` | `14sp` | `16sp` | `-0.41sp` | regular / medium / bold | `titleSmall.regular` | production | Source-backed role using the DS runtime font-family decision. |
+| `WooTheme.text.bodyLarge` | `17sp` | `24sp` | `-0.41sp` | regular / medium / bold | `bodyLarge.regular` | production | Source-backed role using the DS runtime font-family decision. |
+| `WooTheme.text.bodyMedium` | `15sp` | `20sp` | `-0.41sp` | regular / medium / bold | `bodyMedium.regular` | production | Source-backed role using the DS runtime font-family decision. |
+| `WooTheme.text.bodySmall` | `13sp` | `16sp` | `-0.41sp` | regular / medium / bold | `bodySmall.regular` | production | Source-backed role using the DS runtime font-family decision. |
+| `WooTheme.text.labelLarge` | `16sp` | `24sp` | `-0.41sp` | regular / medium / bold | `labelLarge.regular` | production | Source-backed role using the DS runtime font-family decision. |
+| `WooTheme.text.labelMedium` | `14sp` | `20sp` | `-0.41sp` | regular / medium / bold | `labelMedium.regular` | production | Source-backed role using the DS runtime font-family decision. |
+| `WooTheme.text.labelSmall` | `10sp` | `14sp` | `-0.07sp` | regular / medium / bold | `labelSmall.regular` | production | Source-backed role using the DS runtime font-family decision. |
+
+## Spacing And Padding
+
+Spacing and padding use the same i1 primitive scale today, but remain separate public groups because
+they encode different design intent.
+
+| Android API | Source path | Value | Material projection | Status | Notes |
+| --- | --- | ---: | --- | --- | --- |
+| `WooTheme.spacing.space0` | `Spacing/Spacing/0` | `0dp` | No Material role | production | Source-ready. |
+| `WooTheme.spacing.space1` | `Spacing/Spacing/1` | `2dp` | No Material role | production | Source-ready. |
+| `WooTheme.spacing.space2` | `Spacing/Spacing/2` | `4dp` | No Material role | production | Source-ready. |
+| `WooTheme.spacing.space3` | `Spacing/Spacing/3` | `8dp` | No Material role | production | Source-ready. |
+| `WooTheme.spacing.space4` | `Spacing/Spacing/4` | `12dp` | No Material role | production | Source-ready. |
+| `WooTheme.spacing.space5` | `Spacing/Spacing/5` | `16dp` | No Material role | production | Source-ready. |
+| `WooTheme.spacing.space6` | `Spacing/Spacing/6` | `20dp` | No Material role | production | Source-ready. |
+| `WooTheme.spacing.space7` | `Spacing/Spacing/7` | `24dp` | No Material role | production | Source-ready. |
+| `WooTheme.spacing.space8` | `Spacing/Spacing/8` | `32dp` | No Material role | production | Source-ready. |
+| `WooTheme.spacing.space9` | `Spacing/Spacing/9` | `40dp` | No Material role | production | Source-ready. |
+| `WooTheme.spacing.space10` | `Spacing/Spacing/10` | `48dp` | No Material role | production | Source-ready. |
+| `WooTheme.spacing.space11` | `Spacing/Spacing/11` | `56dp` | No Material role | production | Source-ready. |
+| `WooTheme.spacing.space12` | `Spacing/Spacing/12` | `64dp` | No Material role | production | Source-ready. |
+| `WooTheme.padding.padding0` | `Spacing/Padding/0` | `0dp` | No Material role | production | Source-ready. |
+| `WooTheme.padding.padding1` | `Spacing/Padding/1` | `2dp` | No Material role | production | Source-ready. |
+| `WooTheme.padding.padding2` | `Spacing/Padding/2` | `4dp` | No Material role | production | Source-ready. |
+| `WooTheme.padding.padding3` | `Spacing/Padding/3` | `8dp` | No Material role | production | Source-ready. |
+| `WooTheme.padding.padding4` | `Spacing/Padding/4` | `12dp` | No Material role | production | Source-ready. |
+| `WooTheme.padding.padding5` | `Spacing/Padding/5` | `16dp` | No Material role | production | Source-ready. |
+| `WooTheme.padding.padding6` | `Spacing/Padding/6` | `20dp` | No Material role | production | Source-ready. |
+| `WooTheme.padding.padding7` | `Spacing/Padding/7` | `24dp` | No Material role | production | Source-ready. |
+| `WooTheme.padding.padding8` | `Spacing/Padding/8` | `32dp` | No Material role | production | Source-ready. |
+| `WooTheme.padding.padding9` | `Spacing/Padding/9` | `40dp` | No Material role | production | Source-ready. |
+| `WooTheme.padding.padding10` | `Spacing/Padding/10` | `48dp` | No Material role | production | Source-ready. |
+| `WooTheme.padding.padding11` | `Spacing/Padding/11` | `56dp` | No Material role | production | Source-ready. |
+| `WooTheme.padding.padding12` | `Spacing/Padding/12` | `64dp` | No Material role | production | Source-ready. |
+
+## Radius, Icon Size, And Internal Stroke
+
+Radius is source-backed and public through `WooTheme.radius`. Icon size is source-backed and public
+through `WooTheme.iconSize`, scoped to glyph sizes only. Stroke remains internal in PR2. Do not add
+public stroke, elevation, state-layer, or minimum-touch-target accessors on the Store design-system
+theme namespace.
+
+| Token | Source path | Value | Material projection | Status | Notes |
+| --- | --- | ---: | --- | --- | --- |
+| `WooTheme.radius.none` | `Shape/Corner-Radius/None` | `0dp` | No Material role | production | Public zero-radius token. |
+| `WooTheme.radius.extraSmall` | `Shape/Corner-Radius/Extra-small` | `2dp` | `MaterialTheme.shapes.extraSmall` | production | Shape projection. |
+| `WooTheme.radius.small` | `Shape/Corner-Radius/Small` | `4dp` | `MaterialTheme.shapes.small` | production | Shape projection. |
+| `WooTheme.radius.medium` | `Shape/Corner-Radius/Medium` | `8dp` | `MaterialTheme.shapes.medium` | production | Shape projection. |
+| `WooTheme.radius.large` | `Shape/Corner-Radius/Large` | `12dp` | `MaterialTheme.shapes.large` | production | Shape projection; visual review risk because current projection is `8dp`. |
+| `WooTheme.radius.extraLarge` | `Shape/Corner-Radius/Extra-large` | `16dp` | `MaterialTheme.shapes.extraLarge` | production | Shape projection; visual review risk because current projection is `8dp`. |
+| `WooTheme.radius.full` | `Shape/Corner-Radius/Full` | `999dp` | No Material role | production | Woo-only pill/full-radius sentinel. |
+| `WooTheme.iconSize.size14` | `Icon/Size/Extra-small` | `14dp` | No Material role | production | Glyph size only. |
+| `WooTheme.iconSize.size16` | `Icon/Size/Small` | `16dp` | No Material role | production | Glyph size only. |
+| `WooTheme.iconSize.size18` | `Icon/Size/Medium` | `18dp` | No Material role | production | Glyph size only. |
+| `WooTheme.iconSize.size20` | `Icon/Size/Large` | `20dp` | No Material role | production | Glyph size only. |
+| `WooTheme.iconSize.size24` | `Icon/Size/Large-Increased` | `24dp` | No Material role | production | Glyph size only. |
+| `WooTheme.iconSize.size32` | `Icon/Size/Extra-Large` | `32dp` | No Material role | production | Glyph size only. |
+| `WooStroke.none` | `Shape/Stroke/Weight/None` | `0dp` | No Material role | preview_only | Internal only. |
+| `WooStroke.extraThin` | `Shape/Stroke/Weight/Extra-Thin` | `0.5dp` | No Material role | preview_only | Internal only; verify fractional rendering before broad use. |
+| `WooStroke.thin` | `Shape/Stroke/Weight/Thin` | `0.75dp` | No Material role | preview_only | Internal only; verify fractional rendering before broad use. |
+| `WooStroke.regular` | `Shape/Stroke/Weight/Regular` | `1dp` | No Material role | preview_only | Internal only. |
+| `WooStroke.medium` | `Shape/Stroke/Weight/Medium` | `1.5dp` | No Material role | preview_only | Internal only; verify fractional rendering before broad use. |
+| `WooStroke.mediumIncreased` | `Shape/Stroke/Weight/Medium-Increased` | `2dp` | No Material role | preview_only | Internal only. |
+| `WooStroke.thick` | `Shape/Stroke/Weight/Thick` | `3dp` | No Material role | preview_only | Internal only. |
+| `WooStroke.extraThick` | `Shape/Stroke/Weight/Extra-Thick` | `4dp` | No Material role | preview_only | Internal only. |
+
+## Unresolved Groups
+
+| Group | Source status | Android status | Public API | Notes |
+| --- | --- | --- | --- | --- |
+| Elevation | No non-`Semantic` elevation, shadow, effect, z-depth, or tonal-elevation source found in `figma-export.json` | needs_design | None | Do not promote legacy app elevation resources or hardcoded shadows to Store Design System tokens without design source. |
+| State layers | `Woo theme/State-Layers/On-Surface/Opacity-08`, `Opacity-10`, and `Opacity-16` exist as mode-aware color tokens | needs_android_mapping | None | State semantics and dark/high-contrast behavior need design/API approval; do not create public `WooTheme.stateAlpha` floats. |
+| Minimum touch target | No non-`Semantic` minimum-touch-target source found in `figma-export.json` | needs_design | None | Preserve accessible component behavior and legacy `48dp` guidance, but do not create a public token from legacy dimensions or screen-size variables. |
+| High-contrast color modes | Present for color tokens | needs_android_mapping | None | Exclude from normal `Light` / `Dark` runtime mapping until separately scoped. |

--- a/docs/design-system/token-map.md
+++ b/docs/design-system/token-map.md
@@ -12,8 +12,7 @@ Source references use public-repo shorthands:
 - Figma file: `Woo Mobile Design System` (`50XIH5MmOf4xUYEkM6fAm6-fi`).
 - Full Figma variable export: `figma-export.json`.
 
-Use source shorthands in the source-reference column. Do not use raw P2 or Figma URLs in public repo
-docs.
+Use source shorthands in source-reference columns.
 
 Agent note: Figma references use the public GitHub shorthand `{fileKey}-fi`. When using Figma tools,
 strip the `-fi` suffix and pass only `{fileKey}` as the Figma `fileKey`.
@@ -33,9 +32,8 @@ reconciliation. Refreshing the export should preserve this parser contract:
 - If a future component audit proves a `Semantic` variable is the intended source, update this
   token map with the component evidence and approved mapping before consuming that section.
 
-Use the committed full export plus the per-foundation audit files under
-`docs/design-system/foundation-audit/` for row-level source paths, values, and unresolved notes. Do
-not use older split token exports as current foundation sources.
+Use the committed full export for row-level source paths and values. Keep unresolved notes in this
+token map. Do not use older split token exports as current foundation sources.
 
 The Figma `Color roles` frame validates the role inventory and light-mode values for Primary and
 Secondary, Container, Surface, Outline, and Error/alert/success. Background, Overlay, and Palette are
@@ -96,20 +94,13 @@ Group the public API shallowly by source intent; do not collapse the source into
 - `outline` and `outlineVariant` are source-backed and public under `WooTheme.colors`.
 - Keep state layers internal-first until semantic names and mode behavior are approved. Do not create
   public `WooTheme.stateAlpha` floats from mode-aware state-layer color tokens.
-- Do not expose the top-level `Semantic` section unless a concrete component audit updates this token
-  map with approved evidence.
 - Do not create a separate `WooTheme.semanticColors` group in PR 2.
 - If a non-color Figma variable has no clean Material 3 role, add it as an internal adapter token
   first.
 - Expose a non-color token with no clean Material 3 role publicly only when a production component
   or first-wave screen needs it.
-- Keep `WooTheme.colors` as the Store authoring API even when color primitives are resource-backed internally.
-- Store design-system color primitives are the XML-safe exception and may live in module-local
-  Android color resources so Compose and targeted XML/View usage share the same values.
-- Non-color foundations remain Kotlin/Compose-owned unless a later approved plan says otherwise.
-- Do not keep parallel Kotlin/Compose and XML resource definitions for the same token primitive value.
-- Keep source token names or page references in this document when useful, but do not record raw
-  Figma variable IDs in repo docs.
+- Follow [Token Ownership And XML/View Usage](#token-ownership-and-xmlview-usage) for resource-backed
+  color and non-color foundation boundaries.
 - Include light and dark values before marking a token `production`.
 - Include the closest Material 3 role when the token maps to `ColorScheme`, typography, shape, or elevation.
 - Mark unsettled tokens `preview_only`, `needs_design`, or `needs_android_mapping`.
@@ -144,10 +135,8 @@ When defining tokens:
 
 ## Public Color Source Reconciliation
 
-Every production `WooTheme.colors` field below is backed by normal `Light` / `Dark` values from the
-non-`Semantic` `Woo theme` section in `figma-export.json`. The `Semantic` section and high-contrast
-modes are not runtime/public mapping sources. Source paths are public shorthands; keep raw variable
-IDs and raw Figma node IDs out of repo docs.
+Every production `WooTheme.colors` field below is backed by normal `Light` / `Dark` values from
+`figma-export.json` according to the Figma export parsing rules.
 
 | Android API | Source path | Export file | Light hex / alpha | Dark hex / alpha | M3 projection | Status | Notes |
 | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -233,10 +222,9 @@ IDs and raw Figma node IDs out of repo docs.
 `lightColorScheme(...)` / `darkColorScheme(...)` builders. Direct rows reuse public source fields.
 Alias rows are internal projection decisions only and are not additional public `WooTheme.colors`
 fields. Omitted rows intentionally use Material 3 defaults until a source-backed Store token is
-approved. Use normal `Light` / `Dark` values from non-`Semantic` `Woo theme` sources; do not fold
-high-contrast modes into the normal projection. In this projection table only, `defaulted` means
-omitted from the builder to use Material defaults, and `implicit` means resolved by the Material
-builder from another supplied source role.
+approved. Projection inputs follow the Figma export parsing rules. In this projection table only,
+`defaulted` means omitted from the builder to use Material defaults, and `implicit` means resolved by
+the Material builder from another supplied source role.
 
 | Material role | Projection source | Status | Notes |
 | --- | --- | --- | --- |

--- a/docs/store-compose.md
+++ b/docs/store-compose.md
@@ -15,7 +15,9 @@ We follow the official [Compose API guidelines for App development](https://gith
 
 ## Fragment Hosting
 
-Compose screens live inside Fragments in a 1:1 relationship. Use the `composeView {}` extension (from `com.woocommerce.android.ui.compose.composeView`) which handles `DisposeOnViewTreeLifecycleDestroyed` and `WooThemeWithBackground` automatically:
+Compose screens live inside Fragments in a 1:1 relationship. Legacy Store Compose screens use the
+current `composeView {}` extension from `com.woocommerce.android.ui.compose.composeView`, which
+handles `DisposeOnViewTreeLifecycleDestroyed` and the legacy Store Compose theme root automatically:
 
 ```kotlin
 @AndroidEntryPoint
@@ -50,8 +52,14 @@ class MyFeatureFragment : BaseFragment() {
 
 Key points:
 - Set `activityAppBarStatus = AppBarStatus.Hidden` when the screen has its own Compose `Toolbar`
+- For design-system migrated screens, follow the toolbar policy in
+  [design-system/rollout-direction.md](design-system/rollout-direction.md): Compose-owned screens use
+  `WooTopAppBar`, while heavy XML screens may keep a DS-looking XML toolbar when required for
+  `SearchView`, `ActionMode`, collapsing behavior, or existing ownership
+- Screen migration is explicit: migrated design-system screens opt into the DS root with the
+  rollout-approved builder, while non-migrated screens stay on the legacy root
 - Handle navigation events (`MultiLiveEvent`) in `onViewCreated`, not in composables
-- Do NOT create XML layouts — use `composeView {}` directly
+- For fully Compose-owned screens, use `composeView {}` directly instead of creating a new XML layout
 
 ## Screen Composable Pattern
 
@@ -101,9 +109,15 @@ State observation patterns (both are used in the codebase):
 
 - Use `UPPER_SNAKE_CASE` for constants (overrides the Compose guideline suggesting `PascalCase`)
 - The project nests Material 2 inside Material 3 for backward compatibility
-- `composeView {}` already wraps content in `WooThemeWithBackground` — do not double-wrap
-- For previews, wrap in `WooThemeWithBackground { ... }`
+- Legacy `composeView {}` already wraps content in the legacy root — do not double-wrap
+- For legacy Store previews, wrap in `WooThemeWithBackground { ... }`. For design-system migrated
+  screen previews, use the DS preview root in light and dark mode
 - Theme files: `ui/compose/theme/` (Theme.kt, WooColors.kt, Typography.kt, Shapes.kt)
+- Store design-system foundations and components live in `:libs:store-design-system` under
+  `com.woocommerce.android.ui.compose.designsystem.*`.
+- `WooThemeWithBackground` remains app-owned for legacy Store Compose. Current design-system rollout
+  scope, explicit root migration, and toolbar policy are documented in
+  [design-system/rollout-direction.md](design-system/rollout-direction.md).
 - Navigation uses XML nav graphs with `NavController` — Compose screens are hosted inside Fragments
 
 ## Existing Components
@@ -133,7 +147,7 @@ Also available: `annotatedStringRes()` and `clickableAnnotatedStringRes()` in `T
 
 ## Previews
 
-Use the project's custom preview annotations for consistency:
+Use the project's custom preview annotations for legacy Store Compose screens:
 
 ```kotlin
 @LightDarkThemePreviews  // Light + Dark mode
@@ -154,10 +168,16 @@ Available annotations from `ui/compose/preview/PreviewAnnotations.kt`:
 - `@FontScalePreviews` — normal and large font
 - `@LayoutDirectionPreviews` — LTR and RTL
 
+New design-system foundations, components, and migrated screen previews use
+`androidx.compose.ui.tooling.preview.PreviewLightDark`. Migrated screen previews should cover the
+design-system root in light and dark mode.
+
 ## File Structure
 
 - `ui/compose/component/` — shared components reused across features
 - `ui/compose/theme/` — themes, colors, shapes, typography
+- `:libs:store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/` —
+  Store design-system foundations and components
 - `ui/compose/animations/` — shared reusable animations
 - `ui/compose/preview/` — preview annotations
 - `ui/compose/modifier/` and `ui/compose/modifiers/` — shared modifier extensions


### PR DESCRIPTION
Fixes WOOMOB-3328

> [!NOTE]
> The foundation code is in https://github.com/woocommerce/woocommerce-android/pull/16120, if you want to check how these docs are in real code.

### Description

This PR documents the Store Management App path for adopting the Woo Mobile Design System, including the foundation source contract, Android adapter guidance, Material 3 projection rules, rollout direction, and migration playbooks future foundation/component/screen work should build on.

#### What this adds

- `docs/design-system/figma-export.json`, a full Figma variables export used as the source artifact for foundation docs.
- `token-map.md` as the source-backed Store foundation map for colors, text, spacing, padding, radius, and icon sizes.
- Parser/source rules that keep top-level `Semantic` traceability-only and use non-`Semantic` foundation sections such as `Woo theme`, `Typescale`, `Spacing`, `Shape`, `Font theme`, and `Icon` for runtime/public mapping.
- Updated color guidance based on the current Figma variables export:
  - palette ramps, including gray, are public production `WooTheme.colors.palette.*` tokens
  - `surfaceDim`, `surfaceBright`, and `surfaceContainerHighest` are public source-backed roles
- Typography guidance that treats Android default font as the runtime equivalent for Figma's Android `Roboto` source.
- Material 3 reference docs that describe how Store source roles project into Material interop without making Material aliases the Store authoring surface.
- Android adapter and implementation-plan docs for future foundation/module work, including module boundaries and migration-era wrapper naming.
- Rollout, integration checkpoint, component catalog, pilot, and screen-migration docs for future Store screen adoption work.
- Store Compose guidance that points future Store UI work toward the design-system rollout and toolbar policy.

#### What this does not do

- Does not add implementation code.
- Does not add the foundations module or design-system components.
- Does not migrate product screens.
- Does not touch POS.
- Does not globally remap XML/View styles or legacy app themes.
- Does not add Code Connect, generated tokens, or Figma automation.
- Does not introduce permanent duplicate legacy and design-system screen implementations.
- Does not add hand-maintained contrast ratios or alpha-derived contrast notes.

#### Helpful review focus

- Is `WooTheme` clearly documented as the Store authoring API, with Material roles kept as interop projections?
- Are the public color groups clear enough?
- Is the split between public foundations and internal Material projection details precise enough?
- Is `rollout-direction.md` clear enough as the canonical scope source for future agents and PRs?
- Do the docs give a clear path for the next PRs: foundations, components, first-wave migration, then scoped legacy convergence?
- Does the playbook make the difference between first-wave screens, out-of-scope child flows, and unassigned future screens clear?

#### Context references

- Woo Mobile Design System i1 P2: `pe5sF9-5ox-p2`
- Android adoption RFC: `pe5sF9-5sW-p2`
- Mobile Design System Integration Strategy P2: `pe5sF9-5vr-p2`
- Figma file shorthand: `50XIH5MmOf4xUYEkM6fAm6-fi`

No release notes: this is an internal design-system documentation change.

### Test Steps

N/A

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
