### PR TITLE
Support plugin-version remote feature flags

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/SiteObserver.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/SiteObserver.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android
 
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.config.WPComMobileActivePluginVersionsProvider
 import com.woocommerce.android.config.WPComRemoteFeatureFlagRepository
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.tools.SiteConnectionType
@@ -40,6 +41,7 @@ class SiteObserver @Inject constructor(
     private val analyticsTracker: AnalyticsTrackerWrapper,
     private val dispatcher: Dispatcher,
     private val appVersionName: GetAppVersionName,
+    private val activePluginVersionsProvider: WPComMobileActivePluginVersionsProvider,
 ) {
     suspend fun observeAndUpdateSelectedSiteData() {
         selectedSite.observe()
@@ -47,16 +49,13 @@ class SiteObserver @Inject constructor(
             .distinctUntilChanged { old, new -> new.id == old.id }
             .collectLatest { site ->
                 coroutineScope {
-                    launch { fetchPlugins(site) }
+                    launch { fetchPluginsAndRemoteFeatureFlags(site) }
 
                     launch { fetchStoreId(site) }
 
                     launch { fetchOrderStatusOptions(site) }
 
                     launch { sendSiteDataToWearable(site) }
-
-                    launch { fetchRemoteFeatureFlags() }
-
                     if (site.connectionType == SiteConnectionType.ApplicationPasswords) {
                         launch { checkIfSiteIsWPComSuspended(site) }
                     }
@@ -64,9 +63,20 @@ class SiteObserver @Inject constructor(
             }
     }
 
-    private suspend fun fetchPlugins(site: SiteModel) {
+    private suspend fun fetchPluginsAndRemoteFeatureFlags(site: SiteModel) {
+        val activePluginVersions = fetchActivePluginVersions(site)
+        fetchRemoteFeatureFlags(site, activePluginVersions)
+    }
+
+    private suspend fun fetchActivePluginVersions(site: SiteModel): Map<String, String> {
         WooLog.d(WooLog.T.UTILS, "Fetch plugins for site ${site.name}")
-        wooCommerceStore.fetchSitePlugins(site)
+        val fetchResult = wooCommerceStore.fetchSitePlugins(site)
+        return if (fetchResult.isError) {
+            WooLog.e(WooLog.T.UTILS, "Error fetching plugins for site ${site.name}: ${fetchResult.error}")
+            emptyMap()
+        } else {
+            activePluginVersionsProvider.buildActivePluginVersions(fetchResult.model)
+        }
     }
 
     private suspend fun fetchStoreId(site: SiteModel) {
@@ -96,9 +106,16 @@ class SiteObserver @Inject constructor(
         wearableConnectionRepository.sendSiteData(site)
     }
 
-    private suspend fun fetchRemoteFeatureFlags() {
+    private suspend fun fetchRemoteFeatureFlags(
+        site: SiteModel,
+        activePluginVersions: Map<String, String>
+    ) {
         WooLog.d(WooLog.T.UTILS, "Fetching remote feature flags")
-        featureFlagRepository.fetchAndCacheFeatureFlags(appVersionName())
+        featureFlagRepository.fetchAndCacheFeatureFlags(
+            appVersion = appVersionName(),
+            localSiteId = site.localId(),
+            activePluginVersions = activePluginVersions
+        )
     }
 
     private suspend fun checkIfSiteIsWPComSuspended(site: SiteModel) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/config/WPComMobileActivePluginVersionsProvider.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/config/WPComMobileActivePluginVersionsProvider.kt
@@ -1,0 +1,23 @@
+package com.woocommerce.android.config
+
+import org.wordpress.android.fluxc.model.plugin.SitePluginModel
+import org.wordpress.android.fluxc.store.WooCommerceStore.WooPlugin
+import javax.inject.Inject
+
+class WPComMobileActivePluginVersionsProvider @Inject constructor() {
+    fun buildActivePluginVersions(plugins: List<SitePluginModel>?): Map<String, String> {
+        val wooCorePlugin = plugins.orEmpty().firstOrNull { plugin ->
+            plugin.isActive &&
+                plugin.name == WooPlugin.WOO_CORE.pluginName &&
+                plugin.version.isNotBlank()
+        }
+
+        return wooCorePlugin?.let { plugin ->
+            mapOf(WOO_CORE_PLUGIN_PATH to plugin.version)
+        }.orEmpty()
+    }
+
+    private companion object {
+        const val WOO_CORE_PLUGIN_PATH = "woocommerce/woocommerce.php"
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/config/WPComRemoteFeatureFlagRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/config/WPComRemoteFeatureFlagRepository.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.config
 
 import com.woocommerce.android.OnChangedException
 import com.woocommerce.android.util.WooLog
+import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.store.mobile.FeatureFlagsStore
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -20,14 +21,20 @@ class WPComRemoteFeatureFlagRepository @Inject constructor(
      * @param appVersion (Optional) In the backend, a remote feature flag can be set with various rules based on
      * app version. This parameter can be used to work with those rules.
      */
-    suspend fun fetchAndCacheFeatureFlags(appVersion: String = ""): Result<Unit> {
+    suspend fun fetchAndCacheFeatureFlags(
+        appVersion: String = "",
+        localSiteId: LocalId = FeatureFlagsStore.DEFAULT_LOCAL_SITE_ID,
+        activePluginVersions: Map<String, String> = emptyMap()
+    ): Result<Unit> {
         // Empty string are parameters not used by this app.
         val result = featureFlagsStore.fetchFeatureFlags(
             buildNumber = "",
             deviceId = "",
             identifier = "",
             marketingVersion = appVersion,
-            platform = PLATFORM_NAME
+            platform = PLATFORM_NAME,
+            localSiteId = localSiteId,
+            activePluginVersions = activePluginVersions
         )
         return if (result.isError) {
             WooLog.e(WooLog.T.UTILS, "Error fetching WPCom remote feature flags: ${result.error}")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlagRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlagRepository.kt
@@ -2,9 +2,11 @@ package com.woocommerce.android.util
 
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.di.AppCoroutineScope
+import com.woocommerce.android.tools.SelectedSite
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
@@ -16,16 +18,26 @@ import javax.inject.Singleton
 
 @Singleton
 class FeatureFlagRepository @Inject constructor(
-    featureFlagsStore: FeatureFlagsStore,
+    private val featureFlagsStore: FeatureFlagsStore,
+    private val selectedSite: SelectedSite,
     @AppCoroutineScope appCoroutineScope: CoroutineScope,
 ) {
     private val remoteFlagValues = MutableStateFlow<Map<String, Boolean>?>(null)
 
     init {
         appCoroutineScope.launch {
-            featureFlagsStore.observeFeatureFlags().collect { remoteFlags ->
-                remoteFlagValues.value = remoteFlags.associate { remoteFlag -> remoteFlag.key to remoteFlag.value }
-            }
+            selectedSite.observe()
+                .distinctUntilChanged { old, new -> old?.id == new?.id }
+                .collectLatest { site ->
+                    remoteFlagValues.value = null
+                    site ?: return@collectLatest
+
+                    featureFlagsStore.observeFeatureFlags(site.localId()).collect { remoteFlags ->
+                        remoteFlagValues.value = remoteFlags.associate { remoteFlag ->
+                            remoteFlag.key to remoteFlag.value
+                        }
+                    }
+                }
         }
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/SiteObserverTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/SiteObserverTest.kt
@@ -66,7 +66,9 @@ class SiteObserverTest : BaseUnitTest() {
             origin = SiteModel.ORIGIN_WPAPI
         }
         whenever(selectedSite.observe()).thenReturn(flowOf(site))
-        whenever(siteStore.fetchConnectSiteInfoSync(site.url)).thenReturn(mock())
+        whenever(siteStore.fetchConnectSiteInfoSync(site.url)).thenReturn(
+            SiteStore.ConnectSiteInfoPayload(url = site.url)
+        )
         whenever(wooCommerceStore.fetchSitePlugins(site)).thenReturn(WooResult(emptyList()))
         whenever(appVersionName()).thenReturn(APP_VERSION)
 
@@ -150,7 +152,9 @@ class SiteObserverTest : BaseUnitTest() {
             origin = SiteModel.ORIGIN_WPAPI
         }
         whenever(selectedSite.observe()).thenReturn(flowOf(site))
-        whenever(siteStore.fetchConnectSiteInfoSync(site.url)).thenReturn(mock())
+        whenever(siteStore.fetchConnectSiteInfoSync(site.url)).thenReturn(
+            SiteStore.ConnectSiteInfoPayload(url = site.url)
+        )
         whenever(wooCommerceStore.fetchSitePlugins(site)).thenReturn(WooResult(emptyList()))
         whenever(appVersionName()).thenReturn(APP_VERSION)
 
@@ -184,7 +188,9 @@ class SiteObserverTest : BaseUnitTest() {
             )
         )
         whenever(selectedSite.observe()).thenReturn(flowOf(site))
-        whenever(siteStore.fetchConnectSiteInfoSync(site.url)).thenReturn(mock())
+        whenever(siteStore.fetchConnectSiteInfoSync(site.url)).thenReturn(
+            SiteStore.ConnectSiteInfoPayload(url = site.url)
+        )
         whenever(wooCommerceStore.fetchSitePlugins(site)).thenReturn(WooResult(plugins))
         whenever(appVersionName()).thenReturn(APP_VERSION)
 
@@ -216,7 +222,9 @@ class SiteObserverTest : BaseUnitTest() {
                 url = "https://example.com"
             }
             whenever(selectedSite.observe()).thenReturn(flowOf(site))
-            whenever(siteStore.fetchConnectSiteInfoSync(site.url)).thenReturn(mock())
+            whenever(siteStore.fetchConnectSiteInfoSync(site.url)).thenReturn(
+                SiteStore.ConnectSiteInfoPayload(url = site.url)
+            )
             whenever(wooCommerceStore.fetchSitePlugins(site)).thenReturn(
                 WooResult(WooError(GENERIC_ERROR, UNKNOWN))
             )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/SiteObserverTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/SiteObserverTest.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android
 
+import com.woocommerce.android.config.WPComMobileActivePluginVersionsProvider
 import com.woocommerce.android.config.WPComRemoteFeatureFlagRepository
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.common.environment.EnvironmentRepository
@@ -13,11 +14,18 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.plugin.SitePluginModel
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.UNKNOWN
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.GENERIC_ERROR
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.WooCommerceStore
 
@@ -34,6 +42,7 @@ class SiteObserverTest : BaseUnitTest() {
     private val appPrefs: AppPrefsWrapper = mock()
     private val dispatcher: FakeDispatcher = FakeDispatcher()
     private val appVersionName: GetAppVersionName = mock()
+    private val activePluginVersionsProvider = WPComMobileActivePluginVersionsProvider()
 
     private val siteObserver = SiteObserver(
         selectedSite = selectedSite,
@@ -45,17 +54,21 @@ class SiteObserverTest : BaseUnitTest() {
         appPrefs = appPrefs,
         analyticsTracker = mock(),
         dispatcher = dispatcher,
-        appVersionName = appVersionName
+        appVersionName = appVersionName,
+        activePluginVersionsProvider = activePluginVersionsProvider
     )
 
     @Test
     fun `given app password connection, when starting observing, then fetch WPCom connect site info`() = testBlocking {
         val site = SiteModel().apply {
+            id = SITE_LOCAL_ID.value
             url = "https://example.com"
             origin = SiteModel.ORIGIN_WPAPI
         }
         whenever(selectedSite.observe()).thenReturn(flowOf(site))
         whenever(siteStore.fetchConnectSiteInfoSync(site.url)).thenReturn(mock())
+        whenever(wooCommerceStore.fetchSitePlugins(site)).thenReturn(WooResult(emptyList()))
+        whenever(appVersionName()).thenReturn(APP_VERSION)
 
         val job = launch {
             siteObserver.observeAndUpdateSelectedSiteData()
@@ -72,10 +85,13 @@ class SiteObserverTest : BaseUnitTest() {
         testBlocking {
             listOf(false, true).forEach { isSuspended ->
                 val site = SiteModel().apply {
+                    id = SITE_LOCAL_ID.value
                     url = "https://example.com"
                     origin = SiteModel.ORIGIN_WPAPI
                 }
                 whenever(selectedSite.observe()).thenReturn(flowOf(site))
+                whenever(wooCommerceStore.fetchSitePlugins(site)).thenReturn(WooResult(emptyList()))
+                whenever(appVersionName()).thenReturn(APP_VERSION)
                 val connectSiteInfo = if (isSuspended) {
                     SiteStore.ConnectSiteInfoPayload(
                         error = SiteStore.SiteError(type = SiteStore.SiteErrorType.WPCOM_SITE_SUSPENDED),
@@ -101,10 +117,13 @@ class SiteObserverTest : BaseUnitTest() {
     fun `given site with app password connection, when fetching site info fails, then don't update flag`() =
         testBlocking {
             val site = SiteModel().apply {
+                id = SITE_LOCAL_ID.value
                 url = "https://example.com"
                 origin = SiteModel.ORIGIN_WPAPI
             }
             whenever(selectedSite.observe()).thenReturn(flowOf(site))
+            whenever(wooCommerceStore.fetchSitePlugins(site)).thenReturn(WooResult(emptyList()))
+            whenever(appVersionName()).thenReturn(APP_VERSION)
             whenever(siteStore.fetchConnectSiteInfoSync(site.url)).thenReturn(
                 SiteStore.ConnectSiteInfoPayload(
                     error = SiteStore.SiteError(type = SiteStore.SiteErrorType.INVALID_SITE),
@@ -126,12 +145,14 @@ class SiteObserverTest : BaseUnitTest() {
     fun `when observeAndUpdateSelectedSiteData is called, fetchRemoteFeatureFlags is called`() = testBlocking {
         // GIVEN
         val site = SiteModel().apply {
+            id = SITE_LOCAL_ID.value
             url = "https://example.com"
             origin = SiteModel.ORIGIN_WPAPI
         }
         whenever(selectedSite.observe()).thenReturn(flowOf(site))
         whenever(siteStore.fetchConnectSiteInfoSync(site.url)).thenReturn(mock())
-        whenever(appVersionName()).thenReturn("1.0.0")
+        whenever(wooCommerceStore.fetchSitePlugins(site)).thenReturn(WooResult(emptyList()))
+        whenever(appVersionName()).thenReturn(APP_VERSION)
 
         // WHEN
         val job = launch {
@@ -140,8 +161,82 @@ class SiteObserverTest : BaseUnitTest() {
         advanceUntilIdle()
 
         // THEN
-        verify(featureFlagRepository).fetchAndCacheFeatureFlags(appVersionName())
+        verify(featureFlagRepository).fetchAndCacheFeatureFlags(APP_VERSION, site.localId(), emptyMap())
 
         job.cancel()
+    }
+
+    @Test
+    fun `when plugins are fetched successfully, then fetch remote feature flags with Woo plugin version`() = testBlocking {
+        // GIVEN
+        val site = SiteModel().apply {
+            id = SITE_LOCAL_ID.value
+            url = "https://example.com"
+        }
+        val plugins = listOf(
+            SitePluginModel(
+                siteId = site.localId(),
+                name = WooCommerceStore.WooPlugin.WOO_CORE.pluginName,
+                version = WOO_VERSION,
+                slug = "woocommerce",
+                authorName = "",
+                isActive = true
+            )
+        )
+        whenever(selectedSite.observe()).thenReturn(flowOf(site))
+        whenever(siteStore.fetchConnectSiteInfoSync(site.url)).thenReturn(mock())
+        whenever(wooCommerceStore.fetchSitePlugins(site)).thenReturn(WooResult(plugins))
+        whenever(appVersionName()).thenReturn(APP_VERSION)
+
+        // WHEN
+        val job = launch {
+            siteObserver.observeAndUpdateSelectedSiteData()
+        }
+        advanceUntilIdle()
+
+        // THEN
+        inOrder(wooCommerceStore, featureFlagRepository) {
+            verify(wooCommerceStore).fetchSitePlugins(site)
+            verify(featureFlagRepository).fetchAndCacheFeatureFlags(
+                APP_VERSION,
+                site.localId(),
+                mapOf("woocommerce/woocommerce.php" to WOO_VERSION)
+            )
+        }
+
+        job.cancel()
+    }
+
+    @Test
+    fun `given plugin fetch fails, when observing site, then fetch remote feature flags with empty plugin map`() =
+        testBlocking {
+            // GIVEN
+            val site = SiteModel().apply {
+                id = SITE_LOCAL_ID.value
+                url = "https://example.com"
+            }
+            whenever(selectedSite.observe()).thenReturn(flowOf(site))
+            whenever(siteStore.fetchConnectSiteInfoSync(site.url)).thenReturn(mock())
+            whenever(wooCommerceStore.fetchSitePlugins(site)).thenReturn(
+                WooResult(WooError(GENERIC_ERROR, UNKNOWN))
+            )
+            whenever(appVersionName()).thenReturn(APP_VERSION)
+
+            // WHEN
+            val job = launch {
+                siteObserver.observeAndUpdateSelectedSiteData()
+            }
+            advanceUntilIdle()
+
+            // THEN
+            verify(featureFlagRepository).fetchAndCacheFeatureFlags(APP_VERSION, site.localId(), emptyMap())
+
+            job.cancel()
+        }
+
+    private companion object {
+        val SITE_LOCAL_ID = LocalId(1)
+        const val APP_VERSION = "1.0.0"
+        const val WOO_VERSION = "10.9.2"
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/config/WPComMobileActivePluginVersionsProviderTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/config/WPComMobileActivePluginVersionsProviderTest.kt
@@ -1,0 +1,78 @@
+package com.woocommerce.android.config
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
+import org.wordpress.android.fluxc.model.plugin.SitePluginModel
+import org.wordpress.android.fluxc.store.WooCommerceStore.WooPlugin
+
+class WPComMobileActivePluginVersionsProviderTest {
+    private val sut = WPComMobileActivePluginVersionsProvider()
+
+    @Test
+    fun `given active Woo core with version, when building versions, then return Woo plugin path`() {
+        // GIVEN
+        val plugin = createPlugin(version = WOO_VERSION)
+
+        // WHEN
+        val activePluginVersions = sut.buildActivePluginVersions(listOf(plugin))
+
+        // THEN
+        assertThat(activePluginVersions).containsExactlyEntriesOf(
+            mapOf("woocommerce/woocommerce.php" to WOO_VERSION)
+        )
+    }
+
+    @Test
+    fun `given inactive Woo core, when building versions, then return empty map`() {
+        // GIVEN
+        val plugin = createPlugin(version = WOO_VERSION, isActive = false)
+
+        // WHEN
+        val activePluginVersions = sut.buildActivePluginVersions(listOf(plugin))
+
+        // THEN
+        assertThat(activePluginVersions).isEmpty()
+    }
+
+    @Test
+    fun `given blank Woo core version, when building versions, then return empty map`() {
+        // GIVEN
+        val plugin = createPlugin(version = " ")
+
+        // WHEN
+        val activePluginVersions = sut.buildActivePluginVersions(listOf(plugin))
+
+        // THEN
+        assertThat(activePluginVersions).isEmpty()
+    }
+
+    @Test
+    fun `given non Woo core plugin, when building versions, then return empty map`() {
+        // GIVEN
+        val plugin = createPlugin(name = WooPlugin.WOO_PAYMENTS.pluginName, version = WOO_VERSION)
+
+        // WHEN
+        val activePluginVersions = sut.buildActivePluginVersions(listOf(plugin))
+
+        // THEN
+        assertThat(activePluginVersions).isEmpty()
+    }
+
+    private fun createPlugin(
+        name: String = WooPlugin.WOO_CORE.pluginName,
+        version: String,
+        isActive: Boolean = true
+    ) = SitePluginModel(
+        siteId = LocalId(1),
+        name = name,
+        version = version,
+        slug = name.substringBefore("/"),
+        authorName = "",
+        isActive = isActive
+    )
+
+    private companion object {
+        const val WOO_VERSION = "10.9.2"
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/config/WPComRemoteFeatureFlagRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/config/WPComRemoteFeatureFlagRepositoryTest.kt
@@ -6,8 +6,11 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.network.rest.wpcom.mobile.FeatureFlagsError
 import org.wordpress.android.fluxc.network.rest.wpcom.mobile.FeatureFlagsErrorType
 import org.wordpress.android.fluxc.store.mobile.FeatureFlagsStore
@@ -28,7 +31,7 @@ class WPComRemoteFeatureFlagRepositoryTest : BaseUnitTest() {
     fun `given fetching success, when fetchAndCacheFeatureFlags is called, then get success Result`() =
         testBlocking {
             val fetchResult = mapOf("key" to true)
-            whenever(featureFlagStore.fetchFeatureFlags(any(), any(), any(), any(), any()))
+            whenever(featureFlagStore.fetchFeatureFlags(any(), any(), any(), any(), any(), any(), any()))
                 .thenReturn(FeatureFlagsStore.FeatureFlagsResult(fetchResult))
 
             val result = sut.fetchAndCacheFeatureFlags()
@@ -38,12 +41,40 @@ class WPComRemoteFeatureFlagRepositoryTest : BaseUnitTest() {
     @Test
     fun `given fetching failure, when fetchAndCacheFeatureFlags is called, then get failure Result`() =
         testBlocking {
-            whenever(featureFlagStore.fetchFeatureFlags(any(), any(), any(), any(), any()))
+            whenever(featureFlagStore.fetchFeatureFlags(any(), any(), any(), any(), any(), any(), any()))
                 .thenReturn(
                     FeatureFlagsStore.FeatureFlagsResult(FeatureFlagsError(FeatureFlagsErrorType.GENERIC_ERROR))
                 )
 
             val result = sut.fetchAndCacheFeatureFlags()
             assertThat(result.isFailure).isTrue()
+        }
+
+    @Test
+    fun `when fetchAndCacheFeatureFlags is called with site and plugin versions, then forward context to store`() =
+        testBlocking {
+            // GIVEN
+            val localSiteId = LocalId(123)
+            val activePluginVersions = mapOf("woocommerce/woocommerce.php" to "10.9.2")
+            whenever(featureFlagStore.fetchFeatureFlags(any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(FeatureFlagsStore.FeatureFlagsResult(emptyMap()))
+
+            // WHEN
+            sut.fetchAndCacheFeatureFlags(
+                appVersion = "1.0.0",
+                localSiteId = localSiteId,
+                activePluginVersions = activePluginVersions
+            )
+
+            // THEN
+            verify(featureFlagStore).fetchFeatureFlags(
+                buildNumber = eq(""),
+                deviceId = eq(""),
+                identifier = eq(""),
+                marketingVersion = eq("1.0.0"),
+                platform = eq("android"),
+                localSiteId = eq(localSiteId),
+                activePluginVersions = eq(activePluginVersions)
+            )
         }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aiassistant/AIAssistantEligibilityCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aiassistant/AIAssistantEligibilityCheckerTest.kt
@@ -15,9 +15,11 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceUntilIdle
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.persistence.FeatureFlagConfigDao
 import org.wordpress.android.fluxc.store.mobile.FeatureFlagsStore
@@ -82,15 +84,16 @@ class AIAssistantEligibilityCheckerTest : BaseUnitTest() {
             // GIVEN
             val remoteFlags = MutableStateFlow<List<FeatureFlagConfigDao.FeatureFlag>>(emptyList())
             val featureFlagsStore: FeatureFlagsStore = mock {
-                on { observeFeatureFlags() } doReturn remoteFlags
+                on { observeFeatureFlags(any()) } doReturn remoteFlags
             }
-            val repository = FeatureFlagRepository(
-                featureFlagsStore = featureFlagsStore,
-                appCoroutineScope = CoroutineScope(coroutinesTestRule.testDispatcher),
-            )
             val selectedSite: SelectedSite = mock {
                 on { observe() } doReturn flowOf(eligibleSite())
             }
+            val repository = FeatureFlagRepository(
+                featureFlagsStore = featureFlagsStore,
+                selectedSite = selectedSite,
+                appCoroutineScope = CoroutineScope(coroutinesTestRule.testDispatcher),
+            )
             advanceUntilIdle()
 
             // WHEN
@@ -110,15 +113,16 @@ class AIAssistantEligibilityCheckerTest : BaseUnitTest() {
                 listOf(createRemoteFlag("woo_mobile_ai_assistant", true))
             )
             val featureFlagsStore: FeatureFlagsStore = mock {
-                on { observeFeatureFlags() } doReturn remoteFlags
+                on { observeFeatureFlags(any()) } doReturn remoteFlags
             }
-            val repository = FeatureFlagRepository(
-                featureFlagsStore = featureFlagsStore,
-                appCoroutineScope = CoroutineScope(coroutinesTestRule.testDispatcher),
-            )
             val selectedSite: SelectedSite = mock {
                 on { observe() } doReturn flowOf(eligibleSite())
             }
+            val repository = FeatureFlagRepository(
+                featureFlagsStore = featureFlagsStore,
+                selectedSite = selectedSite,
+                appCoroutineScope = CoroutineScope(coroutinesTestRule.testDispatcher),
+            )
             advanceUntilIdle()
 
             // WHEN
@@ -138,15 +142,16 @@ class AIAssistantEligibilityCheckerTest : BaseUnitTest() {
                 listOf(createRemoteFlag("woo_mobile_ai_assistant", false))
             )
             val featureFlagsStore: FeatureFlagsStore = mock {
-                on { observeFeatureFlags() } doReturn remoteFlags
+                on { observeFeatureFlags(any()) } doReturn remoteFlags
             }
-            val repository = FeatureFlagRepository(
-                featureFlagsStore = featureFlagsStore,
-                appCoroutineScope = CoroutineScope(coroutinesTestRule.testDispatcher),
-            )
             val selectedSite: SelectedSite = mock {
                 on { observe() } doReturn flowOf(eligibleSite())
             }
+            val repository = FeatureFlagRepository(
+                featureFlagsStore = featureFlagsStore,
+                selectedSite = selectedSite,
+                appCoroutineScope = CoroutineScope(coroutinesTestRule.testDispatcher),
+            )
             advanceUntilIdle()
 
             // WHEN
@@ -164,15 +169,16 @@ class AIAssistantEligibilityCheckerTest : BaseUnitTest() {
             // GIVEN
             val remoteFlags = MutableStateFlow<List<FeatureFlagConfigDao.FeatureFlag>>(emptyList())
             val featureFlagsStore: FeatureFlagsStore = mock {
-                on { observeFeatureFlags() } doReturn remoteFlags
+                on { observeFeatureFlags(any()) } doReturn remoteFlags
             }
-            val repository = FeatureFlagRepository(
-                featureFlagsStore = featureFlagsStore,
-                appCoroutineScope = CoroutineScope(coroutinesTestRule.testDispatcher),
-            )
             val selectedSite: SelectedSite = mock {
                 on { observe() } doReturn flowOf(eligibleSite())
             }
+            val repository = FeatureFlagRepository(
+                featureFlagsStore = featureFlagsStore,
+                selectedSite = selectedSite,
+                appCoroutineScope = CoroutineScope(coroutinesTestRule.testDispatcher),
+            )
             val emissions = mutableListOf<Boolean>()
 
             // WHEN
@@ -199,15 +205,16 @@ class AIAssistantEligibilityCheckerTest : BaseUnitTest() {
                 listOf(createRemoteFlag("woo_mobile_ai_assistant", true))
             )
             val featureFlagsStore: FeatureFlagsStore = mock {
-                on { observeFeatureFlags() } doReturn remoteFlags
+                on { observeFeatureFlags(any()) } doReturn remoteFlags
             }
-            val repository = FeatureFlagRepository(
-                featureFlagsStore = featureFlagsStore,
-                appCoroutineScope = CoroutineScope(coroutinesTestRule.testDispatcher),
-            )
             val selectedSite: SelectedSite = mock {
                 on { observe() } doReturn flowOf(eligibleSite())
             }
+            val repository = FeatureFlagRepository(
+                featureFlagsStore = featureFlagsStore,
+                selectedSite = selectedSite,
+                appCoroutineScope = CoroutineScope(coroutinesTestRule.testDispatcher),
+            )
             val emissions = mutableListOf<Boolean>()
 
             // WHEN
@@ -228,6 +235,7 @@ class AIAssistantEligibilityCheckerTest : BaseUnitTest() {
 
     private fun createRemoteFlag(key: String, value: Boolean) = FeatureFlagConfigDao.FeatureFlag(
         key = key,
+        localSiteId = LOCAL_SITE_ID,
         value = value,
         createdAt = 0L,
         modifiedAt = 0L,
@@ -235,7 +243,10 @@ class AIAssistantEligibilityCheckerTest : BaseUnitTest() {
     )
 
     private companion object {
+        val LOCAL_SITE_ID = LocalId(0)
+
         fun eligibleSite() = SiteModel().apply {
+            id = LOCAL_SITE_ID.value
             planActiveFeatures = "ai-assistant"
         }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/FeatureFlagRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/FeatureFlagRepositoryTest.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.util
 
 import com.woocommerce.android.viewmodel.BaseUnitTest
+import com.woocommerce.android.tools.SelectedSite
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -10,20 +11,32 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.persistence.FeatureFlagConfigDao
 import org.wordpress.android.fluxc.store.mobile.FeatureFlagsStore
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class FeatureFlagRepositoryTest : BaseUnitTest() {
     private val remoteFlags = MutableStateFlow<List<FeatureFlagConfigDao.FeatureFlag>>(emptyList())
+    private val secondSiteRemoteFlags = MutableStateFlow<List<FeatureFlagConfigDao.FeatureFlag>>(emptyList())
     private val featureFlagsStore: FeatureFlagsStore = mock {
-        on { observeFeatureFlags() } doReturn remoteFlags
+        on { observeFeatureFlags(LOCAL_SITE_ID) } doReturn remoteFlags
+        on { observeFeatureFlags(SECOND_LOCAL_SITE_ID) } doReturn secondSiteRemoteFlags
+    }
+    private val selectedSiteFlow = MutableStateFlow<SiteModel?>(SITE)
+    private val selectedSite: SelectedSite = mock {
+        on { observe() } doReturn selectedSiteFlow
     }
     private lateinit var sut: FeatureFlagRepository
 
     @Before
     fun setup() {
-        sut = FeatureFlagRepository(featureFlagsStore, CoroutineScope(coroutinesTestRule.testDispatcher))
+        sut = FeatureFlagRepository(
+            featureFlagsStore,
+            selectedSite,
+            CoroutineScope(coroutinesTestRule.testDispatcher)
+        )
     }
 
     @Test
@@ -123,6 +136,24 @@ class FeatureFlagRepositoryTest : BaseUnitTest() {
         // THEN
         assertThat(state.remoteValue).isNull()
     }
+
+    @Test
+    fun `given selected site changes, when getFlagState called, then previous remote value is cleared`() =
+        testBlocking {
+            // GIVEN
+            val flag = FeatureFlag.WC_SHIPPING_BANNER
+            remoteFlags.value = listOf(createRemoteFlag(flag.remoteFlagKey, false))
+            advanceUntilIdle()
+
+            // WHEN
+            selectedSiteFlow.value = SiteModel().apply { id = SECOND_LOCAL_SITE_ID.value }
+            advanceUntilIdle()
+            val state = sut.getFlagState(flag)
+
+            // THEN
+            assertThat(state.remoteValue).isNull()
+            assertThat(state.effectiveValue).isTrue()
+        }
 
     @Test
     fun `given self driven push notifications feature flag, when inspected, then local value follows debug build`() {
@@ -254,9 +285,16 @@ class FeatureFlagRepositoryTest : BaseUnitTest() {
 
     private fun createRemoteFlag(key: String, value: Boolean) = FeatureFlagConfigDao.FeatureFlag(
         key = key,
+        localSiteId = LOCAL_SITE_ID,
         value = value,
         createdAt = 0L,
         modifiedAt = 0L,
         source = FeatureFlagConfigDao.FeatureFlagValueSource.REMOTE
     )
+
+    private companion object {
+        val LOCAL_SITE_ID = LocalId(1)
+        val SECOND_LOCAL_SITE_ID = LocalId(2)
+        val SITE = SiteModel().apply { id = LOCAL_SITE_ID.value }
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/FeatureFlagRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/FeatureFlagRepositoryTest.kt
@@ -1,7 +1,7 @@
 package com.woocommerce.android.util
 
-import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/mobile/FeatureFlagsRestClientTest.kt
+++ b/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/mobile/FeatureFlagsRestClientTest.kt
@@ -83,6 +83,30 @@ class FeatureFlagsRestClientTest {
     }
 
     @Test
+    fun `given active plugin versions, when feature flags are requested, then plugin versions are serialized`() =
+        test {
+            val json = UnitTestUtils.getStringFromResourceFile(javaClass, SUCCESS_JSON)
+            initFetchFeatureFlags(data = getResponseFromJsonString(json))
+
+            restClient.fetchFeatureFlags(
+                FeatureFlagsPayload(
+                    buildNumber = BUILD_NUMBER_PARAM,
+                    deviceId = DEVICE_ID_PARAM,
+                    identifier = IDENTIFIER_PARAM,
+                    marketingVersion = MARKETING_VERSION_PARAM,
+                    platform = PLATFORM_PARAM,
+                    osVersion = OS_VERSION_PARAM,
+                    activePluginVersions = mapOf(WOO_CORE_PLUGIN_PATH to WOO_VERSION)
+                )
+            )
+
+            assertEquals(
+                WOO_VERSION,
+                paramsCaptor.firstValue["active_plugin_versions[$WOO_CORE_PLUGIN_PATH]"]
+            )
+        }
+
+    @Test
     fun `given success call, when f-flags are requested, then correct response is returned`() = test {
         val json = UnitTestUtils.getStringFromResourceFile(javaClass, SUCCESS_JSON)
         initFetchFeatureFlags(data = getResponseFromJsonString(json))
@@ -255,6 +279,8 @@ class FeatureFlagsRestClientTest {
         private const val MARKETING_VERSION_PARAM = "marketing_version_param"
         private const val PLATFORM_PARAM = "platform_param"
         private const val OS_VERSION_PARAM = "os_version_param"
+        private const val WOO_CORE_PLUGIN_PATH = "woocommerce/woocommerce.php"
+        private const val WOO_VERSION = "10.9.2"
 
         private const val SUCCESS_JSON = "wp/mobile/feature-flags-success.json"
     }

--- a/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/store/mobile/FeatureFlagsStoreTest.kt
+++ b/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/store/mobile/FeatureFlagsStoreTest.kt
@@ -9,6 +9,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.network.rest.wpcom.mobile.FeatureFlagsError
 import org.wordpress.android.fluxc.network.rest.wpcom.mobile.FeatureFlagsErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.network.rest.wpcom.mobile.FeatureFlagsFetchedPayload
@@ -51,10 +52,11 @@ class FeatureFlagsStoreTest {
                 marketingVersion = MARKETING_VERSION_PARAM,
                 platform = PLATFORM_PARAM,
                 osVersion = OS_VERSION_PARAM,
-            )
+            ),
+            localSiteId = LOCAL_SITE_ID
         )
 
-        verify(featureFlagConfigDao).insert(successResponse)
+        verify(featureFlagConfigDao).insert(successResponse, LOCAL_SITE_ID)
         assertNotNull(response.featureFlags)
         assertEquals(FeatureFlagsResult(successResponse), response)
     }
@@ -88,5 +90,6 @@ class FeatureFlagsStoreTest {
         private const val MARKETING_VERSION_PARAM = "marketing_version_param"
         private const val PLATFORM_PARAM = "platform_param"
         private const val OS_VERSION_PARAM = "os_version_param"
+        private val LOCAL_SITE_ID = LocalId(123)
     }
 }

--- a/libs/fluxc/schemas/org.wordpress.android.fluxc.persistence.WPAndroidDatabase/38.json
+++ b/libs/fluxc/schemas/org.wordpress.android.fluxc.persistence.WPAndroidDatabase/38.json
@@ -1,0 +1,855 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 38,
+    "identityHash": "185c8ceed4b7fee3ba1c9a55b29e9bf3",
+    "entities": [
+      {
+        "tableName": "AccountEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `userName` TEXT NOT NULL, `userId` INTEGER NOT NULL, `displayName` TEXT NOT NULL, `profileUrl` TEXT NOT NULL, `avatarUrl` TEXT NOT NULL, `primarySiteId` INTEGER NOT NULL, `emailVerified` INTEGER NOT NULL, `siteCount` INTEGER NOT NULL, `visibleSiteCount` INTEGER NOT NULL, `email` TEXT NOT NULL, `hasUnseenNotes` INTEGER NOT NULL, `firstName` TEXT NOT NULL, `lastName` TEXT NOT NULL, `aboutMe` TEXT NOT NULL, `date` TEXT NOT NULL, `newEmail` TEXT NOT NULL, `pendingEmailChange` INTEGER NOT NULL, `twoStepEnabled` INTEGER NOT NULL, `webAddress` TEXT NOT NULL, `tracksOptOut` INTEGER NOT NULL, `usernameCanBeChanged` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userName",
+            "columnName": "userName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileUrl",
+            "columnName": "profileUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarUrl",
+            "columnName": "avatarUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "primarySiteId",
+            "columnName": "primarySiteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "emailVerified",
+            "columnName": "emailVerified",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "siteCount",
+            "columnName": "siteCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "visibleSiteCount",
+            "columnName": "visibleSiteCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "email",
+            "columnName": "email",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasUnseenNotes",
+            "columnName": "hasUnseenNotes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstName",
+            "columnName": "firstName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastName",
+            "columnName": "lastName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "aboutMe",
+            "columnName": "aboutMe",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "newEmail",
+            "columnName": "newEmail",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pendingEmailChange",
+            "columnName": "pendingEmailChange",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "twoStepEnabled",
+            "columnName": "twoStepEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "webAddress",
+            "columnName": "webAddress",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tracksOptOut",
+            "columnName": "tracksOptOut",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "usernameCanBeChanged",
+            "columnName": "usernameCanBeChanged",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "FeatureFlagConfigurations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT NOT NULL, `local_site_id` INTEGER NOT NULL, `value` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, `modified_at` INTEGER NOT NULL, `source` TEXT NOT NULL, PRIMARY KEY(`key`, `local_site_id`))",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localSiteId",
+            "columnName": "local_site_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modifiedAt",
+            "columnName": "modified_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "key",
+            "local_site_id"
+          ]
+        }
+      },
+      {
+        "tableName": "Domains",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`siteLocalId` INTEGER NOT NULL, `domain` TEXT NOT NULL, `primaryDomain` INTEGER NOT NULL, `wpcomDomain` INTEGER NOT NULL, PRIMARY KEY(`domain`))",
+        "fields": [
+          {
+            "fieldPath": "siteLocalId",
+            "columnName": "siteLocalId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "domain",
+            "columnName": "domain",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "primaryDomain",
+            "columnName": "primaryDomain",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wpcomDomain",
+            "columnName": "wpcomDomain",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "domain"
+          ]
+        }
+      },
+      {
+        "tableName": "BlazeCampaigns",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`siteId` INTEGER NOT NULL, `campaignId` TEXT NOT NULL, `title` TEXT NOT NULL, `imageUrl` TEXT, `startTime` TEXT NOT NULL, `durationInDays` INTEGER NOT NULL, `uiStatus` TEXT NOT NULL, `impressions` INTEGER NOT NULL, `clicks` INTEGER NOT NULL, `targetUrn` TEXT, `totalBudget` REAL NOT NULL, `spentBudget` REAL NOT NULL, `isEndlessCampaign` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`siteId`, `campaignId`))",
+        "fields": [
+          {
+            "fieldPath": "siteId",
+            "columnName": "siteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "campaignId",
+            "columnName": "campaignId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "imageUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "startTime",
+            "columnName": "startTime",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationInDays",
+            "columnName": "durationInDays",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uiStatus",
+            "columnName": "uiStatus",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "impressions",
+            "columnName": "impressions",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "clicks",
+            "columnName": "clicks",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetUrn",
+            "columnName": "targetUrn",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "totalBudget",
+            "columnName": "totalBudget",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "spentBudget",
+            "columnName": "spentBudget",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isEndlessCampaign",
+            "columnName": "isEndlessCampaign",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "siteId",
+            "campaignId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_BlazeCampaigns_siteId",
+            "unique": false,
+            "columnNames": [
+              "siteId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_BlazeCampaigns_siteId` ON `${TABLE_NAME}` (`siteId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "BlazeCampaignObjectives",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT NOT NULL, `description` TEXT NOT NULL, `suitableForDescription` TEXT NOT NULL, `locale` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "suitableForDescription",
+            "columnName": "suitableForDescription",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locale",
+            "columnName": "locale",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "BlazeTargetingLanguages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `locale` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locale",
+            "columnName": "locale",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "BlazeTargetingDevices",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `locale` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locale",
+            "columnName": "locale",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "BlazeTargetingTopics",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `description` TEXT NOT NULL, `locale` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locale",
+            "columnName": "locale",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "ThemeEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`siteId` INTEGER NOT NULL, `themeId` TEXT NOT NULL, `name` TEXT NOT NULL, `demoUrl` TEXT, `active` INTEGER NOT NULL, `isWpComTheme` INTEGER NOT NULL, PRIMARY KEY(`siteId`, `themeId`, `isWpComTheme`))",
+        "fields": [
+          {
+            "fieldPath": "siteId",
+            "columnName": "siteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "themeId",
+            "columnName": "themeId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "demoUrl",
+            "columnName": "demoUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "active",
+            "columnName": "active",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isWpComTheme",
+            "columnName": "isWpComTheme",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "siteId",
+            "themeId",
+            "isWpComTheme"
+          ]
+        }
+      },
+      {
+        "tableName": "WhatsNewAnnouncementEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`announcementId` INTEGER NOT NULL, `minimumAppVersion` TEXT NOT NULL, `maximumAppVersion` TEXT NOT NULL, `appVersionTargets` TEXT NOT NULL, `detailsUrl` TEXT NOT NULL DEFAULT '', `localized` INTEGER NOT NULL, PRIMARY KEY(`announcementId`))",
+        "fields": [
+          {
+            "fieldPath": "announcementId",
+            "columnName": "announcementId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "minimumAppVersion",
+            "columnName": "minimumAppVersion",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maximumAppVersion",
+            "columnName": "maximumAppVersion",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appVersionTargets",
+            "columnName": "appVersionTargets",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "detailsUrl",
+            "columnName": "detailsUrl",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "localized",
+            "columnName": "localized",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "announcementId"
+          ]
+        }
+      },
+      {
+        "tableName": "WhatsNewAnnouncementFeatureEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`announcementId` INTEGER NOT NULL, `title` TEXT NOT NULL, `subtitle` TEXT, `iconUrl` TEXT, `iconBase64` TEXT, PRIMARY KEY(`announcementId`, `title`), FOREIGN KEY(`announcementId`) REFERENCES `WhatsNewAnnouncementEntity`(`announcementId`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "announcementId",
+            "columnName": "announcementId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subtitle",
+            "columnName": "subtitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "iconUrl",
+            "columnName": "iconUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "iconBase64",
+            "columnName": "iconBase64",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "announcementId",
+            "title"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "WhatsNewAnnouncementEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "announcementId"
+            ],
+            "referencedColumns": [
+              "announcementId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "SitePluginEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`siteId` INTEGER NOT NULL, `name` TEXT NOT NULL, `version` TEXT NOT NULL, `slug` TEXT NOT NULL, `authorName` TEXT NOT NULL, `isActive` INTEGER NOT NULL, PRIMARY KEY(`siteId`, `name`, `slug`))",
+        "fields": [
+          {
+            "fieldPath": "siteId",
+            "columnName": "siteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "slug",
+            "columnName": "slug",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "authorName",
+            "columnName": "authorName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "siteId",
+            "name",
+            "slug"
+          ]
+        }
+      },
+      {
+        "tableName": "ListEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `lastModified` TEXT, `descriptorUniqueIdentifierDbValue` INTEGER NOT NULL, `descriptorTypeIdentifierDbValue` INTEGER NOT NULL, `stateDbValue` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastModified",
+            "columnName": "lastModified",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "descriptorUniqueIdentifierDbValue",
+            "columnName": "descriptorUniqueIdentifierDbValue",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "descriptorTypeIdentifierDbValue",
+            "columnName": "descriptorTypeIdentifierDbValue",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stateDbValue",
+            "columnName": "stateDbValue",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_ListEntity_descriptorUniqueIdentifierDbValue_descriptorTypeIdentifierDbValue",
+            "unique": true,
+            "columnNames": [
+              "descriptorUniqueIdentifierDbValue",
+              "descriptorTypeIdentifierDbValue"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_ListEntity_descriptorUniqueIdentifierDbValue_descriptorTypeIdentifierDbValue` ON `${TABLE_NAME}` (`descriptorUniqueIdentifierDbValue`, `descriptorTypeIdentifierDbValue`)"
+          }
+        ]
+      },
+      {
+        "tableName": "ListItemEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`listId` INTEGER NOT NULL, `remoteItemId` INTEGER NOT NULL, PRIMARY KEY(`listId`, `remoteItemId`), FOREIGN KEY(`listId`) REFERENCES `ListEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "listId",
+            "columnName": "listId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteItemId",
+            "columnName": "remoteItemId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "listId",
+            "remoteItemId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "ListEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "listId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "NotificationEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`remoteSiteId` INTEGER NOT NULL, `remoteNoteId` INTEGER NOT NULL, `noteHash` INTEGER NOT NULL, `type` TEXT NOT NULL, `subtype` TEXT, `read` INTEGER NOT NULL, `icon` TEXT, `noticon` TEXT, `timestamp` TEXT, `url` TEXT, `title` TEXT, `formattableBody` TEXT, `formattableSubject` TEXT, `formattableMeta` TEXT, PRIMARY KEY(`remoteSiteId`, `remoteNoteId`))",
+        "fields": [
+          {
+            "fieldPath": "remoteSiteId",
+            "columnName": "remoteSiteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteNoteId",
+            "columnName": "remoteNoteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "noteHash",
+            "columnName": "noteHash",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subtype",
+            "columnName": "subtype",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "read",
+            "columnName": "read",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "noticon",
+            "columnName": "noticon",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "formattableBody",
+            "columnName": "formattableBody",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "formattableSubject",
+            "columnName": "formattableSubject",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "formattableMeta",
+            "columnName": "formattableMeta",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "remoteSiteId",
+            "remoteNoteId"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '185c8ceed4b7fee3ba1c9a55b29e9bf3')"
+    ]
+  }
+}

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/mobile/FeatureFlagsRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/mobile/FeatureFlagsRestClient.kt
@@ -29,7 +29,6 @@ class FeatureFlagsRestClient @Inject constructor(
     userAgent: UserAgent
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
     suspend fun fetchFeatureFlags(payload: FeatureFlagsPayload): FeatureFlagsFetchedPayload {
-        // https://public-api.wordpress.com/wpcom/v2/mobile/feature-flagsdevice_id=12345&platform=android&build_number=570&marketing_version=15.1.1&identifier=com.jetpack.android
         val url = WPCOMV2.mobile.feature_flags.url
         val params = buildFeatureFlagsParams(payload)
         val response = wpComGsonRequestBuilder.syncGetRequest(
@@ -44,14 +43,17 @@ class FeatureFlagsRestClient @Inject constructor(
         }
     }
 
-    private fun buildFeatureFlagsParams(payload: FeatureFlagsPayload) = mapOf(
-            "build_number" to payload.buildNumber,
-            "device_id" to payload.deviceId,
-            "identifier" to payload.identifier,
-            "marketing_version" to payload.marketingVersion,
-            "platform" to payload.platform,
-            "os_version" to payload.osVersion,
-    )
+    private fun buildFeatureFlagsParams(payload: FeatureFlagsPayload) = buildMap {
+        put("build_number", payload.buildNumber)
+        put("device_id", payload.deviceId)
+        put("identifier", payload.identifier)
+        put("marketing_version", payload.marketingVersion)
+        put("platform", payload.platform)
+        put("os_version", payload.osVersion)
+        payload.activePluginVersions.forEach { (pluginPath, version) ->
+            put("active_plugin_versions[$pluginPath]", version)
+        }
+    }
 
     data class FeatureFlagsPayload(
         val buildNumber: String,
@@ -60,6 +62,7 @@ class FeatureFlagsRestClient @Inject constructor(
         val marketingVersion: String,
         val platform: String,
         val osVersion: String = Build.VERSION.RELEASE,
+        val activePluginVersions: Map<String, String> = emptyMap(),
     )
 
     private fun buildFeatureFlagsFetchedPayload(featureFlags: Map<*, *>?): FeatureFlagsFetchedPayload {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/FeatureFlagConfigDao.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/FeatureFlagConfigDao.kt
@@ -9,6 +9,7 @@ import androidx.room.Query
 import androidx.room.Transaction
 import androidx.room.TypeConverter
 import kotlinx.coroutines.flow.Flow
+import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.persistence.FeatureFlagConfigDao.FeatureFlagValueSource.REMOTE
 
 @Dao
@@ -16,19 +17,20 @@ abstract class FeatureFlagConfigDao {
     @Query("SELECT * from FeatureFlagConfigurations")
     abstract fun getFeatureFlagList(): List<FeatureFlag>
 
-    @Query("SELECT * from FeatureFlagConfigurations")
-    abstract fun observeFeatureFlagList(): Flow<List<FeatureFlag>>
+    @Query("SELECT * from FeatureFlagConfigurations WHERE local_site_id = :localSiteId")
+    abstract fun observeFeatureFlagList(localSiteId: LocalId): Flow<List<FeatureFlag>>
 
-    @Query("SELECT * from FeatureFlagConfigurations WHERE `key` = :key")
-    abstract fun getFeatureFlag(key: String): List<FeatureFlag>
+    @Query("SELECT * from FeatureFlagConfigurations WHERE `key` = :key AND local_site_id = :localSiteId")
+    abstract fun getFeatureFlag(key: String, localSiteId: LocalId): List<FeatureFlag>
 
     @Transaction
     @Suppress("SpreadOperator")
-    open fun insert(featureFlags: Map<String, Boolean>) {
+    open fun insert(featureFlags: Map<String, Boolean>, localSiteId: LocalId) {
         featureFlags.forEach {
             insert(
                     FeatureFlag(
                             key = it.key,
+                            localSiteId = localSiteId,
                             value = it.value,
                             createdAt = System.currentTimeMillis(),
                             modifiedAt = System.currentTimeMillis(),
@@ -46,10 +48,11 @@ abstract class FeatureFlagConfigDao {
 
     @Entity(
             tableName = "FeatureFlagConfigurations",
-            primaryKeys = ["key"]
+            primaryKeys = ["key", "local_site_id"]
     )
     data class FeatureFlag(
         val key: String,
+        @ColumnInfo(name = "local_site_id") val localSiteId: LocalId,
         val value: Boolean,
         @ColumnInfo(name = "created_at") val createdAt: Long,
         @ColumnInfo(name = "modified_at") val modifiedAt: Long,

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WPAndroidDatabase.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WPAndroidDatabase.kt
@@ -40,7 +40,7 @@ import org.wordpress.android.fluxc.persistence.entity.WhatsNewAnnouncementEntity
 import org.wordpress.android.fluxc.persistence.entity.WhatsNewAnnouncementFeatureEntity
 
 @Database(
-        version = 37,
+        version = 38,
         entities = [
             AccountEntity::class,
             FeatureFlag::class,
@@ -132,6 +132,7 @@ abstract class WPAndroidDatabase : RoomDatabase() {
                 .addMigrations(MIGRATION_19_20)
                 .addMigrations(MIGRATION_20_21)
                 .addMigrations(MIGRATION_26_27)
+                .addMigrations(MIGRATION_37_38)
                 .build()
 
         val MIGRATION_1_2 = object : Migration(1, 2) {
@@ -362,6 +363,25 @@ abstract class WPAndroidDatabase : RoomDatabase() {
                     execSQL(
                         "CREATE INDEX IF NOT EXISTS `index_BlazeCampaigns_siteId` " +
                                 "ON `BlazeCampaigns` (`siteId`)"
+                    )
+                }
+            }
+        }
+
+        val MIGRATION_37_38 = object : Migration(37, 38) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.apply {
+                    execSQL("DROP TABLE IF EXISTS `FeatureFlagConfigurations`")
+                    execSQL(
+                        "CREATE TABLE IF NOT EXISTS `FeatureFlagConfigurations` (" +
+                            "`key` TEXT NOT NULL, " +
+                            "`local_site_id` INTEGER NOT NULL, " +
+                            "`value` INTEGER NOT NULL, " +
+                            "`created_at` INTEGER NOT NULL, " +
+                            "`modified_at` INTEGER NOT NULL, " +
+                            "`source` TEXT NOT NULL, " +
+                            "PRIMARY KEY(`key`, `local_site_id`)" +
+                            ")"
                     )
                 }
             }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/mobile/FeatureFlagsStore.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/mobile/FeatureFlagsStore.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.store.mobile
 
 import kotlinx.coroutines.flow.Flow
+import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.network.rest.wpcom.mobile.FeatureFlagsError
 import org.wordpress.android.fluxc.network.rest.wpcom.mobile.FeatureFlagsErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.network.rest.wpcom.mobile.FeatureFlagsRestClient
@@ -24,24 +25,31 @@ class FeatureFlagsStore @Inject constructor(
         deviceId: String,
         identifier: String,
         marketingVersion: String,
-        platform: String
+        platform: String,
+        localSiteId: LocalId = DEFAULT_LOCAL_SITE_ID,
+        activePluginVersions: Map<String, String> = emptyMap()
     ) = fetchFeatureFlags(
-        FeatureFlagsPayload(
+        payload = FeatureFlagsPayload(
             buildNumber = buildNumber,
             deviceId = deviceId,
             identifier = identifier,
             marketingVersion = marketingVersion,
-            platform = platform
-        )
+            platform = platform,
+            activePluginVersions = activePluginVersions
+        ),
+        localSiteId = localSiteId
     )
 
-    suspend fun fetchFeatureFlags(payload: FeatureFlagsPayload) =
+    suspend fun fetchFeatureFlags(
+        payload: FeatureFlagsPayload,
+        localSiteId: LocalId = DEFAULT_LOCAL_SITE_ID
+    ) =
         coroutineEngine.withDefaultContext(AppLog.T.API, this, "fetch feature-flags") {
             val payload = featureFlagsRestClient.fetchFeatureFlags(payload)
             return@withDefaultContext when {
                 payload.isError -> FeatureFlagsResult(payload.error)
                 payload.featureFlags != null -> {
-                    featureFlagConfigDao.insert(payload.featureFlags)
+                    featureFlagConfigDao.insert(payload.featureFlags, localSiteId)
                     FeatureFlagsResult(payload.featureFlags)
                 }
 
@@ -49,8 +57,8 @@ class FeatureFlagsStore @Inject constructor(
             }
         }
 
-    fun observeFeatureFlags(): Flow<List<FeatureFlag>> {
-        return featureFlagConfigDao.observeFeatureFlagList()
+    fun observeFeatureFlags(localSiteId: LocalId = DEFAULT_LOCAL_SITE_ID): Flow<List<FeatureFlag>> {
+        return featureFlagConfigDao.observeFeatureFlagList(localSiteId)
     }
 
     data class FeatureFlagsResult(
@@ -59,5 +67,9 @@ class FeatureFlagsStore @Inject constructor(
         constructor(error: FeatureFlagsError) : this() {
             this.error = error
         }
+    }
+
+    companion object {
+        val DEFAULT_LOCAL_SITE_ID = LocalId(-1)
     }
 }


### PR DESCRIPTION
### Description
Adds WooCommerce Android support for WPCOM mobile remote feature flag rules that evaluate client-reported active plugin versions.

This change fetches site plugins before remote feature flags during selected-site bootstrap, sends only the allowlisted active WooCommerce core plugin version as `active_plugin_versions[woocommerce/woocommerce.php]`, and falls back to an empty plugin map if plugin fetching fails. The selected site's local ID is used only for local cache scoping and is not sent to WPCOM.

Remote feature flag persistence is now site-scoped. Legacy global rows are dropped during the Room migration because they cannot be attributed to a selected site context, which forces a fresh sync instead of briefly exposing another site's remote values.

Existing callers that do not pass plugin versions continue to send the same request params as before.

### Test Steps
TBD. We'll likely need to use a dummy remote FF to test this properly. 

1. Select or log in to a WooCommerce site with WooCommerce core active.
2. Confirm the app syncs plugins before fetching WPCOM mobile remote feature flags.
3. Confirm the feature flag request includes only `active_plugin_versions[woocommerce/woocommerce.php]` when WooCommerce core is active with a non-blank version.
4. Switch to another selected site and confirm remote feature flag values are reloaded for that site context with the correct version of WooCommerce. 

### Images/gif
N/A

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.