### PR TITLE
[WOOMOB-3296] Detect rest_invalid_signature and guide the merchant

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 25.1
 -----
 - [*] You're now returned to the store picker with an explanation when the app can no longer access the selected store, instead of being stuck with repeated errors [https://github.com/woocommerce/woocommerce-android/pull/16117]
+- [*] Show a clear alert guiding the merchant to support when their store can't be reached due to a server-side connection error, instead of failing silently [https://github.com/woocommerce/woocommerce-android/pull/16132]
 - [*] Fixed QR login retrying an expired number challenge re-showing the old number with "Expires in 0s"; it now returns you to the QR scanner to scan a fresh code [https://github.com/woocommerce/woocommerce-android/pull/16094]
 - [*] Show the orders troubleshooting banner (instead of a generic error) when your store returns an unexpected non-JSON response, and open the in-app Troubleshoot Connection screen from it [https://github.com/woocommerce/woocommerce-android/pull/16108]
 - [*] Renamed the empty Orders "test order" prompt to "Place your first order" and clarified that processing fees aren't refundable [https://github.com/woocommerce/woocommerce-android/pull/16086]

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/background/UpdateDataOnBackgroundWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/background/UpdateDataOnBackgroundWorker.kt
@@ -3,22 +3,26 @@ package com.woocommerce.android.background
 import android.content.Context
 import androidx.hilt.work.HiltWorker
 import androidx.work.CoroutineWorker
+import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.network.StoreConnectionErrorMonitor
 import com.woocommerce.android.ui.login.AccountRepository
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 
 @HiltWorker
+@Suppress("LongParameterList")
 class UpdateDataOnBackgroundWorker @AssistedInject constructor(
     @Assisted private val appContext: Context,
     @Assisted workerParams: WorkerParameters,
     private val accountRepository: AccountRepository,
     private val updateAnalyticsDashboardRangeSelections: UpdateAnalyticsDashboardRangeSelections,
     private val updateOrderListBySelectedStore: UpdateOrderListBySelectedStore,
-    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
+    private val storeConnectionErrorMonitor: StoreConnectionErrorMonitor
 ) : CoroutineWorker(appContext, workerParams) {
     companion object {
         const val REFRESH_TIME = 4L
@@ -39,6 +43,13 @@ class UpdateDataOnBackgroundWorker @AssistedInject constructor(
                     mapOf(AnalyticsTracker.KEY_TIME_TAKEN to (System.currentTimeMillis() - startTime))
                 )
                 Result.success()
+            }
+
+            storeConnectionErrorMonitor.isDetectedForSelectedSite() -> {
+                // The store can't be reached due to a server-side signature problem the app can't fix.
+                // Stop the silent retry loop (it's re-enqueued the next time the app goes to background).
+                WorkManager.getInstance(appContext).cancelUniqueWork(WORK_NAME)
+                Result.failure()
             }
 
             else -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/background/UpdateDataOnBackgroundWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/background/UpdateDataOnBackgroundWorker.kt
@@ -46,7 +46,6 @@ class UpdateDataOnBackgroundWorker @AssistedInject constructor(
             }
 
             storeConnectionErrorMonitor.isDetectedForSelectedSite() -> {
-                // The store can't be reached due to a server-side signature problem the app can't fix.
                 // Stop the silent retry loop (it's re-enqueued the next time the app goes to background).
                 WorkManager.getInstance(appContext).cancelUniqueWork(WORK_NAME)
                 Result.failure()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/di/InvalidSignatureModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/di/InvalidSignatureModule.kt
@@ -1,0 +1,19 @@
+package com.woocommerce.android.di
+
+import com.woocommerce.android.network.StoreConnectionErrorMonitor
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.InvalidSignatureListener
+
+// The optional binding is declared in commons' InvalidSignatureListenerModule (installed in every Hilt graph);
+// the main app additionally binds the concrete implementation here.
+@Module
+@InstallIn(SingletonComponent::class)
+interface InvalidSignatureModule {
+    @Binds
+    fun bindInvalidSignatureListener(
+        monitor: StoreConnectionErrorMonitor
+    ): InvalidSignatureListener
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/network/StoreConnectionErrorMonitor.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/network/StoreConnectionErrorMonitor.kt
@@ -1,0 +1,47 @@
+package com.woocommerce.android.network
+
+import com.woocommerce.android.tools.SelectedSite
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.InvalidSignatureListener
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * App-wide holder that records when a store request fails with the invalid signature error
+ * (Jetpack's `rest_invalid_signature`). This is a server-side problem the app can't fix, so instead of
+ * silently retrying we surface it to the merchant in a dialog shown across the app.
+ *
+ * The detected state is keyed by the remote site id so it only applies to the affected store, and it clears
+ * automatically once a request to that store succeeds again (self-healing).
+ */
+@Singleton
+class StoreConnectionErrorMonitor @Inject constructor(
+    private val selectedSite: SelectedSite
+) : InvalidSignatureListener {
+    private val _invalidSignatureDetected = MutableStateFlow<Long?>(null)
+
+    /**
+     * Emits the remote site id of the store currently affected by the invalid signature error, or `null`
+     * when no store is affected.
+     */
+    val invalidSignatureDetected: StateFlow<Long?> = _invalidSignatureDetected.asStateFlow()
+
+    /**
+     * Returns `true` when the invalid signature error is currently active for the selected store.
+     */
+    fun isDetectedForSelectedSite(): Boolean =
+        _invalidSignatureDetected.value != null && _invalidSignatureDetected.value == selectedSite.getOrNull()?.siteId
+
+    override fun onInvalidSignatureDetected(siteModel: SiteModel) {
+        _invalidSignatureDetected.value = siteModel.siteId
+    }
+
+    override fun onSuccessfulConnection(siteModel: SiteModel) {
+        if (_invalidSignatureDetected.value == siteModel.siteId) {
+            _invalidSignatureDetected.value = null
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/help/HelpOrigin.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/help/HelpOrigin.kt
@@ -35,6 +35,7 @@ enum class HelpOrigin(private val stringValue: String) {
     CONNECTIVITY_TOOL("origin:connectivity-tool"),
     AI_TROUBLESHOOTING("origin:ai-troubleshooting"),
     APPLICATION_PASSWORD_TUTORIAL("origin:application-password-tutorial"),
+    CONNECTION_ERROR("origin:connection-error"),
     POS("origin:point-of-sale");
 
     override fun toString(): String {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/StoreConnectionErrorDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/StoreConnectionErrorDialog.kt
@@ -28,7 +28,7 @@ fun StoreConnectionErrorDialog(
 ) {
     Dialog(
         onDismissRequest = onDismissClick,
-        properties = DialogProperties(dismissOnBackPress = false, dismissOnClickOutside = false),
+        properties = DialogProperties(dismissOnBackPress = true, dismissOnClickOutside = false),
     ) {
         Surface(
             shape = MaterialTheme.shapes.medium,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/StoreConnectionErrorDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/StoreConnectionErrorDialog.kt
@@ -1,0 +1,84 @@
+package com.woocommerce.android.ui.dashboard
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.component.WCColoredButton
+import com.woocommerce.android.ui.compose.component.WCOutlinedButton
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+
+@Composable
+fun StoreConnectionErrorDialog(
+    onContactSupportClick: () -> Unit,
+    onDismissClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Dialog(
+        onDismissRequest = onDismissClick,
+        properties = DialogProperties(dismissOnBackPress = false, dismissOnClickOutside = false),
+    ) {
+        Surface(
+            shape = MaterialTheme.shapes.medium,
+            color = MaterialTheme.colorScheme.surface,
+            modifier = modifier.fillMaxWidth()
+        ) {
+            Column(
+                modifier = Modifier.padding(dimensionResource(id = R.dimen.major_150))
+            ) {
+                Text(
+                    text = stringResource(id = R.string.store_connection_error_dialog_title),
+                    style = MaterialTheme.typography.titleLarge,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+
+                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
+
+                Text(
+                    text = stringResource(id = R.string.store_connection_error_dialog_body),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+
+                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_200)))
+
+                WCColoredButton(
+                    onClick = onContactSupportClick,
+                    text = stringResource(id = R.string.store_connection_error_dialog_contact_support),
+                    modifier = Modifier.fillMaxWidth(),
+                )
+
+                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.minor_100)))
+
+                WCOutlinedButton(
+                    onClick = onDismissClick,
+                    text = stringResource(id = R.string.dismiss),
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun StoreConnectionErrorDialogPreview() {
+    WooThemeWithBackground {
+        StoreConnectionErrorDialog(
+            onContactSupportClick = {},
+            onDismissClick = {},
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -219,9 +219,9 @@ class MainActivity :
 
     private val viewModel: MainActivityViewModel by viewModels()
 
-    private val appForegroundObserver = object : DefaultLifecycleObserver {
-        override fun onStart(owner: LifecycleOwner) {
-            viewModel.onAppForegrounded()
+    private val appBackgroundObserver = object : DefaultLifecycleObserver {
+        override fun onStop(owner: LifecycleOwner) {
+            viewModel.onAppBackgrounded()
         }
     }
 
@@ -497,7 +497,7 @@ class MainActivity :
     }
 
     public override fun onDestroy() {
-        ProcessLifecycleOwner.get().lifecycle.removeObserver(appForegroundObserver)
+        ProcessLifecycleOwner.get().lifecycle.removeObserver(appBackgroundObserver)
         presenter.dropView()
         handler.removeCallbacks(notificationPermissionBarRunnable)
         super.onDestroy()
@@ -884,9 +884,9 @@ class MainActivity :
     // endregion
 
     private fun setupStoreConnectionErrorDialog() {
-        // Reset the dialog snooze only when the app truly returns to the foreground (process lifecycle),
-        // not when returning from another in-app activity such as the support flow.
-        ProcessLifecycleOwner.get().lifecycle.addObserver(appForegroundObserver)
+        // Reset the dialog snooze when the app goes to the background (process lifecycle), so a
+        // still-unreachable store re-alerts on the next foreground.
+        ProcessLifecycleOwner.get().lifecycle.addObserver(appBackgroundObserver)
 
         binding.storeConnectionErrorComposeView.setViewCompositionStrategy(
             ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -23,6 +23,8 @@ import androidx.activity.viewModels
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.appcompat.widget.Toolbar
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.content.ContextCompat
@@ -33,6 +35,9 @@ import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentManager.FragmentLifecycleCallbacks
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.navigation.NavController
 import androidx.navigation.NavDestination
 import androidx.navigation.NavOptions
@@ -61,7 +66,9 @@ import com.woocommerce.android.extensions.collapse
 import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.show
+import com.woocommerce.android.extensions.startHelpActivity
 import com.woocommerce.android.model.Notification
+import com.woocommerce.android.support.help.HelpOrigin
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.appwidgets.WidgetUpdater
 import com.woocommerce.android.ui.base.BaseFragment
@@ -69,7 +76,9 @@ import com.woocommerce.android.ui.base.TopLevelFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.bookings.tab.BookingsTabController
 import com.woocommerce.android.ui.common.InfoScreenFragment
+import com.woocommerce.android.ui.compose.theme.WooTheme
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.dashboard.StoreConnectionErrorDialog
 import com.woocommerce.android.ui.feedback.SurveyType
 import com.woocommerce.android.ui.login.LoginActivity
 import com.woocommerce.android.ui.main.BottomNavigationPosition.BOOKINGS
@@ -210,6 +219,12 @@ class MainActivity :
 
     private val viewModel: MainActivityViewModel by viewModels()
 
+    private val appForegroundObserver = object : DefaultLifecycleObserver {
+        override fun onStart(owner: LifecycleOwner) {
+            viewModel.onAppForegrounded()
+        }
+    }
+
     private var unfilledOrderCount: Int = 0
     private var menu: Menu? = null
 
@@ -336,6 +351,8 @@ class MainActivity :
 
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
+
+        setupStoreConnectionErrorDialog()
 
         edgeToEdgeHelper.applyEdgeToEdgeSettings(binding)
 
@@ -480,6 +497,7 @@ class MainActivity :
     }
 
     public override fun onDestroy() {
+        ProcessLifecycleOwner.get().lifecycle.removeObserver(appForegroundObserver)
         presenter.dropView()
         handler.removeCallbacks(notificationPermissionBarRunnable)
         super.onDestroy()
@@ -865,6 +883,27 @@ class MainActivity :
     }
     // endregion
 
+    private fun setupStoreConnectionErrorDialog() {
+        // Reset the dialog snooze only when the app truly returns to the foreground (process lifecycle),
+        // not when returning from another in-app activity such as the support flow.
+        ProcessLifecycleOwner.get().lifecycle.addObserver(appForegroundObserver)
+
+        binding.storeConnectionErrorComposeView.setViewCompositionStrategy(
+            ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed
+        )
+        binding.storeConnectionErrorComposeView.setContent {
+            WooTheme {
+                val showDialog by viewModel.showStoreConnectionErrorDialog.observeAsState(false)
+                if (showDialog) {
+                    StoreConnectionErrorDialog(
+                        onContactSupportClick = viewModel::onStoreConnectionErrorContactSupportClicked,
+                        onDismissClick = viewModel::onStoreConnectionErrorDismissed,
+                    )
+                }
+            }
+        }
+    }
+
     @Suppress("ComplexMethod")
     private fun setupObservers() {
         viewModel.event.observe(this) { event ->
@@ -886,6 +925,8 @@ class MainActivity :
                 ViewWooPosPromo -> showWooPosPromoCarousel()
                 ShortcutOpenPayments -> shortcutShowPayments()
                 ShortcutOpenOrderCreation -> shortcutOpenOrderCreation()
+                is MainActivityViewModel.ContactSupportForStoreConnection ->
+                    startHelpActivity(HelpOrigin.CONNECTION_ERROR)
                 is MainActivityViewModel.ShowPrivacyPreferenceUpdatedFailed -> {
                     uiMessageResolver.getIndefiniteActionSnack(
                         R.string.privacy_banner_error_save,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
@@ -96,8 +96,8 @@ class MainActivityViewModel @Inject constructor(
 
     val isUserAgeRangeEligible = ageEligibilityChecker.ageEligibilityState.asLiveData()
 
-    // Snoozes the dialog when the merchant taps Dismiss. Reset when the app returns to the foreground
-    // (see [onAppForegrounded]) so a still-unreachable store reminds the merchant again next session.
+    // Snoozes the dialog when the merchant taps Dismiss. Reset when the app goes to the background
+    // (see [onAppBackgrounded]) so a still-unreachable store reminds the merchant again next session.
     private val connectionErrorSnoozed = MutableStateFlow(false)
     private val _showStoreConnectionErrorDialog = MutableStateFlow(false)
     val showStoreConnectionErrorDialog = _showStoreConnectionErrorDialog.asLiveData()
@@ -132,7 +132,7 @@ class MainActivityViewModel @Inject constructor(
         connectionErrorSnoozed.value = true
     }
 
-    fun onAppForegrounded() {
+    fun onAppBackgrounded() {
         connectionErrorSnoozed.value = false
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
@@ -116,18 +116,9 @@ class MainActivityViewModel @Inject constructor(
                 val isAffected = site != null && site.siteId == affectedSiteId
                 isAffected to snoozed
             }.collect { (isAffected, snoozed) ->
-                // The dialog tracks the live error state: it stays visible (across navigation, on every
-                // main-app screen) until the store connection is resolved, and is only hidden early if the
-                // merchant taps Dismiss (snooze).
-                when {
-                    !isAffected -> {
-                        connectionErrorSnoozed.value = false
-                        _showStoreConnectionErrorDialog.value = false
-                    }
-
-                    snoozed -> _showStoreConnectionErrorDialog.value = false
-
-                    else -> _showStoreConnectionErrorDialog.value = true
+                _showStoreConnectionErrorDialog.value = isAffected && !snoozed
+                if (!isAffected) {
+                    connectionErrorSnoozed.value = false
                 }
             }
         }
@@ -141,10 +132,6 @@ class MainActivityViewModel @Inject constructor(
         connectionErrorSnoozed.value = true
     }
 
-    /**
-     * Called when the app returns to the foreground; clears the dialog snooze so a still-unreachable store
-     * reminds the merchant again.
-     */
     fun onAppForegrounded() {
         connectionErrorSnoozed.value = false
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
@@ -11,6 +11,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.model.FeatureAnnouncement
 import com.woocommerce.android.model.Notification
+import com.woocommerce.android.network.StoreConnectionErrorMonitor
 import com.woocommerce.android.notifications.NotificationChannelType
 import com.woocommerce.android.notifications.UnseenReviewsCountHandler
 import com.woocommerce.android.notifications.WooNotificationType
@@ -55,6 +56,7 @@ class MainActivityViewModel @Inject constructor(
     savedState: SavedStateHandle,
     private val siteStore: SiteStore,
     private val selectedSite: SelectedSite,
+    private val storeConnectionErrorMonitor: StoreConnectionErrorMonitor,
     private val notificationHandler: NotificationMessageHandler,
     private val featureAnnouncementRepository: FeatureAnnouncementRepository,
     private val buildConfigWrapper: BuildConfigWrapper,
@@ -93,6 +95,59 @@ class MainActivityViewModel @Inject constructor(
     val trialStatusBarState = determineTrialStatusBarState(_bottomBarState).asLiveData()
 
     val isUserAgeRangeEligible = ageEligibilityChecker.ageEligibilityState.asLiveData()
+
+    // Snoozes the dialog when the merchant taps Dismiss. Reset when the app returns to the foreground
+    // (see [onAppForegrounded]) so a still-unreachable store reminds the merchant again next session.
+    private val connectionErrorSnoozed = MutableStateFlow(false)
+    private val _showStoreConnectionErrorDialog = MutableStateFlow(false)
+    val showStoreConnectionErrorDialog = _showStoreConnectionErrorDialog.asLiveData()
+
+    init {
+        observeStoreConnectionError()
+    }
+
+    private fun observeStoreConnectionError() {
+        launch {
+            combine(
+                selectedSite.observe(),
+                storeConnectionErrorMonitor.invalidSignatureDetected,
+                connectionErrorSnoozed
+            ) { site, affectedSiteId, snoozed ->
+                val isAffected = site != null && site.siteId == affectedSiteId
+                isAffected to snoozed
+            }.collect { (isAffected, snoozed) ->
+                // The dialog tracks the live error state: it stays visible (across navigation, on every
+                // main-app screen) until the store connection is resolved, and is only hidden early if the
+                // merchant taps Dismiss (snooze).
+                when {
+                    !isAffected -> {
+                        connectionErrorSnoozed.value = false
+                        _showStoreConnectionErrorDialog.value = false
+                    }
+
+                    snoozed -> _showStoreConnectionErrorDialog.value = false
+
+                    else -> _showStoreConnectionErrorDialog.value = true
+                }
+            }
+        }
+    }
+
+    fun onStoreConnectionErrorContactSupportClicked() {
+        triggerEvent(ContactSupportForStoreConnection)
+    }
+
+    fun onStoreConnectionErrorDismissed() {
+        connectionErrorSnoozed.value = true
+    }
+
+    /**
+     * Called when the app returns to the foreground; clears the dialog snooze so a still-unreachable store
+     * reminds the merchant again.
+     */
+    fun onAppForegrounded() {
+        connectionErrorSnoozed.value = false
+    }
 
     fun handleShortcutAction(action: String?) {
         if (!selectedSite.exists()) return
@@ -366,6 +421,7 @@ class MainActivityViewModel @Inject constructor(
     ) : Event()
     data class ViewSurvey(val surveyType: SurveyType) : Event()
 
+    object ContactSupportForStoreConnection : Event()
     object ShortcutOpenPayments : Event()
     object ShortcutOpenOrderCreation : Event()
     object LaunchBlazeCampaignCreation : Event()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/searchbyidentifier/WooPosSearchByIdentifierGlobalUniqueSearch.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/searchbyidentifier/WooPosSearchByIdentifierGlobalUniqueSearch.kt
@@ -16,6 +16,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.INVALID_RE
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.INVALID_VARIATION_ID
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.NO_CONNECTION
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.RESOURCE_ALREADY_EXISTS
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.REST_INVALID_SIGNATURE
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.TIMEOUT
 import org.wordpress.android.fluxc.store.WCProductStore
 import javax.inject.Inject
@@ -66,7 +67,8 @@ class WooPosSearchByIdentifierGlobalUniqueSearch @Inject constructor(
     private fun WooError.mapError(): WooPosSearchByIdentifierResult.Error =
         when (type) {
             TIMEOUT, NO_CONNECTION -> WooPosSearchByIdentifierResult.Error.NetworkError
-            API_ERROR -> WooPosSearchByIdentifierResult.Error.ServerError(
+            API_ERROR,
+            REST_INVALID_SIGNATURE -> WooPosSearchByIdentifierResult.Error.ServerError(
                 message?.ifEmpty { null } ?: "API error occurred"
             )
 

--- a/WooCommerce/src/main/res/layout/activity_main.xml
+++ b/WooCommerce/src/main/res/layout/activity_main.xml
@@ -116,4 +116,12 @@
         app:layout_constraintStart_toStartOf="parent"
         app:menu="@menu/menu_bottom_bar" />
 
+    <!-- Hosts the store-connection-error dialog so it overlays every main-app screen. -->
+    <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/store_connection_error_compose_view"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -460,6 +460,11 @@
     <string name="dashboard_scheduled_import_option_selected">Selected</string>
     <string name="dashboard_scheduled_import_update_error">Couldn\'t update the setting. Please try again.</string>
 
+    <!-- Store connection error -->
+    <string name="store_connection_error_dialog_title">Your store can\'t be reached</string>
+    <string name="store_connection_error_dialog_body">We\'re having trouble connecting to your store. This is usually a connection issue on your WordPress site — often caused by a security plugin, a recent plugin update, or a Jetpack connection that needs to be refreshed. The WooCommerce app can\'t fix this from your phone.</string>
+    <string name="store_connection_error_dialog_contact_support">Contact support</string>
+
     <string name="dashboard_action_view_all_orders">View all orders</string>
 
     <string name="dashboard_action_view_all_messages">View all messages</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -462,7 +462,7 @@
 
     <!-- Store connection error -->
     <string name="store_connection_error_dialog_title">Your store can\'t be reached</string>
-    <string name="store_connection_error_dialog_body">We\'re having trouble connecting to your store. This is usually a connection issue on your WordPress site — often caused by a security plugin, a recent plugin update, or a Jetpack connection that needs to be refreshed. The WooCommerce app can\'t fix this from your phone.</string>
+    <string name="store_connection_error_dialog_body">We\'re having trouble connecting to your store. This is usually a connection issue on your WordPress site, often caused by a security plugin, a recent plugin update, or a Jetpack connection that needs to be refreshed. The WooCommerce app can\'t fix this from your phone.</string>
     <string name="store_connection_error_dialog_contact_support">Contact support</string>
 
     <string name="dashboard_action_view_all_orders">View all orders</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/network/StoreConnectionErrorMonitorTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/network/StoreConnectionErrorMonitorTest.kt
@@ -1,0 +1,56 @@
+package com.woocommerce.android.network
+
+import com.woocommerce.android.tools.SelectedSite
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.SiteModel
+
+class StoreConnectionErrorMonitorTest {
+    private val selectedSite: SelectedSite = mock()
+    private val sut = StoreConnectionErrorMonitor(selectedSite)
+
+    private fun site(id: Long) = SiteModel().apply { siteId = id }
+
+    @Test
+    fun `when invalid signature is detected, then expose the affected site id`() {
+        sut.onInvalidSignatureDetected(site(123L))
+
+        assertThat(sut.invalidSignatureDetected.value).isEqualTo(123L)
+    }
+
+    @Test
+    fun `given affected site, when a request to it succeeds, then clear the state`() {
+        sut.onInvalidSignatureDetected(site(123L))
+
+        sut.onSuccessfulConnection(site(123L))
+
+        assertThat(sut.invalidSignatureDetected.value).isNull()
+    }
+
+    @Test
+    fun `given affected site, when a request to a different site succeeds, then keep the state`() {
+        sut.onInvalidSignatureDetected(site(123L))
+
+        sut.onSuccessfulConnection(site(456L))
+
+        assertThat(sut.invalidSignatureDetected.value).isEqualTo(123L)
+    }
+
+    @Test
+    fun `given selected site is affected, when checking selected site, then return true`() {
+        whenever(selectedSite.getOrNull()).thenReturn(site(123L))
+        sut.onInvalidSignatureDetected(site(123L))
+
+        assertThat(sut.isDetectedForSelectedSite()).isTrue()
+    }
+
+    @Test
+    fun `given a different site is affected, when checking selected site, then return false`() {
+        whenever(selectedSite.getOrNull()).thenReturn(site(123L))
+        sut.onInvalidSignatureDetected(site(456L))
+
+        assertThat(sut.isDetectedForSelectedSite()).isFalse()
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.model.FeatureAnnouncement
 import com.woocommerce.android.model.FeatureAnnouncementItem
+import com.woocommerce.android.network.StoreConnectionErrorMonitor
 import com.woocommerce.android.notifications.NotificationChannelType
 import com.woocommerce.android.notifications.UnseenReviewsCountHandler
 import com.woocommerce.android.notifications.WooNotificationType
@@ -41,6 +42,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.advanceUntilIdle
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -81,8 +83,14 @@ class MainActivityViewModelTest : BaseUnitTest() {
 
     private lateinit var viewModel: MainActivityViewModel
     private val savedStateHandle: SavedStateHandle = SavedStateHandle()
-    private val selectedSite: SelectedSite = mock()
+    private val selectedSite: SelectedSite = mock {
+        on { observe() } doReturn flowOf<SiteModel?>(null)
+    }
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper = mock()
+    private val invalidSignatureFlow = MutableStateFlow<Long?>(null)
+    private val storeConnectionErrorMonitor: StoreConnectionErrorMonitor = mock {
+        on { invalidSignatureDetected } doReturn invalidSignatureFlow
+    }
 
     private val siteStore: SiteStore = mock()
     private val siteModel: SiteModel = SiteModel().apply {
@@ -723,12 +731,96 @@ class MainActivityViewModelTest : BaseUnitTest() {
         verify(analyticsTrackerWrapper).track(AnalyticsEvent.PUSH_NOTIFICATION_OS_ALERT_DENIED)
     }
 
+    @Test
+    fun `given store has invalid signature, when it is detected, then show the connection error dialog`() =
+        testBlocking {
+            whenever(selectedSite.observe()).thenReturn(flowOf(SiteModel().apply { siteId = 42L }))
+            createViewModel()
+            var shown: Boolean? = null
+            viewModel.showStoreConnectionErrorDialog.observeForever { shown = it }
+
+            invalidSignatureFlow.value = 42L
+            advanceUntilIdle()
+
+            assertThat(shown).isTrue()
+        }
+
+    @Test
+    fun `given dialog is shown, when the error resolves, then hide the dialog`() = testBlocking {
+        whenever(selectedSite.observe()).thenReturn(flowOf(SiteModel().apply { siteId = 42L }))
+        createViewModel()
+        var shown: Boolean? = null
+        viewModel.showStoreConnectionErrorDialog.observeForever { shown = it }
+
+        invalidSignatureFlow.value = 42L
+        advanceUntilIdle()
+        invalidSignatureFlow.value = null
+        advanceUntilIdle()
+
+        assertThat(shown).isFalse()
+    }
+
+    @Test
+    fun `given dialog is shown, when cancelled, then hide the dialog`() = testBlocking {
+        whenever(selectedSite.observe()).thenReturn(flowOf(SiteModel().apply { siteId = 42L }))
+        createViewModel()
+        var shown: Boolean? = null
+        viewModel.showStoreConnectionErrorDialog.observeForever { shown = it }
+
+        invalidSignatureFlow.value = 42L
+        advanceUntilIdle()
+        viewModel.onStoreConnectionErrorDismissed()
+        advanceUntilIdle()
+
+        assertThat(shown).isFalse()
+    }
+
+    @Test
+    fun `given dialog was cancelled, when app returns to foreground and store still unreachable, then show again`() =
+        testBlocking {
+            whenever(selectedSite.observe()).thenReturn(flowOf(SiteModel().apply { siteId = 42L }))
+            createViewModel()
+            var shown: Boolean? = null
+            viewModel.showStoreConnectionErrorDialog.observeForever { shown = it }
+
+            invalidSignatureFlow.value = 42L
+            advanceUntilIdle()
+            viewModel.onStoreConnectionErrorDismissed()
+            advanceUntilIdle()
+            viewModel.onAppForegrounded()
+            advanceUntilIdle()
+
+            assertThat(shown).isTrue()
+        }
+
+    @Test
+    fun `given dialog is shown, when contact support is tapped, then keep dialog and emit support event`() =
+        testBlocking {
+            whenever(selectedSite.observe()).thenReturn(flowOf(SiteModel().apply { siteId = 42L }))
+            createViewModel()
+            var shown: Boolean? = null
+            viewModel.showStoreConnectionErrorDialog.observeForever { shown = it }
+            var event: MainActivityViewModel.ContactSupportForStoreConnection? = null
+            viewModel.event.observeForever {
+                if (it is MainActivityViewModel.ContactSupportForStoreConnection) event = it
+            }
+
+            invalidSignatureFlow.value = 42L
+            advanceUntilIdle()
+            viewModel.onStoreConnectionErrorContactSupportClicked()
+            advanceUntilIdle()
+
+            assertThat(shown).isTrue()
+            assertThat(event).isEqualTo(MainActivityViewModel.ContactSupportForStoreConnection)
+        }
+
     private fun createViewModel() {
         viewModel = spy(
             MainActivityViewModel(
                 savedState = savedStateHandle,
                 siteStore = siteStore,
                 selectedSite = selectedSite,
+                storeConnectionErrorMonitor = storeConnectionErrorMonitor,
                 notificationHandler = notificationMessageHandler,
                 featureAnnouncementRepository = featureAnnouncementRepository,
                 buildConfigWrapper = buildConfigWrapper,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
@@ -776,7 +776,7 @@ class MainActivityViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given dialog was cancelled, when app returns to foreground and store still unreachable, then show again`() =
+    fun `given dialog was dismissed, when app goes to background and store still unreachable, then show again`() =
         testBlocking {
             whenever(selectedSite.observe()).thenReturn(flowOf(SiteModel().apply { siteId = 42L }))
             createViewModel()
@@ -787,7 +787,7 @@ class MainActivityViewModelTest : BaseUnitTest() {
             advanceUntilIdle()
             viewModel.onStoreConnectionErrorDismissed()
             advanceUntilIdle()
-            viewModel.onAppForegrounded()
+            viewModel.onAppBackgrounded()
             advanceUntilIdle()
 
             assertThat(shown).isTrue()

--- a/libs/commons/src/main/java/com/woocommerce/android/di/InvalidSignatureListenerModule.kt
+++ b/libs/commons/src/main/java/com/woocommerce/android/di/InvalidSignatureListenerModule.kt
@@ -1,0 +1,23 @@
+package com.woocommerce.android.di
+
+import dagger.BindsOptionalOf
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.InvalidSignatureListener
+
+/**
+ * Declares [InvalidSignatureListener] as an optional binding so that
+ * [org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork] can inject `Optional<InvalidSignatureListener>`
+ * in every Hilt graph that uses it (main app, Wear app, feature test graphs, etc.). The concrete implementation
+ * is bound by the main app only; other consumers get an empty Optional.
+ *
+ * Lives in `commons` (a shared dependency of all those graphs) and uses `@InstallIn` so Hilt auto-installs it
+ * everywhere, avoiding per-graph wiring.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+interface InvalidSignatureListenerModule {
+    @BindsOptionalOf
+    fun bindOptionalInvalidSignatureListener(): InvalidSignatureListener
+}

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/InvalidSignatureListener.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/InvalidSignatureListener.kt
@@ -1,0 +1,22 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc
+
+import org.wordpress.android.fluxc.model.SiteModel
+
+/**
+ * Listener for detecting the [WooError.REST_INVALID_SIGNATURE_CODE] error centrally at the network layer.
+ *
+ * Jetpack returns this error when signature verification fails on the merchant's site, which is a server-side
+ * problem the app cannot fix. The implementation can surface this to the merchant and stop silent retries.
+ */
+interface InvalidSignatureListener {
+    /**
+     * Called when a request for the given [siteModel] fails with the invalid signature error.
+     */
+    fun onInvalidSignatureDetected(siteModel: SiteModel)
+
+    /**
+     * Called when a request for the given [siteModel] succeeds, allowing the implementation to clear any
+     * previously recorded invalid signature state (self-healing once the server-side issue is resolved).
+     */
+    fun onSuccessfulConnection(siteModel: SiteModel) {}
+}

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooError.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooError.kt
@@ -25,7 +25,16 @@ data class WooError(
     val message: String? = null,
     val apiErrorCode: String? = null,
     val errorData: JSONObject? = null
-) : OnChangedError
+) : OnChangedError {
+    companion object {
+        /**
+         * Returned by Jetpack (HTTP 400) when signature verification fails on the merchant's site.
+         * This is a server-side problem the app cannot fix (broken Jetpack connection, security plugin
+         * conflict, outdated Jetpack, etc.).
+         */
+        const val REST_INVALID_SIGNATURE_CODE = "rest_invalid_signature"
+    }
+}
 
 enum class WooErrorType {
     TIMEOUT,
@@ -40,7 +49,8 @@ enum class WooErrorType {
     EMPTY_RESPONSE,
     INVALID_COUPON,
     INVALID_VARIATION_ID,
-    RESOURCE_ALREADY_EXISTS
+    RESOURCE_ALREADY_EXISTS,
+    REST_INVALID_SIGNATURE
 }
 
 fun WPComGsonNetworkError.toWooError() = WooError(
@@ -88,6 +98,7 @@ private fun GenericErrorType?.getWooErrorType(apiError: String?) = when (this) {
             "rest_no_route" -> WooErrorType.API_NOT_FOUND
             "woocommerce_rest_invalid_coupon" -> WooErrorType.INVALID_COUPON
             "order_item_product_invalid_variation_id" -> WooErrorType.INVALID_VARIATION_ID
+            WooError.REST_INVALID_SIGNATURE_CODE -> WooErrorType.REST_INVALID_SIGNATURE
             else -> WooErrorType.GENERIC_ERROR
         }
     }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooNetwork.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooNetwork.kt
@@ -35,7 +35,8 @@ class WooNetwork @Inject constructor(
     private val jetpackTunnelWPAPINetwork: JetpackTunnelWPAPINetwork,
     private val jetpackApplicationPasswordsSupport: JetpackApplicationPasswordsSupport,
     private val jetpackApplicationPasswordsErrorHandler: JetpackApplicationPasswordsErrorHandler,
-    private val unknownBlogListener: Optional<UnknownBlogListener>
+    private val unknownBlogListener: Optional<UnknownBlogListener>,
+    private val invalidSignatureListener: Optional<InvalidSignatureListener>
 ) : WPAPINetwork {
     override suspend fun <T : Any> executeGetGsonRequest(
         site: SiteModel,
@@ -126,12 +127,26 @@ class WooNetwork @Inject constructor(
             }
         }
         notifyIfUnknownBlog(site, response)
+        notifyInvalidSignatureListener(site, response)
         return response
     }
 
     private fun <T : Any> notifyIfUnknownBlog(site: SiteModel, response: WPAPIResponse<T>) {
         if (response is WPAPIResponse.Error && response.error.errorCode == UNKNOWN_BLOG_ERROR_CODE) {
             unknownBlogListener.ifPresent { it.onUnknownBlog(site.siteId) }
+        }
+    }
+
+    private fun <T : Any> notifyInvalidSignatureListener(site: SiteModel, response: WPAPIResponse<T>) {
+        val listener = invalidSignatureListener.orElse(null) ?: return
+        when (response) {
+            is WPAPIResponse.Error -> {
+                if (response.error.errorCode == WooError.REST_INVALID_SIGNATURE_CODE) {
+                    listener.onInvalidSignatureDetected(site)
+                }
+            }
+
+            is WPAPIResponse.Success -> listener.onSuccessfulConnection(site)
         }
     }
 

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/utils/WPAPIResponseExtTests.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/utils/WPAPIResponseExtTests.kt
@@ -6,6 +6,7 @@ import org.wordpress.android.fluxc.network.BaseRequest
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetworkError
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
 
@@ -67,5 +68,19 @@ class WPAPIResponseExtTests {
 
         assertThat(result.isError).isTrue
         assertThat(result.error.type).isEqualTo(WooErrorType.INVALID_COUPON)
+    }
+
+    @Test
+    fun `given invalid signature error, when converting, then map the error type`() {
+        val error = WPAPINetworkError(
+            BaseNetworkError(BaseRequest.GenericErrorType.UNKNOWN),
+            WooError.REST_INVALID_SIGNATURE_CODE
+        )
+        val response = WPAPIResponse.Error<String>(error)
+
+        val result = response.toWooPayload { it.hashCode() }
+
+        assertThat(result.isError).isTrue
+        assertThat(result.error.type).isEqualTo(WooErrorType.REST_INVALID_SIGNATURE)
     }
 }

--- a/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooNetworkTest.kt
+++ b/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooNetworkTest.kt
@@ -39,6 +39,7 @@ class WooNetworkTest {
     private val jetpackApplicationPasswordsErrorHandler: JetpackApplicationPasswordsErrorHandler = mock()
     private val jetpackApplicationPasswordsSupport: JetpackApplicationPasswordsSupport = mock()
     private val unknownBlogListener: UnknownBlogListener = mock()
+    private val invalidSignatureListener: InvalidSignatureListener = mock()
 
     private val sut = WooNetwork(
         applicationPasswordsConfiguration = applicationPasswordsConfiguration,
@@ -46,7 +47,8 @@ class WooNetworkTest {
         jetpackTunnelWPAPINetwork = jetpackTunnelWPAPINetwork,
         jetpackApplicationPasswordsSupport = jetpackApplicationPasswordsSupport,
         jetpackApplicationPasswordsErrorHandler = jetpackApplicationPasswordsErrorHandler,
-        unknownBlogListener = Optional.of(unknownBlogListener)
+        unknownBlogListener = Optional.of(unknownBlogListener),
+        invalidSignatureListener = Optional.of(invalidSignatureListener)
     )
 
     @Test
@@ -192,6 +194,50 @@ class WooNetworkTest {
         sut.executeGetGsonRequest(site = testSite, path = testPath, clazz = SampleResponse::class.java)
 
         verify(unknownBlogListener, never()).onUnknownBlog(any())
+    }
+
+    @Test
+    fun `given invalid signature error, when making request, then notify invalid signature listener`() = test {
+        whenever(jetpackApplicationPasswordsSupport.supportsAppPasswords(testSite)).thenReturn(false)
+        givenJetpackTunnelResponse(
+            WPAPIResponse.Error(WPAPINetworkError(mock(), WooError.REST_INVALID_SIGNATURE_CODE))
+        )
+
+        sut.executeGetGsonRequest(
+            site = testSite,
+            path = testPath,
+            clazz = SampleResponse::class.java
+        )
+
+        verify(invalidSignatureListener).onInvalidSignatureDetected(testSite)
+    }
+
+    @Test
+    fun `given a different error code, when making request, then do not notify invalid signature listener`() = test {
+        whenever(jetpackApplicationPasswordsSupport.supportsAppPasswords(testSite)).thenReturn(false)
+        givenJetpackTunnelResponse(WPAPIResponse.Error(WPAPINetworkError(mock(), "rest_too_many_requests")))
+
+        sut.executeGetGsonRequest(
+            site = testSite,
+            path = testPath,
+            clazz = SampleResponse::class.java
+        )
+
+        verify(invalidSignatureListener, never()).onInvalidSignatureDetected(testSite)
+    }
+
+    @Test
+    fun `given a successful response, when making request, then notify listener of successful connection`() = test {
+        whenever(jetpackApplicationPasswordsSupport.supportsAppPasswords(testSite)).thenReturn(false)
+        givenJetpackTunnelResponse(WPAPIResponse.Success(SampleResponse("value"), emptyList()))
+
+        sut.executeGetGsonRequest(
+            site = testSite,
+            path = testPath,
+            clazz = SampleResponse::class.java
+        )
+
+        verify(invalidSignatureListener).onSuccessfulConnection(testSite)
     }
 
     private suspend fun givenAppPasswordsResponse(response: WPAPIResponse<SampleResponse>) {


### PR DESCRIPTION
### Description

Fixes WOOMOB-3296

When Jetpack can't verify a request's signature on the merchant's WordPress site, it returns `HTTP 400` with `{"code":"rest_invalid_signature","message":"The request is not signed correctly.","data":{"status":400}}`. This is a **server-side** problem the app cannot fix (broken Jetpack connection, a security plugin, a recent plugin update, etc.). Today the app just keeps retrying silently — the background sync loop re-runs every ~4h indefinitely — so merchants assume the app is broken and reinstall, which doesn't help.

This PR detects that error and guides the merchant instead of failing silently:

- **Typed error (FluxC).** `rest_invalid_signature` is mapped to a new `WooErrorType.REST_INVALID_SIGNATURE` (+ a shared `WooError.REST_INVALID_SIGNATURE_CODE` constant).
- **Central detection.** `WooNetwork` (the chokepoint every WooCommerce REST call flows through) reports the error via a new optional `InvalidSignatureListener`. The app-side `StoreConnectionErrorMonitor` (`@Singleton`) records the affected store (keyed by remote site id) and clears it automatically once a request to that store succeeds again. `WooNetwork` keeps the listener as an `Optional` so the fluxc-plugin graph stays valid without the app's binding.
- **Stop the silent retry loop.** When the selected store is affected, `UpdateDataOnBackgroundWorker` cancels its unique periodic work and returns `Result.failure()` instead of retrying. It is naturally re-enqueued (`ExistingPeriodicWorkPolicy.KEEP`) the next time the app goes to background, so it recovers on its own once the server-side issue is fixed.
- **Merchant-facing dialog, app-wide.** A custom Compose dialog ("Your store can't be reached") is hosted in `MainActivity` so it overlays **every** main-app screen, not just the dashboard. It stays visible across navigation until the connection is restored. It is modal (can't be dismissed by tapping outside / back) and offers two actions:
  - **Contact support** — opens the in-app support flow
  - **Dismiss** — snoozes the dialog for the current session; it reappears the next time the app returns to the foreground if the store is still unreachable.

### Test Steps

These steps reproduce the server-side error on a [Jurassic Ninja](https://jurassic.ninja/) test site by faking the REST response with a custom mu-plugin.

1. Spin up a Jurassic Ninja site (with Jetpack), and log into the app with that store so it's the selected store.
2. On the JN site, add a mu-plugin that forces the signature error for Jetpack-tunneled requests:
   ```
   cat > ~/htdocs/wp-content/mu-plugins/simulate-invalid-signature.php << 'EOF'
   <?php
   add_filter( 'rest_authentication_errors', function ( $result ) {
       if ( isset( $_GET['_for'] ) && 'jetpack' === $_GET['_for'] ) {
           return new WP_Error(
               'rest_invalid_signature',
               'The request is not signed correctly.',
               array( 'status' => 400 )
           );
       }
       return $result;
   }, 99 );
   EOF
   ```
3. In the app, trigger a store request (e.g. open the Orders tab or pull-to-refresh the dashboard). Verify the **"Your store can't be reached"** dialog appears.
5. Tap **Contact support** — confirm it opens the support request form. 
6. Re-trigger the dialog, tap **Dismiss** — confirm it closes. Send the app to the background and reopen it; with the error still active, confirm the dialog reappears.
7. Background sync: with the error active, send the app to background; confirm the periodic data-sync worker stops retrying (it no longer loops).
8. Recovery: remove the mu-plugin to clear the error:
   ```
   rm ~/htdocs/wp-content/mu-plugins/simulate-invalid-signature.php
   ```
   Pull-to-refresh / re-enter the app; confirm a successful request clears the state and the dialog no longer appears.

### Images/gif


https://github.com/user-attachments/assets/2849ea3d-a023-4072-9c5f-07cb9d847587



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.