### PR TITLE
[Design System] Add rows and cells

### DIFF
--- a/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooCell.kt
+++ b/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooCell.kt
@@ -1,0 +1,196 @@
+package com.woocommerce.android.ui.compose.designsystem.component
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import com.woocommerce.android.ui.compose.designsystem.WooTheme
+import com.woocommerce.android.ui.compose.designsystem.foundation.WooDesignSystemTheme
+import com.woocommerce.android.ui.compose.designsystem.icons.AngleRight
+import com.woocommerce.android.ui.compose.designsystem.icons.CircleInfo
+import com.woocommerce.android.ui.compose.designsystem.icons.WooIcons
+
+@Composable
+internal fun WooCellContent(
+    title: String,
+    modifier: Modifier = Modifier,
+    description: String? = null,
+    enabled: Boolean = true,
+) {
+    val colors = WooTheme.colors
+
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(WooTheme.spacing.space1),
+    ) {
+        Text(
+            text = title,
+            color = if (enabled) colors.surface.onDefault else colors.surface.onVariantLowest,
+            style = WooTheme.text.bodyLarge.emphasized,
+        )
+        if (description != null) {
+            Text(
+                text = description,
+                color = if (enabled) colors.surface.onVariant else colors.surface.onVariantLowest,
+                style = WooTheme.text.bodyMedium.regular,
+            )
+        }
+    }
+}
+
+@Composable
+fun WooCellTrailingAffordance(
+    modifier: Modifier = Modifier,
+) {
+    Icon(
+        imageVector = WooIcons.Regular.AngleRight,
+        contentDescription = null,
+        modifier = modifier.size(WooTheme.iconSize.size18),
+    )
+}
+
+/**
+ * Use either a row-owned [onClick] action or independently clickable slot actions, not both for the same action.
+ */
+@Composable
+fun WooCell(
+    title: String,
+    modifier: Modifier = Modifier,
+    description: String? = null,
+    enabled: Boolean = true,
+    onClick: (() -> Unit)? = null,
+    leadingContent: (@Composable () -> Unit)? = null,
+    trailingContent: (@Composable () -> Unit)? = null,
+) {
+    val rowModifier = if (onClick != null) {
+        modifier.clickable(
+            enabled = enabled,
+            role = Role.Button,
+            onClick = onClick,
+        )
+    } else {
+        modifier
+    }
+
+    WooCellLayout(
+        title = title,
+        description = description,
+        enabled = enabled,
+        modifier = rowModifier,
+        leadingContent = leadingContent,
+        trailingContent = trailingContent,
+    )
+}
+
+@Composable
+internal fun WooCellLayout(
+    title: String,
+    description: String?,
+    enabled: Boolean,
+    modifier: Modifier = Modifier,
+    leadingContent: (@Composable () -> Unit)? = null,
+    trailingContent: (@Composable () -> Unit)? = null,
+) {
+    val slotContentColor = if (enabled) {
+        WooTheme.colors.surface.onDefault
+    } else {
+        WooTheme.colors.surface.onVariantLowest
+    }
+
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .heightIn(min = MIN_TOUCH_TARGET_SIZE)
+            .padding(horizontal = WooTheme.padding.padding7, vertical = WooTheme.padding.padding4),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        if (leadingContent != null) {
+            Box(
+                modifier = Modifier.padding(end = WooTheme.spacing.space5),
+                contentAlignment = Alignment.Center,
+            ) {
+                CompositionLocalProvider(LocalContentColor provides slotContentColor) {
+                    leadingContent()
+                }
+            }
+        }
+
+        WooCellContent(
+            title = title,
+            description = description,
+            enabled = enabled,
+            modifier = Modifier.weight(1f),
+        )
+
+        if (trailingContent != null) {
+            Box(
+                modifier = Modifier.padding(start = WooTheme.spacing.space5),
+                contentAlignment = Alignment.Center,
+            ) {
+                CompositionLocalProvider(LocalContentColor provides slotContentColor) {
+                    trailingContent()
+                }
+            }
+        }
+    }
+}
+
+@Suppress("UnusedPrivateMember")
+@PreviewLightDark
+@Composable
+private fun WooCellPreview() {
+    WooDesignSystemTheme {
+        Surface(color = WooTheme.colors.background.section) {
+            WooCellDemo(modifier = Modifier.padding(vertical = WooTheme.padding.padding3))
+        }
+    }
+}
+
+@Composable
+internal fun WooCellDemo(
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier) {
+        WooCell(
+            title = "Cell title",
+            description = "Cell with a title and description",
+        )
+        WooCell(
+            title = "Store details",
+            description = "Manage address, currency, and contact information.",
+            onClick = {},
+            leadingContent = {
+                Icon(
+                    imageVector = WooIcons.Regular.CircleInfo,
+                    contentDescription = null,
+                )
+            },
+            trailingContent = { WooCellTrailingAffordance() },
+        )
+        WooDivider()
+        WooCell(
+            title = "Disabled cell",
+            description = "This row cannot be opened.",
+            enabled = false,
+            onClick = {},
+        )
+    }
+}
+
+private val MIN_TOUCH_TARGET_SIZE = 48.dp

