### PR TITLE
[WOOMOB-3273] Suppress back press while card payment is being captured

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentController.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentController.kt
@@ -810,6 +810,7 @@ class CardReaderPaymentController(
     }
 
     fun onBackPressed() {
+        if (_paymentState.value is CardReaderPaymentState.PaymentCapturing) return
         onCancelPaymentFlow()
         disconnectFromReaderIfPaymentFailedState()
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentControllerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentControllerTest.kt
@@ -2122,6 +2122,21 @@ class CardReaderPaymentControllerTest : BaseUnitTest() {
         }
 
     @Test
+    fun `given payment flow is capturing state, when user presses back button, then exit event is not emitted`() =
+        testBlocking {
+            whenever(cardReaderManager.collectPayment(any())).thenAnswer {
+                flow { emit(CapturingPayment) }
+            }
+
+            val events = controller.event.runAndCaptureValues {
+                controller.start()
+                controller.onBackPressed()
+            }
+
+            assertThat(events).noneMatch { it is CardReaderPaymentEvent.Exit }
+        }
+
+    @Test
     fun `given payment flow is payment failed, when user presses back button, then cancel event is not tracked`() =
         testBlocking {
             whenever(errorMapper.mapPaymentErrorToUiError(NoNetwork, false))

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentControllerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentControllerTest.kt
@@ -2109,7 +2109,7 @@ class CardReaderPaymentControllerTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given payment flow is capturing state, when user presses back button, then cancel event is tracked`() =
+    fun `given payment flow is capturing state, when user presses back button, then cancel event is not tracked`() =
         testBlocking {
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(CapturingPayment) }
@@ -2118,7 +2118,7 @@ class CardReaderPaymentControllerTest : BaseUnitTest() {
 
             controller.onBackPressed()
 
-            verify(tracker).trackPaymentCancelled("Capturing")
+            verify(tracker, never()).trackPaymentCancelled(anyOrNull())
         }
 
     @Test


### PR DESCRIPTION
### Description

Fixes WOOMOB-3273

Makes the IPP payment flow non-cancellable once it reaches the payment-in-progress (capturing) state, so Back no longer exits while the payment is completing; the earlier present-card phase stays cancellable.

### Test Steps

Requires a real card reader (the capturing state isn't reachable on an emulator).

1. Create an order, add a product, and collect payment with a card reader.
2. Tap a test card and let the flow reach the **"Capturing payment"** screen.
3. Press **Back** there → it's ignored; you stay until capture completes.
4. On the earlier **"present card"** screen, press **Back** → still cancels, as before.

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.