### PR TITLE
Make remote feature flag value take precedence over local

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -4,9 +4,10 @@ package com.woocommerce.android.util
  * Feature flags control feature availability.
  *
  * - If overridden (debug builds) → use override value
- * - If [localValue] is false → the feature stays disabled
- * - If [localValue] is true and remote has a value for [remoteFlagKey] → use remote value
- * - Otherwise → use [localValue]
+ * - If remote has a value for [remoteFlagKey] → use remote value
+ * - Otherwise → fall back to [localValue]
+ *
+ * Remote is authoritative once known. [localValue] is the fallback whenever no remote value is available.
  *
  * Access via [FeatureFlagRepository.isEnabled].
  */

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -33,13 +33,16 @@ enum class FeatureFlag(
     POS_PRODUCTS_FTS("pos_products_fts", localValue = PackageUtils.isDebugBuild()),
     AGE_ELIGIBILITY_CHECKS("age_eligibility_checks"),
     BOOKINGS_RESCHEDULE("bookings_reschedule", localValue = PackageUtils.isDebugBuild()),
-    WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M1("woo_self_driven_push_notifications_m1"),
+    WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M1(
+        "woo_self_driven_push_notifications_m1",
+        localValue = PackageUtils.isDebugBuild()
+    ),
     LOGGED_OUT_FF_PANEL("logged_out_ff_panel", localValue = PackageUtils.isDebugBuild()),
     AI_ASSISTANT("woo_mobile_ai_assistant"),
     AI_SUPPORT_CHAT("ai_support_chat"),
-    SMARTER_NOTIFICATIONS("smarter_notifications"),
+    SMARTER_NOTIFICATIONS("smarter_notifications", localValue = PackageUtils.isDebugBuild()),
     IPP_COUNTRY_EXPANSION("woo_ipp_country_expansion"),
     IPP_COUNTRY_EXPANSION_EU_EXTENDED("woo_ipp_country_expansion_eu_extended"),
     IPP_AUSTRALIA_WOOPAYMENTS("woo_ipp_australia_woopayments"),
-    QR_LOGIN("woo_qr_code_login", localValue = true),
+    QR_LOGIN("woo_qr_code_login", localValue = PackageUtils.isDebugBuild()),
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlagRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlagRepository.kt
@@ -71,6 +71,6 @@ class FeatureFlagRepository @Inject constructor(
         val overrideValue: Boolean?
     ) {
         val effectiveValue: Boolean
-            get() = overrideValue ?: (localValue && (remoteValue ?: true))
+            get() = overrideValue ?: (remoteValue ?: localValue)
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/FeatureFlagRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/FeatureFlagRepositoryTest.kt
@@ -151,12 +151,46 @@ class FeatureFlagRepositoryTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given local is false and remote is true, when effectiveValue accessed, then local keeps feature disabled`() {
+    fun `given local is false and remote is true, when effectiveValue accessed, then remote enables feature`() {
         // GIVEN
         val state = FeatureFlagRepository.FeatureFlagState(
             flag = FeatureFlag.WC_SHIPPING_BANNER,
             localValue = false,
             remoteValue = true,
+            overrideValue = null
+        )
+
+        // WHEN
+        val effectiveValue = state.effectiveValue
+
+        // THEN
+        assertThat(effectiveValue).isTrue()
+    }
+
+    @Test
+    fun `given local is false and remote is null, when effectiveValue accessed, then feature stays disabled`() {
+        // GIVEN
+        val state = FeatureFlagRepository.FeatureFlagState(
+            flag = FeatureFlag.WC_SHIPPING_BANNER,
+            localValue = false,
+            remoteValue = null,
+            overrideValue = null
+        )
+
+        // WHEN
+        val effectiveValue = state.effectiveValue
+
+        // THEN
+        assertThat(effectiveValue).isFalse()
+    }
+
+    @Test
+    fun `given local is false and remote is false, when effectiveValue accessed, then feature stays disabled`() {
+        // GIVEN
+        val state = FeatureFlagRepository.FeatureFlagState(
+            flag = FeatureFlag.WC_SHIPPING_BANNER,
+            localValue = false,
+            remoteValue = false,
             overrideValue = null
         )
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/FeatureFlagRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/FeatureFlagRepositoryTest.kt
@@ -125,12 +125,12 @@ class FeatureFlagRepositoryTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given self driven push notifications feature flag, when inspected, then local value is enabled`() {
+    fun `given self driven push notifications feature flag, when inspected, then local value follows debug build`() {
         // WHEN
         val localValue = FeatureFlag.WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M1.localValue
 
         // THEN
-        assertThat(localValue).isTrue()
+        assertThat(localValue).isEqualTo(PackageUtils.isDebugBuild())
     }
 
     @Test


### PR DESCRIPTION
### Description

Today the local value takes precedence over remote:

```
effectiveValue = overrideValue ?: (localValue && (remoteValue ?: true))
```

Because `localValue` is an AND gate, a known remote value can only turn a feature off, never on: if `localValue` is false the feature stays off whatever the server says. An unknown remote value (fetch pending or failed) is also treated as `true`, so a flag with `localValue = true` shows up during the first-launch window before the remote value lands. There is also no way to ship a feature off in the binary and enable it from the server later.

This PR flips the precedence so a known remote value wins:

```
effectiveValue = overrideValue ?: (remoteValue ?: localValue)
```

The remote value now decides whenever it is known (it can enable or disable), and `localValue` is used only as the fallback until a remote value is available. For flags with `localValue = true` the result is mathematically unchanged.

It also changes three recently-added, remote-controlled flags (`WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M1`, `SMARTER_NOTIFICATIONS`, `QR_LOGIN`) from `localValue = true` to `localValue = PackageUtils.isDebugBuild()`. Now that remote is authoritative these features no longer have to default on, so they default off in release (on in debug) and are turned on through their remote values. For `WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M1` this also fixes the first-launch window where it could become wrongly visible before the remote value loaded. None of this changes the resolved value in practice: these flags are already driven by remote, so once the remote value loads the result is the same as before, and the only difference is the brief pre-fetch window, which now defaults to off.

Background and discussion: 

### Test Steps

1. On a debug build, open **Settings → Developer options → Feature Flags**.
2. The screen lists every flag with its resolved value. On a debug build this change does not alter any existing flag, so the page should look the same as on `trunk`.
3. Compare a few flags against a `trunk` build, including `WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M1`, `SMARTER_NOTIFICATIONS` and `QR_LOGIN`: the resolved values should match.

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.