### PR TITLE
[WOOMOB-3389] Revert product-type CIAB gating

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/filter/ProductFilterListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/filter/ProductFilterListViewModel.kt
@@ -9,8 +9,6 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
-import com.woocommerce.android.ciab.CIABAffectedFeature
-import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.model.PluginUrls
 import com.woocommerce.android.model.ProductCategory
 import com.woocommerce.android.model.WooPlugin
@@ -55,7 +53,6 @@ class ProductFilterListViewModel @Inject constructor(
     private val pluginRepository: PluginRepository,
     private val selectedSite: SelectedSite,
     private val analyticsTracker: AnalyticsTrackerWrapper,
-    private val ciabSiteGateKeeper: CIABSiteGateKeeper,
 ) : ScopedViewModel(savedState) {
     companion object {
         private const val KEY_PRODUCT_FILTER_OPTIONS = "key_product_filter_options"
@@ -577,16 +574,14 @@ class ProductFilterListViewModel @Inject constructor(
     private val ProductType.isVisible: Boolean
         get() = when (this) {
             ProductType.SIMPLE,
-            ProductType.EXTERNAL -> true
+            ProductType.EXTERNAL,
+            ProductType.GROUPED,
+            ProductType.VARIABLE,
+            ProductType.SUBSCRIPTION,
+            ProductType.VARIABLE_SUBSCRIPTION,
+            ProductType.BUNDLE,
+            ProductType.COMPOSITE -> true
 
-            ProductType.GROUPED -> ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.GroupedProducts)
-            ProductType.VARIABLE -> ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.VariableProducts)
-            ProductType.SUBSCRIPTION -> ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.SubscriptionProducts)
-            ProductType.VARIABLE_SUBSCRIPTION ->
-                ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.SubscriptionProducts)
-
-            ProductType.BUNDLE -> ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.BundleProducts)
-            ProductType.COMPOSITE -> ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.CompositeProducts)
             ProductType.VARIATION,
             ProductType.OTHER -> false
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/typesbottomsheet/ProductTypeBottomSheetBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/typesbottomsheet/ProductTypeBottomSheetBuilder.kt
@@ -1,16 +1,13 @@
 package com.woocommerce.android.ui.products.typesbottomsheet
 
 import com.woocommerce.android.R
