### PR TITLE
[WOOMOB-997] Make ProductListHandler#searchInCache suspendable

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductListHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductListHandler.kt
@@ -10,7 +10,6 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import org.wordpress.android.fluxc.store.WCProductStore
@@ -113,21 +112,19 @@ class ProductListHandler @Inject constructor(private val repository: ProductSele
         }.map { }
     }
 
-    private fun searchInCache() {
+    private suspend fun searchInCache() {
         val searchOptions = if (searchType.value == SearchType.SKU) {
             SkuSearchOptions.PartialMatch
         } else {
             SkuSearchOptions.Disabled
         }
-        runBlocking {
-            repository.searchProductsInCache(
-                offset = offset.value,
-                pageSize = PAGE_SIZE,
-                searchQuery = searchQuery.value,
-                skuSearchOptions = searchOptions,
-            ).let { loadedProducts ->
-                searchResults.update { list -> updateSearchResult(list, loadedProducts) }
-            }
+        repository.searchProductsInCache(
+            offset = offset.value,
+            pageSize = PAGE_SIZE,
+            searchQuery = searchQuery.value,
+            skuSearchOptions = searchOptions,
+        ).let { loadedProducts ->
+            searchResults.update { list -> updateSearchResult(list, loadedProducts) }
         }
     }
 


### PR DESCRIPTION
Fixes WOOMOB-997

### Description

`ProductListHandler.searchInCache` used `runBlocking` to call the suspend `ProductSelectorRepository.searchProductsInCache` function. This PR makes `searchInCache` suspend and removes the blocking call.

`loadFromCacheAndFetch` and `loadMore` were already suspend, so no call-site changes were needed.

### Test Steps

No user-visible change; this is an internal threading fix. On a store that has products:

1. Open the **Orders** tab.
2. Start creating a new order.
3. Tap **Add products** to open the product selector.
4. Search for a product by name and confirm matching products are shown.

### Images/gif

N/A, no UI change.

- [x] I have considered if this change warrants release notes. This is an internal refactor with no behavior change, so none were added.