### PR TITLE
[WOOMOB-2011] Sanitize application password device names

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/applicationpasswords/WooApplicationPasswordsConfiguration.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/applicationpasswords/WooApplicationPasswordsConfiguration.kt
@@ -13,7 +13,7 @@ class WooApplicationPasswordsConfiguration @Inject constructor(
     private val featureFlagRepository: FeatureFlagRepository,
 ) : ApplicationPasswordsConfiguration {
     override val applicationName: String =
-        "${BuildConfig.APPLICATION_ID}.app-client.${DeviceInfo.name.replace(' ', '-')}"
+        "${BuildConfig.APPLICATION_ID}.app-client.${DeviceInfo.name.toApplicationPasswordSafeDeviceName()}"
 
     override suspend fun isEnabledForJetpackAccess(): Boolean {
         if (!appPrefs.jetpackAppPasswordsEnabled) return false
@@ -22,3 +22,8 @@ class WooApplicationPasswordsConfiguration @Inject constructor(
         return featureFlagRepository.isEnabled(FeatureFlag.APP_PASSWORDS_FOR_JETPACK_SITES)
     }
 }
+
+internal fun String.toApplicationPasswordSafeDeviceName(): String =
+    replace(' ', '-')
+        .replace('/', '-')
+        .replace('\\', '-')

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/applicationpasswords/WooApplicationPasswordsConfigurationTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/applicationpasswords/WooApplicationPasswordsConfigurationTest.kt
@@ -1,0 +1,30 @@
+package com.woocommerce.android.applicationpasswords
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class WooApplicationPasswordsConfigurationTest {
+    @Test
+    fun `given device name contains path separators, when sanitized, then separators are replaced`() {
+        // GIVEN
+        val deviceName = "FIH Sharp Aquos S2 4/64\\test"
+
+        // WHEN
+        val sanitizedDeviceName = deviceName.toApplicationPasswordSafeDeviceName()
+
+        // THEN
+        assertThat(sanitizedDeviceName).isEqualTo("FIH-Sharp-Aquos-S2-4-64-test")
+    }
+
+    @Test
+    fun `given device name contains spaces, when sanitized, then existing format is preserved`() {
+        // GIVEN
+        val deviceName = "Google Pixel 8"
+
+        // WHEN
+        val sanitizedDeviceName = deviceName.toApplicationPasswordSafeDeviceName()
+
+        // THEN
+        assertThat(sanitizedDeviceName).isEqualTo("Google-Pixel-8")
+    }
+}


### PR DESCRIPTION
### Description
Fixes WOOMOB-2011

Device names can contain path separators, but the app password application name is also used to build an encrypted SharedPreferences filename. This PR sanitizes the device name before using it in the application name, while preserving the existing space-to-hyphen format.

### Test Steps
N/A - covered by unit tests. Manual verification is difficult because it depends on the device model name.

### Images/gif
N/A, no UI change.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.