-import com.woocommerce.android.ciab.CIABAffectedFeature
-import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.ui.products.ProductType
 import com.woocommerce.android.ui.products.typesbottomsheet.ProductTypesBottomSheetViewModel.ProductTypesBottomSheetUiItem
 import com.woocommerce.android.ui.subscriptions.IsEligibleForSubscriptions
 import javax.inject.Inject
 
 class ProductTypeBottomSheetBuilder @Inject constructor(
-    private val isEligibleForSubscriptions: IsEligibleForSubscriptions,
-    private val ciabSiteGateKeeper: CIABSiteGateKeeper
+    private val isEligibleForSubscriptions: IsEligibleForSubscriptions
 ) {
     @Suppress("LongMethod")
     suspend fun buildBottomSheetList(): List<ProductTypesBottomSheetUiItem> {
@@ -41,8 +38,7 @@ class ProductTypeBottomSheetBuilder @Inject constructor(
                 type = ProductType.VARIABLE,
                 titleResource = R.string.product_type_variable_title,
                 descResource = R.string.product_type_variable_desc,
-                iconResource = R.drawable.ic_gridicons_types,
-                isVisible = ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.VariableProducts)
+                iconResource = R.drawable.ic_gridicons_types
             ),
 
             ProductTypesBottomSheetUiItem(
@@ -56,8 +52,7 @@ class ProductTypeBottomSheetBuilder @Inject constructor(
                 type = ProductType.GROUPED,
                 titleResource = R.string.product_type_grouped_title,
                 descResource = R.string.product_type_grouped_desc,
-                iconResource = R.drawable.ic_widgets,
-                isVisible = ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.GroupedProducts)
+                iconResource = R.drawable.ic_widgets
             ),
             ProductTypesBottomSheetUiItem(
                 type = ProductType.EXTERNAL,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/filter/ProductFilterListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/filter/ProductFilterListViewModelTest.kt
@@ -3,7 +3,6 @@ package com.woocommerce.android.ui.products.filter
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
-import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.model.PluginUrls
 import com.woocommerce.android.model.WooPlugin
 import com.woocommerce.android.tools.NetworkStatus
@@ -41,7 +40,6 @@ class ProductFilterListViewModelTest : BaseUnitTest() {
     private lateinit var productFilterListViewModel: ProductFilterListViewModel
     private lateinit var pluginRepository: PluginRepository
     private lateinit var analyticsTrackerWrapper: AnalyticsTrackerWrapper
-    private lateinit var ciabSiteGateKeeper: CIABSiteGateKeeper
     private val siteModel: SiteModel = SiteModel().apply { id = 123 }
     private val selectedSiteMock: SelectedSite = mock {
         on { getIfExists() }.doReturn(siteModel)
@@ -57,9 +55,6 @@ class ProductFilterListViewModelTest : BaseUnitTest() {
         productRestrictions = mock()
         pluginRepository = mock()
         analyticsTrackerWrapper = mock()
-        ciabSiteGateKeeper = mock {
-            on { isFeatureSupported(any()) }.doReturn(true)
-        }
         productFilterListViewModel = ProductFilterListViewModel(
             savedState = ProductFilterListFragmentArgs(
                 selectedStockStatus = "instock",
@@ -74,7 +69,6 @@ class ProductFilterListViewModelTest : BaseUnitTest() {
             productRestrictions = productRestrictions,
             pluginRepository = pluginRepository,
             selectedSite = selectedSiteMock,
-            ciabSiteGateKeeper = ciabSiteGateKeeper,
             analyticsTracker = analyticsTrackerWrapper
         )
 
@@ -221,41 +215,6 @@ class ProductFilterListViewModelTest : BaseUnitTest() {
             exploreOptions.forEach { option ->
                 Assertions.assertThat(option.url).isEqualTo(PluginUrls.COMPOSITE_URL)
             }
-        }
-
-    @Test
-    fun `given CIAB site, when product type list build, then limited options available`() =
-        testBlocking {
-            whenever(ciabSiteGateKeeper.isFeatureSupported(any())).thenReturn(false)
-            whenever(pluginRepository.getPluginsInfo(any(), any())).thenReturn(
-                mapOf(
-                    WooCommerceStore.WooPlugin.WOO_SUBSCRIPTIONS.pluginName to installedPlugin,
-                    WooCommerceStore.WooPlugin.WOO_PRODUCT_BUNDLES.pluginName to installedPlugin,
-                    WooCommerceStore.WooPlugin.WOO_COMPOSITE_PRODUCTS.pluginName to notInstalledPlugin
-                )
-            )
-            var productFilters: List<ProductFilterListViewModel.FilterListItemUiModel> = emptyList()
-            productFilterListViewModel.filterListItems.observeForever {
-                productFilters = it
-            }
-
-            productFilterListViewModel.loadFilters()
-
-            val productTypeFilter = productFilters
-                .find { it.filterItemKey == WCProductStore.ProductFilterOption.TYPE }!!
-
-            val productTypeFilterOptions = productTypeFilter.filterOptionListItems
-                .filterIsInstance<FilterListOptionItemUiModel.DefaultFilterListOptionItemUiModel>()
-                .map { it.filterOptionItemValue }
-
-            val expectedTypeFilters = buildList {
-                add("") // Empty represent the Any option
-                addAll(
-                    listOf(ProductType.SIMPLE, ProductType.EXTERNAL).map { it.value }
-                )
-            }
-
-            Assertions.assertThat(productTypeFilterOptions).isEqualTo(expectedTypeFilters)
         }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/typesbottomsheet/ProductTypeBottomSheetBuilderTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/typesbottomsheet/ProductTypeBottomSheetBuilderTest.kt
@@ -1,14 +1,11 @@
 package com.woocommerce.android.ui.products.typesbottomsheet
 
-import com.woocommerce.android.ciab.CIABAffectedFeature
-import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.ui.products.ProductType
 import com.woocommerce.android.ui.subscriptions.IsEligibleForSubscriptions
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
-import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.given
 import org.mockito.kotlin.mock
@@ -18,13 +15,9 @@ class ProductTypeBottomSheetBuilderTest : BaseUnitTest() {
     private val isEligibleForSubscriptions: IsEligibleForSubscriptions = mock {
         on { invoke() } doReturn true
     }
-    private val ciabSiteGateKeeper: CIABSiteGateKeeper = mock {
-        on { isFeatureSupported(any()) } doReturn true
-    }
 
     private val sut = ProductTypeBottomSheetBuilder(
-        isEligibleForSubscriptions = isEligibleForSubscriptions,
-        ciabSiteGateKeeper = ciabSiteGateKeeper
+        isEligibleForSubscriptions = isEligibleForSubscriptions
     )
 
     @Test
@@ -54,10 +47,8 @@ class ProductTypeBottomSheetBuilderTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given variable products are supported, when building bottom sheet list, then variable products are visible`() =
+    fun `when building bottom sheet list, then variable products are visible`() =
         testBlocking {
-            given(ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.VariableProducts)).willReturn(true)
-
             val result = sut.buildBottomSheetList()
 
             val variableProduct = result.find { it.type == ProductType.VARIABLE }
@@ -65,35 +56,11 @@ class ProductTypeBottomSheetBuilderTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given variable products not supported, when building bottom sheet list, then variable and grouped products are not visible`() =
+    fun `when building bottom sheet list, then grouped products are visible`() =
         testBlocking {
-            given(ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.VariableProducts)).willReturn(false)
-
-            val result = sut.buildBottomSheetList()
-
-            val variableProduct = result.find { it.type == ProductType.VARIABLE }
-            assertThat(variableProduct?.isVisible).isFalse()
-        }
-
-    @Test
-    fun `given grouped products are supported, when building bottom sheet list, then grouped products are visible`() =
-        testBlocking {
-            given(ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.GroupedProducts)).willReturn(true)
-
             val result = sut.buildBottomSheetList()
 
             val groupedProduct = result.find { it.type == ProductType.GROUPED }
             assertThat(groupedProduct?.isVisible).isTrue
-        }
-
-    @Test
-    fun `given grouped products not supported, when building bottom sheet list, then grouped products are not visible`() =
-        testBlocking {
-            given(ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.GroupedProducts)).willReturn(false)
-
-            val result = sut.buildBottomSheetList()
-
-            val groupedProduct = result.find { it.type == ProductType.GROUPED }
-            assertThat(groupedProduct?.isVisible).isFalse()
         }
 }


### PR DESCRIPTION
### Description

Fixes WOOMOB-3389

Part of the CIAB ("Commerce In A Box") retirement on Android. Before this change, several product types were hidden on CIAB sites via per-type `CIABAffectedFeature` gates. This PR removes that gating so product types behave the same everywhere — as they already do on non-CIAB sites (all types visible), which is the pre-CIAB behavior we're restoring.

**Stacked PR:** targets `issue/woomob-3390-revert-order-status-gating` (the order-status revert), not `trunk`. Review/merge that one first.

Changes:
- `ProductTypeBottomSheetBuilder` — drop the CIAB gates on the **Variable** and **Grouped** "add product" options (now always visible). Subscription / Variable-subscription remain gated by `isEligibleForSubscriptions` (subscription eligibility, not CIAB).
- `ProductFilterListViewModel` — `ProductType.isVisible` now returns `true` for Simple/External/Grouped/Variable/Subscription/Variable-subscription/Bundle/Composite (Variation/Other stay hidden), dropping the `ciabSiteGateKeeper` checks.
- Removed the now-unused `CIABSiteGateKeeper` constructor dependency and imports from both classes.
- Tests updated to drop the CIAB cases; added always-visible assertions for Variable & Grouped in the bottom-sheet test.

`CIABSiteGateKeeper` / `CIABAffectedFeature` stay in the codebase — they're removed in the final teardown (WOOMOB-3386), which merges last.

### Test Steps

1. On a store, tap to add a new product and open the product-type bottom sheet.
2. Confirm all product types are offered — including **Variable** and **Grouped** (plus Simple/Virtual/External; Subscription types appear when the site is subscription-eligible).
3. Go to the Products list → Filters → Product type.
4. Confirm the filter lists Simple, Grouped, External, Variable, and the Bundle/Composite/Subscription explore options — none are hidden.

### Images/gif

N/A

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.