### PR TITLE
[WOOMOB-3388] Revert POS eligibility CIAB gating

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/eligibility/WooPosEligibilityScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/eligibility/WooPosEligibilityScreen.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -20,11 +19,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
-import androidx.core.net.toUri
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleEventObserver
-import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButton
@@ -51,17 +46,6 @@ fun WooPosEligibilityScreen(
         viewModel.initialize(initialReason)
     }
 
-    val lifecycleOwner = LocalLifecycleOwner.current
-    DisposableEffect(lifecycleOwner) {
-        val observer = LifecycleEventObserver { _, event ->
-            if (event == Lifecycle.Event.ON_RESUME) {
-                viewModel.onResumed()
-            }
-        }
-        lifecycleOwner.lifecycle.addObserver(observer)
-        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
-    }
-
     var isNavigatingAway by remember { mutableStateOf(false) }
 
     LaunchedEffect(Unit) {
@@ -78,7 +62,6 @@ fun WooPosEligibilityScreen(
         onNavigationEvent = onNavigationEvent,
         retryState = retryState,
         onRetry = { viewModel.retryEligibilityCheckTapped() },
-        onLearnMoreTapped = { viewModel.learnMoreTapped() },
     )
 }
 
@@ -87,7 +70,6 @@ fun WooPosEligibilityScreen(
     onNavigationEvent: (WooPosNavigationEvent) -> Unit,
     retryState: WooPosEligibilityRetryState,
     onRetry: () -> Unit,
-    onLearnMoreTapped: () -> Unit,
 ) {
     BackHandler {
         onNavigationEvent(WooPosNavigationEvent.ExitPosClicked)
@@ -161,22 +143,6 @@ fun WooPosEligibilityScreen(
                         modifier = buttonModifier,
                     )
                 }
-
-                is WooPosEligibilityRetryState.CiabPlanUpgradeRequired -> {
-                    WooPosButton(
-                        text = stringResource(id = R.string.woopos_eligibility_learn_more_label),
-                        onClick = {
-                            onLearnMoreTapped()
-                            onNavigationEvent(
-                                WooPosNavigationEvent.OpenWebView(
-                                    url = retryState.learnMoreUrl.toString()
-                                )
-                            )
-                        },
-                        state = WooPosButtonState.ENABLED,
-                        modifier = buttonModifier,
-                    )
-                }
             }
 
             Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
@@ -204,26 +170,6 @@ fun WooPosEligibilityScreenRetryablePreview() {
                     "Please check your store currency settings or contact support for assistance.",
             ),
             onRetry = {},
