### PR TITLE
[WOOMOB-3321] Show POS tab after switching stores without an app restart

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosIsCountryAllowed.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosIsCountryAllowed.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.woopos.tab
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.FeatureFlagRepository
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import javax.inject.Inject
 
@@ -20,12 +21,22 @@ class WooPosIsCountryAllowed @Inject constructor(
     private val wooCommerceStore: WooCommerceStore,
     private val featureFlagRepository: FeatureFlagRepository,
 ) {
-    operator fun invoke(): Boolean {
+    suspend operator fun invoke(): Boolean {
         if (featureFlagRepository.isEnabled(FeatureFlag.WOO_POS_ALL_COUNTRIES)) return true
 
         val site = selectedSite.getOrNull() ?: return false
-        val countryCode = wooCommerceStore.getStoreCountryCode(site)?.uppercase() ?: return false
+        val countryCode = getStoreCountryCode(site) ?: return false
         return countryCode in SUPPORTED_COUNTRIES
+    }
+
+    private suspend fun getStoreCountryCode(site: SiteModel): String? {
+        wooCommerceStore.getStoreCountryCode(site)?.let { return it.uppercase() }
+
+        // The store's general settings (which hold the country code) aren't fetched when switching
+        // stores, so the local cache can be empty right after a switch. Fetch on demand so POS
+        // visibility is resolved without requiring an app restart.
+        wooCommerceStore.fetchSiteGeneralSettings(site)
+        return wooCommerceStore.getStoreCountryCode(site)?.uppercase()
     }
 
     private companion object {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosIsCountryAllowedTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosIsCountryAllowedTest.kt
@@ -3,14 +3,19 @@ package com.woocommerce.android.ui.woopos.tab
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.FeatureFlagRepository
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.WooCommerceStore
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class WooPosIsCountryAllowedTest {
 
     private val site = SiteModel().apply { id = 1 }
@@ -25,7 +30,7 @@ class WooPosIsCountryAllowedTest {
     )
 
     @Test
-    fun `given all-countries flag enabled, when invoked, then returns true regardless of country`() {
+    fun `given all-countries flag enabled, when invoked, then returns true regardless of country`() = runTest {
         whenever(featureFlagRepository.isEnabled(FeatureFlag.WOO_POS_ALL_COUNTRIES)).thenReturn(true)
         whenever(wooCommerceStore.getStoreCountryCode(site)).thenReturn("JP")
 
@@ -33,7 +38,7 @@ class WooPosIsCountryAllowedTest {
     }
 
     @Test
-    fun `given flag disabled and supported country, when invoked, then returns true`() {
+    fun `given flag disabled and supported country, when invoked, then returns true`() = runTest {
         whenever(featureFlagRepository.isEnabled(FeatureFlag.WOO_POS_ALL_COUNTRIES)).thenReturn(false)
         whenever(wooCommerceStore.getStoreCountryCode(site)).thenReturn("US")
 
@@ -41,20 +46,21 @@ class WooPosIsCountryAllowedTest {
     }
 
     @Test
-    fun `given flag disabled and POS-supported country, when invoked, then returns true for each supported country`() {
-        whenever(featureFlagRepository.isEnabled(FeatureFlag.WOO_POS_ALL_COUNTRIES)).thenReturn(false)
+    fun `given flag disabled and POS-supported country, when invoked, then returns true for each supported country`() =
+        runTest {
+            whenever(featureFlagRepository.isEnabled(FeatureFlag.WOO_POS_ALL_COUNTRIES)).thenReturn(false)
 
-        listOf("US", "PR", "GB", "CA", "IE", "NL", "SG", "NZ", "FI", "LU", "AU").forEach { countryCode ->
-            whenever(wooCommerceStore.getStoreCountryCode(site)).thenReturn(countryCode)
+            listOf("US", "PR", "GB", "CA", "IE", "NL", "SG", "NZ", "FI", "LU", "AU").forEach { countryCode ->
+                whenever(wooCommerceStore.getStoreCountryCode(site)).thenReturn(countryCode)
 
-            assertThat(sut())
-                .describedAs("$countryCode should be allowed")
-                .isTrue
+                assertThat(sut())
+                    .describedAs("$countryCode should be allowed")
+                    .isTrue
+            }
         }
-    }
 
     @Test
-    fun `given flag disabled and lowercase country code, when invoked, then matches case-insensitively`() {
+    fun `given flag disabled and lowercase country code, when invoked, then matches case-insensitively`() = runTest {
         whenever(featureFlagRepository.isEnabled(FeatureFlag.WOO_POS_ALL_COUNTRIES)).thenReturn(false)
         whenever(wooCommerceStore.getStoreCountryCode(site)).thenReturn("gb")
 
@@ -62,7 +68,7 @@ class WooPosIsCountryAllowedTest {
     }
 
     @Test
-    fun `given flag disabled and unsupported country, when invoked, then returns false`() {
+    fun `given flag disabled and unsupported country, when invoked, then returns false`() = runTest {
         whenever(featureFlagRepository.isEnabled(FeatureFlag.WOO_POS_ALL_COUNTRIES)).thenReturn(false)
         whenever(wooCommerceStore.getStoreCountryCode(site)).thenReturn("JP")
 
@@ -70,7 +76,7 @@ class WooPosIsCountryAllowedTest {
     }
 
     @Test
-    fun `given flag disabled and fiscalization-only country, when invoked, then returns false`() {
+    fun `given flag disabled and fiscalization-only country, when invoked, then returns false`() = runTest {
         whenever(featureFlagRepository.isEnabled(FeatureFlag.WOO_POS_ALL_COUNTRIES)).thenReturn(false)
 
         listOf("AT", "BE", "FR", "IT", "DE", "PT", "ES").forEach { countryCode ->
@@ -83,7 +89,7 @@ class WooPosIsCountryAllowedTest {
     }
 
     @Test
-    fun `given flag disabled and no selected site, when invoked, then returns false`() {
+    fun `given flag disabled and no selected site, when invoked, then returns false`() = runTest {
         whenever(featureFlagRepository.isEnabled(FeatureFlag.WOO_POS_ALL_COUNTRIES)).thenReturn(false)
         whenever(selectedSite.getOrNull()).thenReturn(null)
 
@@ -91,10 +97,29 @@ class WooPosIsCountryAllowedTest {
     }
 
     @Test
-    fun `given flag disabled and site without country code, when invoked, then returns false`() {
+    fun `given cached country code present, when invoked, then does not fetch general settings`() = runTest {
+        whenever(featureFlagRepository.isEnabled(FeatureFlag.WOO_POS_ALL_COUNTRIES)).thenReturn(false)
+        whenever(wooCommerceStore.getStoreCountryCode(site)).thenReturn("CA")
+
+        assertThat(sut()).isTrue
+        verify(wooCommerceStore, never()).fetchSiteGeneralSettings(site)
+    }
+
+    @Test
+    fun `given country code missing, when invoked, then fetches general settings and re-reads country`() = runTest {
+        whenever(featureFlagRepository.isEnabled(FeatureFlag.WOO_POS_ALL_COUNTRIES)).thenReturn(false)
+        whenever(wooCommerceStore.getStoreCountryCode(site)).thenReturn(null, "CA")
+
+        assertThat(sut()).isTrue
+        verify(wooCommerceStore).fetchSiteGeneralSettings(site)
+    }
+
+    @Test
+    fun `given country code missing even after fetch, when invoked, then returns false`() = runTest {
         whenever(featureFlagRepository.isEnabled(FeatureFlag.WOO_POS_ALL_COUNTRIES)).thenReturn(false)
         whenever(wooCommerceStore.getStoreCountryCode(site)).thenReturn(null)
 
         assertThat(sut()).isFalse
+        verify(wooCommerceStore).fetchSiteGeneralSettings(site)
     }
 }


### PR DESCRIPTION
### Description

Fixes WOOMOB-3321

When switching to a different store via the store picker, the Point of Sale tab could stay hidden until the app was restarted. The logs showed `POS Tab Not visible reason: Store country is not in the supported list`, even for stores in supported countries (e.g. Canada).

**Root cause:** POS tab eligibility includes a store-country check (`WooPosIsCountryAllowed`), which reads the country code from the locally cached store *general settings* (`WooCommerceStore.getStoreCountryCode`). Those settings are **not** fetched when switching stores.

### Test Steps

1. Log in to an account that has at least two stores, where the currently selected store's POS tab is visible.
2. Using the store picker (Menu → tap the store name at the top), switch to a store in a POS-supported country (e.g. Canada) that hasn't been opened in this session.
3. Do **not** restart the app — wait for it to land on the dashboard after the switch.
4. Confirm the **Point of Sale** tab now appears in the bottom navigation.

### Images/gif
Before:

https://github.com/user-attachments/assets/ccf3557a-e9fa-4416-8a70-3b8c4c993bfb

After:

https://github.com/user-attachments/assets/7465254f-9101-48c4-b52d-7c1deb035ac2


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.