### PR TITLE
Bump min Woo version to 10.9.2 for self-driven push notifications

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -20,6 +20,7 @@
 - [Internal] Migrated media upload and media-list endpoints to Application Passwords [https://github.com/woocommerce/woocommerce-android/pull/15550]
 - [*] Fixed newest orders sometimes missing from the order list until a filter was applied or the list was refreshed [https://github.com/woocommerce/woocommerce-android/pull/16088]
 - [*] Fixed Analytics Hub Customize screen showing a discard-changes dialog on back when no changes were made [https://github.com/woocommerce/woocommerce-android/pull/16092]
+- [Internal] Raised the minimum WooCommerce plugin version for self-driven push notifications to 10.9.2 [https://github.com/woocommerce/woocommerce-android/pull/16157]
 
 25.0
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/CheckWooPluginPushNotificationsSupport.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/CheckWooPluginPushNotificationsSupport.kt
@@ -10,7 +10,7 @@ class CheckWooPluginPushNotificationsSupport @Inject constructor(
     private val getWooCorePluginCachedVersion: GetWooCorePluginCachedVersion
 ) {
     companion object {
-        const val PUSH_NOTIFICATIONS_MIN_WC_VERSION = "10.9.0"
+        const val PUSH_NOTIFICATIONS_MIN_WC_VERSION = "10.9.2"
     }
 
     suspend operator fun invoke(forceRefresh: Boolean): Result {


### PR DESCRIPTION
### Description

This bumps the minimum required WooCommerce plugin version for self-driven push notifications from `10.9.0` to `10.9.2`.

### Test Steps

1. Fire up a fresh JN site and install Woo 10.9.1 on it.
2. Install the app and login to that site.
3. Enable the FF.
4. Restart the app.
5. Note the dashboard card should appear.
6. Start the PN enablement
7. It should fail with 10.9.1 needs update.

### Screenhot
<img height="600" alt="image" src="https://github.com/user-attachments/assets/c93f61e1-ca7f-4c37-a2b9-cdc27e95c465" />


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
