### PR TITLE
[WOOMOB-3392] Revert Blaze / Plugins / split-shipments CIAB gating

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ciab/CIABAffectedFeature.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ciab/CIABAffectedFeature.kt
@@ -1,9 +1,7 @@
 package com.woocommerce.android.ciab
 
 enum class CIABAffectedFeature {
-    Blaze,
     InPersonPayments,
-    WooShippingSplitShipments,
     GroupedProducts,
     VariableProducts,
     SubscriptionProducts,
@@ -11,6 +9,5 @@ enum class CIABAffectedFeature {
     CompositeProducts,
     GiftCardEditing,
     OrderStatusEditing,
-    Plugins,
     POS
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/IsBlazeEnabled.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/IsBlazeEnabled.kt
@@ -1,8 +1,6 @@
 package com.woocommerce.android.ui.blaze
 
 import androidx.annotation.VisibleForTesting
-import com.woocommerce.android.ciab.CIABAffectedFeature
-import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.tools.SiteConnectionType.Jetpack
 import com.woocommerce.android.tools.connectionType
@@ -10,8 +8,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import javax.inject.Inject
 
 class IsBlazeEnabled @Inject constructor(
-    private val selectedSite: SelectedSite,
-    private val ciabSiteGateKeeper: CIABSiteGateKeeper
+    private val selectedSite: SelectedSite
 ) {
     companion object {
         @VisibleForTesting
@@ -22,8 +19,7 @@ class IsBlazeEnabled @Inject constructor(
         val site = selectedSite.getOrNull() ?: return false
         return site.isAdmin &&
             site.hasAValidJetpackConnectionForBlaze() &&
-            site.canBlaze &&
-            ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.Blaze)
+            site.canBlaze
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -17,8 +17,6 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_ERROR
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_STATE
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_STARTED
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
-import com.woocommerce.android.ciab.CIABAffectedFeature
-import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.extensions.combine
 import com.woocommerce.android.extensions.sumByFloat
 import com.woocommerce.android.model.Address
@@ -128,7 +126,6 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     private val fetchShippingLabelFile: FetchShippingLabelFile,
     private val observeShippingLabelStatus: ObserveShippingLabelStatus,
     private val downloadAndPrintInvoiceUseCase: DownloadAndPrintInvoiceUseCase,
-    private val ciabSiteGateKeeper: CIABSiteGateKeeper,
     private val analyticsTracker: AnalyticsTrackerWrapper,
 ) : ScopedViewModel(savedState) {
     private val navArgs: WooShippingLabelCreationFragmentArgs by savedState.navArgs()
@@ -809,9 +806,6 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                     formattedPrice = shipmentUIList[uiState.selectedIndex].shipmentCostUI?.formattedTotalPrice,
                     onMarkOrderCompleteChange = ::onMarkOrderCompleteChange,
                     onPurchaseShippingLabel = ::onPurchaseShippingLabel
-                ),
-                isSplitShipmentsSupported = ciabSiteGateKeeper.isFeatureSupported(
-                    feature = CIABAffectedFeature.WooShippingSplitShipments
                 )
             )
         }.combine(loadTrigger.onStart { emit(Unit) }) { viewState, _ ->
@@ -1402,16 +1396,14 @@ class WooShippingLabelCreationViewModel @Inject constructor(
             val uiState: UIControlsState,
             val destinationStatus: AddressStatus,
             val paymentsSectionUI: PaymentsSectionUI,
-            val purchaseSectionUI: PurchaseSectionUI,
-            val isSplitShipmentsSupported: Boolean
+            val purchaseSectionUI: PurchaseSectionUI
         ) : WooShippingViewState() {
             val shouldShowSplitShipmentButton: Boolean
                 get() {
                     val unpurchasedShipments = shipmentUIList.filterNot { it.isPurchased }
                     val hasMultipleUnfulfilledItems = unpurchasedShipments.size > 1 ||
                         (unpurchasedShipments.firstOrNull()?.totalItemQuantity ?: 0) > 1
-                    return isSplitShipmentsSupported &&
-                        shipmentUIList.none { it.isPurchaseInProgress } &&
+                    return shipmentUIList.none { it.isPurchaseInProgress } &&
                         hasMultipleUnfulfilledItems
                 }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsContract.kt
@@ -18,7 +18,6 @@ interface MainSettingsContract {
 
         val isCloseAccountOptionVisible: Boolean
         val isThemePickerOptionVisible: Boolean
-        val isPluginsSectionVisible: Boolean
         val wooPluginVersion: String
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -212,8 +212,6 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
                 .navigateSafely(R.id.action_mainSettingsFragment_to_troubleshootConnectionFragment)
         }
 
-        binding.pluginsContainer.isVisible = presenter.isPluginsSectionVisible
-
         binding.optionSitePlugins.setOnClickListener {
             findNavController()
                 .navigateSafely(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
@@ -126,9 +126,6 @@ class MainSettingsPresenter @Inject constructor(
     override val isThemePickerOptionVisible: Boolean
         get() = selectedSite.get().isWPComAtomic
 
-    override val isPluginsSectionVisible: Boolean
-        get() = true
-
     override fun setupEnablePushNotificationsOption() {
         coroutineScope.launch {
             shouldShowEnablePushNotificationsUi().collect { shouldShowOption ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
@@ -3,8 +3,6 @@ package com.woocommerce.android.ui.prefs
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
-import com.woocommerce.android.ciab.CIABAffectedFeature
-import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.notifications.NotificationChannelsHandler
 import com.woocommerce.android.notifications.NotificationChannelsHandler.NewOrderNotificationSoundStatus
 import com.woocommerce.android.notifications.push.PushNotificationRepository
@@ -39,7 +37,6 @@ class MainSettingsPresenter @Inject constructor(
     private val analyticsTracker: AnalyticsTrackerWrapper,
     private val getWooVersion: GetWooCorePluginCachedVersion,
     private val appPrefs: AppPrefsWrapper,
-    private val ciabSiteGateKeeper: CIABSiteGateKeeper,
     private val featureFlagRepository: FeatureFlagRepository,
     private val pushNotificationRepository: PushNotificationRepository
 ) : MainSettingsContract.Presenter {
@@ -130,7 +127,7 @@ class MainSettingsPresenter @Inject constructor(
         get() = selectedSite.get().isWPComAtomic
 
     override val isPluginsSectionVisible: Boolean
-        get() = ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.Plugins)
+        get() = true
 
     override fun setupEnablePushNotificationsOption() {
         coroutineScope.launch {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/IsBlazeEnabledTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/IsBlazeEnabledTest.kt
@@ -1,12 +1,9 @@
 package com.woocommerce.android.ui.blaze
 
-import com.woocommerce.android.ciab.CIABAffectedFeature
-import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
-import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.given
 import org.mockito.kotlin.mock
 import org.wordpress.android.fluxc.model.SiteModel
@@ -15,33 +12,8 @@ import kotlin.test.Test
 @OptIn(ExperimentalCoroutinesApi::class)
 class IsBlazeEnabledTest : BaseUnitTest() {
     private val selectedSite: SelectedSite = mock()
-    private val ciabSiteGateKeeper: CIABSiteGateKeeper = mock {
-        on { isFeatureSupported(CIABAffectedFeature.Blaze) } doReturn true
-    }
 
-    val sut = IsBlazeEnabled(selectedSite, ciabSiteGateKeeper)
-
-    @Test
-    fun `given Blaze is supported, when feature is disabled by CIAB gate keepe, then Blaze is disabled`() {
-        val site = createSite()
-        given(selectedSite.getOrNull()).willReturn(site)
-        given(ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.Blaze)).willReturn(false)
-
-        val result = sut.invoke()
-
-        assertThat(result).isFalse()
-    }
-
-    @Test
-    fun `given Blaze is supported, when feature is enabled by CIAB gate keeper, then Blaze is enabled`() {
-        val site = createSite()
-        given(selectedSite.getOrNull()).willReturn(site)
-        given(ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.Blaze)).willReturn(true)
-
-        val result = sut.invoke()
-
-        assertThat(result).isTrue()
-    }
+    val sut = IsBlazeEnabled(selectedSite)
 
     @Test
     fun `given site without admin capabilities, when checking if Blaze is enabled, then Blaze is disabled`() {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
@@ -10,8 +10,6 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_CARRIER
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_ERROR
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_STATE
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
-import com.woocommerce.android.ciab.CIABAffectedFeature
-import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.model.Address
 import com.woocommerce.android.model.AmbiguousLocation
 import com.woocommerce.android.model.Location
@@ -339,9 +337,6 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
     private val file: File = mock()
     private val analyticsTracker: AnalyticsTrackerWrapper = mock()
     private val createDefaultCustomsData = CreateDefaultCustomsData(mock())
-    private val ciabSiteGateKeeper: CIABSiteGateKeeper = mock {
-        on { isFeatureSupported(CIABAffectedFeature.WooShippingSplitShipments) } doReturn true
-    }
 
     private lateinit var sut: WooShippingLabelCreationViewModel
 
@@ -367,7 +362,6 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
             observeShippingLabelStatus = observeShippingLabelStatus,
             downloadAndPrintInvoiceUseCase = mock(),
             analyticsTracker = analyticsTracker,
-            ciabSiteGateKeeper = ciabSiteGateKeeper,
             savedState = savedState
         )
     }
@@ -2123,24 +2117,8 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given split shipments unsupported, when displaying shipments, then hide split option`() = testBlocking {
+    fun `given multiple items, when displaying shipments, then show split option`() = testBlocking {
         // The default `getShipments` mock already returns a shipment with multiple items
-        given(ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.WooShippingSplitShipments))
-            .willReturn(false)
-
-        createViewModel()
-
-        val currentViewState = sut.viewState.value as DataState
-
-        assertThat(currentViewState.shouldShowSplitShipmentButton).isFalse
-    }
-
-    @Test
-    fun `given split shipments supported, when displaying shipments, then hide split option`() = testBlocking {
-        // The default `getShipments` mock already returns a shipment with multiple items
-        given(ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.WooShippingSplitShipments))
-            .willReturn(true)
-
         createViewModel()
 
         val currentViewState = sut.viewState.value as DataState

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenterTest.kt
@@ -3,8 +3,6 @@ package com.woocommerce.android.ui.prefs
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
-import com.woocommerce.android.ciab.CIABAffectedFeature
-import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.notifications.NotificationChannelsHandler
 import com.woocommerce.android.notifications.NotificationChannelsHandler.NewOrderNotificationSoundStatus
 import com.woocommerce.android.notifications.push.PushNotificationRepository
@@ -33,7 +31,6 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -48,7 +45,6 @@ class MainSettingsPresenterTest : BaseUnitTest() {
     private val analyticsTracker: AnalyticsTrackerWrapper = mock()
     private val getWooVersion: GetWooCorePluginCachedVersion = mock()
     private val appPrefs: AppPrefsWrapper = mock()
-    private val ciabSiteGateKeeper: CIABSiteGateKeeper = mock()
     private val shouldShowEnablePushNotificationsUi: ShouldShowEnablePushNotificationsUi = mock()
     private val featureFlagRepository: FeatureFlagRepository = mock()
     private val pushNotificationRepository: PushNotificationRepository = mock()
@@ -70,7 +66,6 @@ class MainSettingsPresenterTest : BaseUnitTest() {
             analyticsTracker = analyticsTracker,
             getWooVersion = getWooVersion,
             appPrefs = appPrefs,
-            ciabSiteGateKeeper = ciabSiteGateKeeper,
             featureFlagRepository = featureFlagRepository,
             pushNotificationRepository = pushNotificationRepository
         )
@@ -262,23 +257,9 @@ class MainSettingsPresenterTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given CIAB site, when checking plugins section visibility, then plugins section is hidden`() =
+    fun `when checking plugins section visibility, then plugins section is visible`() =
         testBlocking {
-            setup {
-                whenever(ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.Plugins))
-                    .thenReturn(false)
-            }
-
-            assertFalse(presenter.isPluginsSectionVisible)
-        }
-
-    @Test
-    fun `given non-CIAB site, when checking plugins section visibility, then plugins section is visible`() =
-        testBlocking {
-            setup {
-                whenever(ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.Plugins))
-                    .thenReturn(true)
-            }
+            setup()
 
             assertTrue(presenter.isPluginsSectionVisible)
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenterTest.kt
@@ -31,7 +31,6 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class MainSettingsPresenterTest : BaseUnitTest() {
@@ -254,14 +253,6 @@ class MainSettingsPresenterTest : BaseUnitTest() {
 
             verify(view, times(1)).setEnablePushNotificationsOptionVisible(true)
             verify(view, times(1)).setEnablePushNotificationsOptionVisible(false)
-        }
-
-    @Test
-    fun `when checking plugins section visibility, then plugins section is visible`() =
-        testBlocking {
-            setup()
-
-            assertTrue(presenter.isPluginsSectionVisible)
         }
 
     @Test


### PR DESCRIPTION
### Description

Fixes WOOMOB-3392

This PR removes three gates so these features behave on all sites the way they already do on **non-CIAB** sites. 

Changes — each drops the `CIABAffectedFeature` gate and keeps the non-CIAB path:

- **`IsBlazeEnabled.kt`** — dropped the `CIABAffectedFeature.Blaze` clause and the now-unused `ciabSiteGateKeeper` dependency. Blaze eligibility is still gated by `isAdmin`, a valid Jetpack connection, and `canBlaze`.
- **`MainSettingsPresenter.kt`** — `isPluginsSectionVisible` is now always `true`; removed the unused `ciabSiteGateKeeper` dependency.
- **`WooShippingLabelCreationViewModel.kt`** — removed the split-shipments gate. The `isSplitShipmentsSupported` field was introduced solely by the CIAB gating commit, so this reverts to the exact pre-CIAB shape: the field and param are removed and `shouldShowSplitShipmentButton` no longer checks it (keeping the later multi-item refactor intact).
- **`CIABAffectedFeature.kt`** — removed the three now-unused enum entries (`Blaze`, `Plugins`, `WooShippingSplitShipments`). They fell through the `else` branch in `CIABSiteGateKeeper`, so no gatekeeper logic changed.
- Tests updated to drop the CIAB-specific cases/mocks.



### Test Steps

Confirm no behavior change:
1. Blaze entry points still appear for an admin site with a valid Jetpack connection and Blaze capability.
2. Settings still shows the **Plugins** section.
3. In shipping label creation for an order with multiple items, the **split shipment** option still appears.

### Images/gif

N/A

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.