### PR TITLE
[CI] Move Nightly Prototype Build Alerts to Woo Android Notifs

### DIFF
--- a/.buildkite/schedules/nightly-prototype-build.yml
+++ b/.buildkite/schedules/nightly-prototype-build.yml
@@ -14,5 +14,5 @@ steps:
 notify:
   - slack:
       channels:
-        - "#android-core-notifs"
+        - "#woo-android-notifs"
     if: "build.state == 'failed'"


### PR DESCRIPTION
Closes: [AINFRA-2555](https://linear.app/a8c/issue/AINFRA-2555/move-nightly-prototype-build-alerts-to-woo-android-notifs)

---

### Description

The nightly prototype build is defined in `.buildkite/schedules/nightly-prototype-build.yml`, and on failure (`build.state == 'failed'`) it posts a Slack alert. Until now that alert went to `#android-core-notifs`, a general Android channel where it was easy for the people who own these builds to miss it.

This PR points that failure notification at `#woo-android-notifs` instead, so the WooCommerce Android team monitors its own nightly prototype build failures directly in the team channel — consistent with how other team build alerts are already routed. The nightly prototype build process itself was introduced in #15537; this only changes where its failure alert lands.

---

### Test Steps

This is a Buildkite schedule configuration change, so there is no app behavior to exercise:

After merge, on the next scheduled nightly prototype build (or by manually triggering the schedule), verify that a failed build posts its alert to `#woo-android-notifs` and no longer to `#android-core-notifs`.

---

### Images/gif

N/A

---

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.