--- a/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooSettingsRow.kt
+++ b/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooSettingsRow.kt
@@ -1,0 +1,129 @@
+package com.woocommerce.android.ui.compose.designsystem.component
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import com.woocommerce.android.ui.compose.designsystem.WooTheme
+import com.woocommerce.android.ui.compose.designsystem.foundation.WooDesignSystemTheme
+import com.woocommerce.android.ui.compose.designsystem.icons.Gear
+import com.woocommerce.android.ui.compose.designsystem.icons.WooIcons
+
+/**
+ * Use either a row-owned [onClick] action or an independently clickable slot action, not both for the same action.
+ */
+@Composable
+fun WooSettingsRow(
+    title: String,
+    modifier: Modifier = Modifier,
+    description: String? = null,
+    enabled: Boolean = true,
+    onClick: (() -> Unit)? = null,
+    leadingContent: (@Composable () -> Unit)? = null,
+    trailingContent: (@Composable () -> Unit)? = null,
+) {
+    WooCell(
+        title = title,
+        description = description,
+        enabled = enabled,
+        onClick = onClick,
+        modifier = modifier,
+        leadingContent = leadingContent,
+        trailingContent = trailingContent,
+    )
+}
+
+@Composable
+fun WooSwitchSettingsRow(
+    title: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+    description: String? = null,
+    enabled: Boolean = true,
+) {
+    WooCellLayout(
+        title = title,
+        description = description,
+        enabled = enabled,
+        modifier = modifier.toggleable(
+            value = checked,
+            enabled = enabled,
+            role = Role.Switch,
+            onValueChange = onCheckedChange,
+        ),
+        trailingContent = {
+            WooSwitch(
+                checked = checked,
+                onCheckedChange = null,
+                enabled = enabled,
+                modifier = Modifier.clearAndSetSemantics { },
+            )
+        },
+    )
+}
+
+@Suppress("UnusedPrivateMember")
+@PreviewLightDark
+@Composable
+private fun WooSettingsRowPreview() {
+    WooDesignSystemTheme {
+        Surface(color = WooTheme.colors.background.section) {
+            WooSettingsRowDemo(modifier = Modifier.padding(vertical = WooTheme.padding.padding3))
+        }
+    }
+}
+
+@Composable
+internal fun WooSettingsRowDemo(
+    modifier: Modifier = Modifier,
+) {
+    var analyticsChecked by rememberSaveable { mutableStateOf(true) }
+
+    Column(modifier = modifier) {
+        WooSettingsRow(
+            title = "Store details",
+            description = "Manage address, currency, and contact information.",
+            onClick = {},
+            leadingContent = {
+                Icon(
+                    imageVector = WooIcons.Solid.Gear,
+                    contentDescription = null,
+                )
+            },
+            trailingContent = { WooCellTrailingAffordance() },
+        )
+        WooDivider()
+        WooSwitchSettingsRow(
+            title = "Usage analytics",
+            description = "Send anonymous usage data.",
+            checked = analyticsChecked,
+            onCheckedChange = { analyticsChecked = it },
+        )
+        WooDivider()
+        WooSwitchSettingsRow(
+            title = "Disabled switch row",
+            description = "This toggle is unavailable.",
+            checked = false,
+            onCheckedChange = {},
+            enabled = false,
+        )
+        WooDivider()
+        WooSettingsRow(
+            title = "Disabled row",
+            description = "This setting is unavailable.",
+            enabled = false,
+            onClick = {},
+        )
+    }
+}

