### PR TITLE
[WOOMOB-3397] Stop reporting non-JSON order proxy responses

### DIFF
--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -52,7 +52,6 @@ import org.wordpress.android.fluxc.store.WCOrderStore.OrderErrorType.TIMEOUT_ERR
 import org.wordpress.android.fluxc.store.WCOrderStore.RemoteOrderPayload
 import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.fluxc.utils.DateUtils
-import org.wordpress.android.fluxc.utils.ErrorUtils.OnUnexpectedError
 import org.wordpress.android.fluxc.utils.putIfNotEmpty
 import org.wordpress.android.fluxc.utils.toWooPayload
 import org.wordpress.android.util.AppLog
@@ -1176,7 +1175,6 @@ class OrderRestClient @Inject constructor(
             wpAPINetworkError.errorCode == "woocommerce_rest_shop_order_invalid_id" -> OrderErrorType.INVALID_ID
             wpAPINetworkError.errorCode == "rest_no_route" -> OrderErrorType.PLUGIN_NOT_ACTIVE
             isSiteReturnedNonJsonResponse(wpAPINetworkError) -> {
-                reportNonJsonResponse(wpAPINetworkError)
                 OrderErrorType.PARSE_ERROR
             }
             wpAPINetworkError.type == BaseRequest.GenericErrorType.PARSE_ERROR -> OrderErrorType.PARSE_ERROR
@@ -1194,20 +1192,6 @@ class OrderRestClient @Inject constructor(
     private fun isSiteReturnedNonJsonResponse(wpAPINetworkError: WPAPINetworkError): Boolean {
         return wpAPINetworkError.errorCode == "no_response_body" &&
             wpAPINetworkError.errorData?.has("raw_body") == true
-    }
-
-    /**
-     * Reports the non-JSON proxy response through the existing FluxC parse-error reporting path so the
-     * occurrence is visible in crash/error reporting (and its impact measurable). The raw body itself
-     * is intentionally not attached as it may contain the merchant's page content.
-     */
-    private fun reportNonJsonResponse(wpAPINetworkError: WPAPINetworkError) {
-        val report = OnUnexpectedError(
-            Exception("Order API returned a non-JSON response through the Jetpack proxy"),
-            ORDER_RESPONSE_PARSE_ERROR_DESCRIPTION
-        )
-        wpAPINetworkError.errorCode?.let { report.addExtra("error_code", it) }
-        dispatcher.emitChange(report)
     }
 
     private fun orderShipmentTrackingResponseToModel(
@@ -1278,8 +1262,6 @@ class OrderRestClient @Inject constructor(
     }
 
     companion object {
-        private const val ORDER_RESPONSE_PARSE_ERROR_DESCRIPTION = "Order API response parse error"
-
         private val ORDER_FIELDS = arrayOf(
             "billing",
             "coupon_lines",

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClientTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClientTest.kt
@@ -12,7 +12,6 @@ import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.Dispatcher
@@ -31,9 +30,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderListResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.OrderErrorType
 import org.wordpress.android.fluxc.tools.CoroutineEngine
-import org.wordpress.android.fluxc.utils.ErrorUtils.OnUnexpectedError
 import org.wordpress.android.fluxc.utils.initCoroutineEngine
-import kotlin.collections.emptyList
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class OrderRestClientTest {
@@ -489,10 +486,6 @@ class OrderRestClientTest {
             val actionCaptor = argumentCaptor<Action<FetchOrderListResponsePayload>>()
             verify(dispatcher).dispatch(actionCaptor.capture())
             assertThat(actionCaptor.firstValue.payload.error?.type).isEqualTo(OrderErrorType.PARSE_ERROR)
-
-            val reportCaptor = argumentCaptor<OnUnexpectedError>()
-            verify(dispatcher).emitChange(reportCaptor.capture())
-            assertThat(reportCaptor.firstValue.description).isEqualTo("Order API response parse error")
         }
 
     @Test
@@ -528,7 +521,6 @@ class OrderRestClientTest {
             val actionCaptor = argumentCaptor<Action<FetchOrderListResponsePayload>>()
             verify(dispatcher).dispatch(actionCaptor.capture())
             assertThat(actionCaptor.firstValue.payload.error?.type).isEqualTo(OrderErrorType.GENERIC_ERROR)
-            verify(dispatcher, never()).emitChange(any<OnUnexpectedError>())
         }
 
     /* HELPER */


### PR DESCRIPTION
### Description
Fixes WOOMOB-3397

Jetpack proxy responses that come back as `no_response_body` with `data.raw_body` are still mapped to `OrderErrorType.PARSE_ERROR`, so the app can keep showing the correct error state for order requests. However, these responses represent upstream non-JSON site output, such as bot protection or maintenance pages, rather than an app-side deserialization failure.

This removes the Sentry reporting path for that specific condition while keeping the parse-error mapping intact. The decision follows the discussion in p1782842251575409-slack-C03L1NF1EA3.

### Test Steps
NA

### Images/gif
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.