### PR TITLE
Fix stale Woo push registration after token refresh

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/PushNotificationRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/PushNotificationRepository.kt
@@ -226,6 +226,33 @@ class PushNotificationRepository @Inject constructor(
             registration.locale != getDeviceLocale()
     }
 
+    suspend fun clearWooPushRegistrationsForStaleToken(currentToken: String) {
+        if (currentToken.isEmpty()) return
+
+        var staleSiteIds = emptyList<Long>()
+
+        pushNotificationsDataStore.edit { preferences ->
+            staleSiteIds = preferences.getSiteIdsWithStalePushRegistration(currentToken)
+            staleSiteIds.forEach { siteId ->
+                preferences.clearPushRegistration(siteId)
+            }
+        }
+        staleSiteIds.forEach { siteId ->
+            WooLog.d(WooLog.T.NOTIFICATIONS, "Cleared stale Woo Core push registration for site $siteId")
+        }
+    }
+
+    private fun Preferences.getSiteIdsWithStalePushRegistration(currentToken: String): List<Long> = asMap().keys
+        .mapNotNull { key ->
+            key.name
+                .takeIf { it.startsWith(PUSH_TOKEN_KEY_PREFIX) }
+                ?.removePrefix(PUSH_TOKEN_KEY_PREFIX)
+                ?.toLongOrNull()
+        }
+        .filter { siteId ->
+            this[getPushTokenValueKeyForSite(siteId)] != currentToken
+        }
+
     fun isWpComPushRegistered(): Boolean =
         prefsWrapper.getFluxCPreferences()
             .getString(WpComPushNotificationStore.WPCOM_PUSH_DEVICE_SERVER_ID, null)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/PushNotificationRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/PushNotificationRepository.kt
@@ -242,13 +242,7 @@ class PushNotificationRepository @Inject constructor(
         }
     }
 
-    private fun Preferences.getSiteIdsWithStalePushRegistration(currentToken: String): List<Long> = asMap().keys
-        .mapNotNull { key ->
-            key.name
-                .takeIf { it.startsWith(PUSH_TOKEN_KEY_PREFIX) }
-                ?.removePrefix(PUSH_TOKEN_KEY_PREFIX)
-                ?.toLongOrNull()
-        }
+    private fun Preferences.getSiteIdsWithStalePushRegistration(currentToken: String): List<Long> = registeredSiteIds()
         .filter { siteId ->
             this[getPushTokenValueKeyForSite(siteId)] != currentToken
         }