--- a/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooSwitch.kt
+++ b/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooSwitch.kt
@@ -1,0 +1,70 @@
+package com.woocommerce.android.ui.compose.designsystem.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import com.woocommerce.android.ui.compose.designsystem.WooTheme
+import com.woocommerce.android.ui.compose.designsystem.foundation.WooDesignSystemTheme
+
+@Composable
+fun WooSwitch(
+    checked: Boolean,
+    onCheckedChange: ((Boolean) -> Unit)?,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+) {
+    Switch(
+        checked = checked,
+        onCheckedChange = onCheckedChange,
+        modifier = modifier.heightIn(min = MIN_TOUCH_TARGET_SIZE),
+        enabled = enabled,
+        colors = SwitchDefaults.colors(
+            checkedThumbColor = WooTheme.colors.onPrimary,
+            checkedTrackColor = WooTheme.colors.primary,
+            checkedBorderColor = WooTheme.colors.primary,
+        ),
+    )
+}
+
+@Suppress("UnusedPrivateMember")
+@PreviewLightDark
+@Composable
+private fun WooSwitchPreview() {
+    WooDesignSystemTheme {
+        Surface(color = WooTheme.colors.background.section) {
+            WooSwitchDemo(modifier = Modifier.padding(WooTheme.padding.padding5))
+        }
+    }
+}
+
+@Composable
+internal fun WooSwitchDemo(
+    modifier: Modifier = Modifier,
+) {
+    var checkedSwitchChecked by rememberSaveable { mutableStateOf(true) }
+    var uncheckedSwitchChecked by rememberSaveable { mutableStateOf(false) }
+
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(WooTheme.spacing.space4),
+    ) {
+        WooSwitch(checked = checkedSwitchChecked, onCheckedChange = { checkedSwitchChecked = it })
+        WooSwitch(checked = uncheckedSwitchChecked, onCheckedChange = { uncheckedSwitchChecked = it })
+        WooSwitch(checked = true, onCheckedChange = {}, enabled = false)
+        WooSwitch(checked = false, onCheckedChange = {}, enabled = false)
+    }
+}
+
+private val MIN_TOUCH_TARGET_SIZE = 48.dp

--- a/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/preview/WooDesignSystemComponentCatalogPreview.kt
+++ b/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/preview/WooDesignSystemComponentCatalogPreview.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.unit.dp
 import com.woocommerce.android.ui.compose.designsystem.WooTheme
 import com.woocommerce.android.ui.compose.designsystem.component.WooBadgeDemo
 import com.woocommerce.android.ui.compose.designsystem.component.WooButtonDemo
+import com.woocommerce.android.ui.compose.designsystem.component.WooCellDemo
 import com.woocommerce.android.ui.compose.designsystem.component.WooDividerDemo
 import com.woocommerce.android.ui.compose.designsystem.component.WooIconButton
 import com.woocommerce.android.ui.compose.designsystem.component.WooIconButtonDemo
@@ -43,6 +44,8 @@ import com.woocommerce.android.ui.compose.designsystem.component.WooNoticeBanner
 import com.woocommerce.android.ui.compose.designsystem.component.WooOutlinedIconButtonDemo
 import com.woocommerce.android.ui.compose.designsystem.component.WooProgressIndicatorDemo
 import com.woocommerce.android.ui.compose.designsystem.component.WooSectionHeader
+import com.woocommerce.android.ui.compose.designsystem.component.WooSettingsRowDemo
+import com.woocommerce.android.ui.compose.designsystem.component.WooSwitchDemo
 import com.woocommerce.android.ui.compose.designsystem.foundation.WooDesignSystemThemeWithBackground
 import com.woocommerce.android.ui.compose.designsystem.icons.AngleLeft
 import com.woocommerce.android.ui.compose.designsystem.icons.ArrowUpRight
