### PR TITLE
[WOOMOB-3387] Revert In-Person Payments CIAB gating

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ciab/CIABAffectedFeature.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ciab/CIABAffectedFeature.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android.ciab
 
 enum class CIABAffectedFeature {
-    InPersonPayments,
     GroupedProducts,
     VariableProducts,
     SubscriptionProducts,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ciab/CIABSiteGateKeeper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ciab/CIABSiteGateKeeper.kt
@@ -9,7 +9,6 @@ class CIABSiteGateKeeper @Inject constructor(private val selectedSite: SelectedS
     ): Boolean {
         return when (feature) {
             CIABAffectedFeature.POS -> true
-            CIABAffectedFeature.InPersonPayments -> !isCurrentSiteCIAB() || isCurrentSiteProCIAB()
             else -> !isCurrentSiteCIAB()
         }
     }
@@ -20,11 +19,6 @@ class CIABSiteGateKeeper @Inject constructor(private val selectedSite: SelectedS
 
     fun isCurrentSiteCIAB(): Boolean =
         selectedSite.getOrNull()?.isCIABSite() ?: false
-
-    private fun isCurrentSiteProCIAB(): Boolean {
-        val site = selectedSite.getOrNull() ?: return false
-        return site.isCIABSite() && CIAB_PRO_PLAN_SLUGS.contains(site.planProductSlug)
-    }
 
     fun buildPlanUpgradeUrl(): String {
         val siteUrl = selectedSite.getOrNull()?.url

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
@@ -19,8 +19,6 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_MORE_M
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_MORE_MENU_UPGRADES
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_MORE_MENU_VIEW_STORE
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
-import com.woocommerce.android.ciab.CIABAffectedFeature
-import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.extensions.adminUrlOrDefault
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.notifications.UnseenReviewsCountHandler
@@ -73,7 +71,6 @@ class MoreMenuViewModel @Inject constructor(
     private val isGoogleForWooEnabled: IsGoogleForWooEnabled,
     private val hasGoogleAdsCampaigns: HasGoogleAdsCampaigns,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
-    private val ciabSiteGateKeeper: CIABSiteGateKeeper,
 ) : ScopedViewModel(savedState) {
     private var storeHasGoogleAdsCampaigns = false
 
@@ -124,7 +121,6 @@ class MoreMenuViewModel @Inject constructor(
             googleForWooState = buttonsStates[MoreMenuItemButton.Type.GoogleForWoo]!!,
             blazeState = buttonsStates[MoreMenuItemButton.Type.Blaze]!!,
             inboxState = buttonsStates[MoreMenuItemButton.Type.Inbox]!!,
-            paymentsState = buttonsStates[MoreMenuItemButton.Type.Payments]!!,
         )
     )
 
@@ -143,7 +139,6 @@ class MoreMenuViewModel @Inject constructor(
         googleForWooState: MoreMenuItemButton.State,
         blazeState: MoreMenuItemButton.State,
         inboxState: MoreMenuItemButton.State,
-        paymentsState: MoreMenuItemButton.State,
     ) = MoreMenuItemSection(
         title = R.string.more_menu_general_section_title,
         items = listOf(
@@ -153,7 +148,6 @@ class MoreMenuViewModel @Inject constructor(
                 icon = R.drawable.ic_more_menu_payments,
                 badgeState = buildPaymentsBadgeState(paymentsFeatureWasClicked),
                 onClick = ::onPaymentsButtonClick,
-                state = paymentsState
             ),
             MoreMenuItemButton(
                 title = R.string.more_menu_button_google,
@@ -471,9 +465,6 @@ class MoreMenuViewModel @Inject constructor(
             doCheckAvailability(MoreMenuItemButton.Type.GoogleForWoo) { isGoogleForWooEnabled() },
             doCheckAvailability(MoreMenuItemButton.Type.Inbox) { moreMenuRepository.isInboxEnabled() },
             doCheckAvailability(MoreMenuItemButton.Type.Settings) { moreMenuRepository.isUpgradesEnabled() },
-            doCheckAvailability(MoreMenuItemButton.Type.Payments) {
-                ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.InPersonPayments)
-            },
         ).merge()
             .map { update ->
                 initialState[update.first] = update.second

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentCollectibilityChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentCollectibilityChecker.kt
@@ -1,7 +1,5 @@
 package com.woocommerce.android.ui.payments.cardreader.payment
 
-import com.woocommerce.android.ciab.CIABAffectedFeature
-import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.extensions.CASH_ON_DELIVERY_PAYMENT_TYPE
 import com.woocommerce.android.extensions.STRIPE_PAYMENTS_PAYMENT_TYPE
 import com.woocommerce.android.extensions.WOOCOMMERCE_BOOKINGS_PAYMENT_TYPE
@@ -18,20 +16,18 @@ import javax.inject.Inject
 
 class CardReaderPaymentCollectibilityChecker @Inject constructor(
     private val orderDetailRepository: OrderDetailRepository,
-    private val cardReaderPaymentCurrencySupportedChecker: CardReaderPaymentCurrencySupportedChecker,
-    private val ciabSiteGateKeeper: CIABSiteGateKeeper
+    private val cardReaderPaymentCurrencySupportedChecker: CardReaderPaymentCurrencySupportedChecker
 ) {
     suspend fun isCollectable(order: Order, allowCancelledStatus: Boolean = false): Boolean {
-        return ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.InPersonPayments) &&
-            with(order) {
-                cardReaderPaymentCurrencySupportedChecker.isCurrencySupported(currency) &&
-                    isStatusCollectable(allowCancelledStatus) &&
-                    !isOrderPaid &&
-                    order.total.compareTo(BigDecimal.ZERO) == 1 &&
-                    BigDecimal.ZERO.compareTo(order.refundTotal) == 0 &&
-                    isPaymentMethodCollectable() &&
-                    !orderDetailRepository.hasSubscriptionProducts(order.getProductIds())
-            }
+        return with(order) {
+            cardReaderPaymentCurrencySupportedChecker.isCurrencySupported(currency) &&
+                isStatusCollectable(allowCancelledStatus) &&
+                !isOrderPaid &&
+                order.total.compareTo(BigDecimal.ZERO) == 1 &&
+                BigDecimal.ZERO.compareTo(order.refundTotal) == 0 &&
+                isPaymentMethodCollectable() &&
+                !orderDetailRepository.hasSubscriptionProducts(order.getProductIds())
+        }
     }
 
     private fun Order.isPaymentMethodCollectable() =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodFragment.kt
@@ -128,20 +128,9 @@ class SelectPaymentMethodFragment : BaseFragment(R.layout.fragment_select_paymen
             binding.container.addView(MaterialDivider(requireContext()))
         }
 
-        when (val footer = state.learnMoreIpp) {
-            is Success.LearnMoreIpp.Standard -> {
-                binding.learnMoreIppPaymentMethodsTv.learnMore.isVisible = footer.isVisible
-                binding.learnMoreIppPaymentMethodsTv.learnMore.setOnClickListener { footer.onClick() }
-                UiHelpers.setTextOrHide(binding.learnMoreIppPaymentMethodsTv.learnMore, footer.label)
-            }
-            is Success.LearnMoreIpp.CiabUpgrade -> {
-                binding.learnMoreIppPaymentMethodsTv.learnMore.isVisible = true
-                UiHelpers.setTextOrHide(binding.learnMoreIppPaymentMethodsTv.learnMore, footer.text)
-                binding.learnMoreIppPaymentMethodsTv.learnMore.setOnClickListener { footer.onLearnMoreClick() }
-            }
-            is Success.LearnMoreIpp.Hidden -> {
-                binding.learnMoreIppPaymentMethodsTv.learnMore.isVisible = false
-            }
+        with(binding.learnMoreIppPaymentMethodsTv) {
+            learnMore.setOnClickListener { state.learnMoreIpp.onClick.invoke() }
+            UiHelpers.setTextOrHide(binding.learnMoreIppPaymentMethodsTv.learnMore, state.learnMoreIpp.label)
         }
     }
 
@@ -340,7 +329,6 @@ class SelectPaymentMethodFragment : BaseFragment(R.layout.fragment_select_paymen
     override fun onResume() {
         super.onResume()
         AnalyticsTracker.trackViewShown(this)
-        viewModel.onResumed()
     }
 
     override fun onStop() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodViewModel.kt
@@ -11,14 +11,11 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_SIMPLE
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_SIMPLE_PAYMENTS_COLLECT_CASH
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_SIMPLE_PAYMENTS_COLLECT_LINK
 import com.woocommerce.android.cardreader.internal.payments.PaymentUtils
-import com.woocommerce.android.ciab.CIABAffectedFeature
-import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.extensions.CASH_ON_DELIVERY_PAYMENT_TYPE
 import com.woocommerce.android.extensions.isNotNullOrEmpty
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.OrderMapper
 import com.woocommerce.android.model.UiString.UiStringRes
-import com.woocommerce.android.model.UiString.UiStringText
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.tracker.OrderDurationRecorder
@@ -45,7 +42,6 @@ import com.woocommerce.android.ui.payments.tracking.PaymentsFlowTracker
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.viewmodel.MultiLiveEvent
-import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -81,9 +77,7 @@ class SelectPaymentMethodViewModel @Inject constructor(
     private val tapToPayAvailabilityStatus: TapToPayAvailabilityStatus,
     private val cardReaderTrackingInfoKeeper: CardReaderTrackingInfoKeeper,
     private val paymentsUtils: PaymentUtils,
-    private val logOrderCurrencyMismatchWithSiteSettings: SelectPaymentMethodCurrencyMissMatchLog,
-    private val ciabSiteGateKeeper: CIABSiteGateKeeper,
-    private val resourceProvider: ResourceProvider
+    private val logOrderCurrencyMismatchWithSiteSettings: SelectPaymentMethodCurrencyMissMatchLog
 ) : ScopedViewModel(savedState) {
     private val navArgs: SelectPaymentMethodFragmentArgs by savedState.navArgs()
 
@@ -94,8 +88,6 @@ class SelectPaymentMethodViewModel @Inject constructor(
     private val order = _order.filterNotNull()
     private val cardReaderPaymentFlowParam
         get() = navArgs.cardReaderFlowParam as Payment
-
-    private var hasOpenedCiabLearnMore = false
 
     init {
         checkStatus()
@@ -177,7 +169,13 @@ class SelectPaymentMethodViewModel @Inject constructor(
         return Success(
             orderTotal = formatOrderTotal(order.total),
             rows = rows,
-            learnMoreIpp = buildLearnMoreIppState()
+            learnMoreIpp = Success.LearnMoreIpp(
+                label = UiStringRes(
+                    R.string.card_reader_connect_learn_more,
+                    containsHtml = true
+                ),
+                onClick = ::onLearnMoreIppClicked
+            )
         )
     }
 
@@ -477,38 +475,6 @@ class SelectPaymentMethodViewModel @Inject constructor(
             WOO_POS -> AnalyticsTracker.VALUE_WOO_POS_PAYMENTS_FLOW
         }
 
-    private fun buildLearnMoreIppState(): Success.LearnMoreIpp {
-        val ippSupported = ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.InPersonPayments)
-        val isCiab = ciabSiteGateKeeper.isCurrentSiteCIAB()
-
-        return when {
-            ippSupported -> Success.LearnMoreIpp.Standard(
-                label = UiStringRes(R.string.card_reader_connect_learn_more, containsHtml = true),
-                isVisible = true,
-                onClick = ::onLearnMoreIppClicked,
-            )
-            isCiab -> {
-                val body = resourceProvider.getString(R.string.woopos_eligibility_reason_ciab_plan_upgrade_html)
-                val learnMore = resourceProvider.getString(R.string.woopos_eligibility_learn_more_label)
-                Success.LearnMoreIpp.CiabUpgrade(
-                    text = UiStringText("$body <a href=''>$learnMore</a>", containsHtml = true),
-                    onLearnMoreClick = ::onCiabLearnMoreClicked,
-                )
-            }
-            else -> Success.LearnMoreIpp.Hidden
-        }
-    }
-
-    private fun onCiabLearnMoreClicked() {
-        hasOpenedCiabLearnMore = true
-        paymentsFlowTracker.trackIPPLearnMoreClicked(CIAB_UPGRADE_SOURCE)
-        triggerEvent(
-            MultiLiveEvent.Event.LaunchUrlInAuthenticatedWebView(
-                url = ciabSiteGateKeeper.buildPlanUpgradeUrl()
-            )
-        )
-    }
-
     private fun onLearnMoreIppClicked() {
         paymentsFlowTracker.trackIPPLearnMoreClicked(SOURCE)
         triggerEvent(
@@ -530,23 +496,11 @@ class SelectPaymentMethodViewModel @Inject constructor(
             wooCommerceStore.getSiteSettings(selectedSite.get())?.currencyCode ?: ""
         }
 
-    fun onResumed() {
-        if (!hasOpenedCiabLearnMore) return
-        hasOpenedCiabLearnMore = false
-        launch {
-            wooCommerceStore.fetchWooCommerceSite(selectedSite.get()).model?.let {
-                selectedSite.set(it)
-            }
-            showPaymentState()
-        }
-    }
-
     companion object {
         private const val DELAY_MS = 1L
         const val UTM_CAMPAIGN = "feature_announcement_card"
         const val UTM_SOURCE = "payment_method"
         const val UTM_CONTENT = "upsell_card_readers"
         private const val SOURCE = "payment_methods"
-        private const val CIAB_UPGRADE_SOURCE = "ciab_upgrade"
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodViewState.kt
@@ -28,19 +28,9 @@ sealed class SelectPaymentMethodViewState {
             ) : Row()
         }
 
-        sealed interface LearnMoreIpp {
-            data class Standard(
-                val label: UiString,
-                val isVisible: Boolean,
-                val onClick: () -> Unit,
-            ) : LearnMoreIpp
-
-            data class CiabUpgrade(
-                val text: UiString,
-                val onLearnMoreClick: () -> Unit,
-            ) : LearnMoreIpp
-
-            object Hidden : LearnMoreIpp
-        }
+        data class LearnMoreIpp(
+            val label: UiString,
+            val onClick: () -> Unit,
+        )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/TapToPayAvailabilityStatus.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/TapToPayAvailabilityStatus.kt
@@ -3,8 +3,6 @@ package com.woocommerce.android.ui.payments.taptopay
 import com.woocommerce.android.cardreader.config.CardReaderConfigForSupportedCountry
 import com.woocommerce.android.cardreader.config.CardReaderConfigForUnsupportedCountry
 import com.woocommerce.android.cardreader.connection.ReaderType
-import com.woocommerce.android.ciab.CIABAffectedFeature
-import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.payments.cardreader.CardReaderCountryConfigProvider
 import com.woocommerce.android.util.DeviceFeatures
@@ -18,12 +16,10 @@ class TapToPayAvailabilityStatus @Inject constructor(
     private val systemVersionUtilsWrapper: SystemVersionUtilsWrapper,
     private val cardReaderCountryConfigProvider: CardReaderCountryConfigProvider,
     private val wooStore: WooCommerceStore,
-    private val ciabSiteGateKeeper: CIABSiteGateKeeper,
     private val tapToPayDeviceSupportChecker: TapToPayDeviceSupportChecker,
 ) {
     operator fun invoke() =
         when {
-            ciabSiteGateKeeper.isFeatureUnsupported(CIABAffectedFeature.InPersonPayments) -> Result.Hidden
             !systemVersionUtilsWrapper.isAtLeastR() -> Result.NotAvailable.SystemVersionNotSupported
             !deviceFeatures.isGooglePlayServicesAvailable() -> Result.NotAvailable.GooglePlayServicesNotAvailable
             !deviceFeatures.isNFCAvailable() -> Result.NotAvailable.NfcNotAvailable
@@ -44,7 +40,6 @@ class TapToPayAvailabilityStatus @Inject constructor(
 
     sealed class Result {
         object Available : Result()
-        object Hidden : Result()
         sealed class NotAvailable : Result() {
             object SystemVersionNotSupported : NotAvailable()
             object GooglePlayServicesNotAvailable : NotAvailable()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/shortcuts/AppShortcutsHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/shortcuts/AppShortcutsHandler.kt
@@ -5,8 +5,6 @@ import android.content.Intent
 import androidx.core.content.pm.ShortcutInfoCompat
 import androidx.core.content.pm.ShortcutManagerCompat
 import androidx.core.graphics.drawable.IconCompat
-import com.woocommerce.android.ciab.CIABAffectedFeature
-import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.di.AppCoroutineScope
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.main.MainActivity
@@ -18,7 +16,6 @@ import javax.inject.Inject
 class AppShortcutsHandler @Inject constructor(
     private val context: Context,
     private val selectedSite: SelectedSite,
-    private val ciabSiteGateKeeper: CIABSiteGateKeeper,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
 ) {
     fun init() {
@@ -37,10 +34,7 @@ class AppShortcutsHandler @Inject constructor(
 
     private fun buildShortcutsList(): List<ShortcutInfoCompat> {
         return buildList {
-            if (ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.InPersonPayments)) {
-                add(AppShortcut.Payments.toShortcutInfo())
-            }
-
+            add(AppShortcut.Payments.toShortcutInfo())
             add(AppShortcut.CreateOrder.toShortcutInfo())
         }
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ciab/CIABSiteGateKeeperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ciab/CIABSiteGateKeeperTest.kt
@@ -23,77 +23,11 @@ class CIABSiteGateKeeperTest : BaseUnitTest() {
         // WHEN / THEN
         CIABAffectedFeature.entries
             .filter {
-                it != CIABAffectedFeature.POS &&
-                    it != CIABAffectedFeature.InPersonPayments
+                it != CIABAffectedFeature.POS
             }
             .forEach {
                 assertThat(ciabSiteGateKeeper.isFeatureSupported(it)).isFalse()
             }
-    }
-
-    @Test
-    fun `given current site is CIAB without Pro plan, when checking InPersonPayments support, then feature is unsupported`() {
-        // GIVEN
-        val site = createSite(isCIAB = true, planSlug = "woo_hosted_free_plan")
-        given(selectedSite.getOrNull()).willReturn(site)
-
-        // WHEN
-        val result = ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.InPersonPayments)
-
-        // THEN
-        assertThat(result).isFalse()
-    }
-
-    @Test
-    fun `given CIAB site with Pro monthly plan, when checking IPP support, then feature is supported`() {
-        // GIVEN
-        val site = createSite(isCIAB = true, planSlug = "woo_hosted_pro_plan_monthly")
-        given(selectedSite.getOrNull()).willReturn(site)
-
-        // WHEN
-        val result = ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.InPersonPayments)
-
-        // THEN
-        assertThat(result).isTrue()
-    }
-
-    @Test
-    fun `given CIAB site with Pro yearly plan, when checking IPP support, then feature is supported`() {
-        // GIVEN
-        val site = createSite(isCIAB = true, planSlug = "woo_hosted_pro_plan_yearly")
-        given(selectedSite.getOrNull()).willReturn(site)
-
-        // WHEN
-        val result = ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.InPersonPayments)
-
-        // THEN
-        assertThat(result).isTrue()
-    }
-
-    @Test
-    fun `given CIAB site with free plan, when checking IPP support, then feature is unsupported`() {
-        // GIVEN
-        val site = createSite(isCIAB = true, planSlug = "woo_hosted_free_plan")
-        given(selectedSite.getOrNull()).willReturn(site)
-
-        // WHEN
-        val result = ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.InPersonPayments)
-
-        // THEN
-        assertThat(result).isFalse()
-    }
-
-    @Test
-    fun `given non-CIAB site, when checking IPP support, then feature is supported`() {
-        // GIVEN
-        val site = createSite(isCIAB = false)
-        given(selectedSite.getOrNull()).willReturn(site)
-
-        // WHEN
-        val result = ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.InPersonPayments)
-
-        // THEN
-        assertThat(result).isTrue()
     }
 
     @Test
@@ -115,11 +49,10 @@ class CIABSiteGateKeeperTest : BaseUnitTest() {
             }
     }
 
-    private fun createSite(isCIAB: Boolean, planSlug: String? = null): SiteModel {
+    private fun createSite(isCIAB: Boolean): SiteModel {
         return SiteModel().apply {
             setIsGardenSite(isCIAB)
             this.gardenName = if (isCIAB) SiteModel.CIAB_GARDEN_NAME else null
-            this.planProductSlug = planSlug
         }
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModelTests.kt
@@ -3,8 +3,6 @@ package com.woocommerce.android.ui.moremenu
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
-import com.woocommerce.android.ciab.CIABAffectedFeature
-import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.notifications.UnseenReviewsCountHandler
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.blaze.IsBlazeEnabled
@@ -89,10 +87,6 @@ class MoreMenuViewModelTests : BaseUnitTest() {
 
     private val blazeCampaignsStore: BlazeCampaignsStore = mock()
 
-    private val ciabSiteGateKeeper: CIABSiteGateKeeper = mock {
-        on { isFeatureSupported(any()) } doReturn true
-    }
-
     private lateinit var viewModel: MoreMenuViewModel
     private val tapToPayAvailabilityStatus: TapToPayAvailabilityStatus = mock()
 
@@ -113,7 +107,6 @@ class MoreMenuViewModelTests : BaseUnitTest() {
             isGoogleForWooEnabled = isGoogleForWooEnabled,
             hasGoogleAdsCampaigns = hasGoogleAdsCampaigns,
             analyticsTrackerWrapper = analyticsTrackerWrapper,
-            ciabSiteGateKeeper = ciabSiteGateKeeper,
         )
     }
 
@@ -493,22 +486,6 @@ class MoreMenuViewModelTests : BaseUnitTest() {
 
         // THEN
         assertThat(event).isInstanceOf(MultiLiveEvent.Event.LaunchUrlInAuthenticatedWebView::class.java)
-    }
-
-    @Test
-    fun `given CIAB reports payments disabled, when building state, then payments button is hidden`() = testBlocking {
-        // GIVEN
-        setup {
-            whenever(ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.InPersonPayments))
-                .thenReturn(false)
-        }
-
-        // WHEN
-        val state = viewModel.moreMenuViewState.captureValues().last()
-
-        // THEN
-        val items = state.menuSections.flatMap { it.items }
-        assertThat(items.none { it.title == R.string.more_menu_button_payments }).isTrue()
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/SelectPaymentMethodViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/SelectPaymentMethodViewModelTest.kt
@@ -3,8 +3,6 @@ package com.woocommerce.android.ui.payments
 import com.woocommerce.android.AppUrls
 import com.woocommerce.android.R
 import com.woocommerce.android.cardreader.internal.payments.PaymentUtils
-import com.woocommerce.android.ciab.CIABAffectedFeature
-import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.extensions.CASH_ON_DELIVERY_PAYMENT_TYPE
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.OrderMapper
@@ -47,7 +45,6 @@ import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.any
-import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -116,9 +113,6 @@ class SelectPaymentMethodViewModelTest : BaseUnitTest() {
     private val paymentsUtils: PaymentUtils = mock()
     private val cardReaderTrackingInfoKeeper: CardReaderTrackingInfoKeeper = mock()
     private val logOrderCurrencyMismatchWithSiteSettings = mock<SelectPaymentMethodCurrencyMissMatchLog>()
-    private val ciabSiteGateKeeper: CIABSiteGateKeeper = mock {
-        on { isFeatureSupported(CIABAffectedFeature.InPersonPayments) } doReturn true
-    }
 
     @Test
     fun `given hub flow, when view model init, then navigate to hub flow emitted`() = testBlocking {
@@ -917,7 +911,7 @@ class SelectPaymentMethodViewModelTest : BaseUnitTest() {
         )
 
         // WHEN
-        ((viewModel.viewStateData.value as Success).learnMoreIpp as Success.LearnMoreIpp.Standard).onClick.invoke()
+        (viewModel.viewStateData.value as Success).learnMoreIpp.onClick.invoke()
 
         // THEN
         assertThat(viewModel.event.value).isInstanceOf(OpenGenericWebView::class.java)
@@ -934,7 +928,7 @@ class SelectPaymentMethodViewModelTest : BaseUnitTest() {
         )
 
         // WHEN
-        ((viewModel.viewStateData.value as Success).learnMoreIpp as Success.LearnMoreIpp.Standard).onClick.invoke()
+        (viewModel.viewStateData.value as Success).learnMoreIpp.onClick.invoke()
 
         // THEN
         assertThat(viewModel.event.value).isEqualTo(
@@ -1196,20 +1190,6 @@ class SelectPaymentMethodViewModelTest : BaseUnitTest() {
         )
     }
 
-    @Test
-    fun `given WooPayments unsupported by CIAB, when view model initialized, then hide IPP learn more link`() =
-        testBlocking {
-            // GIVEN
-            whenever(ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.InPersonPayments)).thenReturn(false)
-
-            // WHEN
-            val viewModel = initViewModel(Payment(1L, ORDER))
-
-            // THEN
-            val state = (viewModel.viewStateData.value as Success).learnMoreIpp
-            assertThat(state).isInstanceOf(Success.LearnMoreIpp.Hidden::class.java)
-        }
-
     private fun initViewModel(cardReaderFlowParam: CardReaderFlowParam): SelectPaymentMethodViewModel {
         return SelectPaymentMethodViewModel(
             savedState = SelectPaymentMethodFragmentArgs(
@@ -1229,9 +1209,7 @@ class SelectPaymentMethodViewModelTest : BaseUnitTest() {
             tapToPayAvailabilityStatus = tapToPayAvailabilityStatus,
             cardReaderTrackingInfoKeeper = cardReaderTrackingInfoKeeper,
             paymentsUtils = paymentsUtils,
-            logOrderCurrencyMismatchWithSiteSettings = logOrderCurrencyMismatchWithSiteSettings,
-            ciabSiteGateKeeper = ciabSiteGateKeeper,
-            resourceProvider = mock()
+            logOrderCurrencyMismatchWithSiteSettings = logOrderCurrencyMismatchWithSiteSettings
         )
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderPaymentCollectibilityCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderPaymentCollectibilityCheckerTest.kt
@@ -1,7 +1,5 @@
 package com.woocommerce.android.ui.payments.cardreader
 
-import com.woocommerce.android.ciab.CIABAffectedFeature
-import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.orders.OrderTestUtils
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
@@ -24,13 +22,9 @@ import java.util.Date
 class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
     private val repository: OrderDetailRepository = mock()
     private val cardReaderPaymentCurrencySupportedChecker: CardReaderPaymentCurrencySupportedChecker = mock()
-    private val testCiabSiteGateKeeper: CIABSiteGateKeeper = mock {
-        on { isFeatureSupported(CIABAffectedFeature.InPersonPayments) } doReturn true
-    }
     private val checker: CardReaderPaymentCollectibilityChecker = CardReaderPaymentCollectibilityChecker(
         orderDetailRepository = repository,
-        cardReaderPaymentCurrencySupportedChecker = cardReaderPaymentCurrencySupportedChecker,
-        ciabSiteGateKeeper = testCiabSiteGateKeeper
+        cardReaderPaymentCurrencySupportedChecker = cardReaderPaymentCurrencySupportedChecker
     )
 
     private val generatedOrder = OrderTestUtils.generateTestOrder()
@@ -348,20 +342,6 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
 
             // THEN
             assertThat(isCollectable).isTrue()
-        }
-
-    @Test
-    fun `given WooPayments is not supported by CIAB, when check order is collectable, then returns false`() =
-        testBlocking {
-            // GIVEN
-            whenever(testCiabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.InPersonPayments)) doReturn false
-            val order = getOrder()
-
-            // WHEN
-            val isCollectable = checker.isCollectable(order)
-
-            // THEN
-            assertThat(isCollectable).isFalse()
         }
 
     private fun getOrder(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/taptopay/TapToPayAvailabilityStatusTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/taptopay/TapToPayAvailabilityStatusTest.kt
@@ -3,8 +3,6 @@ package com.woocommerce.android.ui.payments.taptopay
 import com.woocommerce.android.cardreader.config.CardReaderConfigForCanada
 import com.woocommerce.android.cardreader.config.CardReaderConfigForUSA
 import com.woocommerce.android.cardreader.config.CardReaderConfigForUnsupportedCountry
-import com.woocommerce.android.ciab.CIABAffectedFeature
-import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.payments.cardreader.CardReaderCountryConfigProvider
 import com.woocommerce.android.util.DeviceFeatures
@@ -33,9 +31,6 @@ class TapToPayAvailabilityStatusTest {
         on { getStoreCountryCode(siteModel) }.thenReturn("US")
     }
     private val deviceFeatures = mock<DeviceFeatures>()
-    private val ciabSiteGateKeeper: CIABSiteGateKeeper = mock {
-        on { isFeatureUnsupported(CIABAffectedFeature.InPersonPayments) }.thenReturn(false)
-    }
     private val tapToPayDeviceSupportChecker: TapToPayDeviceSupportChecker = mock {
         on { isSupported() }.thenReturn(true)
     }
@@ -46,7 +41,6 @@ class TapToPayAvailabilityStatusTest {
         systemVersionUtilsWrapper = systemVersionUtilsWrapper,
         cardReaderCountryConfigProvider = cardReaderCountryConfigProvider,
         wooStore = wooStore,
-        ciabSiteGateKeeper = ciabSiteGateKeeper,
         tapToPayDeviceSupportChecker = tapToPayDeviceSupportChecker,
     )
 
@@ -128,17 +122,5 @@ class TapToPayAvailabilityStatusTest {
         val result = availabilityStatus.invoke()
 
         assertThat(result).isEqualTo(TapToPayAvailabilityStatus.Result.Available)
-    }
-
-    @Test
-    fun `given CIAB blocks WooPayments, when invoking, then tpp hidden returned`() {
-        whenever(deviceFeatures.isNFCAvailable()).thenReturn(true)
-        whenever(deviceFeatures.isGooglePlayServicesAvailable()).thenReturn(true)
-        whenever(systemVersionUtilsWrapper.isAtLeastR()).thenReturn(true)
-        whenever(ciabSiteGateKeeper.isFeatureUnsupported(CIABAffectedFeature.InPersonPayments)).thenReturn(true)
-
-        val result = availabilityStatus.invoke()
-
-        assertThat(result).isEqualTo(TapToPayAvailabilityStatus.Result.Hidden)
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardreader/WooPosIsTapToPayAvailableTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardreader/WooPosIsTapToPayAvailableTest.kt
@@ -32,14 +32,6 @@ class WooPosIsTapToPayAvailableTest {
     }
 
     @Test
-    fun `given flag on but Hidden, when invoked, then returns false`() {
-        whenever(featureFlagRepository.isEnabled(FeatureFlag.WOO_POS_TAP_TO_PAY)).thenReturn(true)
-        whenever(tapToPayAvailabilityStatus.invoke()).thenReturn(TapToPayAvailabilityStatus.Result.Hidden)
-
-        assertThat(sut()).isFalse()
-    }
-
-    @Test
     fun `given flag on but country not supported, when invoked, then returns false`() {
         val unavailable: TapToPayAvailabilityStatus = mock {
             on { invoke() } doReturn TapToPayAvailabilityStatus.Result.NotAvailable.CountryNotSupported

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
@@ -179,7 +179,7 @@ class WooPosTotalsViewModelTest {
     private val featureFlagRepository: FeatureFlagRepository = mock()
     private val builtInReaderConnector: WooPosBuiltInReaderConnector = mock()
     private val tapToPayAvailabilityStatus: TapToPayAvailabilityStatus = mock {
-        on { invoke() } doReturn TapToPayAvailabilityStatus.Result.Hidden
+        on { invoke() } doReturn TapToPayAvailabilityStatus.Result.Available
     }
     private val remoteReaderSession: WooPosRemoteReaderSession = mock {
         on { state }.thenReturn(MutableStateFlow(WooPosRemoteReaderSession.State.Idle))
@@ -2314,10 +2314,10 @@ class WooPosTotalsViewModelTest {
         }
 
     @Test
-    fun `given flag on and TTP Hidden, when ViewModel created, then reason not tracked`() = runTest {
+    fun `given flag on and TTP Available, when ViewModel created, then reason not tracked`() = runTest {
         // GIVEN
         whenever(isTapToPayAvailable.isFeatureFlagEnabled()).thenReturn(true)
-        whenever(tapToPayAvailabilityStatus.invoke()).thenReturn(TapToPayAvailabilityStatus.Result.Hidden)
+        whenever(tapToPayAvailabilityStatus.invoke()).thenReturn(TapToPayAvailabilityStatus.Result.Available)
         clearInvocations(tracker)
 
         // WHEN

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
@@ -2314,20 +2314,6 @@ class WooPosTotalsViewModelTest {
         }
 
     @Test
-    fun `given flag on and TTP Available, when ViewModel created, then reason not tracked`() = runTest {
-        // GIVEN
-        whenever(isTapToPayAvailable.isFeatureFlagEnabled()).thenReturn(true)
-        whenever(tapToPayAvailabilityStatus.invoke()).thenReturn(TapToPayAvailabilityStatus.Result.Available)
-        clearInvocations(tracker)
-
-        // WHEN
-        createViewModelAndSetupForSuccessfulOrderCreation()
-
-        // THEN
-        verify(tracker, never()).trackTapToPayNotAvailableReason(any(), any())
-    }
-
-    @Test
     fun `given missing location permission, when TTP clicked, then permission request event is emitted`() = runTest {
         // GIVEN
         whenever(networkStatus.isConnected()).thenReturn(true)


### PR DESCRIPTION
### Description

Fixes WOOMOB-3387

Part of the CIAB ("Commerce In A Box") retirement on Android. In-Person Payments call-sites were previously gated behind `CIABSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.InPersonPayments)`, which hid/blocked IPP on non-Pro CIAB sites. This PR unwinds that gating so IPP behaves as it always has on non-CIAB sites, and removes the `InPersonPayments` feature entirely.

What changed:
- **CardReaderPaymentCollectibilityChecker** — dropped the gate; card payments are collectible on the normal path.
- **TapToPayAvailabilityStatus** — removed the `Result.Hidden` branch and the `Hidden` result type; TTP availability is determined by device/country only.
- **SelectPaymentMethod (ViewModel/ViewState/Fragment)** — full revert of the "learn more IPP" footer to its pre-CIAB form (single `LearnMoreIpp` data class), removing the CIAB plan-upgrade "learn more" dialog branch and the post-upgrade `onResumed` refresh.
- **AppShortcutsHandler** — the Payments launcher shortcut is always added.
- **MoreMenuViewModel** — the "Payments" more-menu item is no longer gated; reverted to always visible.
- **CIABAffectedFeature / CIABSiteGateKeeper** — removed the `InPersonPayments` enum value and its dedicated gatekeeper branch (plus the now-orphaned `isCurrentSiteProCIAB()`). `CIAB_PRO_PLAN_SLUGS` and `buildPlanUpgradeUrl()` are kept — still used by POS eligibility.
- Tests updated to drop CIAB cases and assert the unconditional (available) behavior.

### Test Steps

On a standard (non-CIAB) store, behavior should be unchanged:

1. Open an unpaid order → **Collect Payment** is available and can be started with a card reader / Tap to Pay (subject to the usual device/country support).
2. On the payment method selection screen, confirm the "Learn more about In-Person Payments" footer link is shown and opens the learn-more web page.
3. Long-press the app launcher icon → the **Payments** shortcut is present.
4. Open **More menu** → the **Payments** entry is visible.

### Images/gif

N/A

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.