### PR TITLE
Bump min Woo version to 10.9.2 for self-driven push notifications

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/CheckWooPluginPushNotificationsSupport.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/CheckWooPluginPushNotificationsSupport.kt
@@ -10,7 +10,7 @@ class CheckWooPluginPushNotificationsSupport @Inject constructor(
     private val getWooCorePluginCachedVersion: GetWooCorePluginCachedVersion
 ) {
     companion object {
-        const val PUSH_NOTIFICATIONS_MIN_WC_VERSION = "10.9.0"
+        const val PUSH_NOTIFICATIONS_MIN_WC_VERSION = "10.9.2"
     }
 
     suspend operator fun invoke(forceRefresh: Boolean): Result {


### PR DESCRIPTION
### Description

Cherry-picks the code change from https://github.com/woocommerce/woocommerce-android/pull/16157 into `release/25.0.1`.

This bumps the minimum required WooCommerce plugin version for self-driven push notifications from `10.9.0` to `10.9.2`.

### Test Steps

Same as https://github.com/woocommerce/woocommerce-android/pull/16157:

1. Fire up a fresh JN site and install Woo 10.9.1 on it.
2. Install the app and login to that site.
3. Enable the FF.
4. Restart the app.
5. Note the dashboard card should appear.
6. Start the PN enablement.
7. It should fail with 10.9.1 needs update.

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
