### PR TITLE
[WOOMOB-998] Make ProductsMapper#mapProductIdsToProduct suspendable

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductsMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductsMapper.kt
@@ -3,7 +3,6 @@ package com.woocommerce.android.ui.products.selector
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.tools.SelectedSite
-import kotlinx.coroutines.runBlocking
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCProductModel
 import org.wordpress.android.fluxc.store.WCProductStore
@@ -13,7 +12,7 @@ class ProductsMapper @Inject constructor(
     private val site: SelectedSite,
     private val productStore: WCProductStore
 ) {
-    fun mapProductIdsToProduct(productIds: List<Long>): List<Product> {
+    suspend fun mapProductIdsToProduct(productIds: List<Long>): List<Product> {
         return productIds.asProductList(site.get()).map { product ->
             product.toAppModel()
         }
@@ -23,12 +22,8 @@ class ProductsMapper @Inject constructor(
      * This method gets all Products from the IDs described by the
      * List<Long>, but it only gets the product that are already available in the database.
      */
-    private fun List<Long>.asProductList(
+    private suspend fun List<Long>.asProductList(
         site: SiteModel,
-    ): List<WCProductModel> {
-        return runBlocking {
-            filter { productStore.getProductExistsByRemoteId(site, it) }
-                .mapNotNull { productStore.getProduct(site, it) }
-        }
-    }
+    ): List<WCProductModel> = filter { productStore.getProductExistsByRemoteId(site, it) }
+        .mapNotNull { productStore.getProduct(site, it) }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
@@ -883,6 +883,7 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
             val recentOrdersList = generateMockTestOrders()
             val totalOrders = ordersThatAreNotPaidYet + recentOrdersList
             whenever(orderStore.getPaidOrdersForSiteDesc(selectedSite.get())).thenReturn(totalOrders)
+            whenever(productsMapper.mapProductIdsToProduct(any())).thenReturn(ProductTestUtils.generateProductList())
             val argumentCaptor = argumentCaptor<List<Long>>()
 
             createViewModel(navArgs)


### PR DESCRIPTION
Fixes WOOMOB-998

### Description

`ProductsMapper.mapProductIdsToProduct` (and its private `asProductList` helper) were non-suspend and used `runBlocking` to call the suspend `WCProductStore` DB functions. Both callers in `ProductSelectorViewModel` (`loadRecentProducts`, `loadPopularProducts`) are already suspend and run on `viewModelScope`, so that `runBlocking` was blocking the main thread while Room queried the database, with no benefit.

This PR makes the function suspend and removes the `runBlocking`, so the DB access suspends instead of blocking the main thread. No call sites changed, since the callers were already suspend.

This is part of WOOMOB-983. This one was small because the callers were already suspend; the other sub-issues of WOOMOB-983 also need changes on the caller side, so they involve larger changes.

### Test Steps

No user-visible change; this is an internal threading fix. On a store that has at least one paid order containing products:

1. Open the **Orders** tab.
2. Start creating a new order.
3. Tap **Add products** to open the product selector.
4. Confirm the **Popular** and **Last Sold** sections show the expected products.

### Images/gif

N/A, no UI change.

- [x] I have considered if this change warrants release notes. This is an internal refactor with no behavior change, so none were added.