### PR TITLE
Update 25.1 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 <!--
 Contains editorialized release notes. Raw release notes should go into `RELEASE-NOTES.txt`.
 -->
+## 25.1
+Refunds in Woo POS now open full screen for a cleaner flow. This release also makes the app more dependable when your store can't be reached, with clearer alerts and a quick path to support. Sign-in errors are easier to understand, and we fixed missing recent orders, a startup crash, and other small glitches. Happy selling!
+
 ## 25.0
 Selling on the go just got smoother. Woo POS is now available in Canada with an improved refund flow, and we've fine-tuned Tap to Pay so it only shows on supported devices—with a clearer message (and setup link) when it's not. We've also added age verification to meet updated store requirements. Happy selling!
 

--- a/fastlane/metadata/android/en-US/changelogs/default.txt
+++ b/fastlane/metadata/android/en-US/changelogs/default.txt
@@ -1,12 +1,1 @@
-- [*] POS: the Issue Refund flow now opens full screen from the start instead of inside the order details pane [https://github.com/woocommerce/woocommerce-android/pull/16116]
-- [*] Fixed a startup crash when WordPress.com returns malformed site details [https://github.com/woocommerce/woocommerce-android/pull/16102]
-- [*] You're now returned to the store picker with an explanation when the app can no longer access the selected store, instead of being stuck with repeated errors [https://github.com/woocommerce/woocommerce-android/pull/16117]
-- [*] Show a clear alert guiding the merchant to support when their store can't be reached due to a server-side connection error, instead of failing silently [https://github.com/woocommerce/woocommerce-android/pull/16132]
-- [*] Fixed QR login retrying an expired number challenge re-showing the old number with "Expires in 0s"; it now returns you to the QR scanner to scan a fresh code [https://github.com/woocommerce/woocommerce-android/pull/16094]
-- [*] Show the orders troubleshooting banner (instead of a generic error) when your store returns an unexpected non-JSON response, and open the in-app Troubleshoot Connection screen from it [https://github.com/woocommerce/woocommerce-android/pull/16108]
-- [*] Renamed the empty Orders "test order" prompt to "Place your first order" and clarified that processing fees aren't refundable [https://github.com/woocommerce/woocommerce-android/pull/16086]
-- [*] Improved login error messages for site security certificate issues [https://github.com/woocommerce/woocommerce-android/pull/16042]
-- [Internal] Fixed a screen flash when navigating from the login prologue to the (feature-flagged) QR login screen [https://github.com/woocommerce/woocommerce-android/pull/16095]
-- [Internal] Migrated media upload and media-list endpoints to Application Passwords [https://github.com/woocommerce/woocommerce-android/pull/15550]
-- [*] Fixed newest orders sometimes missing from the order list until a filter was applied or the list was refreshed [https://github.com/woocommerce/woocommerce-android/pull/16088]
-- [*] Fixed Analytics Hub Customize screen showing a discard-changes dialog on back when no changes were made [https://github.com/woocommerce/woocommerce-android/pull/16092]
+Refunds in Woo POS now open full screen for a cleaner flow. This release also makes the app more dependable when your store can't be reached, with clearer alerts and a quick path to support. Sign-in errors are easier to understand, and we fixed missing recent orders, a startup crash, and other small glitches. Happy selling!


### PR DESCRIPTION
### Description

Editorializes the user-facing release notes for 25.1. Replaces the raw bullet list in `fastlane/metadata/android/en-US/changelogs/default.txt` with a single paragraph, and adds the same copy to the top of `CHANGELOG.md` under `## 25.1`. No `[WEAR]` bullets this release, so the Wear changelog is unchanged.

### Copy

> Refunds in Woo POS now open full screen for a cleaner flow. This release also makes the app more dependable when your store can't be reached, with clearer alerts and a quick path to support. Sign-in errors are easier to understand, and we fixed missing recent orders, a startup crash, and other small glitches. Happy selling!