### PR TITLE
[Design System] Add buttons and display components

### DIFF
--- a/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooBadge.kt
+++ b/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooBadge.kt
@@ -1,0 +1,138 @@
+package com.woocommerce.android.ui.compose.designsystem.component
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import com.woocommerce.android.ui.compose.designsystem.WooTheme
+import com.woocommerce.android.ui.compose.designsystem.foundation.WooDesignSystemTheme
+import com.woocommerce.android.ui.compose.designsystem.icons.Star
+import com.woocommerce.android.ui.compose.designsystem.icons.WooDsIcons
+
+@Composable
+fun WooBadge(
+    text: String,
+    modifier: Modifier = Modifier,
+    tone: WooBadgeTone = WooBadgeTone.Neutral,
+    leadingIcon: (@Composable () -> Unit)? = null,
+) {
+    val colors = tone.toBadgeColors()
+
+    Surface(
+        modifier = modifier.heightIn(min = BADGE_MIN_HEIGHT),
+        color = colors.containerColor,
+        contentColor = colors.contentColor,
+        border = colors.border,
+        shape = RoundedCornerShape(WooTheme.radius.medium),
+    ) {
+        Row(
+            modifier = Modifier.padding(
+                horizontal = WooTheme.padding.padding3,
+            ),
+            horizontalArrangement = Arrangement.spacedBy(WooTheme.spacing.space1),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            if (leadingIcon != null) {
+                CompositionLocalProvider(LocalContentColor provides colors.contentColor) {
+                    Box(
+                        modifier = Modifier.size(WooTheme.iconSize.size14),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        leadingIcon()
+                    }
+                }
+            }
+            Text(
+                text = text,
+                style = WooTheme.text.bodySmall.regular,
+            )
+        }
+    }
+}
+
+@Suppress("UnusedPrivateMember")
+@PreviewLightDark
+@Composable
+private fun WooBadgePreview() {
+    WooDesignSystemTheme {
+        Surface(color = WooTheme.colors.background.section) {
+            WooBadgeDemo(modifier = Modifier.padding(WooTheme.padding.padding5))
+        }
+    }
+}
+
+@Composable
+internal fun WooBadgeDemo(
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(WooTheme.spacing.space2),
+    ) {
+        Row(horizontalArrangement = Arrangement.spacedBy(WooTheme.spacing.space2)) {
+            WooBadge("Error", tone = WooBadgeTone.Error, leadingIcon = { BadgeLeadingIcon() })
+            WooBadge("Caution", tone = WooBadgeTone.Caution, leadingIcon = { BadgeLeadingIcon() })
+            WooBadge("Warning", tone = WooBadgeTone.Warning, leadingIcon = { BadgeLeadingIcon() })
+        }
+        Row(horizontalArrangement = Arrangement.spacedBy(WooTheme.spacing.space2)) {
+            WooBadge("Success", tone = WooBadgeTone.Success, leadingIcon = { BadgeLeadingIcon() })
+            WooBadge("Info", tone = WooBadgeTone.Info, leadingIcon = { BadgeLeadingIcon() })
+            WooBadge("Neutral", tone = WooBadgeTone.Neutral, leadingIcon = { BadgeLeadingIcon() })
+            WooBadge(
+                "Outlined",
+                tone = WooBadgeTone.NeutralOutlined,
+                leadingIcon = { BadgeLeadingIcon() },
+            )
+        }
+    }
+}
+
+@Composable
+private fun BadgeLeadingIcon() {
+    Icon(
+        imageVector = WooDsIcons.Regular.Star,
+        contentDescription = null,
+    )
+}
+
+@Composable
+private fun WooBadgeTone.toBadgeColors(): WooBadgeColors {
+    val colors = WooTheme.colors
+    return when (this) {
+        WooBadgeTone.Neutral -> WooBadgeColors(colors.status.neutralContainer, colors.status.onNeutralContainer)
+        WooBadgeTone.NeutralOutlined -> WooBadgeColors(
+            containerColor = Color.Transparent,
+            contentColor = colors.surface.onDefault,
+            border = BorderStroke(WooTheme.stroke.regular, colors.outlineVariant),
+        )
+        WooBadgeTone.Info -> WooBadgeColors(colors.status.infoContainer, colors.status.onInfoContainer)
+        WooBadgeTone.Success -> WooBadgeColors(colors.status.successContainer, colors.status.onSuccessContainer)
+        WooBadgeTone.Warning -> WooBadgeColors(colors.status.warningContainer, colors.status.onWarningContainer)
+        WooBadgeTone.Caution -> WooBadgeColors(colors.status.cautionContainer, colors.status.onCautionContainer)
+        WooBadgeTone.Error -> WooBadgeColors(colors.status.errorContainer, colors.status.onErrorContainer)
+    }
+}
+
+private data class WooBadgeColors(
+    val containerColor: Color,
+    val contentColor: Color,
+    val border: BorderStroke? = null,
+)
+
+private val BADGE_MIN_HEIGHT = 24.dp

--- a/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooBadge.kt
+++ b/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooBadge.kt
@@ -23,7 +23,7 @@ import androidx.compose.ui.unit.dp
 import com.woocommerce.android.ui.compose.designsystem.WooTheme
 import com.woocommerce.android.ui.compose.designsystem.foundation.WooDesignSystemTheme
 import com.woocommerce.android.ui.compose.designsystem.icons.Star