-            onLearnMoreTapped = {},
-        )
-    }
-}
-
-@WooPosPreview
-@Composable
-fun WooPosEligibilityCiabPreview() {
-    WooPosTheme {
-        WooPosEligibilityScreen(
-            onNavigationEvent = {},
-            retryState = WooPosEligibilityRetryState.CiabPlanUpgradeRequired(
-                title = "Pro plan required",
-                suggestionText = "Accept payments in person for just 2.70% + \$0.10 per transaction. " +
-                    "Upgrade to Pro to access tap-to-pay on your phone and our full " +
-                    "point of sale system with real-time inventory and order syncing.",
-                learnMoreUrl = "https://wordpress.com/setup/woo-hosted-plans/".toUri(),
-            ),
-            onRetry = {},
-            onLearnMoreTapped = {},
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/eligibility/WooPosEligibilityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/eligibility/WooPosEligibilityViewModel.kt
@@ -1,11 +1,8 @@
 package com.woocommerce.android.ui.woopos.eligibility
 
-import android.net.Uri
-import androidx.core.net.toUri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R
-import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.woopos.tab.WooPosCanBeLaunchedInTab
 import com.woocommerce.android.ui.woopos.tab.WooPosLaunchability
@@ -33,12 +30,6 @@ sealed interface WooPosEligibilityRetryState {
         override val title: String,
         override val suggestionText: String,
     ) : Ineligible
-
-    data class CiabPlanUpgradeRequired(
-        override val title: String,
-        override val suggestionText: String,
-        val learnMoreUrl: Uri,
-    ) : Ineligible
 }
 
 @HiltViewModel
@@ -48,7 +39,6 @@ class WooPosEligibilityViewModel @Inject constructor(
     private val resourceProvider: ResourceProvider,
     private val selectedSite: SelectedSite,
     private val wooCommerceStore: WooCommerceStore,
-    private val ciabSiteGateKeeper: CIABSiteGateKeeper,
 ) : ViewModel() {
 
     private val _retryState = MutableStateFlow<WooPosEligibilityRetryState?>(null)
@@ -58,7 +48,6 @@ class WooPosEligibilityViewModel @Inject constructor(
     val navigateToPos = _navigateToPos.receiveAsFlow()
 
     private var currentReason: WooPosLaunchability.NonLaunchabilityReason? = null
-    private var hasOpenedLearnMore = false
 
     suspend fun initialize(reason: WooPosLaunchability.NonLaunchabilityReason) {
         currentReason = reason
@@ -70,20 +59,6 @@ class WooPosEligibilityViewModel @Inject constructor(
         viewModelScope.launch {
             trackIneligibleRetryTapped()
         }
-        recheckEligibility()
-    }
-
-    fun learnMoreTapped() {
-        hasOpenedLearnMore = true
-        val reason = currentReason ?: return
-        viewModelScope.launch {
-            tracker.track(WooPosAnalyticsEvent.Event.IneligibleUILearnMoreTapped(reason))
-        }
-    }
-
-    fun onResumed() {
-        if (!hasOpenedLearnMore) return
-        hasOpenedLearnMore = false
         recheckEligibility()
     }
 
@@ -117,26 +92,10 @@ class WooPosEligibilityViewModel @Inject constructor(
     private fun buildIneligibleState(
         reason: WooPosLaunchability.NonLaunchabilityReason
     ): WooPosEligibilityRetryState.Ineligible {
-        val suggestionText = getSuggestionText(reason)
-        return when (reason) {
-            WooPosLaunchability.NonLaunchabilityReason.CiabPlanUpgradeRequired -> {
-                WooPosEligibilityRetryState.CiabPlanUpgradeRequired(
-                    title = resourceProvider.getString(R.string.woopos_eligibility_ciab_title),
-                    suggestionText = suggestionText,
-                    learnMoreUrl = buildLearnMoreUrl(),
-                )
-            }
-            else -> {
-                WooPosEligibilityRetryState.RetryableIneligible(
-                    title = resourceProvider.getString(R.string.woopos_eligibility_screen_unable_to_load),
-                    suggestionText = suggestionText,
-                )
-            }
-        }
-    }
-
-    private fun buildLearnMoreUrl(): Uri {
-        return ciabSiteGateKeeper.buildPlanUpgradeUrl().toUri()
+        return WooPosEligibilityRetryState.RetryableIneligible(
+            title = resourceProvider.getString(R.string.woopos_eligibility_screen_unable_to_load),
+            suggestionText = getSuggestionText(reason),
+        )
     }
 
     private fun getSuggestionText(reason: WooPosLaunchability.NonLaunchabilityReason): String {
@@ -148,8 +107,6 @@ class WooPosEligibilityViewModel @Inject constructor(
                 )
             WooPosLaunchability.NonLaunchabilityReason.SiteSettingsUnavailable ->
                 resourceProvider.getString(R.string.woopos_eligibility_reason_check_connection)
-            WooPosLaunchability.NonLaunchabilityReason.CiabPlanUpgradeRequired ->
-                resourceProvider.getString(R.string.woopos_eligibility_reason_ciab_plan_upgrade)
             WooPosLaunchability.NonLaunchabilityReason.NoSiteSelected,
             WooPosLaunchability.NonLaunchabilityReason.UnknownNoPositiveCache ->
                 resourceProvider.getString(R.string.woopos_eligibility_reason_check_connection)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/store/WooPosSettingsStoreViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/store/WooPosSettingsStoreViewModel.kt
@@ -2,9 +2,7 @@ package com.woocommerce.android.ui.woopos.settings.details.store
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.woopos.common.data.WOO_POS_CIAB_SETTINGS_PATH
 import com.woocommerce.android.ui.woopos.common.data.WOO_POS_SETTINGS_PATH
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
@@ -23,7 +21,6 @@ class WooPosSettingsStoreViewModel @Inject constructor(
     private val storeRepository: WooPosSettingsStoreRepository,
     private val receiptRepository: WooPosSettingsReceiptRepository,
     private val selectedSite: SelectedSite,
-    private val ciabSiteGateKeeper: CIABSiteGateKeeper,
     private val analyticsTracker: WooPosAnalyticsTracker,
 ) : ViewModel() {
     private val _state = MutableStateFlow(WooPosSettingsStoreState())
@@ -50,11 +47,7 @@ class WooPosSettingsStoreViewModel @Inject constructor(
 
     private fun buildReceiptSettingsUrl(): String {
         val siteUrl = selectedSite.get().url.trimEnd('/')
-        return if (ciabSiteGateKeeper.isCurrentSiteCIAB()) {
-            "$siteUrl$WOO_POS_CIAB_SETTINGS_PATH"
-        } else {
-            "$siteUrl$WOO_POS_SETTINGS_PATH"
-        }
+        return "$siteUrl$WOO_POS_SETTINGS_PATH"
     }
 
     private fun loadStoreData() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTab.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTab.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android.ui.woopos.tab
 
 import com.woocommerce.android.AppPrefs
-import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.extensions.semverCompareTo
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
@@ -9,7 +8,6 @@ import com.woocommerce.android.util.FetchActiveWCPluginVersion
 import com.woocommerce.android.util.GetWooCorePluginCachedVersion
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import org.wordpress.android.fluxc.model.SiteModel
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -42,10 +40,6 @@ class WooPosCanBeLaunchedInTab @Inject constructor(
             ?: return WooPosLaunchability.NotLaunchable(
                 reason = WooPosLaunchability.NonLaunchabilityReason.NoSiteSelected
             )
-
-        getCiabPlanNonLaunchabilityReason(site)?.let {
-            return prepareNotLaunchableStateWithCacheUpdate(site.id, it)
-        }
 
         val cachedPositive = appPrefs.isPOSLaunchableForSite(site.id)
 
@@ -89,14 +83,6 @@ class WooPosCanBeLaunchedInTab @Inject constructor(
         return wooCoreVersion.semverCompareTo(MINIMUM_SUPPORTED_WC_VERSION) >= 0
     }
 
-    private fun getCiabPlanNonLaunchabilityReason(
-        site: SiteModel
-    ): WooPosLaunchability.NonLaunchabilityReason? {
-        if (!site.isCIABSite) return null
-        if (CIABSiteGateKeeper.CIAB_PRO_PLAN_SLUGS.contains(site.planProductSlug)) return null
-        return WooPosLaunchability.NonLaunchabilityReason.CiabPlanUpgradeRequired
-    }
-
     companion object {
         const val MINIMUM_SUPPORTED_WC_VERSION = "9.6.0"
     }
@@ -111,6 +97,5 @@ sealed class WooPosLaunchability {
         SiteSettingsUnavailable,
         NoSiteSelected,
         UnknownNoPositiveCache,
-        CiabPlanUpgradeRequired,
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosTabShouldBeVisible.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosTabShouldBeVisible.kt
@@ -1,8 +1,6 @@
 package com.woocommerce.android.ui.woopos.tab
 
 import com.woocommerce.android.AppPrefs
-import com.woocommerce.android.ciab.CIABAffectedFeature
-import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.woopos.WooPosIsScreenSizeAllowed
 import com.woocommerce.android.ui.woopos.common.util.WooPosCouldNotDetermineValueException
@@ -15,7 +13,6 @@ class WooPosTabShouldBeVisible @Inject constructor(
     private val appPrefs: AppPrefs,
     private val selectedSite: SelectedSite,
     private val isScreenSizeAllowed: WooPosIsScreenSizeAllowed,
-    private val ciabSiteGateKeeper: CIABSiteGateKeeper,
     private val isCountryAllowed: WooPosIsCountryAllowed,
     private val wooPosLog: WooPosLogWrapper,
 ) {
@@ -25,13 +22,6 @@ class WooPosTabShouldBeVisible @Inject constructor(
 
         if (!forceRefresh && appPrefs.isPOSTabVisibleForSite(site.id)) {
             return@withContext Result.success(true)
-        }
-
-        if (ciabSiteGateKeeper.isFeatureUnsupported(CIABAffectedFeature.POS)) {
-            appPrefs.clearPOSTabVisibilityForSite(site.id)
-            return@withContext Result.success(false).also {
-                wooPosLog.i("POS Tab Not visible reason: Site is CIAB")
-            }
         }
 
         if (!isScreenSizeAllowed()) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
@@ -1367,7 +1367,6 @@ internal fun WooPosLaunchability.NonLaunchabilityReason.toAnalyticsReason(): Str
         WooPosLaunchability.NonLaunchabilityReason.SiteSettingsUnavailable,
         WooPosLaunchability.NonLaunchabilityReason.UnknownNoPositiveCache,
         WooPosLaunchability.NonLaunchabilityReason.NoSiteSelected -> "other"
-        WooPosLaunchability.NonLaunchabilityReason.CiabPlanUpgradeRequired -> "ciab_plan_upgrade_required"
     }
 }
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4249,10 +4249,7 @@
     <string name="woopos_eligibility_reason_unsupported_woocommerce_version">Your WooCommerce version is not supported. The POS system requires WooCommerce version %1$s or above. Please update WooCommerce to the latest version.</string>
     <string name="woopos_eligibility_reason_check_connection">Check your internet connection and try relaunching the app. If the issue persists, please contact support.</string>
     <string name="woopos_eligibility_screen_unable_to_load">Unable to load</string>
-    <string name="woopos_eligibility_ciab_title">Pro plan required</string>
-    <string name="woopos_eligibility_reason_ciab_plan_upgrade">Accept payments in person for just 2.70% + $0.10 per transaction. Upgrade to Pro to access tap-to-pay on your phone and our full point of sale system with real-time inventory and order syncing.</string>
     <string name="woopos_eligibility_reason_ciab_plan_upgrade_html">Accept payments in person for just 2.70% + $0.10 per transaction. &lt;b&gt;Upgrade to Pro&lt;/b&gt; to access tap-to-pay on your phone and our full point of sale system with real-time inventory and order syncing.</string>
-    <string name="woopos_eligibility_learn_more_label">Learn More</string>
 
     <string name="woopos_scanning_setup_dialog_content_description">Scanner setup dialog</string>
     <string name="woopos_scanning_setup_barcode_content_description">Barcode</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/eligibility/WooPosEligibilityViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/eligibility/WooPosEligibilityViewModelTest.kt
@@ -1,7 +1,5 @@
 package com.woocommerce.android.ui.woopos.eligibility
 
-import android.net.Uri
-import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.woopos.tab.WooPosCanBeLaunchedInTab
 import com.woocommerce.android.ui.woopos.tab.WooPosLaunchability
@@ -17,8 +15,6 @@ import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
 import org.junit.Test
-import org.mockito.MockedStatic
-import org.mockito.Mockito.mockStatic
 import org.mockito.Mockito.reset
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
@@ -34,7 +30,6 @@ class WooPosEligibilityViewModelTest {
     private val mockResourceProvider: ResourceProvider = mock()
     private val mockSelectedSite: SelectedSite = mock()
     private val mockWooCommerceStore: WooCommerceStore = mock()
-    private val mockCiabSiteGateKeeper: CIABSiteGateKeeper = mock()
 
     @Rule
     @JvmField
@@ -109,7 +104,6 @@ class WooPosEligibilityViewModelTest {
             mockResourceProvider,
             mockSelectedSite,
             mockWooCommerceStore,
-            mockCiabSiteGateKeeper,
         )
 
         // WHEN
@@ -131,7 +125,6 @@ class WooPosEligibilityViewModelTest {
             mockResourceProvider,
             mockSelectedSite,
             mockWooCommerceStore,
-            mockCiabSiteGateKeeper,
         )
 
         sut.initialize(reason)
@@ -158,7 +151,6 @@ class WooPosEligibilityViewModelTest {
             mockResourceProvider,
             mockSelectedSite,
             mockWooCommerceStore,
-            mockCiabSiteGateKeeper,
         )
 
         sut.initialize(initialReason)
@@ -173,52 +165,6 @@ class WooPosEligibilityViewModelTest {
         verify(tracker).track(IneligibleUIShown(retryReason))
     }
 
-    @Test
-    fun `given CIAB plan upgrade reason, when initialized, then state is CiabPlanUpgradeRequired`() = runTest {
-        mockUriParse().use {
-            // GIVEN
-            val reason = WooPosLaunchability.NonLaunchabilityReason.CiabPlanUpgradeRequired
-            whenever(mockCiabSiteGateKeeper.buildPlanUpgradeUrl()).thenReturn("https://example.com")
-            val sut = createSut()
-
-            // WHEN
-            sut.initialize(reason)
-
-            // THEN
-            assertThat(sut.retryState.value)
-                .isInstanceOf(WooPosEligibilityRetryState.CiabPlanUpgradeRequired::class.java)
-        }
-    }
-
-    @Test
-    fun `given learn more tapped, when onResumed and becomes eligible, then navigation is emitted`() = runTest {
-        mockUriParse().use {
-            // GIVEN
-            val reason = WooPosLaunchability.NonLaunchabilityReason.CiabPlanUpgradeRequired
-            whenever(mockCiabSiteGateKeeper.buildPlanUpgradeUrl()).thenReturn("https://example.com")
-            whenever(canBeLaunchedInTab(forceRefresh = true)).thenReturn(WooPosLaunchability.Launchable)
-            val sut = createSut()
-            sut.initialize(reason)
-            val navigated = mutableListOf<Unit>()
-            val job = launch { sut.navigateToPos.collect { navigated.add(it) } }
-
-            // WHEN
-            sut.learnMoreTapped()
-            sut.onResumed()
-            advanceUntilIdle()
-
-            // THEN
-            assertThat(navigated).hasSize(1)
-            job.cancel()
-        }
-    }
-
-    private fun mockUriParse(): MockedStatic<Uri> {
-        return mockStatic(Uri::class.java).apply {
-            `when`<Uri> { Uri.parse(any()) }.thenReturn(mock())
-        }
-    }
-
     private fun createSut(): WooPosEligibilityViewModel {
         return WooPosEligibilityViewModel(
             canBeLaunchedInTab,
@@ -226,7 +172,6 @@ class WooPosEligibilityViewModelTest {
             mockResourceProvider,
             mockSelectedSite,
             mockWooCommerceStore,
-            mockCiabSiteGateKeeper,
         )
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/settings/details/store/WooPosSettingsStoreViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/settings/details/store/WooPosSettingsStoreViewModelTest.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.woopos.settings.details.store
 
-import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
@@ -26,7 +25,6 @@ class WooPosSettingsStoreViewModelTest {
     private val storeRepository: WooPosSettingsStoreRepository = mock()
     private val receiptRepository: WooPosSettingsReceiptRepository = mock()
     private val selectedSite: SelectedSite = mock()
-    private val ciabSiteGateKeeper: CIABSiteGateKeeper = mock()
     private val analyticsTracker: WooPosAnalyticsTracker = mock()
 
     @Test
@@ -132,7 +130,6 @@ class WooPosSettingsStoreViewModelTest {
         // GIVEN
         val site = SiteModel().apply { url = "https://mystore.com" }
         whenever(selectedSite.get()).thenReturn(site)
-        whenever(ciabSiteGateKeeper.isCurrentSiteCIAB()).thenReturn(false)
         whenever(storeRepository.getStoreInfo()).thenReturn(
             WooPosSettingsStoreState.StoreInfo(storeName = "", address = "")
         )
@@ -156,40 +153,10 @@ class WooPosSettingsStoreViewModelTest {
         job.cancel()
     }
 
-    @Test
-    fun `when edit receipt clicked on CIAB site, then emits URL with next-admin path`() = runTest {
-        // GIVEN
-        val site = SiteModel().apply { url = "https://my.commerce-garden.com" }
-        whenever(selectedSite.get()).thenReturn(site)
-        whenever(ciabSiteGateKeeper.isCurrentSiteCIAB()).thenReturn(true)
-        whenever(storeRepository.getStoreInfo()).thenReturn(
-            WooPosSettingsStoreState.StoreInfo(storeName = "", address = "")
-        )
-        whenever(receiptRepository.getReceiptInfo()).thenReturn(WooPosReceiptDataResult.NotAvailable)
-
-        val viewModel = createViewModel()
-        advanceUntilIdle()
-
-        // WHEN
-        val results = mutableListOf<WooPosSettingsStoreViewModel.EditReceiptTarget>()
-        val job = launch(coroutineTestRule.testDispatcher) {
-            viewModel.openEditReceiptEvent.collect { results.add(it) }
-        }
-        viewModel.onEditReceiptClicked()
-        advanceUntilIdle()
-
-        // THEN
-        assertThat(results).hasSize(1)
-        assertThat(results.first().url).contains("next-admin")
-        assertThat(results.first().url).contains("woocommerce%2Fsettings%2Fpayments%2Fpos")
-        job.cancel()
-    }
-
     private fun createViewModel() = WooPosSettingsStoreViewModel(
         storeRepository = storeRepository,
         receiptRepository = receiptRepository,
         selectedSite = selectedSite,
-        ciabSiteGateKeeper = ciabSiteGateKeeper,
         analyticsTracker = analyticsTracker,
     )
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTabTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTabTest.kt
@@ -128,33 +128,10 @@ class WooPosCanBeLaunchedInTabTest {
         assertEquals(Launchable, result)
     }
 
-    // --- CIAB plan eligibility ---
+    // --- Plan eligibility ---
 
     @Test
-    fun `given CIAB site with free plan, when invoked, then return CiabPlanUpgradeRequired`() = runTest {
-        siteModel.setIsGardenSite(true)
-        siteModel.gardenName = SiteModel.CIAB_GARDEN_NAME
-        siteModel.planProductSlug = "woo_hosted_free_plan"
-
-        val result = sut()
-
-        assertEquals(NotLaunchable(NonLaunchabilityReason.CiabPlanUpgradeRequired), result)
-    }
-
-    @Test
-    fun `given CIAB site with pro monthly plan, when invoked, then return Launchable`() = runTest {
-        siteModel.setIsGardenSite(true)
-        siteModel.gardenName = SiteModel.CIAB_GARDEN_NAME
-        siteModel.planProductSlug = "woo_hosted_pro_plan_monthly"
-
-        val result = sut()
-
-        assertEquals(Launchable, result)
-    }
-
-    @Test
-    fun `given non-CIAB site with free plan, when invoked, then not blocked by CIAB check`() = runTest {
-        siteModel.setIsGardenSite(false)
+    fun `given site with free plan, when invoked, then not gated by plan`() = runTest {
         siteModel.planProductSlug = "woo_hosted_free_plan"
 
         val result = sut()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosTabShouldBeVisibleTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosTabShouldBeVisibleTest.kt
@@ -1,8 +1,6 @@
 package com.woocommerce.android.ui.woopos.tab
 
 import com.woocommerce.android.AppPrefs
-import com.woocommerce.android.ciab.CIABAffectedFeature
-import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.woopos.WooPosIsScreenSizeAllowed
 import com.woocommerce.android.ui.woopos.common.util.WooPosCouldNotDetermineValueException
@@ -27,9 +25,6 @@ class WooPosTabShouldBeVisibleTest {
     private val appPrefs: AppPrefs = mock()
     private val selectedSite: SelectedSite = mock()
     private val isScreenSizeAllowed: WooPosIsScreenSizeAllowed = mock()
-    private val ciabSiteGateKeeper: CIABSiteGateKeeper = mock {
-        on { isFeatureUnsupported(CIABAffectedFeature.POS) } doReturn false
-    }
     private val isCountryAllowed: WooPosIsCountryAllowed = mock {
         on { invoke() } doReturn true
     }
@@ -52,7 +47,6 @@ class WooPosTabShouldBeVisibleTest {
             appPrefs = appPrefs,
             selectedSite = selectedSite,
             isScreenSizeAllowed = isScreenSizeAllowed,
-            ciabSiteGateKeeper = ciabSiteGateKeeper,
             isCountryAllowed = isCountryAllowed,
             wooPosLog = mock()
         )
@@ -79,16 +73,6 @@ class WooPosTabShouldBeVisibleTest {
         val r = sut(forceRefresh = true)
         assertTrue(r.isFailure)
         assertTrue(r.exceptionOrNull() is WooPosCouldNotDetermineValueException)
-    }
-
-    @Test
-    fun `given feature unsupported for CIAB site, when invoked with forceRefresh, then return success false`() = runTest {
-        whenever(ciabSiteGateKeeper.isFeatureUnsupported(CIABAffectedFeature.POS)).thenReturn(true)
-
-        val r = sut(forceRefresh = true)
-
-        assertTrue(r.isSuccess)
-        assertFalse(r.getOrThrow())
     }
 
     @Test


### PR DESCRIPTION
Fixes WOOMOB-3388

### Description

Part of the CIAB ("Commerce In A Box") retirement on Android. This sub-task reverts the POS-specific CIAB / Pro-plan eligibility gating so POS eligibility behaves as it did before CIAB on all sites — there is no longer a Pro-plan upgrade gate, and POS launchability/visibility depends only on the normal checks (WooCommerce version, screen size, country).

What changed:

- `WooPosCanBeLaunchedInTab` — removed the CIAB free-plan check; POS is always launchable subject to the version check. Dropped the now-unused `CiabPlanUpgradeRequired` non-launchability reason.
- `WooPosTabShouldBeVisible` — removed the CIAB-unsupported early return (and its `CIABSiteGateKeeper` dependency).
- `WooPosEligibilityViewModel` / `WooPosEligibilityScreen` — removed the `CiabPlanUpgradeRequired` state, the learn-more/upgrade button, and the resume-recheck round-trip that existed only for the upgrade flow.
- `WooPosSettingsStoreViewModel` — the "edit receipt" deep link always uses the standard `wc-settings` path (dropped the CIAB `next-admin` path).
- `WooPosAnalyticsEvent` — removed the `ciab_plan_upgrade_required` analytics reason mapping.
- Removed three now-dead POS eligibility CIAB strings from `values/strings.xml`.
- Updated the POS eligibility/tab/settings unit tests to drop CIAB cases and assert the standard behavior.


### Test Steps

1. Open the app and confirm the POS tab is visible (on a supported tablet/screen size and country) and POS launches normally.
2. In POS settings, tap "Edit receipt" and confirm it opens the standard `wp-admin/admin.php?page=wc-settings&tab=point-of-sale` URL.
3. Eligibility screen (only reached when POS can't launch — e.g. WooCommerce core older than 9.6.0):
   verify via the `WooPosEligibilityScreenRetryablePreview` Compose preview that the screen offers
   only "Retry"/"Exit POS" and that the former CIAB "Pro plan required" / "Learn More" variant is gone
   (its preview has been removed).

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.