@@ -275,12 +269,17 @@ class PushNotificationRepository @Inject constructor(
 
     suspend fun getWooPushRegisteredSiteIds(): Set<Long> {
         val preferences = pushNotificationsDataStore.data.first()
-        return preferences.asMap().keys
-            .mapNotNull { key ->
-                key.name.removePrefix(PUSH_TOKEN_KEY_PREFIX).toLongOrNull()
-            }
-            .toSet()
+        return preferences.registeredSiteIds()
     }
+
+    private fun Preferences.registeredSiteIds(): Set<Long> = asMap().keys
+        .mapNotNull { key ->
+            key.name
+                .takeIf { it.startsWith(PUSH_TOKEN_KEY_PREFIX) }
+                ?.removePrefix(PUSH_TOKEN_KEY_PREFIX)
+                ?.toLongOrNull()
+        }
+        .toSet()
 
     suspend fun unregisterDeviceFromPushNotifications() {
         coroutineScope {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/PushNotificationRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/PushNotificationRepository.kt
@@ -78,12 +78,14 @@ class PushNotificationRepository @Inject constructor(
         }
     }
 
-    suspend fun registerPushTokenInWpComSystem(token: String) {
+    suspend fun registerPushTokenInWpComSystem(
+        token: String
+    ): WpComPushNotificationStore.RegisterDeviceResponsePayload {
         WooLog.d(
             tag = WooLog.T.NOTIFICATIONS,
             message = "Registering FCM token in WPCOM instance${if (BuildConfig.DEBUG) ": $token" else ""}"
         )
-        wpComPushNotificationStore.registerDevice(
+        return wpComPushNotificationStore.registerDevice(
             token,
             WpComPushNotificationStore.NotificationAppKey.WOOCOMMERCE
         )
@@ -180,6 +182,25 @@ class PushNotificationRepository @Inject constructor(
         }
     }
 
+    suspend fun enableWpComNotificationsForSites(siteIds: Set<Long>) {
+        if (siteIds.isEmpty()) return
+
+        val settings = siteIds.map { siteId ->
+            SiteNotificationSetting(
+                siteId = siteId,
+                newCommentEnabled = true,
+                storeOrderEnabled = true
+            )
+        }
+
+        val result = wpComPushNotificationStore.updateNotificationSettingsFor(settings)
+        if (result.isFailure) {
+            WooLog.w(WooLog.T.NOTIFICATIONS, "Failed to enable WPCom notifications for sites $siteIds")
+        } else {
+            WooLog.d(WooLog.T.NOTIFICATIONS, "WPCom notifications enabled for sites $siteIds")
+        }
+    }
+
     private suspend fun savePushTokenForSite(siteId: Long, registration: WooPushRegistrationData) {
         pushNotificationsDataStore.edit { preferences ->
             preferences.savePushRegistration(siteId, registration)
@@ -226,10 +247,10 @@ class PushNotificationRepository @Inject constructor(
             registration.locale != getDeviceLocale()
     }
 
-    suspend fun clearWooPushRegistrationsForStaleToken(currentToken: String) {
-        if (currentToken.isEmpty()) return
+    suspend fun clearWooPushRegistrationsForStaleToken(currentToken: String): Set<Long> {
+        if (currentToken.isEmpty()) return emptySet()
 
-        var staleSiteIds = emptyList<Long>()
+        var staleSiteIds = emptySet<Long>()
 
         pushNotificationsDataStore.edit { preferences ->
             staleSiteIds = preferences.getSiteIdsWithStalePushRegistration(currentToken)
@@ -240,12 +261,14 @@ class PushNotificationRepository @Inject constructor(
         staleSiteIds.forEach { siteId ->
             WooLog.d(WooLog.T.NOTIFICATIONS, "Cleared stale Woo Core push registration for site $siteId")
         }
+        return staleSiteIds
     }
 
-    private fun Preferences.getSiteIdsWithStalePushRegistration(currentToken: String): List<Long> = registeredSiteIds()
+    private fun Preferences.getSiteIdsWithStalePushRegistration(currentToken: String): Set<Long> = registeredSiteIds()
         .filter { siteId ->
             this[getPushTokenValueKeyForSite(siteId)] != currentToken
         }
+        .toSet()
 
     fun isWpComPushRegistered(): Boolean =
         prefsWrapper.getFluxCPreferences()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/RegisterDevice.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/RegisterDevice.kt
@@ -80,6 +80,7 @@ class RegisterDevice @Inject constructor(
         }
 
         val shouldForce = trigger == Trigger.TOKEN_REFRESH
+        pushNotificationRepository.clearWooPushRegistrationsForStaleToken(token)
 
         if (featureFlagRepository.isEnabled(FeatureFlag.WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M1)) {
             val sites = when (trigger) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/RegisterDevice.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/RegisterDevice.kt
@@ -80,9 +80,10 @@ class RegisterDevice @Inject constructor(
         }
 
         val shouldForce = trigger == Trigger.TOKEN_REFRESH
-        pushNotificationRepository.clearWooPushRegistrationsForStaleToken(token)
+        val staleWooRegisteredSiteIds = pushNotificationRepository.clearWooPushRegistrationsForStaleToken(token)
 
-        if (featureFlagRepository.isEnabled(FeatureFlag.WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M1)) {
+        val isWooSelfDrivenEnabled = featureFlagRepository.isEnabled(FeatureFlag.WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M1)
+        if (isWooSelfDrivenEnabled) {
             val sites = when (trigger) {
                 Trigger.LOGIN_SUCCESS,
                 Trigger.TOKEN_REFRESH -> getWooVisibleSites()
@@ -118,9 +119,27 @@ class RegisterDevice @Inject constructor(
 
         if (shouldEvaluateWpCom && accountStore.hasAccessToken()) {
             WooLog.d(WooLog.T.NOTIFICATIONS, "Registering WP.com push for $trigger")
-            pushNotificationRepository.registerPushTokenInWpComSystem(token)
+            val wpComRegistration = pushNotificationRepository.registerPushTokenInWpComSystem(token)
+            if (!wpComRegistration.isError) {
+                enableWpComNotificationsForStaleVisibleSites(staleWooRegisteredSiteIds)
+            }
         } else {
             WooLog.d(WooLog.T.NOTIFICATIONS, "Skipping WP.com push registration for $trigger")
+        }
+    }
+
+    private suspend fun enableWpComNotificationsForStaleVisibleSites(
+        staleWooRegisteredSiteIds: Set<Long>
+    ) {
+        if (staleWooRegisteredSiteIds.isEmpty()) return
+
+        val visibleSiteIds = getWooVisibleSites().map { it.siteId }.toSet()
+        val wooRegisteredSiteIds = pushNotificationRepository.getWooPushRegisteredSiteIds()
+        val staleWpComFallbackSiteIds = staleWooRegisteredSiteIds
+            .intersect(visibleSiteIds)
+            .minus(wooRegisteredSiteIds)
+        if (staleWpComFallbackSiteIds.isNotEmpty()) {
+            pushNotificationRepository.enableWpComNotificationsForSites(staleWpComFallbackSiteIds)
         }
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/PushNotificationRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/PushNotificationRepositoryTest.kt
@@ -549,8 +549,9 @@ class PushNotificationRepositoryTest : BaseUnitTest() {
                 preferences
             }
 
-            sut.clearWooPushRegistrationsForStaleToken(currentToken = "new-token")
+            val result = sut.clearWooPushRegistrationsForStaleToken(currentToken = "new-token")
 
+            assertThat(result).containsExactly(SITE_ID)
             verify(mutablePreferences).remove(tokenIdKey)
             verify(mutablePreferences).remove(tokenValueKey)
             verify(mutablePreferences).remove(localeKey)
@@ -572,8 +573,9 @@ class PushNotificationRepositoryTest : BaseUnitTest() {
                 preferences
             }
 
-            sut.clearWooPushRegistrationsForStaleToken(currentToken = "token")
+            val result = sut.clearWooPushRegistrationsForStaleToken(currentToken = "token")
 
+            assertThat(result).isEmpty()
             verify(mutablePreferences, never()).remove(tokenIdKey)
             verify(mutablePreferences, never()).remove(tokenValueKey)
             verify(mutablePreferences, never()).remove(localeKey)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/PushNotificationRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/PushNotificationRepositoryTest.kt
@@ -534,6 +534,52 @@ class PushNotificationRepositoryTest : BaseUnitTest() {
         }
 
     @Test
+    fun `given stored token differs from current FCM token, when clearing stale Woo registrations, then removes metadata`() =
+        testBlocking {
+            val tokenIdKey = stringPreferencesKey("push_token_$SITE_ID")
+            val tokenValueKey = stringPreferencesKey("push_token_value_$SITE_ID")
+            val localeKey = stringPreferencesKey("push_locale_$SITE_ID")
+            val mutablePreferences: MutablePreferences = mock()
+            whenever(preferences.toMutablePreferences()).thenReturn(mutablePreferences)
+            whenever(mutablePreferences.asMap()).thenReturn(mapOf(Pair(tokenIdKey, RETURNED_TOKEN)))
+            whenever(mutablePreferences[tokenValueKey]).thenReturn("old-token")
+            whenever(pushNotificationsDataStore.updateData(any())).thenAnswer { invocation ->
+                val transform = invocation.getArgument<suspend (Preferences) -> Preferences>(0)
+                testBlocking { transform(preferences) }
+                preferences
+            }
+
+            sut.clearWooPushRegistrationsForStaleToken(currentToken = "new-token")
+
+            verify(mutablePreferences).remove(tokenIdKey)
+            verify(mutablePreferences).remove(tokenValueKey)
+            verify(mutablePreferences).remove(localeKey)
+        }
+
+    @Test
+    fun `given stored token matches current FCM token, when clearing stale Woo registrations, then keeps metadata`() =
+        testBlocking {
+            val tokenIdKey = stringPreferencesKey("push_token_$SITE_ID")
+            val tokenValueKey = stringPreferencesKey("push_token_value_$SITE_ID")
+            val localeKey = stringPreferencesKey("push_locale_$SITE_ID")
+            val mutablePreferences: MutablePreferences = mock()
+            whenever(preferences.toMutablePreferences()).thenReturn(mutablePreferences)
+            whenever(mutablePreferences.asMap()).thenReturn(mapOf(Pair(tokenIdKey, RETURNED_TOKEN)))
+            whenever(mutablePreferences[tokenValueKey]).thenReturn("token")
+            whenever(pushNotificationsDataStore.updateData(any())).thenAnswer { invocation ->
+                val transform = invocation.getArgument<suspend (Preferences) -> Preferences>(0)
+                testBlocking { transform(preferences) }
+                preferences
+            }
+
+            sut.clearWooPushRegistrationsForStaleToken(currentToken = "token")
+
+            verify(mutablePreferences, never()).remove(tokenIdKey)
+            verify(mutablePreferences, never()).remove(tokenValueKey)
+            verify(mutablePreferences, never()).remove(localeKey)
+        }
+
+    @Test
     fun `given registration succeeds, when registering push token, then tracks success event`() =
         testBlocking {
             whenever(appPrefsWrapper.wooCorePushDeviceUUID).thenReturn("stored-uuid")

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/RegisterDeviceTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/RegisterDeviceTest.kt
@@ -35,6 +35,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.AccountStore
+import org.wordpress.android.fluxc.store.WpComPushNotificationStore
 import kotlin.time.Duration.Companion.milliseconds
 
 @ExperimentalCoroutinesApi
@@ -72,6 +73,13 @@ class RegisterDeviceTest : BaseUnitTest(StandardTestDispatcher()) {
 
     @Before
     fun setUp() {
+        runBlocking {
+            whenever(pushNotificationRepository.clearWooPushRegistrationsForStaleToken(any())).thenReturn(emptySet())
+            whenever(pushNotificationRepository.getWooPushRegisteredSiteIds()).thenReturn(emptySet())
+            whenever(pushNotificationRepository.registerPushTokenInWpComSystem(any())).thenReturn(
+                WpComPushNotificationStore.RegisterDeviceResponsePayload(deviceId = "device-id-123")
+            )
+        }
         sut = RegisterDevice(
             appPrefsWrapper = appPrefs,
             accountStore = accountStore,
@@ -215,6 +223,57 @@ class RegisterDeviceTest : BaseUnitTest(StandardTestDispatcher()) {
         }
 
     @Test
+    fun `given stale visible Woo registration, when token refresh registers in WPCom, then enables WPCom notifications`() =
+        testBlocking {
+            // GIVEN
+            whenever(pushNotificationRepository.clearWooPushRegistrationsForStaleToken(TEST_TOKEN))
+                .thenReturn(setOf(SITE_ID_ONE, HIDDEN_SITE_ID))
+
+            // WHEN
+            sut(TOKEN_REFRESH)
+
+            // THEN
+            verify(pushNotificationRepository).registerPushTokenInWpComSystem(TEST_TOKEN)
+            verify(pushNotificationRepository).enableWpComNotificationsForSites(setOf(SITE_ID_ONE))
+        }
+
+    @Test
+    fun `given stale visible site is still Woo registered, when WPCom registration succeeds, then does not enable WPCom notifications`() =
+        testBlocking {
+            // GIVEN
+            whenever(pushNotificationRepository.clearWooPushRegistrationsForStaleToken(TEST_TOKEN))
+                .thenReturn(setOf(SITE_ID_ONE))
+            whenever(pushNotificationRepository.getWooPushRegisteredSiteIds()).thenReturn(setOf(SITE_ID_ONE))
+
+            // WHEN
+            sut(TOKEN_REFRESH)
+
+            // THEN
+            verify(pushNotificationRepository).registerPushTokenInWpComSystem(TEST_TOKEN)
+            verify(pushNotificationRepository, never()).enableWpComNotificationsForSites(any())
+        }
+
+    @Test
+    fun `given stale visible Woo registration, when WPCom token refresh registration fails, then does not enable WPCom notifications`() =
+        testBlocking {
+            // GIVEN
+            whenever(pushNotificationRepository.clearWooPushRegistrationsForStaleToken(TEST_TOKEN))
+                .thenReturn(setOf(SITE_ID_ONE))
+            whenever(pushNotificationRepository.registerPushTokenInWpComSystem(TEST_TOKEN)).thenReturn(
+                WpComPushNotificationStore.RegisterDeviceResponsePayload(
+                    WpComPushNotificationStore.DeviceRegistrationError()
+                )
+            )
+
+            // WHEN
+            sut(TOKEN_REFRESH)
+
+            // THEN
+            verify(pushNotificationRepository).registerPushTokenInWpComSystem(TEST_TOKEN)
+            verify(pushNotificationRepository, never()).enableWpComNotificationsForSites(any())
+        }
+
+    @Test
     fun `given app foreground trigger, when Woo registration is unchanged for one site, then registers only stale sites`() =
         testBlocking {
             // GIVEN
@@ -343,5 +402,6 @@ class RegisterDeviceTest : BaseUnitTest(StandardTestDispatcher()) {
         private const val SELECTED_SITE_ID = 123L
         private const val SITE_ID_ONE = 456L
         private const val SITE_ID_TWO = 789L
+        private const val HIDDEN_SITE_ID = 999L
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/RegisterDeviceTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/RegisterDeviceTest.kt
@@ -199,6 +199,22 @@ class RegisterDeviceTest : BaseUnitTest(StandardTestDispatcher()) {
     }
 
     @Test
+    fun `given M1 flag disabled, when token refresh trigger runs, then clears stale Woo registrations`() =
+        testBlocking {
+            // GIVEN
+            whenever(featureFlagRepository.isEnabled(FeatureFlag.WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M1))
+                .thenReturn(false)
+
+            // WHEN
+            sut(TOKEN_REFRESH)
+
+            // THEN
+            verify(pushNotificationRepository).clearWooPushRegistrationsForStaleToken(TEST_TOKEN)
+            verify(pushNotificationRepository, never()).registerPushTokenInWooCoreSystem(eq(TEST_TOKEN), any(), any())
+            verify(pushNotificationRepository).registerPushTokenInWpComSystem(TEST_TOKEN)
+        }
+
+    @Test
     fun `given app foreground trigger, when Woo registration is unchanged for one site, then registers only stale sites`() =
         testBlocking {
             // GIVEN


### PR DESCRIPTION
### Description

This hotfix fixes an Android push notification blackout path after an FCM token change.

When a site is successfully registered in the Woo self-serve push notification system, WP.com notifications are disabled for that site to avoid duplicate notifications. If the FCM token later changes, the local Woo push registration can become stale. If the app then falls back to WP.com delivery, the site can remain with WP.com notifications disabled and stop receiving push notifications.

This PR:
- Clears stale Woo push registrations when the stored Woo token no longer matches the current FCM token.
- Re-enables WP.com notification settings after WP.com registration succeeds, but only for stale visible sites that are not currently Woo-registered.
- Keeps WP.com notifications disabled for sites that successfully return to the Woo push registration path, avoiding duplicate notifications.

### Test Steps

1. Use a Jetpack-connected test store that is registered through Woo self-serve push notifications.
2. Confirm order push notifications are received.
3. Disable the Woo self-serve push notification mobile feature flag.
4. Force an FCM token change and relaunch the app. To do this:

Apply this patch:
[Add_debug_broadcast_receiver_for_FCM_token_refresh.patch](https://github.com/user-attachments/files/29525899/Add_debug_broadcast_receiver_for_FCM_token_refresh.patch)

Run this command:
```
adb shell am broadcast \
  -n com.woocommerce.android.dev/com.woocommerce.android.notifications.push.DebugRefreshFcmTokenReceiver \
  -a com.woocommerce.android.dev.DEBUG_REFRESH_FCM_TOKEN
```

6. Confirm the app registers the new token with WP.com.
7. Create a new order and confirm the push notification is received.

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
