### PR TITLE
[WOOMOB-2212] Remove deprecated log tag migration

### DIFF
--- a/libs/commons/src/main/java/com/woocommerce/android/util/logs/LogEntry.kt
+++ b/libs/commons/src/main/java/com/woocommerce/android/util/logs/LogEntry.kt
@@ -49,8 +49,7 @@ class LogEntry(
 
                 val logDate = formatter.parse(parts[0] + " " + parts[1])
                     ?: Date()
-                val tagName = migrateDeprecatedTagNames(parts[2])
-                val tag = WooLog.T.valueOf(tagName)
+                val tag = WooLog.T.valueOf(parts[2])
                 val level = WooLog.LogLevel.valueOf(parts[3])
 
                 val text = log.substringAfter("] ").takeIf { it.isNotEmpty() }?.trim()
@@ -62,16 +61,6 @@ class LogEntry(
                     logDate = logDate
                 )
             }.getOrNull()
-        }
-
-        // TODO WOOMOB-2212 remove this migration code after a couple of releases,
-        //  logs are only kept for one week so the issue should fix itself by then.
-        private val deprecatedTagNames = mapOf(
-            "NOTIFS" to WooLog.T.NOTIFICATIONS.name
-        )
-
-        private fun migrateDeprecatedTagNames(tagName: String): String {
-            return deprecatedTagNames[tagName] ?: tagName
         }
     }
 }

--- a/libs/commons/src/test/kotlin/com/woocommerce/android/util/logs/LogEntryTest.kt
+++ b/libs/commons/src/test/kotlin/com/woocommerce/android/util/logs/LogEntryTest.kt
@@ -41,7 +41,7 @@ class LogEntryTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when parsing an entry with deprecated NOTIFS tag, then it is migrated to NOTIFICATIONS`() {
+    fun `when parsing an entry with unknown tag, then null is returned`() {
         // GIVEN
         val input = "[Mar-02 14:00:00:000 NOTIFS d] Some notification"
 
@@ -49,7 +49,6 @@ class LogEntryTest : BaseUnitTest() {
         val parsed = LogEntry.fromString(input)
 
         // THEN
-        val entry = requireNotNull(parsed)
-        assertThat(entry.tag).isEqualTo(WooLog.T.NOTIFICATIONS)
+        assertThat(parsed).isNull()
     }
 }


### PR DESCRIPTION
### Description
Fixes WOOMOB-2212

Removes the temporary `NOTIFS` to `NOTIFICATIONS` log tag migration from `LogEntry`.

The migration was only needed for old local log entries. Since app logs are retained for up to seven days, those old entries should no longer be present. With the temporary migration removed, old `NOTIFS` entries are treated like other invalid log entries and skipped by the current log parser.

### Test Steps
1. Log in to the app.
2. Go to Help.
3. Open Application log.
4. Confirm the current log file opens and valid log entries are displayed.

### Images/gif
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.