@@ -277,6 +280,12 @@ private val CatalogRoot = CatalogNode.Group(
                     content = { ProductionSectionHeadersCatalogLeaf() },
                 ),
                 CatalogNode.Leaf(
+                    path = PRODUCTION_ROWS_CELLS_PATH,
+                    title = "Rows and cells",
+                    description = "Cells, settings rows, switches, and switch rows.",
+                    content = { ProductionRowsCellsCatalogLeaf() },
+                ),
+                CatalogNode.Leaf(
                     path = PRODUCTION_DIVIDERS_PATH,
                     title = "Dividers",
                     description = "Horizontal and vertical separators.",
@@ -342,6 +351,15 @@ private fun ProductionSectionHeadersCatalogLeaf() {
     CatalogSection("Section headers") {
         WooSectionHeader("Tracking")
         WooSectionHeader("Orders")
+    }
+}
+
+@Composable
+private fun ProductionRowsCellsCatalogLeaf() {
+    CatalogSection("Rows and cells") {
+        WooCellDemo()
+        WooSwitchDemo(modifier = Modifier.padding(horizontal = WooTheme.padding.padding5))
+        WooSettingsRowDemo()
     }
 }
 
@@ -480,5 +498,6 @@ private const val PRODUCTION_BADGES_PATH = "production/badges"
 private const val PRODUCTION_NOTICE_BANNERS_PATH = "production/notice-banners"
 private const val PRODUCTION_ICON_CONTAINERS_PATH = "production/icon-containers"
 private const val PRODUCTION_SECTION_HEADERS_PATH = "production/section-headers"
+private const val PRODUCTION_ROWS_CELLS_PATH = "production/rows-cells"
 private const val PRODUCTION_DIVIDERS_PATH = "production/dividers"
 private const val PRODUCTION_PROGRESS_INDICATORS_PATH = "production/progress-indicators"


### PR DESCRIPTION
> [!NOTE]
> This is the second split PR for Store Design System components. It builds on `store-design-system/components1`, so review the diff against that base rather than `trunk`.

### Description

This PR adds the rows/cells component slice to `:libs:store-design-system` on top of components1: reusable cells, switches, settings rows, switch settings rows, DS icon reuse, and reduced catalog preview coverage.

#### What this adds

- Production Compose row/cell components under `com.woocommerce.android.ui.compose.designsystem.component`:
  - `WooCell`
  - `WooCellTrailingAffordance`
  - `WooSettingsRow`
  - `WooSwitch`
  - `WooSwitchSettingsRow`
- Shared internal row content/layout helpers used by the row family.
- Component-local Android Studio preview/demo coverage for cells, switches, settings rows, switch settings rows, and disabled switch states.
- Row affordance and demo icon usage backed by DS-owned `WooIcons` from components0:
  - `WooIcons.Regular.AngleRight` / `WooIcons.Regular.AngleLeft`
  - `WooIcons.Regular.CircleInfo`
  - `WooIcons.Solid.Gear`
- An updated reduced `WooDesignSystemComponentCatalogPreview` that represents the production components available from components1 plus this rows/cells slice.

#### Why this shape

The revised split keeps the rows/cells family independently buildable and previewable on top of components1, without pulling in later search, choice controls, tabs, top app bars, page headers, XML toolbar bridge, or app-runtime catalog access.

- `WooCell` provides the base row layout and slot semantics for leading/trailing content.
- `WooSettingsRow` layers settings-specific row APIs on top of the shared cell layout instead of duplicating row structure.
- `WooSwitchSettingsRow` makes the whole row the switch target while clearing duplicate switch semantics from the trailing control.
- The catalog preview renders the real component demos from components1 plus this row slice, so reviewers can inspect the reduced PR2 surface without references to future components.
- The module boundary from foundations and components1 is preserved: this branch stays in `:libs:store-design-system` and does not depend on app `R`, Hilt, `FeatureFlag`, POS, or Store feature packages.

#### What this does not do

- Does not migrate or adopt the components in any product screen.
- Does not add Developer Options runtime wiring.
- Does not include search, choice controls, tabs, top app bars, page headers, XML toolbar bridge, or debug toolbar resources.
- Does not include `WooDesignSystemPreviewOnlyComponents.kt` or preview-only explorations.
- Does not touch `:WooCommerce` app code.
- Does not touch POS.
- Does not globally remap XML/View styles or legacy app themes.
- Does not add generated token, icon, Code Connect, or Figma automation.

#### Helpful review focus

- Are the row/cell APIs clear enough for migrated Store Management screens?
- Does `WooSwitchSettingsRow` expose the right single-toggle interaction and semantics?
- Do leading/trailing slots, disabled styling, and dividers fit the existing foundations/component tokens?
- Does the reduced catalog preview clearly exercise only production components available through components1 and this rows/cells slice?
- Does this slice reuse the DS-owned icon surface from components0 without reintroducing duplicate app icon resources?

No release notes: this is an internal design-system components change.

### Test Steps

1. In Android Studio, render `WooDesignSystemComponentCatalogPreview` from `:libs:store-design-system`.
2. Verify the catalog preview contains the production components from components1 plus the rows/cells slice added in this PR.
3. Open the rows/cells catalog leaf and verify the cell, switch, settings row, and switch settings row demos render in light and dark mode.
4. Optionally render the component-local previews in `WooCell.kt`, `WooSwitch.kt`, and `WooSettingsRow.kt`.

### Images/gif

| Light | Dark |
| --- | --- |
| <img src="components2-catalog-preview-light.png" width="400" alt="Store Design System components2 rows and cells catalog preview in light mode" /> | <img src="components2-catalog-preview-dark.png" width="400" alt="Store Design System components2 rows and cells catalog preview in dark mode" /> |

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
