### PR TITLE
Add success state to WooPos primary buttons

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosButtons.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosButtons.kt
@@ -4,6 +4,13 @@ package com.woocommerce.android.ui.woopos.common.composeui.component
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.animation.togetherWith
+import androidx.compose.runtime.getValue
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -46,6 +53,7 @@ import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosCom
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosCornerRadius
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosIconSize
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosIcons
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.currentWooPosBreakpoint
@@ -79,7 +87,7 @@ fun WooPosButton(
         textStyle = WooPosTypography.BodyLarge,
         text = text,
         state = state,
-        colors = ButtonDefaults.buttonColors(
+        baseColors = ButtonDefaults.buttonColors(
             containerColor = MaterialTheme.colorScheme.primary,
             contentColor = MaterialTheme.colorScheme.onPrimary,
             disabledContainerColor = WooPosTheme.colors.disabledContainer,
@@ -103,7 +111,7 @@ fun WooPosButtonSmall(
         textStyle = WooPosTypography.BodySmall,
         text = text,
         state = state,
-        colors = ButtonDefaults.buttonColors(
+        baseColors = ButtonDefaults.buttonColors(
             containerColor = MaterialTheme.colorScheme.primary,
             contentColor = MaterialTheme.colorScheme.onPrimary,
             disabledContainerColor = WooPosTheme.colors.disabledContainer,
@@ -122,7 +130,7 @@ fun WooPosOutlinedButton(
     textStyle: WooPosTypography = WooPosTypography.BodyLarge,
     onClick: () -> Unit,
 ) {
-    val borderColor = if (state == WooPosButtonState.ENABLED || state == WooPosButtonState.LOADING) {
+    val borderColor = if (state != WooPosButtonState.DISABLED) {
         MaterialTheme.colorScheme.inverseSurface
     } else {
         WooPosTheme.colors.disabledContainer
@@ -134,7 +142,7 @@ fun WooPosOutlinedButton(
         textStyle = textStyle,
         text = text,
         border = BorderStroke(2.dp, borderColor),
-        colors = ButtonDefaults.buttonColors(
+        baseColors = ButtonDefaults.buttonColors(
             containerColor = WooPosTheme.colors.transparent,
             contentColor = MaterialTheme.colorScheme.onSurface,
             disabledContainerColor = WooPosTheme.colors.transparent,
@@ -153,7 +161,7 @@ fun WooPosOutlinedButtonSmall(
     text: String,
     onClick: () -> Unit,
 ) {
-    val borderColor = if (state == WooPosButtonState.ENABLED) {
+    val borderColor = if (state != WooPosButtonState.DISABLED) {
         MaterialTheme.colorScheme.inverseSurface
     } else {
         WooPosTheme.colors.disabledContainer
@@ -165,7 +173,7 @@ fun WooPosOutlinedButtonSmall(
         textStyle = WooPosTypography.BodySmall,
         text = text,
         border = BorderStroke(2.dp, borderColor),
-        colors = ButtonDefaults.buttonColors(
+        baseColors = ButtonDefaults.buttonColors(
             containerColor = WooPosTheme.colors.transparent,
             contentColor = MaterialTheme.colorScheme.onSurface,
             disabledContainerColor = WooPosTheme.colors.transparent,
@@ -263,23 +271,35 @@ private fun Button(
     textStyle: WooPosTypography,
     text: String,
     loadingIndicatorSize: Dp,
-    colors: ButtonColors,
+    baseColors: ButtonColors,
     border: BorderStroke? = null,
     state: WooPosButtonState = WooPosButtonState.ENABLED,
     maxLines: Int = Int.MAX_VALUE,
     onClick: () -> Unit,
 ) {
-    val onClickLocal = if (state == WooPosButtonState.ENABLED) {
-        onClick
-    } else {
-        {}
-    }
+    val isSuccess = state == WooPosButtonState.SUCCESS
+    val animatedContainerColor by animateColorAsState(
+        targetValue = if (isSuccess) WooPosTheme.colors.success else baseColors.containerColor,
+        animationSpec = tween(200),
+        label = "button_container_color",
+    )
+    val animatedContentColor by animateColorAsState(
+        targetValue = if (isSuccess) WooPosTheme.colors.onSuccess else baseColors.contentColor,
+        animationSpec = tween(200),
+        label = "button_content_color",
+    )
+    val onClickLocal: () -> Unit = if (state == WooPosButtonState.ENABLED || isSuccess) onClick else ({})
     Button(
         onClick = onClickLocal,
         shape = RoundedCornerShape(WooPosCornerRadius.Medium.value),
-        enabled = state == WooPosButtonState.ENABLED || state == WooPosButtonState.LOADING,
+        enabled = state == WooPosButtonState.ENABLED || state == WooPosButtonState.LOADING || isSuccess,
         border = border,
-        colors = colors,
+        colors = ButtonDefaults.buttonColors(
+            containerColor = animatedContainerColor,
+            contentColor = animatedContentColor,
+            disabledContainerColor = baseColors.disabledContainerColor,
+            disabledContentColor = baseColors.disabledContentColor,
+        ),
         modifier = modifier
             .heightIn(min = height, max = height * 3),
         elevation = ButtonDefaults.buttonElevation(
@@ -290,24 +310,45 @@ private fun Button(
             focusedElevation = WooPosSpacing.None.value
         )
     ) {
-        Box(contentAlignment = Alignment.Center) {
-            // Always include the text. When loading, hide it with alpha to keep the width
-            WooPosText(
-                text = text,
-                style = textStyle,
-                fontWeight = FontWeight.Bold,
-                maxLines = maxLines,
-                overflow = TextOverflow.Ellipsis,
-                textAlign = TextAlign.Center,
-                modifier = Modifier.alpha(if (state == WooPosButtonState.LOADING) 0f else 1f)
-            )
-            when (state) {
-                WooPosButtonState.ENABLED,
-                WooPosButtonState.DISABLED -> {
+        AnimatedContent(
+            targetState = isSuccess,
+            transitionSpec = {
+                if (targetState) {
+                    slideInVertically(tween(250)) { -it } togetherWith slideOutVertically(tween(250)) { it }
+                } else {
+                    slideInVertically(tween(250)) { it } togetherWith slideOutVertically(tween(250)) { -it }
                 }
-
-                WooPosButtonState.LOADING -> {
-                    ButtonsLoadingIndicator(size = loadingIndicatorSize)
+            },
+            modifier = Modifier.fillMaxWidth(),
+            contentAlignment = Alignment.Center,
+            label = "button_state_content",
+        ) { showSuccess ->
+            Box(
+                modifier = Modifier.fillMaxWidth(),
+                contentAlignment = Alignment.Center,
+            ) {
+                if (showSuccess) {
+                    Icon(
+                        imageVector = WooPosIcons.Check,
+                        contentDescription = null,
+                        modifier = Modifier.size(loadingIndicatorSize),
+                    )
+                } else {
+                    Box(contentAlignment = Alignment.Center) {
+                        // Always include the text. When loading, hide it with alpha to keep the width
+                        WooPosText(
+                            text = text,
+                            style = textStyle,
+                            fontWeight = FontWeight.Bold,
+                            maxLines = maxLines,
+                            overflow = TextOverflow.Ellipsis,
+                            textAlign = TextAlign.Center,
+                            modifier = Modifier.alpha(if (state == WooPosButtonState.LOADING) 0f else 1f)
+                        )
+                        if (state == WooPosButtonState.LOADING) {
+                            ButtonsLoadingIndicator(size = loadingIndicatorSize)
+                        }
+                    }
                 }
             }
         }
@@ -349,6 +390,13 @@ fun WooPosButtonsPreview() {
             WooPosButton(
                 text = "Button",
                 state = WooPosButtonState.LOADING,
+                modifier = Modifier.fillMaxWidth(),
+                onClick = {}
+            )
+
+            WooPosButton(
+                text = "Button",
+                state = WooPosButtonState.SUCCESS,
                 modifier = Modifier.fillMaxWidth(),
                 onClick = {}
             )
@@ -485,5 +533,5 @@ fun WooPosSmallButtonsPreview() {
 }
 
 enum class WooPosButtonState {
-    ENABLED, DISABLED, LOADING
+    ENABLED, DISABLED, LOADING, SUCCESS
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
@@ -75,9 +75,7 @@ import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
 import com.woocommerce.android.ui.woopos.common.composeui.component.ShadowType
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosBackButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButton
-import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButtonState
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosCard
-import com.woocommerce.android.ui.woopos.home.cart.WooPosCartState.CheckoutButtonState
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosCustomAmountInitialsAvatar
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosIconButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosItemImage
@@ -171,8 +169,9 @@ fun WooPosCartScreen(
 
         when (checkoutSlot) {
             WooPosCartCheckoutButtonSlot.Inline -> {
+                val checkoutButtonState = state.checkoutButtonState.toWooPosButtonState()
                 AnimatedVisibility(
-                    visible = state.checkoutButtonState != WooPosCartState.CheckoutButtonState.Invisible,
+                    visible = checkoutButtonState != null,
                     enter = fadeIn(animationSpec = tween(300)),
                     exit = fadeOut(animationSpec = tween(300)),
                     modifier = Modifier
@@ -183,21 +182,22 @@ fun WooPosCartScreen(
                             end.linkTo(parent.end)
                         }
                 ) {
-                    Surface(
-                        color = MaterialTheme.colorScheme.surfaceBright,
-                        modifier = Modifier.fillMaxWidth(),
-                    ) {
-                        WooPosButton(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(horizontal = WooPosSpacing.Medium.value)
-                                .navigationBarsPadding()
-                                .testTag(WooPosTestTags.CHECKOUT_BUTTON),
-                            text = stringResource(R.string.woopos_checkout_button),
-                            state = state.checkoutButtonState.toWooPosButtonState()
-                                ?: WooPosButtonState.ENABLED,
-                            onClick = { onUIEvent(WooPosCartUIEvent.CheckoutClicked) },
-                        )
+                    if (checkoutButtonState != null) {
+                        Surface(
+                            color = MaterialTheme.colorScheme.surfaceBright,
+                            modifier = Modifier.fillMaxWidth(),
+                        ) {
+                            WooPosButton(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = WooPosSpacing.Medium.value)
+                                    .navigationBarsPadding()
+                                    .testTag(WooPosTestTags.CHECKOUT_BUTTON),
+                                text = stringResource(R.string.woopos_checkout_button),
+                                state = checkoutButtonState,
+                                onClick = { onUIEvent(WooPosCartUIEvent.CheckoutClicked) },
+                            )
+                        }
                     }
                 }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
@@ -77,6 +77,7 @@ import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosBackBu
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButtonState
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosCard
+import com.woocommerce.android.ui.woopos.home.cart.WooPosCartState.CheckoutButtonState
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosCustomAmountInitialsAvatar
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosIconButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosItemImage
@@ -193,12 +194,9 @@ fun WooPosCartScreen(
                                 .navigationBarsPadding()
                                 .testTag(WooPosTestTags.CHECKOUT_BUTTON),
                             text = stringResource(R.string.woopos_checkout_button),
+                            state = state.checkoutButtonState.toWooPosButtonState()
+                                ?: WooPosButtonState.ENABLED,
                             onClick = { onUIEvent(WooPosCartUIEvent.CheckoutClicked) },
-                            state = when (state.checkoutButtonState) {
-                                WooPosCartState.CheckoutButtonState.Enabled -> WooPosButtonState.ENABLED
-                                WooPosCartState.CheckoutButtonState.Disabled -> WooPosButtonState.DISABLED
-                                WooPosCartState.CheckoutButtonState.Invisible -> WooPosButtonState.ENABLED
-                            }
                         )
                     }
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartState.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.woopos.home.cart
 
 import android.os.Parcelable
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButtonState
 import kotlinx.parcelize.Parcelize
 import java.math.BigDecimal
 
@@ -11,6 +12,7 @@ data class WooPosCartState(
     val body: Body = Body.Empty,
     val areItemsRemovable: Boolean = true,
     val checkoutButtonState: CheckoutButtonState = CheckoutButtonState.Enabled,
+    val isItemJustAdded: Boolean = false,
 ) : Parcelable {
     @Parcelize
     sealed class Body : Parcelable {
@@ -39,12 +41,20 @@ data class WooPosCartState(
     enum class CheckoutButtonState {
         Enabled,
         Disabled,
-        Invisible
+        Invisible,
+        Success
     }
 }
 
 enum class WooPosCartStatus {
     EDITABLE, CHECKOUT, EMPTY,
+}
+
+fun WooPosCartState.CheckoutButtonState.toWooPosButtonState(): WooPosButtonState? = when (this) {
+    WooPosCartState.CheckoutButtonState.Enabled -> WooPosButtonState.ENABLED
+    WooPosCartState.CheckoutButtonState.Disabled -> WooPosButtonState.DISABLED
+    WooPosCartState.CheckoutButtonState.Success -> WooPosButtonState.SUCCESS
+    WooPosCartState.CheckoutButtonState.Invisible -> null
 }
 
 @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
@@ -49,7 +49,9 @@ import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
 import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import java.util.concurrent.atomic.AtomicInteger
 import javax.inject.Inject
@@ -93,8 +95,10 @@ class WooPosCartViewModel @Inject constructor(
         .map { updateStateDependingOnCartStatus(it) }
 
     private val itemNumberProvider = AtomicInteger(getInitialValueOrHighestUsedItemNumberAfterProcessDeath())
+    private var itemAddedFlashJob: Job? = null
 
     init {
+        _state.value = _state.value.copy(isItemJustAdded = false)
         listenEventsFromParent()
         viewModelScope.launch {
             soundHelper.preloadBarcodeScanFailure()
@@ -135,9 +139,12 @@ class WooPosCartViewModel @Inject constructor(
 
             WooPosCartUIEvent.ClearAllClicked -> {
                 viewModelScope.launch { analyticsTracker.track(ClearCartTapped) }
+                itemAddedFlashJob?.cancel()
+                itemAddedFlashJob = null
                 val currentState = _state.value
                 _state.value = currentState.copy(
-                    body = WooPosCartState.Body.Empty
+                    body = WooPosCartState.Body.Empty,
+                    isItemJustAdded = false,
                 )
             }
 
@@ -175,9 +182,11 @@ class WooPosCartViewModel @Inject constructor(
     }
 
     private fun goToTotals() {
+        itemAddedFlashJob?.cancel()
+        itemAddedFlashJob = null
         val itemClickedDataList = getCartItemsDataList()
         sendEventToParent(ChildToParentEvent.CheckoutClicked(itemClickedDataList))
-        _state.value = _state.value.copy(cartStatus = CHECKOUT)
+        _state.value = _state.value.copy(cartStatus = CHECKOUT, isItemJustAdded = false)
         trackCheckoutTapped(
             itemClickedDataList.filterIsInstance<WooPosItemsViewModel.ItemClickedData.Product>().size,
             itemClickedDataList.filterIsInstance<WooPosItemsViewModel.ItemClickedData.Coupon>().size
@@ -294,6 +303,7 @@ class WooPosCartViewModel @Inject constructor(
             is WooPosCustomAmountCartHandler.SubmittedResult.Added -> {
                 handleNewTransactionIfNeeded()
                 updateCartItem(result.newItem)
+                flashItemAdded()
                 analyticsTracker.track(
                     CustomAmountSubmitted(CustomAmountSubmitted.Mode.ADD, event.isTaxable)
                 )
@@ -426,6 +436,7 @@ class WooPosCartViewModel @Inject constructor(
 
             itemClicked.await()?.let {
                 updateCartItem(it)
+                flashItemAdded()
             }
             event.eventForTracking?.let {
                 analyticsTracker.track(it)
@@ -459,6 +470,8 @@ class WooPosCartViewModel @Inject constructor(
     }
 
     private fun clearCart() {
+        itemAddedFlashJob?.cancel()
+        itemAddedFlashJob = null
         _state.value = WooPosCartState()
     }
 
@@ -512,6 +525,9 @@ class WooPosCartViewModel @Inject constructor(
 
         analyticsTracker.track(WooPosAnalyticsEvent.Event.ItemAddedToCart(item = cartItem))
         updateCartItem(cartItem)
+        if (cartItem !is WooPosCartItemViewState.Error) {
+            flashItemAdded()
+        }
     }
 
     private suspend fun processBarcodeError(result: BarcodeInputDetector.BarcodeResult.Error) {
@@ -646,6 +662,8 @@ class WooPosCartViewModel @Inject constructor(
                 val checkoutButtonState = when {
                     newState.body !is WooPosCartState.Body.WithItems -> WooPosCartState.CheckoutButtonState.Invisible
                     cartContainsLoadingOrErrorItems(newState.body) -> WooPosCartState.CheckoutButtonState.Disabled
+                    cartContainsPurchasableItems(newState.body) && newState.isItemJustAdded ->
+                        WooPosCartState.CheckoutButtonState.Success
                     cartContainsPurchasableItems(newState.body) -> WooPosCartState.CheckoutButtonState.Enabled
                     else -> WooPosCartState.CheckoutButtonState.Invisible
                 }
@@ -659,6 +677,7 @@ class WooPosCartViewModel @Inject constructor(
                 newState.copy(
                     areItemsRemovable = false,
                     checkoutButtonState = WooPosCartState.CheckoutButtonState.Invisible,
+                    isItemJustAdded = false,
                 )
             }
         }
@@ -668,6 +687,15 @@ class WooPosCartViewModel @Inject constructor(
             is WooPosCartState.Body.Empty -> newState.copy(cartStatus = EMPTY)
             is WooPosCartState.Body.WithItems -> newState
         }
+
+    private fun flashItemAdded() {
+        itemAddedFlashJob?.cancel()
+        _state.value = _state.value.copy(isItemJustAdded = true)
+        itemAddedFlashJob = viewModelScope.launch {
+            delay(ITEM_ADDED_FLASH_DURATION_MS)
+            _state.value = _state.value.copy(isItemJustAdded = false)
+        }
+    }
 
     private fun sendEventToParent(event: ChildToParentEvent) {
         viewModelScope.launch {
@@ -786,5 +814,9 @@ class WooPosCartViewModel @Inject constructor(
                 )
             }
         }
+    }
+
+    companion object {
+        private const val ITEM_ADDED_FLASH_DURATION_MS = 1000L
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/phone/WooPosHomePhonePersistentButton.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/phone/WooPosHomePhonePersistentButton.kt
@@ -20,6 +20,7 @@ import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButton
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
 import com.woocommerce.android.ui.woopos.home.WooPosHomeState
 import com.woocommerce.android.ui.woopos.home.cart.WooPosCartState
+import com.woocommerce.android.ui.woopos.home.cart.toWooPosButtonState
 
 enum class WooPosPhonePersistentButtonAction {
     OpenCart,
@@ -63,20 +64,13 @@ class WooPosPhonePersistentButtonStateResolver(
             }
         }
         WooPosHomeState.ScreenPositionState.Cart -> {
-            when (cartState?.checkoutButtonState) {
-                WooPosCartState.CheckoutButtonState.Enabled -> WooPosPhonePersistentButtonState.Primary(
+            cartState?.checkoutButtonState?.toWooPosButtonState()?.let { buttonState ->
+                WooPosPhonePersistentButtonState.Primary(
                     label = checkoutLabel,
-                    buttonState = WooPosButtonState.ENABLED,
+                    buttonState = buttonState,
                     action = WooPosPhonePersistentButtonAction.Checkout,
                 )
-                WooPosCartState.CheckoutButtonState.Disabled -> WooPosPhonePersistentButtonState.Primary(
-                    label = checkoutLabel,
-                    buttonState = WooPosButtonState.DISABLED,
-                    action = WooPosPhonePersistentButtonAction.Checkout,
-                )
-                WooPosCartState.CheckoutButtonState.Invisible,
-                null -> WooPosPhonePersistentButtonState.Hidden
-            }
+            } ?: WooPosPhonePersistentButtonState.Hidden
         }
         is WooPosHomeState.ScreenPositionState.Checkout -> WooPosPhonePersistentButtonState.Hidden
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/phone/WooPosHomePhonePersistentButton.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/phone/WooPosHomePhonePersistentButton.kt
@@ -52,7 +52,8 @@ class WooPosPhonePersistentButtonStateResolver(
                     if (body.amountOfItems > 0) {
                         WooPosPhonePersistentButtonState.Primary(
                             label = buildCartLabel(body.amountOfItems),
-                            buttonState = WooPosButtonState.ENABLED,
+                            buttonState = cartState.checkoutButtonState.toWooPosButtonState()
+                                ?: WooPosButtonState.ENABLED,
                             action = WooPosPhonePersistentButtonAction.OpenCart,
                         )
                     } else {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModelTest.kt
@@ -884,6 +884,7 @@ class WooPosCartViewModelTest {
                 eventForTracking = mockedEventForTracking
             )
         )
+        advanceUntilIdle()
 
         // THEN
         val finalState = states.last()
@@ -915,6 +916,7 @@ class WooPosCartViewModelTest {
                 eventForTracking = mockedEventForTracking
             )
         )
+        advanceUntilIdle()
 
         // THEN
         val finalState = states.last()
@@ -958,6 +960,7 @@ class WooPosCartViewModelTest {
     fun `given cart with products, when navigated to checkout, then checkout button not visible`() = runTest {
         // GIVEN
         val (sut, states) = createSutWithItemsInCart()
+        advanceUntilIdle()
         assertThat(states.last().checkoutButtonState).isEqualTo(WooPosCartState.CheckoutButtonState.Enabled)
 
         // WHEN

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/phone/WooPosHomePhonePersistentButtonTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/phone/WooPosHomePhonePersistentButtonTest.kt
@@ -9,54 +9,34 @@ import org.junit.Test
 
 class WooPosHomePhonePersistentButtonTest {
 
+    private val resolver = WooPosPhonePersistentButtonStateResolver(
+        buildCartLabel = { "Cart ($it)" },
+        checkoutLabel = "Check out",
+    )
+
+    // region Products screen
+
     @Test
     fun `given Products screen and empty cart, when resolving state, then Hidden`() {
-        // GIVEN
         val cartState = WooPosCartState(body = WooPosCartState.Body.Empty)
-        val resolver = WooPosPhonePersistentButtonStateResolver(
-            buildCartLabel = { "Cart ($it)" },
-            checkoutLabel = "Check out",
-        )
 
-        // WHEN
         val result = resolver.resolve(
             screenPositionState = WooPosHomeState.ScreenPositionState.Products,
             cartState = cartState,
         )
 
-        // THEN
         assertThat(result).isEqualTo(WooPosPhonePersistentButtonState.Hidden)
     }
 
     @Test
-    fun `given Products screen and cart with items, when resolving state, then Primary OpenCart`() {
-        // GIVEN
-        val cartState = WooPosCartState(
-            body = WooPosCartState.Body.WithItems(
-                itemsInCart = List(3) {
-                    WooPosCartItemViewState.Product.Simple(
-                        itemNumber = it,
-                        id = it.toLong(),
-                        name = "n",
-                        price = "",
-                        description = null,
-                        imageUrl = null,
-                    )
-                }
-            )
-        )
-        val resolver = WooPosPhonePersistentButtonStateResolver(
-            buildCartLabel = { "Cart ($it)" },
-            checkoutLabel = "Check out",
-        )
+    fun `given Products screen and cart with Enabled checkout, when resolving state, then Primary OpenCart ENABLED`() {
+        val cartState = cartWithItems(checkoutButtonState = WooPosCartState.CheckoutButtonState.Enabled)
 
-        // WHEN
         val result = resolver.resolve(
             screenPositionState = WooPosHomeState.ScreenPositionState.Products,
             cartState = cartState,
         )
 
-        // THEN
         assertThat(result).isEqualTo(
             WooPosPhonePersistentButtonState.Primary(
                 label = "Cart (3)",
@@ -67,23 +47,73 @@ class WooPosHomePhonePersistentButtonTest {
     }
 
     @Test
-    fun `given Cart screen with Enabled checkout, when resolving state, then Primary Checkout ENABLED`() {
-        // GIVEN
-        val cartState = WooPosCartState(
-            checkoutButtonState = WooPosCartState.CheckoutButtonState.Enabled
-        )
-        val resolver = WooPosPhonePersistentButtonStateResolver(
-            buildCartLabel = { "Cart ($it)" },
-            checkoutLabel = "Check out",
+    fun `given Products screen and cart with Success checkout, when resolving state, then Primary OpenCart SUCCESS`() {
+        val cartState = cartWithItems(checkoutButtonState = WooPosCartState.CheckoutButtonState.Success)
+
+        val result = resolver.resolve(
+            screenPositionState = WooPosHomeState.ScreenPositionState.Products,
+            cartState = cartState,
         )
 
-        // WHEN
+        assertThat(result).isEqualTo(
+            WooPosPhonePersistentButtonState.Primary(
+                label = "Cart (3)",
+                buttonState = WooPosButtonState.SUCCESS,
+                action = WooPosPhonePersistentButtonAction.OpenCart,
+            )
+        )
+    }
+
+    @Test
+    fun `given Products screen and cart with Disabled checkout, when resolving state, then Primary OpenCart DISABLED`() {
+        val cartState = cartWithItems(checkoutButtonState = WooPosCartState.CheckoutButtonState.Disabled)
+
+        val result = resolver.resolve(
+            screenPositionState = WooPosHomeState.ScreenPositionState.Products,
+            cartState = cartState,
+        )
+
+        assertThat(result).isEqualTo(
+            WooPosPhonePersistentButtonState.Primary(
+                label = "Cart (3)",
+                buttonState = WooPosButtonState.DISABLED,
+                action = WooPosPhonePersistentButtonAction.OpenCart,
+            )
+        )
+    }
+
+    @Test
+    fun `given Products screen and cart with Invisible checkout, when resolving state, then Primary OpenCart ENABLED`() {
+        // Invisible maps to null via toWooPosButtonState(), falling back to ENABLED
+        val cartState = cartWithItems(checkoutButtonState = WooPosCartState.CheckoutButtonState.Invisible)
+
+        val result = resolver.resolve(
+            screenPositionState = WooPosHomeState.ScreenPositionState.Products,
+            cartState = cartState,
+        )
+
+        assertThat(result).isEqualTo(
+            WooPosPhonePersistentButtonState.Primary(
+                label = "Cart (3)",
+                buttonState = WooPosButtonState.ENABLED,
+                action = WooPosPhonePersistentButtonAction.OpenCart,
+            )
+        )
+    }
+
+    // endregion
+
+    // region Cart screen
+
+    @Test
+    fun `given Cart screen with Enabled checkout, when resolving state, then Primary Checkout ENABLED`() {
+        val cartState = WooPosCartState(checkoutButtonState = WooPosCartState.CheckoutButtonState.Enabled)
+
         val result = resolver.resolve(
             screenPositionState = WooPosHomeState.ScreenPositionState.Cart,
             cartState = cartState,
         )
 
-        // THEN
         assertThat(result).isEqualTo(
             WooPosPhonePersistentButtonState.Primary(
                 label = "Check out",
@@ -94,20 +124,85 @@ class WooPosHomePhonePersistentButtonTest {
     }
 
     @Test
-    fun `given Checkout screen, when resolving state, then Hidden`() {
-        // GIVEN
-        val resolver = WooPosPhonePersistentButtonStateResolver(
-            buildCartLabel = { "Cart ($it)" },
-            checkoutLabel = "Check out",
+    fun `given Cart screen with Success checkout, when resolving state, then Primary Checkout SUCCESS`() {
+        val cartState = WooPosCartState(checkoutButtonState = WooPosCartState.CheckoutButtonState.Success)
+
+        val result = resolver.resolve(
+            screenPositionState = WooPosHomeState.ScreenPositionState.Cart,
+            cartState = cartState,
         )
 
-        // WHEN
+        assertThat(result).isEqualTo(
+            WooPosPhonePersistentButtonState.Primary(
+                label = "Check out",
+                buttonState = WooPosButtonState.SUCCESS,
+                action = WooPosPhonePersistentButtonAction.Checkout,
+            )
+        )
+    }
+
+    @Test
+    fun `given Cart screen with Disabled checkout, when resolving state, then Primary Checkout DISABLED`() {
+        val cartState = WooPosCartState(checkoutButtonState = WooPosCartState.CheckoutButtonState.Disabled)
+
+        val result = resolver.resolve(
+            screenPositionState = WooPosHomeState.ScreenPositionState.Cart,
+            cartState = cartState,
+        )
+
+        assertThat(result).isEqualTo(
+            WooPosPhonePersistentButtonState.Primary(
+                label = "Check out",
+                buttonState = WooPosButtonState.DISABLED,
+                action = WooPosPhonePersistentButtonAction.Checkout,
+            )
+        )
+    }
+
+    @Test
+    fun `given Cart screen with Invisible checkout, when resolving state, then Hidden`() {
+        val cartState = WooPosCartState(checkoutButtonState = WooPosCartState.CheckoutButtonState.Invisible)
+
+        val result = resolver.resolve(
+            screenPositionState = WooPosHomeState.ScreenPositionState.Cart,
+            cartState = cartState,
+        )
+
+        assertThat(result).isEqualTo(WooPosPhonePersistentButtonState.Hidden)
+    }
+
+    // endregion
+
+    // region Checkout screen
+
+    @Test
+    fun `given Checkout screen, when resolving state, then Hidden`() {
         val result = resolver.resolve(
             screenPositionState = WooPosHomeState.ScreenPositionState.Checkout.CartWithTotals,
             cartState = null,
         )
 
-        // THEN
         assertThat(result).isEqualTo(WooPosPhonePersistentButtonState.Hidden)
     }
+
+    // endregion
+
+    private fun cartWithItems(
+        itemCount: Int = 3,
+        checkoutButtonState: WooPosCartState.CheckoutButtonState = WooPosCartState.CheckoutButtonState.Enabled,
+    ) = WooPosCartState(
+        body = WooPosCartState.Body.WithItems(
+            itemsInCart = List(itemCount) {
+                WooPosCartItemViewState.Product.Simple(
+                    itemNumber = it,
+                    id = it.toLong(),
+                    name = "n",
+                    price = "",
+                    description = null,
+                    imageUrl = null,
+                )
+            }
+        ),
+        checkoutButtonState = checkoutButtonState,
+    )
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
This PR introduces a reusable success state for WooPosButton.

As a first use case, the Checkout button now briefly transitions to the success state after an item is added to the cart, providing immediate visual feedback that the action was successful. This improves user feedback by acknowledging that adding a product to the cart was successful, reducing uncertainty after the tap.

### Test Steps
1. Launch Woo POS.
2. Add a product to the cart.
3. Verify the Checkout button briefly transitions to the success state.
4. Verify the button returns to its default enabled state after the animation.
5. Verify existing button states (enabled, disabled and loading) continue to behave as expected.

### Images/gif
Tablet:
https://github.com/user-attachments/assets/d8623e31-a211-47f4-80d5-755cb92f14a3

Phone:
https://github.com/user-attachments/assets/0424b294-d696-4e13-a043-06854a7dc26b


- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->


