### PR TITLE
[WOOMOB-984] Make user eligibility fetcher suspendable

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/UserEligibilityErrorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/UserEligibilityErrorViewModel.kt
@@ -38,14 +38,16 @@ class UserEligibilityErrorViewModel @Inject constructor(
     private var viewState by viewStateData
 
     init {
-        userEligibilityFetcher.getUser()?.let { user ->
-            viewState = viewState.copy(user = user)
-            analyticsTracker.track(
-                AnalyticsEvent.LOGIN_INSUFFICIENT_ROLE,
-                mapOf(
-                    ROLES_KEY to user.roles.joinToString(",") { it.value }
+        launch {
+            userEligibilityFetcher.getUser()?.let { user ->
+                viewState = viewState.copy(user = user)
+                analyticsTracker.track(
+                    AnalyticsEvent.LOGIN_INSUFFICIENT_ROLE,
+                    mapOf(
+                        ROLES_KEY to user.roles.joinToString(",") { it.value }
+                    )
                 )
-            )
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/UserEligibilityFetcher.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/UserEligibilityFetcher.kt
@@ -5,7 +5,6 @@ import com.woocommerce.android.WooException
 import com.woocommerce.android.model.User
 import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.tools.SelectedSite
-import kotlinx.coroutines.runBlocking
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.WCUserStore
 import javax.inject.Inject
@@ -31,9 +30,7 @@ class UserEligibilityFetcher @Inject constructor(
         }
     }
 
-    fun getUser() = runBlocking {
-        userStore.getUserByEmail(selectedSite.get(), appPrefs.getUserEmail())?.toAppModel()
-    }
+    suspend fun getUser() = userStore.getUserByEmail(selectedSite.get(), appPrefs.getUserEmail())?.toAppModel()
 
     private fun updateUserInfo(user: User) {
         appPrefs.setIsUserEligible(user.isEligible)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/common/UserEligibilityErrorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/common/UserEligibilityErrorViewModelTest.kt
@@ -14,7 +14,6 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Logout
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
@@ -33,9 +32,7 @@ class UserEligibilityErrorViewModelTest : BaseUnitTest() {
         roles = listOf(UserRole.Editor, UserRole.Author)
     )
 
-    private val userEligibilityFetcher: UserEligibilityFetcher = mock {
-        on { getUser() } doReturn testUser
-    }
+    private val userEligibilityFetcher: UserEligibilityFetcher = mock()
     private val accountRepository: AccountRepository = mock()
     private val analyticsTracker: AnalyticsTrackerWrapper = mock()
 
@@ -43,8 +40,8 @@ class UserEligibilityErrorViewModelTest : BaseUnitTest() {
 
     private val viewState = ViewState()
 
-    @Before
-    fun setup() {
+    private suspend fun setup(user: User? = testUser) {
+        doReturn(user).whenever(userEligibilityFetcher).getUser()
         viewModel = UserEligibilityErrorViewModel(
             savedState = SavedStateHandle(),
             accountRepository = accountRepository,
@@ -55,6 +52,7 @@ class UserEligibilityErrorViewModelTest : BaseUnitTest() {
 
     @Test
     fun `Displays the user eligibility error screen correctly`() = testBlocking {
+        setup()
         val expectedViewState = viewState.copy(user = testUser)
 
         var userData: ViewState? = null
@@ -67,6 +65,7 @@ class UserEligibilityErrorViewModelTest : BaseUnitTest() {
     fun `Handles retry button correctly when user is not eligible`() =
         testBlocking {
             doReturn(testUser).whenever(userEligibilityFetcher).fetchUserInfo()
+            setup()
 
             val isProgressDialogShown = ArrayList<Boolean>()
             viewModel.viewStateData.observeForever { old, new ->
@@ -92,6 +91,7 @@ class UserEligibilityErrorViewModelTest : BaseUnitTest() {
     fun `Handles retry button correctly when user is eligible`() = testBlocking {
         val user = testUser.copy(roles = listOf(UserRole.ShopManager))
         doReturn(user).whenever(userEligibilityFetcher).fetchUserInfo()
+        setup()
 
         val isProgressDialogShown = ArrayList<Boolean>()
         viewModel.viewStateData.observeForever { old, new ->
@@ -119,6 +119,7 @@ class UserEligibilityErrorViewModelTest : BaseUnitTest() {
     @Test
     fun `when user roles cannot be fetched on retry, then show the role verification error`() = testBlocking {
         whenever(userEligibilityFetcher.fetchUserInfo()).thenReturn(Result.failure(Exception()))
+        setup()
 
         val isProgressDialogShown = ArrayList<Boolean>()
         viewModel.viewStateData.observeForever { old, new ->
@@ -143,6 +144,7 @@ class UserEligibilityErrorViewModelTest : BaseUnitTest() {
     @Test
     fun `Handles logout button click correctly`() = testBlocking {
         doReturn(true).whenever(accountRepository).logout()
+        setup()
 
         var logoutEvent: Logout? = null
         viewModel.event.observeForever {


### PR DESCRIPTION
### Description
Fixes WOOMOB-984

This PR removes `runBlocking` from the user eligibility error flow. The cached user lookup is now suspendable end to end, and the error screen loads that user data from the ViewModel coroutine scope.

No user-facing behavior is expected to change.

### Test Steps
1. Set a test site's user role to an unsupported role, such as Subscriber.
2. Log in to the app with that user and select the site.
3. Confirm the role access error screen opens and shows the user name and role.
4. Tap Retry and confirm the screen remains on the role access error state while the role is still unsupported.

### Images/gif
<img width="300" alt="Screenshot_20260629_013918" src="https://github.com/user-attachments/assets/557d8dfc-bd3f-4fd6-8af1-d79f3c734295" />

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.