### PR TITLE
[WOOMOB-996] Make ProductListRepository#getProductList suspendable

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel.kt
@@ -1111,7 +1111,7 @@ class ProductDetailViewModel @Inject constructor(
      * 1. they arrive to this product details screen from the onboarding list on My Store, or
      * 2. they arrive from other sources while the store's product list is empty.
      */
-    private fun isPublishingFirstProduct(): Boolean =
+    private suspend fun isPublishingFirstProduct(): Boolean =
         navArgs.source == STORE_ONBOARDING || productListRepository.getProductList().isEmpty()
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/list/ProductListRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/list/ProductListRepository.kt
@@ -20,7 +20,6 @@ import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.util.WooLog
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
@@ -206,20 +205,18 @@ class ProductListRepository @Inject constructor(
     /**
      * Returns all products for the current site that are in the database
      */
-    fun getProductList(
+    suspend fun getProductList(
         productFilterOptions: Map<WCProductStore.ProductFilterOption, String> = emptyMap(),
         excludedProductIds: List<Long> = emptyList(),
         sortType: WCProductStore.ProductSorting? = null
     ): List<Product> {
         return if (selectedSite.exists()) {
-            val wcProducts = runBlocking {
-                productStore.getProducts(
-                    selectedSite.get(),
-                    filterOptions = productFilterOptions,
-                    sortType = sortType ?: productSortingChoice,
-                    excludedProductIds = excludedProductIds
-                )
-            }
+            val wcProducts = productStore.getProducts(
+                selectedSite.get(),
+                filterOptions = productFilterOptions,
+                sortType = sortType ?: productSortingChoice,
+                excludedProductIds = excludedProductIds
+            )
             wcProducts.map { it.toAppModel() }
         } else {
             WooLog.w(WooLog.T.PRODUCTS, "No site selected - unable to load products")

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductSelectionListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductSelectionListViewModelTest.kt
@@ -13,6 +13,8 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
@@ -34,7 +36,9 @@ class ProductSelectionListViewModelTest : BaseUnitTest() {
     private val networkStatus: NetworkStatus = mock {
         on { isConnected() } doReturn true
     }
-    private val productRepository: ProductListRepository = mock()
+    private val productRepository: ProductListRepository = mock {
+        on { getProductList(any(), any(), anyOrNull()) } doReturn emptyList()
+    }
     private val savedState = ProductSelectionListFragmentArgs(
         remoteProductId = PRODUCT_REMOTE_ID,
         groupedProductListType = GroupedProductListType.GROUPED,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel_AddFlowTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel_AddFlowTest.kt
@@ -39,6 +39,7 @@ import org.assertj.core.api.Assertions
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.clearInvocations
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
@@ -186,7 +187,9 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
                 selectedSite = selectedSite,
                 getBundledProductsCount = mock(),
                 getComponentProducts = mock(),
-                productListRepository = mock(),
+                productListRepository = mock {
+                    on { getProductList(any(), any(), anyOrNull()) } doReturn emptyList()
+                },
                 isBlazeEnabled = isBlazeEnabled,
                 isProductCurrentlyPromoted = mock(),
                 isWindowClassLargeThanCompact = mock(),

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/list/ProductListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/list/ProductListViewModelTest.kt
@@ -55,6 +55,9 @@ class ProductListViewModelTest : BaseUnitTest() {
     fun setup() {
         doReturn(true).whenever(networkStatus).isConnected()
         doReturn(WCProductStore.ProductSorting.DATE_ASC).whenever(productRepository).productSortingChoice
+        productRepository.stub {
+            on { getProductList(any(), any(), anyOrNull()) } doReturn emptyList()
+        }
     }
 
     private fun createViewModel() {


### PR DESCRIPTION
Fixes WOOMOB-996

### Description

`ProductListRepository.getProductList` was non-suspend and used `runBlocking` to call the suspend `WCProductStore.getProducts`. Most of its callers already run inside a coroutine, so that `runBlocking` was blocking the main thread while Room queried the product list.

This PR makes the function suspend and removes the `runBlocking`. Five of the six call sites were already suspend-ready and needed no changes; the only synchronous caller, `ProductDetailViewModel.isPublishingFirstProduct`, is now suspend too, and its single call site was already inside a coroutine. Part of WOOMOB-983.

### Test Steps

No user-visible change; this is an internal threading fix. On a store with products:

1. Open the **Products** tab.
2. Confirm the product list loads and shows the expected products.

### Images/gif

N/A, no UI change.

- [x] I have considered if this change warrants release notes. This is an internal refactor with no behavior change, so none were added.