-import com.woocommerce.android.ui.compose.designsystem.icons.WooDsIcons
+import com.woocommerce.android.ui.compose.designsystem.icons.WooIcons
 
 @Composable
 fun WooBadge(
@@ -106,7 +106,7 @@ internal fun WooBadgeDemo(
 @Composable
 private fun BadgeLeadingIcon() {
     Icon(
-        imageVector = WooDsIcons.Regular.Star,
+        imageVector = WooIcons.Regular.Star,
         contentDescription = null,
     )
 }

--- a/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooBadge.kt
+++ b/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooBadge.kt
@@ -119,7 +119,7 @@ private fun WooBadgeTone.toBadgeColors(): WooBadgeColors {
         WooBadgeTone.NeutralOutlined -> WooBadgeColors(
             containerColor = Color.Transparent,
             contentColor = colors.surface.onDefault,
-            border = BorderStroke(WooTheme.stroke.regular, colors.outlineVariant),
+            border = BorderStroke(WooTheme.stroke.regular, colors.status.neutralContainer),
         )
         WooBadgeTone.Info -> WooBadgeColors(colors.status.infoContainer, colors.status.onInfoContainer)
         WooBadgeTone.Success -> WooBadgeColors(colors.status.successContainer, colors.status.onSuccessContainer)

--- a/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooBadgeTone.kt
+++ b/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooBadgeTone.kt
@@ -1,0 +1,11 @@
+package com.woocommerce.android.ui.compose.designsystem.component
+
+enum class WooBadgeTone {
+    Neutral,
+    NeutralOutlined,
+    Info,
+    Success,
+    Warning,
+    Caution,
+    Error,
+}

--- a/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooButton.kt
+++ b/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooButton.kt
@@ -1,0 +1,305 @@
+package com.woocommerce.android.ui.compose.designsystem.component
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonColors
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.woocommerce.android.ui.compose.designsystem.WooTheme
+import com.woocommerce.android.ui.compose.designsystem.foundation.WooDesignSystemTheme
+import com.woocommerce.android.ui.compose.designsystem.icons.Star
+import com.woocommerce.android.ui.compose.designsystem.icons.WooDsIcons
+
+@Composable
+fun WooFilledButton(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    size: WooButtonSize = WooButtonSize.Medium,
+    leadingIcon: @Composable (() -> Unit)? = null,
+) {
+    WooButton(
+        text = text,
+        onClick = onClick,
+        modifier = modifier,
+        enabled = enabled,
+        size = size,
+        style = WooButtonStyle.Filled,
+        leadingIcon = leadingIcon,
+    )
+}
+
+@Composable
+fun WooFilledTonalButton(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    size: WooButtonSize = WooButtonSize.Medium,
+    leadingIcon: @Composable (() -> Unit)? = null,
+) {
+    WooButton(
+        text = text,
+        onClick = onClick,
+        modifier = modifier,
+        enabled = enabled,
+        size = size,
+        style = WooButtonStyle.FilledTonal,
+        leadingIcon = leadingIcon,
+    )
+}
+
+@Composable
+fun WooOutlinedButton(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    size: WooButtonSize = WooButtonSize.Medium,
+    leadingIcon: @Composable (() -> Unit)? = null,
+) {
+    WooButton(
+        text = text,
+        onClick = onClick,
+        modifier = modifier,
+        enabled = enabled,
+        size = size,
+        style = WooButtonStyle.Outlined,
+        leadingIcon = leadingIcon,
+    )
+}
+
+@Composable
+private fun WooButton(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier,
+    enabled: Boolean,
+    size: WooButtonSize,
+    style: WooButtonStyle,
+    leadingIcon: @Composable (() -> Unit)?,
+) {
+    val buttonSpec = size.toButtonSpec()
+    val buttonColors = style.toButtonColors(enabled)
+    val shape = RoundedCornerShape(buttonSpec.radius)
+    val buttonModifier = modifier.heightIn(min = buttonSpec.visualHeight)
+    val contentPadding = PaddingValues(horizontal = WooTheme.padding.padding5)
+    val content: @Composable () -> Unit = {
+        WooButtonContent(
+            text = text,
+            buttonSpec = buttonSpec,
+            leadingIcon = leadingIcon,
+        )
+    }
+
+    when (style) {
+        WooButtonStyle.Filled -> Button(
+            onClick = onClick,
+            modifier = buttonModifier,
+            enabled = enabled,
+            shape = shape,
+            colors = buttonColors,
+            elevation = null,
+            contentPadding = contentPadding,
+            content = { content() },
+        )
+        WooButtonStyle.FilledTonal -> FilledTonalButton(
+            onClick = onClick,
+            modifier = buttonModifier,
+            enabled = enabled,
+            shape = shape,
+            colors = buttonColors,
+            elevation = null,
+            contentPadding = contentPadding,
+            content = { content() },
+        )
+        WooButtonStyle.Outlined -> OutlinedButton(
+            onClick = onClick,
+            modifier = buttonModifier,
+            enabled = enabled,
+            shape = shape,
+            colors = buttonColors,
+            border = style.toButtonBorder(enabled),
+            contentPadding = contentPadding,
+            content = { content() },
+        )
+    }
+}
+
+@Composable
+private fun WooButtonContent(
+    text: String,
+    buttonSpec: WooButtonSpec,
+    leadingIcon: @Composable (() -> Unit)?,
+) {
+    if (leadingIcon != null) {
+        Box(
+            modifier = Modifier.size(buttonSpec.iconSize),
+            contentAlignment = Alignment.Center,
+        ) {
+            leadingIcon()
+        }
+        Spacer(modifier = Modifier.width(WooTheme.spacing.space3))
+    }
+    Text(
+        text = text,
+        textAlign = TextAlign.Center,
+        style = buttonSpec.textStyle,
+    )
+}
+
+@Composable
+private fun WooButtonStyle.toButtonColors(enabled: Boolean): ButtonColors {
+    val colors = WooTheme.colors
+    val disabledStateLayerColor = colors.surface.onDefault.copy(alpha = DISABLED_STATE_LAYER_ALPHA)
+    val disabledContentColor = colors.surface.onDefault.copy(alpha = DISABLED_CONTENT_ALPHA)
+
+    return when (this) {
+        WooButtonStyle.Filled -> ButtonDefaults.buttonColors(
+            containerColor = if (enabled) colors.primary else disabledStateLayerColor,
+            contentColor = if (enabled) colors.onPrimary else disabledContentColor,
+            disabledContainerColor = disabledStateLayerColor,
+            disabledContentColor = disabledContentColor,
+        )
+        WooButtonStyle.FilledTonal -> ButtonDefaults.filledTonalButtonColors(
+            containerColor = if (enabled) colors.container.secondaryContainer else disabledStateLayerColor,
+            contentColor = if (enabled) colors.container.onSecondaryContainer else disabledContentColor,
+            disabledContainerColor = disabledStateLayerColor,
+            disabledContentColor = disabledContentColor,
+        )
+        WooButtonStyle.Outlined -> ButtonDefaults.outlinedButtonColors(
+            containerColor = Color.Transparent,
+            contentColor = if (enabled) colors.primary else disabledContentColor,
+            disabledContainerColor = Color.Transparent,
+            disabledContentColor = disabledContentColor,
+        )
+    }
+}
+
+@Composable
+private fun WooButtonStyle.toButtonBorder(enabled: Boolean): BorderStroke? =
+    when (this) {
+        WooButtonStyle.Outlined -> {
+            val colors = WooTheme.colors
+            BorderStroke(
+                width = WooTheme.stroke.medium,
+                color = if (enabled) {
+                    colors.container.secondaryContainer
+                } else {
+                    colors.surface.onDefault.copy(alpha = DISABLED_STATE_LAYER_ALPHA)
+                },
+            )
+        }
+        else -> null
+    }
+
+private enum class WooButtonStyle {
+    Filled,
+    FilledTonal,
+    Outlined,
+}
+
+@Composable
+private fun LeadingButtonIcon() {
+    Icon(
+        imageVector = WooDsIcons.Regular.Star,
+        contentDescription = null,
+    )
+}
+
+@Suppress("UnusedPrivateMember")
+@PreviewLightDark
+@Composable
+private fun WooButtonPreview() {
+    WooDesignSystemTheme {
+        Surface(color = WooTheme.colors.background.section) {
+            WooButtonDemo(modifier = Modifier.padding(WooTheme.padding.padding5))
+        }
+    }
+}
+
+@Composable
+internal fun WooButtonDemo(
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(WooTheme.spacing.space3),
+    ) {
+        WooFilledButton(
+            text = "Label",
+            onClick = {},
+            leadingIcon = { LeadingButtonIcon() },
+        )
+        WooFilledTonalButton(
+            text = "Filled tonal",
+            onClick = {},
+            leadingIcon = { LeadingButtonIcon() },
+        )
+        WooOutlinedButton(
+            text = "Outlined",
+            onClick = {},
+            leadingIcon = { LeadingButtonIcon() },
+        )
+        WooFilledButton(
+            text = "Small",
+            onClick = {},
+            size = WooButtonSize.Small,
+            leadingIcon = { LeadingButtonIcon() },
+        )
+        WooFilledButton(text = "Disabled", onClick = {}, enabled = false)
+    }
+}
+
+@Composable
+private fun WooButtonSize.toButtonSpec(): WooButtonSpec =
+    when (this) {
+        WooButtonSize.Medium -> WooButtonSpec(
+            visualHeight = MEDIUM_BUTTON_VISUAL_HEIGHT,
+            radius = WooTheme.radius.extraLarge,
+            iconSize = WooTheme.iconSize.size18,
+            textStyle = WooTheme.text.labelLarge.emphasized,
+        )
+        WooButtonSize.Small -> WooButtonSpec(
+            visualHeight = SMALL_BUTTON_VISUAL_HEIGHT,
+            radius = WooTheme.radius.large,
+            iconSize = WooTheme.iconSize.size14,
+            textStyle = WooTheme.text.labelMedium.emphasized,
+        )
+    }
+
+private data class WooButtonSpec(
+    val visualHeight: Dp,
+    val radius: Dp,
+    val iconSize: Dp,
+    val textStyle: TextStyle,
+)
+
+private val MEDIUM_BUTTON_VISUAL_HEIGHT = 56.dp
+private val SMALL_BUTTON_VISUAL_HEIGHT = 32.dp
+private const val DISABLED_STATE_LAYER_ALPHA = 0.08f
+private const val DISABLED_CONTENT_ALPHA = 0.30f

--- a/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooButton.kt
+++ b/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooButton.kt
@@ -31,7 +31,7 @@ import androidx.compose.ui.unit.dp
 import com.woocommerce.android.ui.compose.designsystem.WooTheme
 import com.woocommerce.android.ui.compose.designsystem.foundation.WooDesignSystemTheme
 import com.woocommerce.android.ui.compose.designsystem.icons.Star
-import com.woocommerce.android.ui.compose.designsystem.icons.WooDsIcons
+import com.woocommerce.android.ui.compose.designsystem.icons.WooIcons
 
 @Composable
 fun WooFilledButton(
@@ -226,7 +226,7 @@ private enum class WooButtonStyle {
 @Composable
 private fun LeadingButtonIcon() {
     Icon(
-        imageVector = WooDsIcons.Regular.Star,
+        imageVector = WooIcons.Regular.Star,
         contentDescription = null,
     )
 }

--- a/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooButton.kt
+++ b/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooButton.kt
@@ -104,7 +104,7 @@ private fun WooButton(
     leadingIcon: @Composable (() -> Unit)?,
 ) {
     val buttonSpec = size.toButtonSpec()
-    val buttonColors = style.toButtonColors(enabled)
+    val buttonColors = style.toButtonColors()
     val shape = RoundedCornerShape(buttonSpec.radius)
     val buttonModifier = modifier.heightIn(min = buttonSpec.visualHeight)
     val contentPadding = PaddingValues(horizontal = WooTheme.padding.padding5)
@@ -173,27 +173,27 @@ private fun WooButtonContent(
 }
 
 @Composable
-private fun WooButtonStyle.toButtonColors(enabled: Boolean): ButtonColors {
+private fun WooButtonStyle.toButtonColors(): ButtonColors {
     val colors = WooTheme.colors
     val disabledStateLayerColor = colors.surface.onDefault.copy(alpha = DISABLED_STATE_LAYER_ALPHA)
     val disabledContentColor = colors.surface.onDefault.copy(alpha = DISABLED_CONTENT_ALPHA)
 
     return when (this) {
         WooButtonStyle.Filled -> ButtonDefaults.buttonColors(
-            containerColor = if (enabled) colors.primary else disabledStateLayerColor,
-            contentColor = if (enabled) colors.onPrimary else disabledContentColor,
+            containerColor = colors.primary,
+            contentColor = colors.onPrimary,
             disabledContainerColor = disabledStateLayerColor,
             disabledContentColor = disabledContentColor,
         )
         WooButtonStyle.FilledTonal -> ButtonDefaults.filledTonalButtonColors(
-            containerColor = if (enabled) colors.container.secondaryContainer else disabledStateLayerColor,
-            contentColor = if (enabled) colors.container.onSecondaryContainer else disabledContentColor,
+            containerColor = colors.container.secondaryContainer,
+            contentColor = colors.container.onSecondaryContainer,
             disabledContainerColor = disabledStateLayerColor,
             disabledContentColor = disabledContentColor,
         )
         WooButtonStyle.Outlined -> ButtonDefaults.outlinedButtonColors(
             containerColor = Color.Transparent,
-            contentColor = if (enabled) colors.primary else disabledContentColor,
+            contentColor = colors.primary,
             disabledContainerColor = Color.Transparent,
             disabledContentColor = disabledContentColor,
         )

--- a/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooButtonSize.kt
+++ b/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooButtonSize.kt
@@ -1,0 +1,6 @@
+package com.woocommerce.android.ui.compose.designsystem.component
+
+enum class WooButtonSize {
+    Medium,
+    Small,
+}

--- a/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooDivider.kt
+++ b/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooDivider.kt
@@ -1,0 +1,64 @@
+package com.woocommerce.android.ui.compose.designsystem.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Surface
+import androidx.compose.material3.VerticalDivider
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import com.woocommerce.android.ui.compose.designsystem.WooTheme
+import com.woocommerce.android.ui.compose.designsystem.foundation.WooDesignSystemTheme
+
+@Composable
+fun WooDivider(
+    modifier: Modifier = Modifier,
+) {
+    HorizontalDivider(
+        modifier = modifier,
+        thickness = WooTheme.stroke.extraThin,
+        color = WooTheme.colors.outlineVariant,
+    )
+}
+
+@Suppress("UnusedPrivateMember")
+@PreviewLightDark
+@Composable
+private fun WooDividerPreview() {
+    WooDesignSystemTheme {
+        Surface(color = WooTheme.colors.background.section) {
+            WooDividerDemo(modifier = Modifier.padding(WooTheme.padding.padding5))
+        }
+    }
+}
+
+@Composable
+internal fun WooDividerDemo(
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(WooTheme.spacing.space4),
+    ) {
+        WooDivider()
+        Row(modifier = Modifier.height(48.dp)) {
+            WooVerticalDivider()
+        }
+    }
+}
+
+@Composable
+fun WooVerticalDivider(
+    modifier: Modifier = Modifier,
+) {
+    VerticalDivider(
+        modifier = modifier,
+        thickness = WooTheme.stroke.extraThin,
+        color = WooTheme.colors.outlineVariant,
+    )
+}

--- a/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooIconButton.kt
+++ b/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooIconButton.kt
@@ -57,7 +57,7 @@ fun WooIconButton(
     emphasis: WooIconButtonEmphasis = WooIconButtonEmphasis.Neutral,
     icon: @Composable () -> Unit,
 ) {
-    require(contentDescription.isNotBlank()) {
+    assert(contentDescription.isNotBlank()) {
         "WooIconButton contentDescription must not be blank"
     }
 
@@ -110,7 +110,7 @@ internal fun WooIconButtonDemo(
     ) {
         WooIconButton(
             imageVector = WooIcons.Regular.CommentQuestion,
-            contentDescription = "Help",
+            contentDescription = "",
             onClick = {},
         )
         WooIconButton(

--- a/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooIconButton.kt
+++ b/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooIconButton.kt
@@ -22,7 +22,7 @@ import com.woocommerce.android.ui.compose.designsystem.WooTheme
 import com.woocommerce.android.ui.compose.designsystem.foundation.WooDesignSystemTheme
 import com.woocommerce.android.ui.compose.designsystem.icons.ArrowUpRight
 import com.woocommerce.android.ui.compose.designsystem.icons.CommentQuestion
-import com.woocommerce.android.ui.compose.designsystem.icons.WooDsIcons
+import com.woocommerce.android.ui.compose.designsystem.icons.WooIcons
 
 @Composable
 fun WooIconButton(
@@ -109,18 +109,18 @@ internal fun WooIconButtonDemo(
         horizontalArrangement = Arrangement.spacedBy(WooTheme.spacing.space3),
     ) {
         WooIconButton(
-            imageVector = WooDsIcons.Regular.CommentQuestion,
+            imageVector = WooIcons.Regular.CommentQuestion,
             contentDescription = "Help",
             onClick = {},
         )
         WooIconButton(
-            imageVector = WooDsIcons.Regular.ArrowUpRight,
+            imageVector = WooIcons.Regular.ArrowUpRight,
             contentDescription = "Open",
             onClick = {},
             emphasis = WooIconButtonEmphasis.Primary,
         )
         WooIconButton(
-            imageVector = WooDsIcons.Regular.CommentQuestion,
+            imageVector = WooIcons.Regular.CommentQuestion,
             contentDescription = "Disabled help",
             onClick = {},
             enabled = false,

--- a/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooIconButton.kt
+++ b/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooIconButton.kt
@@ -1,0 +1,131 @@
+package com.woocommerce.android.ui.compose.designsystem.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import com.woocommerce.android.ui.compose.designsystem.WooTheme
+import com.woocommerce.android.ui.compose.designsystem.foundation.WooDesignSystemTheme
+import com.woocommerce.android.ui.compose.designsystem.icons.ArrowUpRight
+import com.woocommerce.android.ui.compose.designsystem.icons.CommentQuestion
+import com.woocommerce.android.ui.compose.designsystem.icons.WooDsIcons
+
+@Composable
+fun WooIconButton(
+    imageVector: ImageVector,
+    contentDescription: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    emphasis: WooIconButtonEmphasis = WooIconButtonEmphasis.Neutral,
+) {
+    WooIconButton(
+        onClick = onClick,
+        contentDescription = contentDescription,
+        modifier = modifier,
+        enabled = enabled,
+        emphasis = emphasis,
+    ) {
+        Icon(
+            imageVector = imageVector,
+            contentDescription = null,
+            modifier = Modifier.size(WooTheme.iconSize.size24),
+        )
+    }
+}
+
+@Composable
+fun WooIconButton(
+    onClick: () -> Unit,
+    contentDescription: String,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    emphasis: WooIconButtonEmphasis = WooIconButtonEmphasis.Neutral,
+    icon: @Composable () -> Unit,
+) {
+    require(contentDescription.isNotBlank()) {
+        "WooIconButton contentDescription must not be blank"
+    }
+
+    val colors = WooTheme.colors
+    val contentColor = when (emphasis) {
+        WooIconButtonEmphasis.Neutral -> colors.surface.onDefault
+        WooIconButtonEmphasis.Primary -> colors.primary
+    }
+
+    IconButton(
+        onClick = onClick,
+        modifier = modifier
+            .size(MIN_TOUCH_TARGET_SIZE)
+            .semantics {
+                this.contentDescription = contentDescription
+            },
+        enabled = enabled,
+        colors = IconButtonDefaults.iconButtonColors(
+            contentColor = contentColor,
+            disabledContentColor = colors.surface.onVariantLowest,
+        ),
+    ) {
+        Box(
+            modifier = Modifier.clearAndSetSemantics {},
+            contentAlignment = Alignment.Center,
+        ) {
+            icon()
+        }
+    }
+}
+
+@Suppress("UnusedPrivateMember")
+@PreviewLightDark
+@Composable
+private fun WooIconButtonPreview() {
+    WooDesignSystemTheme {
+        Surface(color = WooTheme.colors.background.section) {
+            WooIconButtonDemo(modifier = Modifier.padding(WooTheme.padding.padding5))
+        }
+    }
+}
+
+@Composable
+internal fun WooIconButtonDemo(
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(WooTheme.spacing.space3),
+    ) {
+        WooIconButton(
+            imageVector = WooDsIcons.Regular.CommentQuestion,
+            contentDescription = "Help",
+            onClick = {},
+        )
+        WooIconButton(
+            imageVector = WooDsIcons.Regular.ArrowUpRight,
+            contentDescription = "Open",
+            onClick = {},
+            emphasis = WooIconButtonEmphasis.Primary,
+        )
+        WooIconButton(
+            imageVector = WooDsIcons.Regular.CommentQuestion,
+            contentDescription = "Disabled help",
+            onClick = {},
+            enabled = false,
+        )
+    }
+}
+
+private val MIN_TOUCH_TARGET_SIZE = 48.dp

--- a/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooIconButtonEmphasis.kt
+++ b/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooIconButtonEmphasis.kt
@@ -1,0 +1,6 @@
+package com.woocommerce.android.ui.compose.designsystem.component
+
+enum class WooIconButtonEmphasis {
+    Neutral,
+    Primary,
+}

--- a/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooIconContainer.kt
+++ b/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooIconContainer.kt
@@ -1,0 +1,129 @@
+package com.woocommerce.android.ui.compose.designsystem.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import com.woocommerce.android.ui.compose.designsystem.WooTheme
+import com.woocommerce.android.ui.compose.designsystem.foundation.WooDesignSystemTheme
+import com.woocommerce.android.ui.compose.designsystem.icons.Star
+import com.woocommerce.android.ui.compose.designsystem.icons.WooDsIcons
+
+@Composable
+fun WooIconContainer(
+    imageVector: ImageVector,
+    modifier: Modifier = Modifier,
+    tone: WooIconContainerTone = WooIconContainerTone.Purple,
+    contentDescription: String? = null,
+) {
+    if (contentDescription != null) {
+        require(contentDescription.isNotBlank()) {
+            "WooIconContainer contentDescription must not be blank when provided"
+        }
+    }
+
+    val colors = tone.toIconContainerColors()
+
+    Surface(
+        modifier = modifier.size(ICON_CONTAINER_SIZE),
+        color = colors.containerColor,
+        contentColor = colors.contentColor,
+        shape = RoundedCornerShape(WooTheme.radius.medium),
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            Icon(
+                imageVector = imageVector,
+                contentDescription = contentDescription,
+                modifier = Modifier.size(WooTheme.iconSize.size18),
+            )
+        }
+    }
+}
+
+@Suppress("UnusedPrivateMember")
+@PreviewLightDark
+@Composable
+private fun WooIconContainerPreview() {
+    WooDesignSystemTheme {
+        Surface(color = WooTheme.colors.background.section) {
+            WooIconContainerDemo(modifier = Modifier.padding(WooTheme.padding.padding5))
+        }
+    }
+}
+
+@Composable
+internal fun WooIconContainerDemo(
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(WooTheme.spacing.space3),
+    ) {
+        Row(horizontalArrangement = Arrangement.spacedBy(WooTheme.spacing.space3)) {
+            WooIconContainer(WooDsIcons.Regular.Star)
+            WooIconContainer(
+                imageVector = WooDsIcons.Regular.Star,
+                tone = WooIconContainerTone.Sandstone,
+            )
+            WooIconContainer(
+                imageVector = WooDsIcons.Regular.Star,
+                tone = WooIconContainerTone.Blue,
+            )
+            WooIconContainer(
+                imageVector = WooDsIcons.Regular.Star,
+                tone = WooIconContainerTone.Green,
+            )
+        }
+        Row(horizontalArrangement = Arrangement.spacedBy(WooTheme.spacing.space3)) {
+            WooIconContainer(
+                imageVector = WooDsIcons.Regular.Star,
+                tone = WooIconContainerTone.Orange,
+            )
+            WooIconContainer(
+                imageVector = WooDsIcons.Regular.Star,
+                tone = WooIconContainerTone.Pink,
+            )
+            WooIconContainer(
+                imageVector = WooDsIcons.Regular.Star,
+                tone = WooIconContainerTone.DarkPurple,
+            )
+        }
+    }
+}
+
+@Composable
+private fun WooIconContainerTone.toIconContainerColors(): WooIconContainerColors {
+    val colors = WooTheme.colors
+    val palette = colors.palette
+
+    return when (this) {
+        WooIconContainerTone.Purple -> WooIconContainerColors(palette.wooPurple.shade0, colors.primary)
+        WooIconContainerTone.Sandstone -> {
+            WooIconContainerColors(palette.sandstone.shade10, palette.sandstone.shade60)
+        }
+        WooIconContainerTone.Blue -> WooIconContainerColors(palette.wooBlue.shade20, palette.wooBlue.shade60)
+        WooIconContainerTone.Green -> WooIconContainerColors(palette.wooGreen.shade20, palette.wooGreen.shade60)
+        WooIconContainerTone.Orange -> WooIconContainerColors(palette.wooOrange.shade20, palette.wooOrange.shade60)
+        WooIconContainerTone.Pink -> WooIconContainerColors(palette.wooPink.shade20, palette.wooPink.shade60)
+        WooIconContainerTone.DarkPurple -> WooIconContainerColors(colors.primary, palette.wooPurple.shade5)
+    }
+}
+
+private data class WooIconContainerColors(
+    val containerColor: Color,
+    val contentColor: Color,
+)
+
+private val ICON_CONTAINER_SIZE = 44.dp

--- a/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooIconContainer.kt
+++ b/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooIconContainer.kt
@@ -28,12 +28,6 @@ fun WooIconContainer(
     tone: WooIconContainerTone = WooIconContainerTone.Purple,
     contentDescription: String? = null,
 ) {
-    if (contentDescription != null) {
-        require(contentDescription.isNotBlank()) {
-            "WooIconContainer contentDescription must not be blank when provided"
-        }
-    }
-
     val colors = tone.toIconContainerColors()
 
     Surface(

--- a/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooIconContainer.kt
+++ b/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooIconContainer.kt
@@ -19,7 +19,7 @@ import androidx.compose.ui.unit.dp
 import com.woocommerce.android.ui.compose.designsystem.WooTheme
 import com.woocommerce.android.ui.compose.designsystem.foundation.WooDesignSystemTheme
 import com.woocommerce.android.ui.compose.designsystem.icons.Star
-import com.woocommerce.android.ui.compose.designsystem.icons.WooDsIcons
+import com.woocommerce.android.ui.compose.designsystem.icons.WooIcons
 
 @Composable
 fun WooIconContainer(
@@ -72,31 +72,31 @@ internal fun WooIconContainerDemo(
         verticalArrangement = Arrangement.spacedBy(WooTheme.spacing.space3),
     ) {
         Row(horizontalArrangement = Arrangement.spacedBy(WooTheme.spacing.space3)) {
-            WooIconContainer(WooDsIcons.Regular.Star)
+            WooIconContainer(WooIcons.Regular.Star)
             WooIconContainer(
-                imageVector = WooDsIcons.Regular.Star,
+                imageVector = WooIcons.Regular.Star,
                 tone = WooIconContainerTone.Sandstone,
             )
             WooIconContainer(
-                imageVector = WooDsIcons.Regular.Star,
+                imageVector = WooIcons.Regular.Star,
                 tone = WooIconContainerTone.Blue,
             )
             WooIconContainer(
-                imageVector = WooDsIcons.Regular.Star,
+                imageVector = WooIcons.Regular.Star,
                 tone = WooIconContainerTone.Green,
             )
         }
         Row(horizontalArrangement = Arrangement.spacedBy(WooTheme.spacing.space3)) {
             WooIconContainer(
-                imageVector = WooDsIcons.Regular.Star,
+                imageVector = WooIcons.Regular.Star,
                 tone = WooIconContainerTone.Orange,
             )
             WooIconContainer(
-                imageVector = WooDsIcons.Regular.Star,
+                imageVector = WooIcons.Regular.Star,
                 tone = WooIconContainerTone.Pink,
             )
             WooIconContainer(
-                imageVector = WooDsIcons.Regular.Star,
+                imageVector = WooIcons.Regular.Star,
                 tone = WooIconContainerTone.DarkPurple,
             )
         }

--- a/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooIconContainerTone.kt
+++ b/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooIconContainerTone.kt
@@ -1,0 +1,11 @@
+package com.woocommerce.android.ui.compose.designsystem.component
+
+enum class WooIconContainerTone {
+    Purple,
+    Sandstone,
+    Blue,
+    Green,
+    Orange,
+    Pink,
+    DarkPurple,
+}

--- a/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooNoticeBanner.kt
+++ b/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooNoticeBanner.kt
@@ -24,7 +24,7 @@ import com.woocommerce.android.ui.compose.designsystem.foundation.WooDesignSyste
 import com.woocommerce.android.ui.compose.designsystem.icons.Bolt
 import com.woocommerce.android.ui.compose.designsystem.icons.CircleInfo
 import com.woocommerce.android.ui.compose.designsystem.icons.CirclePlus
-import com.woocommerce.android.ui.compose.designsystem.icons.WooDsIcons
+import com.woocommerce.android.ui.compose.designsystem.icons.WooIcons
 
 @Composable
 fun WooNoticeBanner(
@@ -99,7 +99,7 @@ internal fun WooNoticeBannerDemo(
             tone = WooNoticeBannerTone.Success,
             leadingIcon = {
                 Icon(
-                    imageVector = WooDsIcons.Solid.CirclePlus,
+                    imageVector = WooIcons.Solid.CirclePlus,
                     contentDescription = null,
                     modifier = Modifier.size(WooTheme.iconSize.size24),
                 )
@@ -111,7 +111,7 @@ internal fun WooNoticeBannerDemo(
             tone = WooNoticeBannerTone.NeutralOutlined,
             leadingIcon = {
                 Icon(
-                    imageVector = WooDsIcons.Regular.CircleInfo,
+                    imageVector = WooIcons.Regular.CircleInfo,
                     contentDescription = null,
                     modifier = Modifier.size(WooTheme.iconSize.size24),
                 )
@@ -123,7 +123,7 @@ internal fun WooNoticeBannerDemo(
             tone = WooNoticeBannerTone.Warning,
             leadingIcon = {
                 Icon(
-                    imageVector = WooDsIcons.Regular.Bolt,
+                    imageVector = WooIcons.Regular.Bolt,
                     contentDescription = null,
                     modifier = Modifier.size(WooTheme.iconSize.size24),
                 )

--- a/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooNoticeBanner.kt
+++ b/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooNoticeBanner.kt
@@ -1,0 +1,166 @@
+package com.woocommerce.android.ui.compose.designsystem.component
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import com.woocommerce.android.ui.compose.designsystem.WooTheme
+import com.woocommerce.android.ui.compose.designsystem.foundation.WooDesignSystemTheme
+import com.woocommerce.android.ui.compose.designsystem.icons.Bolt
+import com.woocommerce.android.ui.compose.designsystem.icons.CircleInfo
+import com.woocommerce.android.ui.compose.designsystem.icons.CirclePlus
+import com.woocommerce.android.ui.compose.designsystem.icons.WooDsIcons
+
+@Composable
+fun WooNoticeBanner(
+    title: String,
+    modifier: Modifier = Modifier,
+    description: String? = null,
+    tone: WooNoticeBannerTone = WooNoticeBannerTone.Neutral,
+    leadingIcon: (@Composable () -> Unit)? = null,
+) {
+    val colors = tone.toNoticeBannerColors()
+
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        color = colors.containerColor,
+        contentColor = colors.contentColor,
+        shape = RoundedCornerShape(WooTheme.radius.medium),
+        border = colors.border,
+    ) {
+        Row(
+            modifier = Modifier.padding(WooTheme.padding.padding4),
+            horizontalArrangement = Arrangement.spacedBy(WooTheme.spacing.space3),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            if (leadingIcon != null) {
+                CompositionLocalProvider(LocalContentColor provides colors.contentColor) {
+                    Box(
+                        modifier = Modifier.size(WooTheme.iconSize.size24),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        leadingIcon()
+                    }
+                }
+            }
+            Column(verticalArrangement = Arrangement.spacedBy(WooTheme.spacing.space1)) {
+                Text(
+                    text = title,
+                    style = WooTheme.text.titleMedium.emphasized,
+                )
+                if (description != null) {
+                    Text(
+                        text = description,
+                        style = WooTheme.text.bodyMedium.regular,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Suppress("UnusedPrivateMember")
+@PreviewLightDark
+@Composable
+private fun WooNoticeBannerPreview() {
+    WooDesignSystemTheme {
+        Surface(color = WooTheme.colors.background.section) {
+            WooNoticeBannerDemo(modifier = Modifier.padding(WooTheme.padding.padding5))
+        }
+    }
+}
+
+@Composable
+internal fun WooNoticeBannerDemo(
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(WooTheme.spacing.space3),
+    ) {
+        WooNoticeBanner(
+            title = "Orders synced",
+            description = "New order data is available.",
+            tone = WooNoticeBannerTone.Success,
+            leadingIcon = {
+                Icon(
+                    imageVector = WooDsIcons.Solid.CirclePlus,
+                    contentDescription = null,
+                    modifier = Modifier.size(WooTheme.iconSize.size24),
+                )
+            },
+        )
+        WooNoticeBanner(
+            title = "Manual review needed",
+            description = "Some settings need another look.",
+            tone = WooNoticeBannerTone.NeutralOutlined,
+            leadingIcon = {
+                Icon(
+                    imageVector = WooDsIcons.Regular.CircleInfo,
+                    contentDescription = null,
+                    modifier = Modifier.size(WooTheme.iconSize.size24),
+                )
+            },
+        )
+        WooNoticeBanner(
+            title = "Connection issue",
+            description = "Some analytics data may be delayed.",
+            tone = WooNoticeBannerTone.Warning,
+            leadingIcon = {
+                Icon(
+                    imageVector = WooDsIcons.Regular.Bolt,
+                    contentDescription = null,
+                    modifier = Modifier.size(WooTheme.iconSize.size24),
+                )
+            },
+        )
+    }
+}
+
+@Composable
+private fun WooNoticeBannerTone.toNoticeBannerColors(): WooNoticeBannerColors {
+    val colors = WooTheme.colors
+    return when (this) {
+        WooNoticeBannerTone.Neutral -> WooNoticeBannerColors(
+            colors.status.neutralContainer,
+            colors.status.onNeutralContainer,
+        )
+        WooNoticeBannerTone.NeutralOutlined -> WooNoticeBannerColors(
+            containerColor = colors.surface.default,
+            contentColor = colors.surface.onDefault,
+            border = BorderStroke(WooTheme.stroke.extraThin, colors.outlineVariant),
+        )
+        WooNoticeBannerTone.Info -> WooNoticeBannerColors(colors.status.infoContainer, colors.status.onInfoContainer)
+        WooNoticeBannerTone.Success -> {
+            WooNoticeBannerColors(colors.status.successContainer, colors.status.onSuccessContainer)
+        }
+        WooNoticeBannerTone.Warning -> {
+            WooNoticeBannerColors(colors.status.warningContainer, colors.status.onWarningContainer)
+        }
+        WooNoticeBannerTone.Caution -> {
+            WooNoticeBannerColors(colors.status.cautionContainer, colors.status.onCautionContainer)
+        }
+        WooNoticeBannerTone.Error -> WooNoticeBannerColors(colors.status.errorContainer, colors.status.onErrorContainer)
+    }
+}
+
+private data class WooNoticeBannerColors(
+    val containerColor: Color,
+    val contentColor: Color,
+    val border: BorderStroke? = null,
+)

--- a/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooNoticeBannerTone.kt
+++ b/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooNoticeBannerTone.kt
@@ -1,0 +1,11 @@
+package com.woocommerce.android.ui.compose.designsystem.component
+
+enum class WooNoticeBannerTone {
+    Neutral,
+    NeutralOutlined,
+    Info,
+    Success,
+    Warning,
+    Caution,
+    Error,
+}

--- a/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooOutlinedIconButton.kt
+++ b/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooOutlinedIconButton.kt
@@ -1,0 +1,134 @@
+package com.woocommerce.android.ui.compose.designsystem.component
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import com.woocommerce.android.ui.compose.designsystem.WooTheme
+import com.woocommerce.android.ui.compose.designsystem.foundation.WooDesignSystemTheme
+import com.woocommerce.android.ui.compose.designsystem.icons.ArrowUpRight
+import com.woocommerce.android.ui.compose.designsystem.icons.CommentQuestion
+import com.woocommerce.android.ui.compose.designsystem.icons.WooDsIcons
+import androidx.compose.material3.OutlinedIconButton as MaterialOutlinedIconButton
+
+@Composable
+fun WooOutlinedIconButton(
+    imageVector: ImageVector,
+    contentDescription: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    emphasis: WooIconButtonEmphasis = WooIconButtonEmphasis.Neutral,
+) {
+    WooOutlinedIconButton(
+        onClick = onClick,
+        contentDescription = contentDescription,
+        modifier = modifier,
+        enabled = enabled,
+        emphasis = emphasis,
+    ) {
+        Icon(
+            imageVector = imageVector,
+            contentDescription = null,
+            modifier = Modifier.size(WooTheme.iconSize.size18),
+        )
+    }
+}
+
+@Composable
+fun WooOutlinedIconButton(
+    onClick: () -> Unit,
+    contentDescription: String,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    emphasis: WooIconButtonEmphasis = WooIconButtonEmphasis.Neutral,
+    icon: @Composable () -> Unit,
+) {
+    require(contentDescription.isNotBlank()) {
+        "WooOutlinedIconButton contentDescription must not be blank"
+    }
+
+    val colors = WooTheme.colors
+    val contentColor = when (emphasis) {
+        WooIconButtonEmphasis.Neutral -> colors.surface.onDefault
+        WooIconButtonEmphasis.Primary -> colors.primary
+    }
+
+    MaterialOutlinedIconButton(
+        onClick = onClick,
+        modifier = modifier
+            .semantics {
+                this.contentDescription = contentDescription
+            },
+        enabled = enabled,
+        colors = IconButtonDefaults.outlinedIconButtonColors(
+            containerColor = Color.Transparent,
+            contentColor = contentColor,
+            disabledContainerColor = Color.Transparent,
+            disabledContentColor = colors.surface.onVariantLowest,
+        ),
+        shape = RoundedCornerShape(WooTheme.radius.large),
+        border = BorderStroke(WooTheme.stroke.extraThin, colors.outlineVariant),
+    ) {
+        Box(
+            modifier = Modifier.clearAndSetSemantics {},
+            contentAlignment = Alignment.Center,
+        ) {
+            icon()
+        }
+    }
+}
+
+@Suppress("UnusedPrivateMember")
+@PreviewLightDark
+@Composable
+private fun WooOutlinedIconButtonPreview() {
+    WooDesignSystemTheme {
+        Surface(color = WooTheme.colors.background.section) {
+            WooOutlinedIconButtonDemo(modifier = Modifier.padding(WooTheme.padding.padding5))
+        }
+    }
+}
+
+@Composable
+internal fun WooOutlinedIconButtonDemo(
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(WooTheme.spacing.space3),
+    ) {
+        WooOutlinedIconButton(
+            imageVector = WooDsIcons.Regular.CommentQuestion,
+            contentDescription = "Help",
+            onClick = {},
+        )
+        WooOutlinedIconButton(
+            imageVector = WooDsIcons.Regular.ArrowUpRight,
+            contentDescription = "Open",
+            onClick = {},
+            emphasis = WooIconButtonEmphasis.Primary,
+        )
+        WooOutlinedIconButton(
+            imageVector = WooDsIcons.Regular.CommentQuestion,
+            contentDescription = "Disabled help",
+            onClick = {},
+            enabled = false,
+        )
+    }
+}

--- a/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooOutlinedIconButton.kt
+++ b/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooOutlinedIconButton.kt
@@ -59,7 +59,7 @@ fun WooOutlinedIconButton(
     emphasis: WooIconButtonEmphasis = WooIconButtonEmphasis.Neutral,
     icon: @Composable () -> Unit,
 ) {
-    require(contentDescription.isNotBlank()) {
+    assert(contentDescription.isNotBlank()) {
         "WooOutlinedIconButton contentDescription must not be blank"
     }
 

--- a/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooOutlinedIconButton.kt
+++ b/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooOutlinedIconButton.kt
@@ -23,7 +23,7 @@ import com.woocommerce.android.ui.compose.designsystem.WooTheme
 import com.woocommerce.android.ui.compose.designsystem.foundation.WooDesignSystemTheme
 import com.woocommerce.android.ui.compose.designsystem.icons.ArrowUpRight
 import com.woocommerce.android.ui.compose.designsystem.icons.CommentQuestion
-import com.woocommerce.android.ui.compose.designsystem.icons.WooDsIcons
+import com.woocommerce.android.ui.compose.designsystem.icons.WooIcons
 import androidx.compose.material3.OutlinedIconButton as MaterialOutlinedIconButton
 
 @Composable
@@ -114,18 +114,18 @@ internal fun WooOutlinedIconButtonDemo(
         horizontalArrangement = Arrangement.spacedBy(WooTheme.spacing.space3),
     ) {
         WooOutlinedIconButton(
-            imageVector = WooDsIcons.Regular.CommentQuestion,
+            imageVector = WooIcons.Regular.CommentQuestion,
             contentDescription = "Help",
             onClick = {},
         )
         WooOutlinedIconButton(
-            imageVector = WooDsIcons.Regular.ArrowUpRight,
+            imageVector = WooIcons.Regular.ArrowUpRight,
             contentDescription = "Open",
             onClick = {},
             emphasis = WooIconButtonEmphasis.Primary,
         )
         WooOutlinedIconButton(
-            imageVector = WooDsIcons.Regular.CommentQuestion,
+            imageVector = WooIcons.Regular.CommentQuestion,
             contentDescription = "Disabled help",
             onClick = {},
             enabled = false,

--- a/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooProgressIndicator.kt
+++ b/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooProgressIndicator.kt
@@ -1,0 +1,104 @@
+package com.woocommerce.android.ui.compose.designsystem.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import com.woocommerce.android.ui.compose.designsystem.WooTheme
+import com.woocommerce.android.ui.compose.designsystem.foundation.WooDesignSystemTheme
+
+@Composable
+fun WooLinearProgressIndicator(
+    modifier: Modifier = Modifier,
+    progress: Float? = null,
+) {
+    val colors = WooTheme.colors
+
+    if (progress == null) {
+        LinearProgressIndicator(
+            modifier = modifier,
+            color = colors.primary,
+            trackColor = colors.secondary,
+        )
+    } else {
+        val coercedProgress = progress.coerceIn(MIN_PROGRESS, MAX_PROGRESS)
+
+        LinearProgressIndicator(
+            progress = { coercedProgress },
+            modifier = modifier,
+            color = colors.primary,
+            trackColor = colors.secondary,
+        )
+    }
+}
+
+@Composable
+fun WooCircularProgressIndicator(
+    modifier: Modifier = Modifier,
+    progress: Float? = null,
+) {
+    val colors = WooTheme.colors
+
+    if (progress == null) {
+        CircularProgressIndicator(
+            modifier = modifier,
+            color = colors.primary,
+            trackColor = colors.secondary,
+        )
+    } else {
+        val coercedProgress = progress.coerceIn(MIN_PROGRESS, MAX_PROGRESS)
+
+        CircularProgressIndicator(
+            progress = { coercedProgress },
+            modifier = modifier,
+            color = colors.primary,
+            trackColor = colors.secondary,
+        )
+    }
+}
+
+@Suppress("UnusedPrivateMember")
+@PreviewLightDark
+@Composable
+private fun WooProgressIndicatorPreview() {
+    WooDesignSystemTheme {
+        Surface(color = WooTheme.colors.background.section) {
+            WooProgressIndicatorDemo(modifier = Modifier.padding(WooTheme.padding.padding5))
+        }
+    }
+}
+
+@Composable
+internal fun WooProgressIndicatorDemo(
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(WooTheme.spacing.space4),
+    ) {
+        WooLinearProgressIndicator(
+            progress = 0.64f,
+            modifier = Modifier.width(180.dp),
+        )
+        WooLinearProgressIndicator(modifier = Modifier.width(180.dp))
+        Row(horizontalArrangement = Arrangement.spacedBy(WooTheme.spacing.space4)) {
+            WooCircularProgressIndicator(
+                progress = 0.64f,
+                modifier = Modifier.size(36.dp),
+            )
+            WooCircularProgressIndicator(modifier = Modifier.size(36.dp))
+        }
+    }
+}
+
+private const val MIN_PROGRESS = 0f
+private const val MAX_PROGRESS = 1f

--- a/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooProgressIndicator.kt
+++ b/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooProgressIndicator.kt
@@ -21,13 +21,9 @@ fun WooLinearProgressIndicator(
     modifier: Modifier = Modifier,
     progress: Float? = null,
 ) {
-    val colors = WooTheme.colors
-
     if (progress == null) {
         LinearProgressIndicator(
             modifier = modifier,
-            color = colors.primary,
-            trackColor = colors.secondary,
         )
     } else {
         val coercedProgress = progress.coerceIn(MIN_PROGRESS, MAX_PROGRESS)
@@ -35,8 +31,6 @@ fun WooLinearProgressIndicator(
         LinearProgressIndicator(
             progress = { coercedProgress },
             modifier = modifier,
-            color = colors.primary,
-            trackColor = colors.secondary,
         )
     }
 }
@@ -46,13 +40,9 @@ fun WooCircularProgressIndicator(
     modifier: Modifier = Modifier,
     progress: Float? = null,
 ) {
-    val colors = WooTheme.colors
-
     if (progress == null) {
         CircularProgressIndicator(
             modifier = modifier,
-            color = colors.primary,
-            trackColor = colors.secondary,
         )
     } else {
         val coercedProgress = progress.coerceIn(MIN_PROGRESS, MAX_PROGRESS)
@@ -60,8 +50,6 @@ fun WooCircularProgressIndicator(
         CircularProgressIndicator(
             progress = { coercedProgress },
             modifier = modifier,
-            color = colors.primary,
-            trackColor = colors.secondary,
         )
     }
 }

--- a/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooSectionHeader.kt
+++ b/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooSectionHeader.kt
@@ -1,0 +1,66 @@
+package com.woocommerce.android.ui.compose.designsystem.component
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import com.woocommerce.android.ui.compose.designsystem.WooTheme
+import com.woocommerce.android.ui.compose.designsystem.foundation.WooDesignSystemTheme
+
+@Composable
+fun WooSectionHeader(
+    text: String,
+    modifier: Modifier = Modifier,
+) {
+    WooSectionHeader(
+        text = text,
+        modifier = modifier,
+        onTextLayout = {},
+    )
+}
+
+@Composable
+internal fun WooSectionHeader(
+    text: String,
+    modifier: Modifier = Modifier,
+    onTextLayout: (TextLayoutResult) -> Unit,
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(
+                horizontal = WooTheme.padding.padding7,
+                vertical = WooTheme.padding.padding6,
+            ),
+    ) {
+        Text(
+            text = text,
+            modifier = Modifier
+                .fillMaxWidth()
+                .semantics { heading() },
+            color = WooTheme.colors.surface.onVariantLowest,
+            onTextLayout = onTextLayout,
+            style = WooTheme.text.titleSmall.emphasized,
+        )
+    }
+}
+
+@Suppress("UnusedPrivateMember")
+@PreviewLightDark
+@Composable
+private fun WooSectionHeaderPreview() {
+    WooDesignSystemTheme {
+        Surface(color = WooTheme.colors.background.section) {
+            WooSectionHeader(
+                text = "Tracking",
+            )
+        }
+    }
+}

--- a/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/preview/WooDesignSystemComponentCatalogPreview.kt
+++ b/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/preview/WooDesignSystemComponentCatalogPreview.kt
@@ -1,0 +1,484 @@
+@file:Suppress("UnusedPrivateMember")
+
+package com.woocommerce.android.ui.compose.designsystem.preview
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.woocommerce.android.ui.compose.designsystem.WooTheme
+import com.woocommerce.android.ui.compose.designsystem.component.WooBadgeDemo
+import com.woocommerce.android.ui.compose.designsystem.component.WooButtonDemo
+import com.woocommerce.android.ui.compose.designsystem.component.WooDividerDemo
+import com.woocommerce.android.ui.compose.designsystem.component.WooIconButton
+import com.woocommerce.android.ui.compose.designsystem.component.WooIconButtonDemo
+import com.woocommerce.android.ui.compose.designsystem.component.WooIconContainerDemo
+import com.woocommerce.android.ui.compose.designsystem.component.WooNoticeBannerDemo
+import com.woocommerce.android.ui.compose.designsystem.component.WooOutlinedIconButtonDemo
+import com.woocommerce.android.ui.compose.designsystem.component.WooProgressIndicatorDemo
+import com.woocommerce.android.ui.compose.designsystem.component.WooSectionHeader
+import com.woocommerce.android.ui.compose.designsystem.foundation.WooDesignSystemThemeWithBackground
+import com.woocommerce.android.ui.compose.designsystem.icons.AngleLeft
+import com.woocommerce.android.ui.compose.designsystem.icons.ArrowUpRight
+import com.woocommerce.android.ui.compose.designsystem.icons.WooDsIcons
+
+@PreviewLightDark
+@Composable
+private fun WooDesignSystemComponentCatalogPreview() {
+    WooDesignSystemPreviewTheme {
+        WooDesignSystemFlatComponentCatalogPreviewContent()
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun WooDesignSystemComponentCatalogLegacyCompatiblePreview() {
+    WooDesignSystemThemeWithBackground {
+        WooDesignSystemFlatComponentCatalogPreviewContent()
+    }
+}
+
+@Preview(name = "Catalog navigation", showBackground = true)
+@Composable
+private fun WooDesignSystemComponentCatalogNavigationPreview() {
+    WooDesignSystemPreviewTheme {
+        Box(modifier = Modifier.width(360.dp)) {
+            WooDesignSystemComponentCatalogScreen(
+                initialPath = ROOT_PATH,
+                onBackClick = {},
+            )
+        }
+    }
+}
+
+@Composable
+fun WooDesignSystemComponentCatalogScreen(
+    initialPath: String,
+    onBackClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val initialCatalogPath = initialPath.takeIf { CatalogRoot.find(it) != null } ?: ROOT_PATH
+    var selectedPath by rememberSaveable { mutableStateOf(initialCatalogPath) }
+    val selectedNode = CatalogRoot.find(selectedPath) ?: CatalogRoot
+
+    fun navigateBack() {
+        if (selectedNode.path == ROOT_PATH) {
+            onBackClick()
+        } else {
+            selectedPath = selectedNode.parentPath
+        }
+    }
+
+    PreviewScreenScaffold(
+        modifier = modifier,
+        title = selectedNode.title,
+        onBackClick = ::navigateBack,
+        contentSpacing = WooTheme.spacing.space6,
+    ) {
+        when (selectedNode) {
+            is CatalogNode.Group -> CatalogGroupContent(
+                group = selectedNode,
+                onNodeClick = { selectedPath = it.path },
+            )
+
+            is CatalogNode.Leaf -> selectedNode.content(this)
+        }
+    }
+}
+
+@Composable
+private fun CatalogGroupContent(
+    group: CatalogNode.Group,
+    onNodeClick: (CatalogNode) -> Unit,
+) {
+    CatalogSection(group.sectionTitle) {
+        group.description?.let {
+            CatalogBodyText(
+                text = it,
+                modifier = Modifier.padding(horizontal = WooTheme.padding.padding5),
+            )
+        }
+        group.children.forEach { child ->
+            CatalogNavigationRow(
+                title = child.title,
+                description = child.description,
+                onClick = { onNodeClick(child) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun CatalogNavigationRow(
+    title: String,
+    description: String?,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(72.dp)
+            .clickable(onClick = onClick)
+            .padding(horizontal = WooTheme.padding.padding5),
+        horizontalArrangement = Arrangement.spacedBy(WooTheme.spacing.space4),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(WooTheme.spacing.space1),
+        ) {
+            Text(
+                text = title,
+                color = WooTheme.colors.surface.onDefault,
+                style = WooTheme.text.bodyLarge.emphasized,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            description?.let {
+                Text(
+                    text = it,
+                    color = WooTheme.colors.surface.onVariant,
+                    style = WooTheme.text.bodySmall.regular,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+        Icon(
+            imageVector = WooDsIcons.Regular.ArrowUpRight,
+            contentDescription = null,
+            modifier = Modifier.size(WooTheme.iconSize.size18),
+            tint = WooTheme.colors.surface.onVariant,
+        )
+    }
+}
+
+@Composable
+private fun WooDesignSystemFlatComponentCatalogPreviewContent() {
+    PreviewScreenScaffold(
+        title = "Store Design System",
+        onBackClick = {},
+        showNavigationIcon = false,
+    ) {
+        CatalogRoot.leaves().forEach { leaf ->
+            leaf.content(this)
+        }
+    }
+}
+
+private sealed class CatalogNode {
+    abstract val path: String
+    abstract val title: String
+    abstract val description: String?
+
+    val parentPath: String
+        get() = path.substringBeforeLast("/", missingDelimiterValue = ROOT_PATH)
+
+    data class Group(
+        override val path: String,
+        override val title: String,
+        override val description: String? = null,
+        val sectionTitle: String = title,
+        val children: List<CatalogNode>,
+    ) : CatalogNode()
+
+    data class Leaf(
+        override val path: String,
+        override val title: String,
+        override val description: String? = null,
+        val content: @Composable ColumnScope.() -> Unit,
+    ) : CatalogNode()
+}
+
+private fun CatalogNode.find(path: String): CatalogNode? {
+    if (this.path == path) return this
+    return when (this) {
+        is CatalogNode.Group -> children.firstNotNullOfOrNull { it.find(path) }
+        is CatalogNode.Leaf -> null
+    }
+}
+
+private fun CatalogNode.leaves(): List<CatalogNode.Leaf> = when (this) {
+    is CatalogNode.Group -> children.flatMap { it.leaves() }
+    is CatalogNode.Leaf -> listOf(this)
+}
+
+private val CatalogRoot = CatalogNode.Group(
+    path = ROOT_PATH,
+    title = "Store Design System",
+    sectionTitle = "Catalog groups",
+    description = "Browse production components available in this slice.",
+    children = listOf(
+        CatalogNode.Group(
+            path = "production",
+            title = "Production components",
+            description = "Components available for migrated Store Management screens.",
+            children = listOf(
+                CatalogNode.Leaf(
+                    path = PRODUCTION_BUTTONS_PATH,
+                    title = "Buttons",
+                    description = "Filled, tonal, outlined, small, and disabled actions.",
+                    content = { ProductionButtonsCatalogLeaf() },
+                ),
+                CatalogNode.Leaf(
+                    path = PRODUCTION_ICON_ACTIONS_PATH,
+                    title = "Icon actions",
+                    description = "Plain and outlined icon actions with neutral and primary emphasis.",
+                    content = { ProductionIconActionsCatalogLeaf() },
+                ),
+                CatalogNode.Leaf(
+                    path = PRODUCTION_BADGES_PATH,
+                    title = "Badges",
+                    description = "Status tones and icon-leading variants.",
+                    content = { ProductionBadgesCatalogLeaf() },
+                ),
+                CatalogNode.Leaf(
+                    path = PRODUCTION_NOTICE_BANNERS_PATH,
+                    title = "Notice banners",
+                    description = "Static status and information banners.",
+                    content = { ProductionNoticeBannersCatalogLeaf() },
+                ),
+                CatalogNode.Leaf(
+                    path = PRODUCTION_ICON_CONTAINERS_PATH,
+                    title = "Icon containers",
+                    description = "Decorative icon tone variants.",
+                    content = { ProductionIconContainersCatalogLeaf() },
+                ),
+                CatalogNode.Leaf(
+                    path = PRODUCTION_SECTION_HEADERS_PATH,
+                    title = "Section headers",
+                    description = "Semantically marked headers for grouped content.",
+                    content = { ProductionSectionHeadersCatalogLeaf() },
+                ),
+                CatalogNode.Leaf(
+                    path = PRODUCTION_DIVIDERS_PATH,
+                    title = "Dividers",
+                    description = "Horizontal and vertical separators.",
+                    content = { ProductionDividersCatalogLeaf() },
+                ),
+                CatalogNode.Leaf(
+                    path = PRODUCTION_PROGRESS_INDICATORS_PATH,
+                    title = "Progress indicators",
+                    description = "Determinate and indeterminate loading indicators.",
+                    content = { ProductionProgressIndicatorsCatalogLeaf() },
+                ),
+            ),
+        ),
+    ),
+)
+
+@Composable
+private fun ProductionButtonsCatalogLeaf() {
+    CatalogSection("Buttons") {
+        WooButtonDemo(
+            modifier = Modifier.padding(horizontal = WooTheme.padding.padding5),
+        )
+    }
+}
+
+@Composable
+private fun ProductionIconActionsCatalogLeaf() {
+    CatalogSection("Icon buttons") {
+        WooIconButtonDemo(modifier = Modifier.padding(horizontal = WooTheme.padding.padding5))
+        WooOutlinedIconButtonDemo(modifier = Modifier.padding(horizontal = WooTheme.padding.padding5))
+    }
+}
+
+@Composable
+private fun ProductionBadgesCatalogLeaf() {
+    CatalogSection("Badges") {
+        WooBadgeDemo(
+            modifier = Modifier.padding(horizontal = WooTheme.padding.padding5),
+        )
+    }
+}
+
+@Composable
+private fun ProductionNoticeBannersCatalogLeaf() {
+    CatalogSection("Notice banners") {
+        WooNoticeBannerDemo(
+            modifier = Modifier.padding(horizontal = WooTheme.padding.padding5),
+        )
+    }
+}
+
+@Composable
+private fun ProductionIconContainersCatalogLeaf() {
+    CatalogSection("Icon containers") {
+        WooIconContainerDemo(
+            modifier = Modifier.padding(horizontal = WooTheme.padding.padding5),
+        )
+    }
+}
+
+@Composable
+private fun ProductionSectionHeadersCatalogLeaf() {
+    CatalogSection("Section headers") {
+        WooSectionHeader("Tracking")
+        WooSectionHeader("Orders")
+    }
+}
+
+@Composable
+private fun ProductionDividersCatalogLeaf() {
+    CatalogSection("Dividers") {
+        WooDividerDemo(
+            modifier = Modifier.padding(horizontal = WooTheme.padding.padding5),
+        )
+    }
+}
+
+@Composable
+private fun ProductionProgressIndicatorsCatalogLeaf() {
+    CatalogSection("Progress indicators") {
+        WooProgressIndicatorDemo(
+            modifier = Modifier.padding(horizontal = WooTheme.padding.padding5),
+        )
+    }
+}
+
+@Composable
+private fun PreviewScreenScaffold(
+    title: String,
+    onBackClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    showNavigationIcon: Boolean = true,
+    contentSpacing: Dp = WooTheme.spacing.space5,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            CatalogTopBar(
+                title = title,
+                onBackClick = onBackClick,
+                showNavigationIcon = showNavigationIcon,
+            )
+        },
+        containerColor = WooTheme.colors.background.section,
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .padding(innerPadding)
+                .verticalScroll(rememberScrollState())
+                .padding(WooTheme.padding.padding5),
+            verticalArrangement = Arrangement.spacedBy(contentSpacing),
+            content = content,
+        )
+    }
+}
+
+@Composable
+private fun CatalogTopBar(
+    title: String,
+    onBackClick: () -> Unit,
+    showNavigationIcon: Boolean,
+) {
+    Surface(
+        color = WooTheme.colors.surface.default,
+        contentColor = WooTheme.colors.surface.onDefault,
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(64.dp)
+                .padding(horizontal = WooTheme.padding.padding2),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            if (showNavigationIcon) {
+                WooIconButton(
+                    imageVector = WooDsIcons.Regular.AngleLeft,
+                    contentDescription = "Back",
+                    onClick = onBackClick,
+                )
+            } else {
+                Box(modifier = Modifier.size(48.dp))
+            }
+            Text(
+                text = title,
+                modifier = Modifier.weight(1f),
+                color = WooTheme.colors.surface.onDefault,
+                style = WooTheme.text.bodyLarge.strong,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Box(modifier = Modifier.size(48.dp))
+        }
+    }
+}
+
+@Composable
+private fun CatalogSection(
+    title: String,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    Surface(
+        color = WooTheme.colors.surface.default,
+        contentColor = WooTheme.colors.surface.onDefault,
+        shape = RoundedCornerShape(WooTheme.radius.medium),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = WooTheme.padding.padding5),
+            verticalArrangement = Arrangement.spacedBy(WooTheme.spacing.space4),
+        ) {
+            Text(
+                text = title,
+                color = WooTheme.colors.surface.onDefault,
+                style = WooTheme.text.titleMedium.strong,
+                modifier = Modifier.padding(horizontal = WooTheme.padding.padding5),
+            )
+            content()
+        }
+    }
+}
+
+@Composable
+private fun CatalogBodyText(
+    text: String,
+    modifier: Modifier = Modifier,
+) {
+    Text(
+        text = text,
+        color = WooTheme.colors.surface.onVariant,
+        style = WooTheme.text.bodyMedium.regular,
+        modifier = modifier,
+    )
+}
+
+private const val ROOT_PATH = ""
+private const val PRODUCTION_BUTTONS_PATH = "production/buttons"
+private const val PRODUCTION_ICON_ACTIONS_PATH = "production/icon-actions"
+private const val PRODUCTION_BADGES_PATH = "production/badges"
+private const val PRODUCTION_NOTICE_BANNERS_PATH = "production/notice-banners"
+private const val PRODUCTION_ICON_CONTAINERS_PATH = "production/icon-containers"
+private const val PRODUCTION_SECTION_HEADERS_PATH = "production/section-headers"
+private const val PRODUCTION_DIVIDERS_PATH = "production/dividers"
+private const val PRODUCTION_PROGRESS_INDICATORS_PATH = "production/progress-indicators"

--- a/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/preview/WooDesignSystemComponentCatalogPreview.kt
+++ b/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/preview/WooDesignSystemComponentCatalogPreview.kt
@@ -46,7 +46,7 @@ import com.woocommerce.android.ui.compose.designsystem.component.WooSectionHeade
 import com.woocommerce.android.ui.compose.designsystem.foundation.WooDesignSystemThemeWithBackground
 import com.woocommerce.android.ui.compose.designsystem.icons.AngleLeft
 import com.woocommerce.android.ui.compose.designsystem.icons.ArrowUpRight
-import com.woocommerce.android.ui.compose.designsystem.icons.WooDsIcons
+import com.woocommerce.android.ui.compose.designsystem.icons.WooIcons
 
 @PreviewLightDark
 @Composable
@@ -171,7 +171,7 @@ private fun CatalogNavigationRow(
             }
         }
         Icon(
-            imageVector = WooDsIcons.Regular.ArrowUpRight,
+            imageVector = WooIcons.Regular.ArrowUpRight,
             contentDescription = null,
             modifier = Modifier.size(WooTheme.iconSize.size18),
             tint = WooTheme.colors.surface.onVariant,
@@ -413,7 +413,7 @@ private fun CatalogTopBar(
         ) {
             if (showNavigationIcon) {
                 WooIconButton(
-                    imageVector = WooDsIcons.Regular.AngleLeft,
+                    imageVector = WooIcons.Regular.AngleLeft,
                     contentDescription = "Back",
                     onClick = onBackClick,
                 )

--- a/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/preview/WooDesignSystemPreviewTheme.kt
+++ b/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/preview/WooDesignSystemPreviewTheme.kt
@@ -1,0 +1,20 @@
+package com.woocommerce.android.ui.compose.designsystem.preview
+
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import com.woocommerce.android.ui.compose.designsystem.WooTheme
+import com.woocommerce.android.ui.compose.designsystem.foundation.WooDesignSystemTheme
+
+@Composable
+internal fun WooDesignSystemPreviewTheme(
+    content: @Composable () -> Unit,
+) {
+    WooDesignSystemTheme {
+        Surface(
+            color = WooTheme.colors.background.section,
+            contentColor = WooTheme.colors.surface.onDefault,
+        ) {
+            content()
+        }
+    }
+}


### PR DESCRIPTION
> [!NOTE]
> This is the first split PR for Store Design System components. It builds on `store-design-system/components0` and targets that branch, so review the diff against that base rather than `trunk`.

### Description

This PR introduces the revised first previewable Store Design System component slice in `:libs:store-design-system`: Material 3-aligned buttons, icon actions, display/status components, and library-local catalog preview infrastructure.

#### What this adds

- Production Compose button components under `com.woocommerce.android.ui.compose.designsystem.component`:
  - `WooFilledButton`
  - `WooFilledTonalButton`
  - `WooOutlinedButton`
  - medium and small sizing through `WooButtonSize`
- Production icon action components:
  - `WooIconButton`
  - `WooOutlinedIconButton`
  - neutral and primary emphasis through `WooIconButtonEmphasis`
- Production display/status components:
  - `WooBadge` and `WooBadgeTone`
  - `WooNoticeBanner` and `WooNoticeBannerTone`
  - `WooIconContainer` and `WooIconContainerTone`
  - `WooSectionHeader`
  - `WooDivider` and `WooVerticalDivider`
  - `WooLinearProgressIndicator` and `WooCircularProgressIndicator`
- Component-local Android Studio preview/demo coverage for the new action and display/status components.
- Library preview/catalog infrastructure under `designsystem.preview`:
  - `WooDesignSystemPreviewTheme`
  - a reduced `WooDesignSystemComponentCatalogPreview` scoped to the production components in this PR.
- Demo/navigation icons use existing Store Design System icon accessors and resources from `components0`; this PR adds no drawable resources.

#### Why this shape

The split keeps the first component PR independently previewable while giving reviewers a coherent starter set: action primitives plus passive display/status primitives. It lands the first reusable production component surface and a catalog preview shell without pulling in later input, navigation, or app-side runtime wiring.

- The catalog preview is the review surface for this slice: it renders the real PR1 action and display/status demos, rather than placeholder rows or references to components from later PRs.
- The module boundary from `components0` is preserved: this branch stays in `:libs:store-design-system` and does not depend on app `R`, Hilt, `FeatureFlag`, POS, or Store feature packages.
- The commit stack separates action components, catalog preview infrastructure, and display/status components so follow-up stacked branches can build from a clear base.

#### What this does not do

- Does not migrate or adopt the components in any product screen.
- Does not add Developer Options runtime wiring.
- Does not include cells, settings rows, switches, search, choice controls, tabs, page headers, top app bars, XML toolbar bridge, or preview-only explorations.
- Does not touch POS.
- Does not globally remap XML/View styles or legacy app themes.
- Does not add generated token, icon, Code Connect, or Figma automation.

#### Helpful review focus

- Are the button and icon-action APIs clear enough for migrated Store Management screens?
- Are the display/status component APIs scoped and named clearly enough for migrated Store Management screens?
- Do the components stay aligned with the foundations tokens and avoid app/POS dependencies?
- Does the reduced catalog preview clearly exercise only the production components available in this PR?
- Are the reused DS icons acceptable for the notice-banner demo states?

No release notes: this is an internal design-system components change.

### Test Steps

1. In Android Studio, render `WooDesignSystemComponentCatalogPreview` from `:libs:store-design-system`.
2. Verify the catalog preview contains only the PR1 production slices: buttons, icon actions, and display/status components.
3. Render the light and dark preview variants and verify the actual component demos appear.
4. Optionally render the component-local previews in the added action and display/status component files.

### Images/gif

| Light | Dark |
| --- | --- |
| <img width="1260" height="6615" alt="components1-catalog-preview-light" src="https://github.com/user-attachments/assets/38780b25-eabb-4e99-be23-147ba692d873" /> | <img width="1260" height="6615" alt="components1-catalog-preview-dark" src="https://github.com/user-attachments/assets/bb7a9606-e5b2-4b00-8c05-bf29fcf40865" /> |


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.