### PR TITLE
[WOOMOB-2116] Increment compile SDK to API 37 (Android 17)

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 
 25.1
 -----
+- [Internal] Updated the app's compile SDK to Android 17 (API 37)
 - [*] POS: the Issue Refund flow now opens full screen from the start instead of inside the order details pane [https://github.com/woocommerce/woocommerce-android/pull/16116]
 - [*] Fixed a startup crash when WordPress.com returns malformed site details [https://github.com/woocommerce/woocommerce-android/pull/16102]
 - [*] You're now returned to the store picker with an explanation when the app can no longer access the selected store, instead of being stuck with repeated errors [https://github.com/woocommerce/woocommerce-android/pull/16117]

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,7 +4,7 @@
 
 25.1
 -----
-- [Internal] Updated the app's compile SDK to Android 17 (API 37)
+- [Internal] Updated the app's compile SDK to Android 17 (API 37) [https://github.com/woocommerce/woocommerce-android/pull/16158]
 - [*] POS: the Issue Refund flow now opens full screen from the start instead of inside the order details pane [https://github.com/woocommerce/woocommerce-android/pull/16116]
 - [*] Fixed a startup crash when WordPress.com returns malformed site details [https://github.com/woocommerce/woocommerce-android/pull/16102]
 - [*] You're now returned to the store picker with an explanation when the app can no longer access the selected store, instead of being stuck with repeated errors [https://github.com/woocommerce/woocommerce-android/pull/16117]

--- a/settings.gradle
+++ b/settings.gradle
@@ -194,7 +194,7 @@ gradle.ext.mediaPickerBinaryPath = "org.wordpress:mediapicker"
 gradle.ext.mediaPickerSourceCameraBinaryPath = "org.wordpress.mediapicker:source-camera"
 
 gradle.ext {
-    compileSdkVersion = 36
+    compileSdkVersion = 37
     targetSdkVersion = 36
     minSdkVersion = 26
 }


### PR DESCRIPTION
### Description
Fixes WOOMOB-2116

Increments the compile SDK from 36 to 37 (Android 17) as part of our [process for mobile OS updates](https://woomobilep2.wordpress.com/process-for-mobile-os-and-ide-updates/). This is a **compileSdk-only** change — `targetSdkVersion` remains at 36 and will be updated separately after a thorough migration review.

This re-applies #15630, which made exactly this change but was closed in April only because Android 17 wasn't stable yet and CI couldn't build against it. Android 17 (API 37) is now stable, so we can land it. The behavioral-changes review below is carried over from that PR.

The version is defined once in `settings.gradle` (`gradle.ext.compileSdkVersion`) and is consumed by every module (main app, Wear, and all `libs/*`), so the single edit propagates everywhere. AGP 8.13.2 builds against compileSdk 37 cleanly — no `android.suppressUnsupportedCompileSdk` flag is needed.

### Android 17 Behavioral Changes Assessment

Because `targetSdkVersion` stays at 36, the app does **not** opt into the changes that only affect apps targeting Android 17. Only the [behavioral changes for all apps](https://developer.android.com/about/versions/17/behavior-changes-all) apply, and none require code changes for a compileSdk-only bump:

| Behavioral Change | Impact | Why it doesn't affect us |
|---|---|---|
| **usesCleartextTraffic deprecation** | None | Already using [`network_security_config.xml`](https://github.com/woocommerce/woocommerce-android/blob/trunk/WooCommerce/src/main/res/xml/network_security_config.xml) (the recommended replacement). Cleartext is only enabled for testing against mock servers. |
| **Implicit URI grants restriction** | None | The app uses `FileProvider` correctly for URI grants (e.g., [`PaymentReceiptShare.kt`](https://github.com/woocommerce/woocommerce-android/blob/trunk/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/receipt/PaymentReceiptShare.kt), [`ActivityUtils.kt`](https://github.com/woocommerce/woocommerce-android/blob/trunk/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ActivityUtils.kt)). Also, the restriction itself takes effect in Android 18, not 17. |
| **Per-app Keystore limits** | None | Minimal AndroidKeyStore usage — only for [`EncryptedSharedPreferences`](https://github.com/woocommerce/woocommerce-android/blob/trunk/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsStore.kt) (application passwords) and [`MemorizingTrustManager`](https://github.com/woocommerce/woocommerce-android/blob/trunk/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/MemorizingTrustManager.java) (SSL trust). Well under the 200,000 key limit. |
| **IME visibility after rotation** | None | The app uses `adjustResize` on activities but doesn't rely on automatic keyboard restoration after rotation. Login flows use explicit `showSoftInput()` calls which are unaffected. |
| **Touchpad relative events** | None | The app doesn't use `View.requestPointerCapture()`. |
| **Background audio hardening** | None | Audio usage is limited to foreground POS sonification sounds ([`WooPosSoundHelper.kt`](https://github.com/woocommerce/woocommerce-android/blob/trunk/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/util/WooPosSoundHelper.kt)). No background audio playback. |
| **Bluetooth autonomous re-pairing** | Beneficial | The card reader library uses Bluetooth ([`cardreader/`](https://github.com/woocommerce/woocommerce-android/tree/trunk/libs/cardreader)), but this change is beneficial — automatic re-pairing of lost bonds means fewer manual reconnection steps. The app doesn't handle `ACTION_KEY_MISSING` or `ACTION_PAIRING_REQUEST` directly. |

Static analysis was re-run against compileSdk 37 (`lintWasabiRelease`, `detektAll`) and surfaced no new errors beyond the existing baseline.

### Test Steps
Runtime behavior is unchanged (the Android 17 behavior changes are gated by `targetSdkVersion`, which stays at 36), so this is a low-risk config bump. A light smoke test on a device/emulator is sufficient:
1. Open the project in Android Studio and confirm Gradle sync completes.
2. Build and install the app (`./gradlew :WooCommerce:installWasabiDebug`).
3. Confirm the app launches and basic navigation works (orders list, open an order, products).
4. Exercise the most platform-coupled flows: connect a card reader and take a test In-Person Payment, and ring up an item in POS.

### Images/gif
N/A — no UI changes.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

Added an `[Internal]` entry; this is a non-user-facing build configuration change.