### PR TITLE
Log Jetpack Tunnel raw_body errors in support logs

### DIFF
--- a/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/jetpacktunnel/JetpackTunnelGsonRequestTest.kt
+++ b/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/jetpacktunnel/JetpackTunnelGsonRequestTest.kt
@@ -10,8 +10,8 @@ import org.junit.runner.RunWith
 import org.mockito.Mockito.mockStatic
 import org.robolectric.RobolectricTestRunner
 import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST
-import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequest
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.UrlUtils

--- a/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/jetpacktunnel/JetpackTunnelGsonRequestTest.kt
+++ b/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/jetpacktunnel/JetpackTunnelGsonRequestTest.kt
@@ -11,6 +11,7 @@ import org.mockito.Mockito.mockStatic
 import org.robolectric.RobolectricTestRunner
 import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequest
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.UrlUtils
@@ -149,15 +150,7 @@ class JetpackTunnelGsonRequestTest {
     @Test
     fun `given failed direct tunnel request, when error is delivered, then API warning logs and listener receives error`() {
         val receivedErrors = mutableListOf<WPComGsonNetworkError>()
-        val request = JetpackTunnelGsonRequest.buildGetRequest(
-            "/wc/v3/orders",
-            DUMMY_SITE_ID,
-            emptyMap(),
-            Any::class.java,
-            { _: Any?, _: Any? -> },
-            { error -> receivedErrors.add(error) },
-            null
-        )
+        val request = buildRequest("GET", "/wc/v3/orders", receivedErrors)
         val volleyError = buildVolleyError()
 
         mockStatic(AppLog::class.java).use { appLog ->
@@ -167,6 +160,8 @@ class JetpackTunnelGsonRequestTest {
                 AppLog.w(
                     AppLog.T.API,
                     "Jetpack Tunnel raw_body error: method=GET, path=/wc/v3/orders, " +
+                        "transport_status=502, proxy_status=500, error_code=no_response_body, " +
+                        "error_message=Remote site returned non-JSON response, " +
                         "raw_body_truncated=false, raw_body_snippet=<html>Fatal error</html>"
                 )
             }
@@ -174,6 +169,85 @@ class JetpackTunnelGsonRequestTest {
         assertThat(receivedErrors).hasSize(1)
         assertEquals("no_response_body", receivedErrors.single().apiError)
         assertEquals("<html>Fatal error</html>", receivedErrors.single().errorData?.optString("raw_body"))
+    }
+
+    @Test
+    fun `given failed direct tunnel requests, when errors are delivered, then each factory logs method and path`() {
+        val methods = listOf("GET", "POST", "PATCH", "PUT", "DELETE")
+        methods.forEach { method ->
+            val path = "/wc/v3/orders/${method.lowercase()}"
+            val receivedErrors = mutableListOf<WPComGsonNetworkError>()
+            val request = buildRequest(method, path, receivedErrors)
+
+            mockStatic(AppLog::class.java).use { appLog ->
+                request.deliverError(buildVolleyError())
+
+                appLog.verify {
+                    AppLog.w(
+                        AppLog.T.API,
+                        "Jetpack Tunnel raw_body error: method=$method, path=$path, " +
+                            "transport_status=502, proxy_status=500, error_code=no_response_body, " +
+                            "error_message=Remote site returned non-JSON response, " +
+                            "raw_body_truncated=false, raw_body_snippet=<html>Fatal error</html>"
+                    )
+                }
+            }
+            assertThat(receivedErrors).hasSize(1)
+        }
+    }
+
+    private fun buildRequest(
+        method: String,
+        path: String,
+        receivedErrors: MutableList<WPComGsonNetworkError>
+    ): WPComGsonRequest<*> {
+        val body = mapOf<String, Any>("name" to "test")
+        val listener = { _: Any?, _: Any? -> }
+        val errorListener = { error: WPComGsonNetworkError -> receivedErrors.add(error); Unit }
+        return when (method) {
+            "GET" -> JetpackTunnelGsonRequest.buildGetRequest(
+                path,
+                DUMMY_SITE_ID,
+                emptyMap(),
+                Any::class.java,
+                listener,
+                errorListener,
+                null
+            )
+            "POST" -> JetpackTunnelGsonRequest.buildPostRequest(
+                path,
+                DUMMY_SITE_ID,
+                body,
+                Any::class.java,
+                listener,
+                errorListener
+            )
+            "PATCH" -> JetpackTunnelGsonRequest.buildPatchRequest(
+                path,
+                DUMMY_SITE_ID,
+                body,
+                Any::class.java,
+                listener,
+                errorListener
+            )
+            "PUT" -> JetpackTunnelGsonRequest.buildPutRequest(
+                path,
+                DUMMY_SITE_ID,
+                body,
+                Any::class.java,
+                listener,
+                errorListener
+            )
+            "DELETE" -> JetpackTunnelGsonRequest.buildDeleteRequest(
+                path,
+                DUMMY_SITE_ID,
+                emptyMap(),
+                Any::class.java,
+                listener,
+                errorListener
+            )
+            else -> error("Unsupported method $method")
+        } ?: error("Expected request for $method")
     }
 
     private fun buildVolleyError(): VolleyError {

--- a/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/jetpacktunnel/JetpackTunnelGsonRequestTest.kt
+++ b/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/jetpacktunnel/JetpackTunnelGsonRequestTest.kt
@@ -1,12 +1,18 @@
 package org.wordpress.android.fluxc.jetpacktunnel
 
 import android.net.Uri
+import com.android.volley.NetworkResponse
+import com.android.volley.VolleyError
 import com.google.gson.Gson
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mockito.mockStatic
 import org.robolectric.RobolectricTestRunner
 import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequest
+import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.UrlUtils
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -138,5 +144,49 @@ class JetpackTunnelGsonRequestTest {
         assertEquals("{\"force\":\"true\"}", generatedBody["body"])
         assertEquals("/wp/v2/posts/6&_method=delete", generatedBody["path"])
         assertEquals("true", generatedBody["json"])
+    }
+
+    @Test
+    fun `given failed direct tunnel request, when error is delivered, then API warning logs and listener receives error`() {
+        val receivedErrors = mutableListOf<WPComGsonNetworkError>()
+        val request = JetpackTunnelGsonRequest.buildGetRequest(
+            "/wc/v3/orders",
+            DUMMY_SITE_ID,
+            emptyMap(),
+            Any::class.java,
+            { _: Any?, _: Any? -> },
+            { error -> receivedErrors.add(error) },
+            null
+        )
+        val volleyError = buildVolleyError()
+
+        mockStatic(AppLog::class.java).use { appLog ->
+            request?.deliverError(volleyError)
+
+            appLog.verify {
+                AppLog.w(
+                    AppLog.T.API,
+                    "Jetpack Tunnel raw_body error: method=GET, path=/wc/v3/orders, " +
+                        "raw_body_truncated=false, raw_body_snippet=<html>Fatal error</html>"
+                )
+            }
+        }
+        assertThat(receivedErrors).hasSize(1)
+        assertEquals("no_response_body", receivedErrors.single().apiError)
+        assertEquals("<html>Fatal error</html>", receivedErrors.single().errorData?.optString("raw_body"))
+    }
+
+    private fun buildVolleyError(): VolleyError {
+        val responseJson = """
+            {
+              "error": "no_response_body",
+              "message": "Remote site returned non-JSON response",
+              "data": {
+                "status": 500,
+                "raw_body": "<html>Fatal error</html>"
+              }
+            }
+        """.trimIndent()
+        return VolleyError(NetworkResponse(502, responseJson.toByteArray(), emptyMap(), true))
     }
 }

--- a/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/network/WPComGsonRequestTest.kt
+++ b/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/network/WPComGsonRequestTest.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.fluxc.network.rest.GsonRequest
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 
 @RunWith(RobolectricTestRunner::class)
 class WPComGsonRequestTest {
@@ -50,6 +51,35 @@ class WPComGsonRequestTest {
         assertEquals(GenericErrorType.UNKNOWN, augmentedError.type)
         assertEquals("rest_no_name", augmentedError.apiError)
         assertEquals("A name from which to derive username suggestions is required.", augmentedError.message)
+    }
+
+    @Test
+    fun `given top level data raw_body, when WPCom error is parsed, then errorData keeps raw_body`() {
+        val url = WPCOMREST.sites.site(123).posts.post(456).urlV1_1
+        val request = WPComGsonRequest.buildGetRequest(
+            url,
+            null,
+            Object::class.java,
+            mock<GsonRequest.ResponseListener<String>>(),
+            mock()
+        )
+
+        val responseJson = """
+            {
+              "error": "no_response_body",
+              "message": "Remote site returned non-JSON response",
+              "data": {
+                "status": 500,
+                "raw_body": "<html>Fatal error</html>"
+              }
+            }
+        """.trimIndent()
+        val baseNetworkError = buildErrorResponseObject(responseJson, 502)
+
+        val augmentedError = request.deliverBaseNetworkError(baseNetworkError) as WPComGsonNetworkError
+
+        assertNotNull(augmentedError.errorData)
+        assertEquals("<html>Fatal error</html>", augmentedError.errorData?.optString("raw_body"))
     }
 
     private fun buildErrorResponseObject(responseJson: String, errorCode: Int): BaseNetworkError {

--- a/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTunnelRawBodyErrorLoggerTest.kt
+++ b/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTunnelRawBodyErrorLoggerTest.kt
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel
 
+import com.android.volley.NetworkResponse
+import com.android.volley.VolleyError
 import org.assertj.core.api.Assertions.assertThat
 import org.json.JSONObject
 import org.junit.Test
@@ -23,6 +25,29 @@ class JetpackTunnelRawBodyErrorLoggerTest {
     }
 
     @Test
+    fun `given raw body and error context, when message is built, then it includes context fields`() {
+        val error = buildError(
+            rawBody = "<html>Fatal error</html>",
+            proxyStatus = 500,
+            transportStatus = 502
+        ).apply {
+            apiError = "no_response_body"
+            message = "Remote site returned non-JSON response"
+        }
+
+        val message = JetpackTunnelRawBodyErrorLogger.buildMessage("GET", "/wc/v3/orders", error)
+
+        assertThat(message).contains("method=GET")
+        assertThat(message).contains("path=/wc/v3/orders")
+        assertThat(message).contains("transport_status=502")
+        assertThat(message).contains("proxy_status=500")
+        assertThat(message).contains("error_code=no_response_body")
+        assertThat(message).contains("error_message=Remote site returned non-JSON response")
+        assertThat(message).contains("raw_body_truncated=false")
+        assertThat(message).contains("raw_body_snippet=<html>Fatal error</html>")
+    }
+
+    @Test
     fun `given no raw body is present, when message is built, then it returns null`() {
         val error = buildError(rawBody = null)
 
@@ -42,15 +67,29 @@ class JetpackTunnelRawBodyErrorLoggerTest {
                 AppLog.w(
                     AppLog.T.API,
                     "Jetpack Tunnel raw_body error: method=GET, path=/wc/v3/orders, " +
+                        "error_code=, error_message=, " +
                         "raw_body_truncated=false, raw_body_snippet=<html>Fatal error</html>"
                 )
             }
         }
     }
 
-    private fun buildError(rawBody: String?): WPComGsonNetworkError {
-        return WPComGsonNetworkError(BaseNetworkError(GenericErrorType.UNKNOWN)).apply {
-            errorData = rawBody?.let { JSONObject().put("raw_body", it) }
+    private fun buildError(
+        rawBody: String?,
+        proxyStatus: Int? = null,
+        transportStatus: Int? = null
+    ): WPComGsonNetworkError {
+        val baseError = transportStatus?.let { status ->
+            BaseNetworkError(VolleyError(NetworkResponse(status, byteArrayOf(), emptyMap(), true)))
+        } ?: BaseNetworkError(GenericErrorType.UNKNOWN)
+        return WPComGsonNetworkError(baseError).apply {
+            errorData = rawBody?.let {
+                JSONObject()
+                    .put("raw_body", it)
+                    .apply {
+                        proxyStatus?.let { status -> put("status", status) }
+                    }
+            }
         }
     }
 }

--- a/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTunnelRawBodyErrorLoggerTest.kt
+++ b/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTunnelRawBodyErrorLoggerTest.kt
@@ -1,0 +1,56 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel
+
+import org.assertj.core.api.Assertions.assertThat
+import org.json.JSONObject
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mockStatic
+import org.robolectric.RobolectricTestRunner
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
+import org.wordpress.android.util.AppLog
+
+@RunWith(RobolectricTestRunner::class)
+class JetpackTunnelRawBodyErrorLoggerTest {
+    @Test
+    fun `given raw body is present, when message is built, then it includes sanitized snippet`() {
+        val error = buildError(rawBody = "<html>\nFatal error</html>")
+
+        val message = JetpackTunnelRawBodyErrorLogger.buildMessage("GET", "/wc/v3/orders", error)
+
+        assertThat(message).contains("raw_body_snippet=<html> Fatal error</html>")
+    }
+
+    @Test
+    fun `given no raw body is present, when message is built, then it returns null`() {
+        val error = buildError(rawBody = null)
+
+        val message = JetpackTunnelRawBodyErrorLogger.buildMessage("GET", "/wc/v3/orders", error)
+
+        assertThat(message).isNull()
+    }
+
+    @Test
+    fun `given raw body is present, when logging, then API warning is emitted`() {
+        val error = buildError(rawBody = "<html>Fatal error</html>")
+
+        mockStatic(AppLog::class.java).use { appLog ->
+            JetpackTunnelRawBodyErrorLogger.logIfPresent("GET", "/wc/v3/orders", error)
+
+            appLog.verify {
+                AppLog.w(
+                    AppLog.T.API,
+                    "Jetpack Tunnel raw_body error: method=GET, path=/wc/v3/orders, " +
+                        "raw_body_truncated=false, raw_body_snippet=<html>Fatal error</html>"
+                )
+            }
+        }
+    }
+
+    private fun buildError(rawBody: String?): WPComGsonNetworkError {
+        return WPComGsonNetworkError(BaseNetworkError(GenericErrorType.UNKNOWN)).apply {
+            errorData = rawBody?.let { JSONObject().put("raw_body", it) }
+        }
+    }
+}

--- a/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTunnelRawBodyErrorLoggerTest.kt
+++ b/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTunnelRawBodyErrorLoggerTest.kt
@@ -130,6 +130,43 @@ class JetpackTunnelRawBodyErrorLoggerTest {
         assertThat(messageCaptor.value).doesNotContain(requestBodySecretValue)
     }
 
+    @Test
+    fun `given raw body below limit, when message is built, then complete raw body is included`() {
+        val rawBody = "a".repeat(MAX_RAW_BODY_LOG_CHARS - 1)
+        val error = buildError(rawBody = rawBody)
+
+        val message = JetpackTunnelRawBodyErrorLogger.buildMessage("GET", "/wc/v3/orders", error)
+
+        assertThat(message).contains("raw_body_truncated=false")
+        assertThat(rawBodySnippet(message)).isEqualTo(rawBody)
+    }
+
+    @Test
+    fun `given raw body at exact limit, when message is built, then complete raw body is included`() {
+        val rawBody = "a".repeat(MAX_RAW_BODY_LOG_CHARS)
+        val error = buildError(rawBody = rawBody)
+
+        val message = JetpackTunnelRawBodyErrorLogger.buildMessage("GET", "/wc/v3/orders", error)
+
+        assertThat(message).contains("raw_body_truncated=false")
+        assertThat(rawBodySnippet(message)).hasSize(MAX_RAW_BODY_LOG_CHARS)
+        assertThat(rawBodySnippet(message)).isEqualTo(rawBody)
+    }
+
+    @Test
+    fun `given raw body above limit, when message is built, then raw body is capped and marked truncated`() {
+        val retainedPrefix = "a".repeat(MAX_RAW_BODY_LOG_CHARS)
+        val truncatedTail = "tail-content"
+        val error = buildError(rawBody = retainedPrefix + truncatedTail)
+
+        val message = JetpackTunnelRawBodyErrorLogger.buildMessage("GET", "/wc/v3/orders", error)
+
+        assertThat(message).contains("raw_body_truncated=true")
+        assertThat(rawBodySnippet(message)).hasSize(MAX_RAW_BODY_LOG_CHARS)
+        assertThat(rawBodySnippet(message)).isEqualTo(retainedPrefix)
+        assertThat(message).doesNotContain(truncatedTail)
+    }
+
     private fun buildError(
         rawBody: String?,
         proxyStatus: Int? = null,
@@ -149,7 +186,12 @@ class JetpackTunnelRawBodyErrorLoggerTest {
         }
     }
 
+    private fun rawBodySnippet(message: String?): String {
+        return message?.substringAfter("raw_body_snippet=").orEmpty()
+    }
+
     private companion object {
+        const val MAX_RAW_BODY_LOG_CHARS = 2048
         const val requestBodySecretValue = "requestBodyShouldNotAppear"
 
         val rawBodyWithSecrets = """

--- a/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTunnelRawBodyErrorLoggerTest.kt
+++ b/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTunnelRawBodyErrorLoggerTest.kt
@@ -6,6 +6,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.json.JSONObject
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.eq
+import org.mockito.ArgumentCaptor
 import org.mockito.Mockito.mockStatic
 import org.robolectric.RobolectricTestRunner
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
@@ -74,6 +76,60 @@ class JetpackTunnelRawBodyErrorLoggerTest {
         }
     }
 
+    @Test
+    fun `given raw body contains secrets, when message is built, then secret values are redacted`() {
+        val error = buildError(rawBody = rawBodyWithSecrets)
+
+        val message = JetpackTunnelRawBodyErrorLogger.buildMessage("GET", "/wc/v3/orders", error)
+
+        assertThat(message).contains("[redacted]")
+        rawBodySecretValues.forEach { secretValue ->
+            assertThat(message).doesNotContain(secretValue)
+        }
+    }
+
+    @Test
+    fun `given context contains secrets, when message is built, then context secret values are redacted`() {
+        val error = buildError(rawBody = "<html>Fatal error</html>").apply {
+            apiError = "no_response_body Bearer apiErrorBearer consumer_secret=apiErrorConsumerSecret"
+            message = "Cookie: wordpress_logged_in=messageCookie password=messagePassword " +
+                "application_password=messageApplicationPassword"
+        }
+        val path = "/wc/v3/orders?consumer_key=pathConsumerKey&consumer_secret=pathConsumerSecret" +
+            "&access_token=pathAccessToken&password=hunter2&application_password=app-pass"
+
+        val message = JetpackTunnelRawBodyErrorLogger.buildMessage("POST", path, error)
+
+        assertThat(message).contains("[redacted]")
+        contextSecretValues.forEach { secretValue ->
+            assertThat(message).doesNotContain(secretValue)
+        }
+        assertThat(message).doesNotContain(requestBodySecretValue)
+    }
+
+    @Test
+    fun `given raw body and context contain secrets, when logging, then emitted API warning is redacted`() {
+        val error = buildError(rawBody = rawBodyWithSecrets).apply {
+            apiError = "consumer_secret=apiErrorConsumerSecret"
+            message = "Authorization: Bearer messageBearer"
+        }
+        val path = "/wc/v3/orders?consumer_key=pathConsumerKey&password=hunter2"
+        val messageCaptor = ArgumentCaptor.forClass(String::class.java)
+
+        mockStatic(AppLog::class.java).use { appLog ->
+            JetpackTunnelRawBodyErrorLogger.logIfPresent("PUT", path, error)
+
+            appLog.verify {
+                AppLog.w(eq(AppLog.T.API), messageCaptor.capture())
+            }
+        }
+        assertThat(messageCaptor.value).contains("[redacted]")
+        (rawBodySecretValues + contextSecretValues).forEach { secretValue ->
+            assertThat(messageCaptor.value).doesNotContain(secretValue)
+        }
+        assertThat(messageCaptor.value).doesNotContain(requestBodySecretValue)
+    }
+
     private fun buildError(
         rawBody: String?,
         proxyStatus: Int? = null,
@@ -91,5 +147,53 @@ class JetpackTunnelRawBodyErrorLoggerTest {
                     }
             }
         }
+    }
+
+    private companion object {
+        const val requestBodySecretValue = "requestBodyShouldNotAppear"
+
+        val rawBodyWithSecrets = """
+            Authorization: Bearer abc123
+            Cookie: wordpress_logged_in=wpLoginSecret
+            Set-Cookie: session=sessionSecret
+            consumer_key=ckSecretValue
+            consumer_secret=csSecretValue
+            {
+              "consumer_key": "jsonConsumerKey",
+              "consumer_secret": "jsonConsumerSecret",
+              "access_token": "jsonAccessToken",
+              "token": "jsonToken",
+              "application_password": "jsonApplicationPassword",
+              "password": "jsonPassword"
+            }
+        """.trimIndent()
+
+        val rawBodySecretValues = listOf(
+            "abc123",
+            "wpLoginSecret",
+            "sessionSecret",
+            "ckSecretValue",
+            "csSecretValue",
+            "jsonConsumerKey",
+            "jsonConsumerSecret",
+            "jsonAccessToken",
+            "jsonToken",
+            "jsonApplicationPassword",
+            "jsonPassword"
+        )
+
+        val contextSecretValues = listOf(
+            "apiErrorBearer",
+            "apiErrorConsumerSecret",
+            "messageCookie",
+            "messagePassword",
+            "messageApplicationPassword",
+            "pathConsumerKey",
+            "pathConsumerSecret",
+            "pathAccessToken",
+            "hunter2",
+            "app-pass",
+            "messageBearer"
+        )
     }
 }

--- a/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTunnelRawBodyErrorLoggerTest.kt
+++ b/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTunnelRawBodyErrorLoggerTest.kt
@@ -59,24 +59,6 @@ class JetpackTunnelRawBodyErrorLoggerTest {
     }
 
     @Test
-    fun `given raw body is present, when logging, then API warning is emitted`() {
-        val error = buildError(rawBody = "<html>Fatal error</html>")
-
-        mockStatic(AppLog::class.java).use { appLog ->
-            JetpackTunnelRawBodyErrorLogger.logIfPresent("GET", "/wc/v3/orders", error)
-
-            appLog.verify {
-                AppLog.w(
-                    AppLog.T.API,
-                    "Jetpack Tunnel raw_body error: method=GET, path=/wc/v3/orders, " +
-                        "error_code=, error_message=, " +
-                        "raw_body_truncated=false, raw_body_snippet=<html>Fatal error</html>"
-                )
-            }
-        }
-    }
-
-    @Test
     fun `given raw body contains secrets, when message is built, then secret values are redacted`() {
         val error = buildError(rawBody = rawBodyWithSecrets)
 
@@ -128,17 +110,6 @@ class JetpackTunnelRawBodyErrorLoggerTest {
             assertThat(messageCaptor.value).doesNotContain(secretValue)
         }
         assertThat(messageCaptor.value).doesNotContain(requestBodySecretValue)
-    }
-
-    @Test
-    fun `given raw body below limit, when message is built, then complete raw body is included`() {
-        val rawBody = "a".repeat(MAX_RAW_BODY_LOG_CHARS - 1)
-        val error = buildError(rawBody = rawBody)
-
-        val message = JetpackTunnelRawBodyErrorLogger.buildMessage("GET", "/wc/v3/orders", error)
-
-        assertThat(message).contains("raw_body_truncated=false")
-        assertThat(rawBodySnippet(message)).isEqualTo(rawBody)
     }
 
     @Test

--- a/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTunnelRawBodyErrorLoggerTest.kt
+++ b/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTunnelRawBodyErrorLoggerTest.kt
@@ -6,8 +6,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.json.JSONObject
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.ArgumentMatchers.eq
 import org.mockito.ArgumentCaptor
+import org.mockito.ArgumentMatchers.eq
 import org.mockito.Mockito.mockStatic
 import org.robolectric.RobolectricTestRunner
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
@@ -175,14 +175,12 @@ class JetpackTunnelRawBodyErrorLoggerTest {
         val baseError = transportStatus?.let { status ->
             BaseNetworkError(VolleyError(NetworkResponse(status, byteArrayOf(), emptyMap(), true)))
         } ?: BaseNetworkError(GenericErrorType.UNKNOWN)
+        val errorData = rawBody?.let { JSONObject().put("raw_body", it) }
+        if (proxyStatus != null) {
+            errorData?.put("status", proxyStatus)
+        }
         return WPComGsonNetworkError(baseError).apply {
-            errorData = rawBody?.let {
-                JSONObject()
-                    .put("raw_body", it)
-                    .apply {
-                        proxyStatus?.let { status -> put("status", status) }
-                    }
-            }
+            this.errorData = errorData
         }
     }
 

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTunnelGsonRequest.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTunnelGsonRequest.kt
@@ -126,11 +126,13 @@ object JetpackTunnelGsonRequest {
                 )
             }
 
+        val wrappedErrorListener = wrapErrorListener("GET", wpApiEndpoint, errorListener)
+
         return jpTimeoutListener?.let { retryListener ->
             JetpackTimeoutRequestHandler(tunnelRequestUrl, wrappedParams, wrappedType,
-                    wrappedListener, errorListener, retryListener).getRequest()
+                    wrappedListener, wrappedErrorListener, retryListener).getRequest()
         } ?: WPComGsonRequest.buildGetRequest(tunnelRequestUrl, wrappedParams, wrappedType,
-                wrappedListener, errorListener)
+                wrappedListener, wrappedErrorListener)
     }
 
     /**
@@ -155,7 +157,7 @@ object JetpackTunnelGsonRequest {
         errorListener: WPComErrorListener
     ): WPComGsonRequest<JetpackTunnelResponse<T>>? {
         val wrappedBody = createTunnelBody(method = "post", body = body, path = wpApiEndpoint)
-        return buildWrappedPostRequest(siteId, wrappedBody, type, listener, errorListener)
+        return buildWrappedPostRequest(siteId, wrappedBody, type, listener, "POST", wpApiEndpoint, errorListener)
     }
 
     /**
@@ -180,7 +182,7 @@ object JetpackTunnelGsonRequest {
         errorListener: WPComErrorListener
     ): WPComGsonRequest<JetpackTunnelResponse<T>>? {
         val wrappedBody = createTunnelBody(method = "patch", body = body, path = wpApiEndpoint)
-        return buildWrappedPostRequest(siteId, wrappedBody, type, listener, errorListener)
+        return buildWrappedPostRequest(siteId, wrappedBody, type, listener, "PATCH", wpApiEndpoint, errorListener)
     }
 
     /**
@@ -205,7 +207,7 @@ object JetpackTunnelGsonRequest {
         errorListener: WPComErrorListener
     ): WPComGsonRequest<JetpackTunnelResponse<T>>? {
         val wrappedBody = createTunnelBody(method = "put", body = body, path = wpApiEndpoint)
-        return buildWrappedPostRequest(siteId, wrappedBody, type, listener, errorListener)
+        return buildWrappedPostRequest(siteId, wrappedBody, type, listener, "PUT", wpApiEndpoint, errorListener)
     }
 
     /**
@@ -230,7 +232,7 @@ object JetpackTunnelGsonRequest {
         errorListener: WPComErrorListener
     ): WPComGsonRequest<JetpackTunnelResponse<T>>? {
         val wrappedBody = createTunnelBody(method = "delete", body = params, path = wpApiEndpoint)
-        return buildWrappedPostRequest(siteId, wrappedBody, type, listener, errorListener)
+        return buildWrappedPostRequest(siteId, wrappedBody, type, listener, "DELETE", wpApiEndpoint, errorListener)
     }
 
     private fun <T : Any> buildWrappedPostRequest(
@@ -238,6 +240,8 @@ object JetpackTunnelGsonRequest {
         wrappedBody: Map<String, Any>,
         type: Type,
         listener: (T?, List<Header>) -> Unit,
+        method: String,
+        wpApiEndpoint: String,
         errorListener: WPComErrorListener
     ): WPComGsonRequest<JetpackTunnelResponse<T>>? {
         val tunnelRequestUrl = getTunnelApiUrl(siteId)
@@ -250,8 +254,21 @@ object JetpackTunnelGsonRequest {
                 )
             }
 
+        val wrappedErrorListener = wrapErrorListener(method, wpApiEndpoint, errorListener)
+
         return WPComGsonRequest.buildPostRequest(tunnelRequestUrl, wrappedBody, wrappedType,
-                wrappedListener, errorListener)
+                wrappedListener, wrappedErrorListener)
+    }
+
+    private fun wrapErrorListener(
+        method: String,
+        wpApiEndpoint: String,
+        errorListener: WPComErrorListener
+    ): WPComErrorListener {
+        return WPComErrorListener { error ->
+            JetpackTunnelRawBodyErrorLogger.logIfPresent(method, wpApiEndpoint, error)
+            errorListener.onErrorResponse(error)
+        }
     }
 
     private fun getTunnelApiUrl(siteId: Long): String = WPCOMREST.jetpack_blogs.site(siteId).rest_api.urlV1_1

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTunnelGsonRequest.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTunnelGsonRequest.kt
@@ -235,6 +235,7 @@ object JetpackTunnelGsonRequest {
         return buildWrappedPostRequest(siteId, wrappedBody, type, listener, "DELETE", wpApiEndpoint, errorListener)
     }
 
+    @Suppress("LongParameterList")
     private fun <T : Any> buildWrappedPostRequest(
         siteId: Long,
         wrappedBody: Map<String, Any>,

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTunnelRawBodyErrorLogger.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTunnelRawBodyErrorLogger.kt
@@ -1,0 +1,25 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel
+
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
+import org.wordpress.android.util.AppLog
+
+object JetpackTunnelRawBodyErrorLogger {
+    fun buildMessage(method: String, path: String, error: WPComGsonNetworkError): String? {
+        val rawBody = error.errorData?.optString("raw_body")?.takeIf { it.isNotBlank() } ?: return null
+        return "Jetpack Tunnel raw_body error: " +
+            "method=${sanitize(method)}, " +
+            "path=${sanitize(path)}, " +
+            "raw_body_truncated=false, " +
+            "raw_body_snippet=${sanitize(rawBody)}"
+    }
+
+    fun logIfPresent(method: String, path: String, error: WPComGsonNetworkError) {
+        buildMessage(method, path, error)?.let { message ->
+            AppLog.w(AppLog.T.API, message)
+        }
+    }
+
+    private fun sanitize(value: String): String {
+        return value.replace(Regex("\\s+"), " ").trim()
+    }
+}

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTunnelRawBodyErrorLogger.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTunnelRawBodyErrorLogger.kt
@@ -26,6 +26,29 @@ object JetpackTunnelRawBodyErrorLogger {
     }
 
     private fun sanitize(value: String?): String {
-        return value.orEmpty().replace(Regex("\\s+"), " ").trim()
+        return value.orEmpty()
+            .replace(BEARER_TOKEN_REGEX, "Bearer [redacted]")
+            .replace(COOKIE_HEADER_REGEX) { matchResult ->
+                "${matchResult.groupValues[1]}: [redacted]"
+            }
+            .replace(JSON_SECRET_REGEX) { matchResult ->
+                "${matchResult.groupValues[1]}[redacted]${matchResult.groupValues[2]}"
+            }
+            .replace(KEY_VALUE_SECRET_REGEX) { matchResult ->
+                "${matchResult.groupValues[1]}${matchResult.groupValues[2]}[redacted]"
+            }
+            .replace(WHITESPACE_REGEX, " ")
+            .trim()
     }
+
+    private val WHITESPACE_REGEX = Regex("\\s+")
+    private val BEARER_TOKEN_REGEX = Regex("""(?i)\bBearer\s+[^\s,;]+""")
+    private val COOKIE_HEADER_REGEX = Regex("""(?i)\b(Cookie|Set-Cookie):\s*[^\n\r,]+""")
+    private val JSON_SECRET_REGEX = Regex(
+        """("(?:consumer_key|consumer_secret|access_token|token|application_password|password)"\s*:\s*")[^"]*(")""",
+        RegexOption.IGNORE_CASE
+    )
+    private val KEY_VALUE_SECRET_REGEX = Regex(
+        """(?i)(^|[?&;\s])((?:consumer_key|consumer_secret|access_token|token|application_password|password)=)[^&;\s,"'}]+"""
+    )
 }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTunnelRawBodyErrorLogger.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTunnelRawBodyErrorLogger.kt
@@ -1,9 +1,11 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel
 
+import androidx.annotation.VisibleForTesting
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
 import org.wordpress.android.util.AppLog
 
 object JetpackTunnelRawBodyErrorLogger {
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     fun buildMessage(method: String, path: String, error: WPComGsonNetworkError): String? {
         val rawBody = error.errorData?.optString("raw_body")?.takeIf { it.isNotBlank() } ?: return null
         val sanitizedRawBody = sanitize(rawBody)

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTunnelRawBodyErrorLogger.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTunnelRawBodyErrorLogger.kt
@@ -6,6 +6,9 @@ import org.wordpress.android.util.AppLog
 object JetpackTunnelRawBodyErrorLogger {
     fun buildMessage(method: String, path: String, error: WPComGsonNetworkError): String? {
         val rawBody = error.errorData?.optString("raw_body")?.takeIf { it.isNotBlank() } ?: return null
+        val sanitizedRawBody = sanitize(rawBody)
+        val isRawBodyTruncated = sanitizedRawBody.length > MAX_RAW_BODY_LOG_CHARS
+        val rawBodySnippet = sanitizedRawBody.take(MAX_RAW_BODY_LOG_CHARS)
         val fields = listOfNotNull(
             "method=${sanitize(method)}",
             "path=${sanitize(path)}",
@@ -13,8 +16,8 @@ object JetpackTunnelRawBodyErrorLogger {
             error.errorData?.opt("status")?.let { "proxy_status=${sanitize(it.toString())}" },
             "error_code=${sanitize(error.apiError)}",
             "error_message=${sanitize(error.message)}",
-            "raw_body_truncated=false",
-            "raw_body_snippet=${sanitize(rawBody)}"
+            "raw_body_truncated=$isRawBodyTruncated",
+            "raw_body_snippet=$rawBodySnippet"
         )
         return "Jetpack Tunnel raw_body error: ${fields.joinToString(", ")}"
     }
@@ -51,4 +54,5 @@ object JetpackTunnelRawBodyErrorLogger {
     private val KEY_VALUE_SECRET_REGEX = Regex(
         """(?i)(^|[?&;\s])((?:consumer_key|consumer_secret|access_token|token|application_password|password)=)[^&;\s,"'}]+"""
     )
+    private const val MAX_RAW_BODY_LOG_CHARS = 2048
 }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTunnelRawBodyErrorLogger.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTunnelRawBodyErrorLogger.kt
@@ -10,7 +10,7 @@ object JetpackTunnelRawBodyErrorLogger {
         val isRawBodyTruncated = sanitizedRawBody.length > MAX_RAW_BODY_LOG_CHARS
         val rawBodySnippet = sanitizedRawBody.take(MAX_RAW_BODY_LOG_CHARS)
         val fields = listOfNotNull(
-            "method=${sanitize(method)}",
+            "method=$method",
             "path=${sanitize(path)}",
             error.volleyError?.networkResponse?.statusCode?.let { "transport_status=$it" },
             error.errorData?.opt("status")?.let { "proxy_status=${sanitize(it.toString())}" },

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTunnelRawBodyErrorLogger.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTunnelRawBodyErrorLogger.kt
@@ -6,11 +6,17 @@ import org.wordpress.android.util.AppLog
 object JetpackTunnelRawBodyErrorLogger {
     fun buildMessage(method: String, path: String, error: WPComGsonNetworkError): String? {
         val rawBody = error.errorData?.optString("raw_body")?.takeIf { it.isNotBlank() } ?: return null
-        return "Jetpack Tunnel raw_body error: " +
-            "method=${sanitize(method)}, " +
-            "path=${sanitize(path)}, " +
-            "raw_body_truncated=false, " +
+        val fields = listOfNotNull(
+            "method=${sanitize(method)}",
+            "path=${sanitize(path)}",
+            error.volleyError?.networkResponse?.statusCode?.let { "transport_status=$it" },
+            error.errorData?.opt("status")?.let { "proxy_status=${sanitize(it.toString())}" },
+            "error_code=${sanitize(error.apiError)}",
+            "error_message=${sanitize(error.message)}",
+            "raw_body_truncated=false",
             "raw_body_snippet=${sanitize(rawBody)}"
+        )
+        return "Jetpack Tunnel raw_body error: ${fields.joinToString(", ")}"
     }
 
     fun logIfPresent(method: String, path: String, error: WPComGsonNetworkError) {
@@ -19,7 +25,7 @@ object JetpackTunnelRawBodyErrorLogger {
         }
     }
 
-    private fun sanitize(value: String): String {
-        return value.replace(Regex("\\s+"), " ").trim()
+    private fun sanitize(value: String?): String {
+        return value.orEmpty().replace(Regex("\\s+"), " ").trim()
     }
 }


### PR DESCRIPTION
### Description
Fixes WOOMOB-3428

This adds a Jetpack Tunnel-specific diagnostic log for WP.com errors that include `data.raw_body`. These errors happen when the tunnel receives a non-JSON response from the remote site, which otherwise leaves support with little context about what the site actually returned.

When `raw_body` is present, the app now logs a single `AppLog.T.API` warning with request and error context plus a sanitized, capped raw body snippet. The logged format is:

```text
Jetpack Tunnel raw_body error: method=<HTTP method>, path=<WP API path>, transport_status=<HTTP status>, proxy_status=<data.status>, error_code=<WP.com error>, error_message=<message>, raw_body_truncated=<true|false>, raw_body_snippet=<sanitized capped raw body>
```

Example:

```text
Jetpack Tunnel raw_body error: method=GET, path=/wc/v3/products/, transport_status=500, proxy_status=500, error_code=no_response_body, error_message=Remote site returned non-JSON response, raw_body_truncated=false, raw_body_snippet=<html>Fatal error consumer_key=[redacted] Authorization: Bearer [redacted] </html>
```

The redaction is intentionally local and best-effort: it removes common credential, token, and cookie-shaped values before the snippet is written to support logs. Existing error delivery and typed error handling are unchanged.

### Test Steps
1. Install and launch a Wasabi debug build on a logged-in emulator/device.
2. Create a fake Jetpack Tunnel error body on your machine:

   ```bash
   cat > /tmp/woomob-3428-response.json <<'JSON'
   {
     "error": "no_response_body",
     "message": "Remote site returned non-JSON response",
     "data": {
       "status": 500,
       "raw_body": "<html>Fatal error consumer_key=secret Authorization: Bearer abc123</html>"
     }
   }
   JSON
   adb -s <device-id> push /tmp/woomob-3428-response.json /data/local/tmp/woomob-3428-response.json
   ```

3. Configure ApiFaker. Use the normalized WP API route, not the full `public-api.wordpress.com/rest/v1.1/jetpack-blogs/.../rest-api/` wrapper, because ApiFaker extracts the tunneled Woo route before matching:

   ```bash
   adb -s <device-id> shell am broadcast -p com.woocommerce.android.dev \
     -a com.woocommerce.android.apifaker.CLEAR_ENDPOINTS

   adb -s <device-id> shell am broadcast -p com.woocommerce.android.dev \
     -a com.woocommerce.android.apifaker.ADD_ENDPOINT \
     --es api_type "wp-api" \
     --es path "/wc/v3/products" \
     --es http_method "GET" \
     --ei response_status_code 500 \
     --es response_body_file "/data/local/tmp/woomob-3428-response.json"

   adb -s <device-id> shell am broadcast -p com.woocommerce.android.dev \
     -a com.woocommerce.android.apifaker.SET_STATUS \
     --ez enabled true
   ```

4. Clear logcat, open the Products tab, and pull to refresh:

   ```bash
   adb -s <device-id> logcat -c
   ```

5. Confirm ApiFaker intercepted the Jetpack Tunnel request and the support log was emitted:

   ```bash
   adb -s <device-id> logcat -d | grep -E "WCApiFaker|Jetpack Tunnel raw_body error"
   ```

6. Verify the log contains `Jetpack Tunnel raw_body error:` with `method=GET`, `path=/wc/v3/products/`, `proxy_status=500`, `error_code=no_response_body`, `raw_body_truncated=false`, and a `raw_body_snippet=` value. Also verify the fake values `secret` and `abc123` are absent and `[redacted]` is present.
7. Clean up ApiFaker:

   ```bash
   adb -s <device-id> shell am broadcast -p com.woocommerce.android.dev \
     -a com.woocommerce.android.apifaker.SET_STATUS \
     --ez enabled false

   adb -s <device-id> shell am broadcast -p com.woocommerce.android.dev \
     -a com.woocommerce.android.apifaker.CLEAR_ENDPOINTS

   adb -s <device-id> shell rm /data/local/tmp/woomob-3428-response.json
   ```

### Images/gif
N/A

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.