### PR TITLE
Add core Maestro smoke flows

### DIFF
--- a/.maestro/env.example
+++ b/.maestro/env.example
@@ -58,13 +58,13 @@ MAESTRO_WOO_SHARED_WPCOM_PASSWORD=
 # stay aligned. Leave commented-out until the matching flow is added.
 
 # ── P2: Login > Not a Woo store (login_not_woo_store.yaml) ──────────────
-# Requires a WordPress site without WooCommerce. Site-admin credentials are
-# the primary login path; WP.com credentials cover sites routed through the
-# WordPress.com login screen instead. Configure both pairs so the flow can
-# follow whichever authentication route the site exposes.
+# Requires a WordPress site without WooCommerce and its site-admin
+# credentials. The WP.com pair is an optional fallback for sites routed
+# through WordPress.com authentication; set both values or leave both blank.
 MAESTRO_WOO_NOT_A_WOO_STORE_URL=https://notawoostore.wordpress.com/
 MAESTRO_WOO_NOT_A_WOO_STORE_SITE_ADMIN_USERNAME=
 MAESTRO_WOO_NOT_A_WOO_STORE_SITE_ADMIN_PASSWORD=
+# Optional WP.com fallback. Set both values or leave both blank.
 MAESTRO_WOO_NOT_A_WOO_STORE_WPCOM_EMAIL=
 MAESTRO_WOO_NOT_A_WOO_STORE_WPCOM_PASSWORD=
 

--- a/.maestro/env.example
+++ b/.maestro/env.example
@@ -58,8 +58,11 @@ MAESTRO_WOO_SHARED_WPCOM_PASSWORD=
 # stay aligned. Leave commented-out until the matching flow is added.
 
 # ── P2: Login > Not a Woo store (login_not_woo_store.yaml) ──────────────
-# Reuses the selected *_WPCOM_EMAIL + *_WPCOM_PASSWORD — only the store URL differs.
+# Requires a WP.com-accessible WordPress site without WooCommerce and the
+# WP.com credentials that can access it.
 MAESTRO_WOO_NOT_A_WOO_STORE_URL=https://notawoostore.wordpress.com/
+MAESTRO_WOO_NOT_A_WOO_STORE_WPCOM_EMAIL=
+MAESTRO_WOO_NOT_A_WOO_STORE_WPCOM_PASSWORD=
 
 # ── P2: Login > Wrong account for the store (login_wrong_account.yaml) ──
 # Reuses the selected *_WPCOM_EMAIL + *_WPCOM_PASSWORD — only the

--- a/.maestro/env.example
+++ b/.maestro/env.example
@@ -58,9 +58,13 @@ MAESTRO_WOO_SHARED_WPCOM_PASSWORD=
 # stay aligned. Leave commented-out until the matching flow is added.
 
 # ── P2: Login > Not a Woo store (login_not_woo_store.yaml) ──────────────
-# Requires a WP.com-accessible WordPress site without WooCommerce and the
-# WP.com credentials that can access it.
+# Requires a WordPress site without WooCommerce. Site-admin credentials are
+# the primary login path; WP.com credentials cover sites routed through the
+# WordPress.com login screen instead. Configure both pairs so the flow can
+# follow whichever authentication route the site exposes.
 MAESTRO_WOO_NOT_A_WOO_STORE_URL=https://notawoostore.wordpress.com/
+MAESTRO_WOO_NOT_A_WOO_STORE_SITE_ADMIN_USERNAME=
+MAESTRO_WOO_NOT_A_WOO_STORE_SITE_ADMIN_PASSWORD=
 MAESTRO_WOO_NOT_A_WOO_STORE_WPCOM_EMAIL=
 MAESTRO_WOO_NOT_A_WOO_STORE_WPCOM_PASSWORD=
 

--- a/.maestro/flows/dashboard_stats.yaml
+++ b/.maestro/flows/dashboard_stats.yaml
@@ -62,32 +62,28 @@ tags:
     id: "stats_range_dropdown_button"
     label: "Tap date range dropdown"
 
-# The DropdownMenu is a Compose Popup — popups render in a separate
-# window, so its own testTag (stats_range_dropdown_menu) doesn't
-# reliably surface in Maestro's view hierarchy. We branch on the
-# visible menu item text instead ("This Week" is always rendered
-# once the menu is open — DashboardViewModel.SUPPORTED_RANGES_ON_MY_STORE_TAB
-# includes Today / This Week / This Month / This Year / Custom).
-- runFlow:
-    when:
-      visible: "This Week"
-    commands:
-      - tapOn: "This Week"
-      - extendedWaitUntil:
-          visible:
-            id: "dashboard_stats_card"
-          timeout: 10000
+# The DropdownMenu is a Compose Popup, so assert its stable item text rather
+# than relying on its test tag surfacing in Maestro's hierarchy. This is
+# mandatory: otherwise the flow could pass without changing the chart range.
+- extendedWaitUntil:
+    visible: "This Week"
+    timeout: 10000
+    label: "Wait for dashboard date range menu"
 
-# Safety net: if the popup didn't dismiss (e.g. the device decided to
-# keep it open, or "This Week" wasn't matched because the menu
-# rendered slightly differently), press back to close it so the
-# subsequent scrolls aren't blocked by a floating popup covering the
-# dashboard content.
-- runFlow:
-    when:
-      visible: "Custom"
-    commands:
-      - back
+- tapOn:
+    text: "This Week"
+    retryTapIfNoChange: true
+    label: "Select This Week range"
+
+- extendedWaitUntil:
+    visible:
+      id: "dashboard_stats_card"
+    timeout: 10000
+    label: "Wait for weekly dashboard stats"
+
+- assertNotVisible:
+    text: "Custom"
+    label: "Date range menu closes after selection"
 
 - takeScreenshot: dashboard_stats_week
 

--- a/.maestro/flows/dashboard_stats.yaml
+++ b/.maestro/flows/dashboard_stats.yaml
@@ -1,0 +1,116 @@
+# Smoke Test: Dashboard / Stats
+# p2: dashboard.stats
+# P2 ref: Dashboard/Stats > Charts respond, View All analytics, Customization
+#
+# Verifies:
+#   - Dashboard loads with stats cards
+#   - Revenue, Orders, Visitors, Conversion stats are visible
+#   - Date range switching works (Today, This Week, This Month, This Year)
+#   - Top performers card is visible
+#   - "View All" store analytics navigation
+appId: com.woocommerce.android.dev
+name: "Dashboard - Stats and analytics"
+tags:
+  - smoke_core
+  - dashboard
+---
+# Reuse the logged-in session — login flows run first and leave the
+# app authenticated. See subflows/ensure_logged_in.yaml.
+- runFlow:
+    file: ../subflows/ensure_logged_in.yaml
+
+# Verify dashboard container loads
+- assertVisible:
+    id: "dashboard_container"
+    label: "Dashboard container is visible"
+
+# Verify stats card via Compose testTag (DashboardStatsTestTags.DASHBOARD_STATS_CARD)
+- scrollUntilVisible:
+    element:
+      id: "dashboard_stats_card"
+    direction: DOWN
+    timeout: 15000
+    label: "Scroll to stats card"
+
+- assertVisible:
+    id: "dashboard_stats_card"
+    label: "Stats card is visible"
+
+# Verify at least one stat-tile label is rendered on the card.
+#
+# The card's inner layout is a legacy AndroidView (DashboardStatsView)
+# with four side-by-side tiles. Their labels come from:
+#   - R.string.analytics_total_sales_title  → "Total sales"
+#     (was "Revenue" on older builds — fall back to that spelling)
+#   - R.string.dashboard_stats_orders       → "Orders"
+#   - dashboard_stats_visitors              → "Visitors"
+#   - dashboard_stats_conversion            → "Conversion"
+#
+# Labels render immediately after the card inflates — only the tile
+# *values* show the skeleton em-dash ("—") while the Analytics API
+# request is in flight. Matching any one of the labels is the most
+# stable signal that the card rendered with its tiles, and it's
+# robust against future string renames.
+- assertVisible:
+    text: ".*Total sales.*|.*Revenue.*|.*Orders.*|.*Visitors.*"
+    label: "At least one stats tile label is visible"
+
+- takeScreenshot: dashboard_stats_overview
+
+# Test date range switching via Compose testTag (DashboardStatsTestTags.STATS_RANGE_DROPDOWN_BUTTON)
+- tapOn:
+    id: "stats_range_dropdown_button"
+    label: "Tap date range dropdown"
+
+# The DropdownMenu is a Compose Popup — popups render in a separate
+# window, so its own testTag (stats_range_dropdown_menu) doesn't
+# reliably surface in Maestro's view hierarchy. We branch on the
+# visible menu item text instead ("This Week" is always rendered
+# once the menu is open — DashboardViewModel.SUPPORTED_RANGES_ON_MY_STORE_TAB
+# includes Today / This Week / This Month / This Year / Custom).
+- runFlow:
+    when:
+      visible: "This Week"
+    commands:
+      - tapOn: "This Week"
+      - extendedWaitUntil:
+          visible:
+            id: "dashboard_stats_card"
+          timeout: 10000
+
+# Safety net: if the popup didn't dismiss (e.g. the device decided to
+# keep it open, or "This Week" wasn't matched because the menu
+# rendered slightly differently), press back to close it so the
+# subsequent scrolls aren't blocked by a floating popup covering the
+# dashboard content.
+- runFlow:
+    when:
+      visible: "Custom"
+    commands:
+      - back
+
+- takeScreenshot: dashboard_stats_week
+
+# Scroll down to top performers via Compose testTag (DashboardStatsTestTags.DASHBOARD_TOP_PERFORMERS_CARD)
+- scrollUntilVisible:
+    element:
+      id: "dashboard_top_performers_card"
+    direction: DOWN
+    timeout: 15000
+    label: "Scroll to top performers card"
+
+- assertVisible:
+    id: "dashboard_top_performers_card"
+    label: "Top performers card is visible"
+
+- takeScreenshot: dashboard_top_performers
+
+# Scroll back up to the top of the dashboard.
+# `swipe: direction: DOWN` swipes the finger downward, which scrolls
+# the list content upward.
+- swipe:
+    direction: DOWN
+    duration: 500
+- swipe:
+    direction: DOWN
+    duration: 500

--- a/.maestro/flows/login_google.yaml
+++ b/.maestro/flows/login_google.yaml
@@ -9,7 +9,7 @@
 # Preconditions (device/emulator):
 #   - A Google account is already signed in on the device.
 #   - That Google identity is LINKED on WP.com to an account with access
-#     to ${WOO_STORE_URL}. This is a stronger requirement than "a WP.com
+#     to ${WOO_JETPACK_STORE_URL}. This is a stronger requirement than "a WP.com
 #     account with the same email exists": WP.com sign-in via Google
 #     uses the Google identity, not the email, so an account created
 #     via email+password will silently fail Google login unless the
@@ -18,7 +18,7 @@
 #     returns to the empty email screen with no visible error.
 #
 # Required env vars:
-#   WOO_STORE_URL                    (any store the linked account accesses)
+#   WOO_JETPACK_STORE_URL            (any Jetpack-connected store the linked account accesses)
 appId: com.woocommerce.android.dev
 name: "Login - Social login (Google)"
 tags:
@@ -54,7 +54,7 @@ tags:
     timeout: 10000
 - tapOn:
     id: "input"
-- inputText: ${WOO_STORE_URL}
+- inputText: ${WOO_JETPACK_STORE_URL}
 - hideKeyboard
 - tapOn:
     id: "bottom_button"

--- a/.maestro/flows/login_google.yaml
+++ b/.maestro/flows/login_google.yaml
@@ -54,10 +54,7 @@ tags:
     timeout: 10000
 - tapOn:
     id: "input"
-- runFlow:
-    file: ../subflows/paste_into_focused_field.yaml
-    env:
-      TEXT_TO_PASTE: ${WOO_JETPACK_STORE_URL}
+- inputText: ${WOO_JETPACK_STORE_URL}
 - hideKeyboard
 - tapOn:
     id: "bottom_button"

--- a/.maestro/flows/login_google.yaml
+++ b/.maestro/flows/login_google.yaml
@@ -54,7 +54,10 @@ tags:
     timeout: 10000
 - tapOn:
     id: "input"
-- inputText: ${WOO_JETPACK_STORE_URL}
+- runFlow:
+    file: ../subflows/paste_into_focused_field.yaml
+    env:
+      TEXT_TO_PASTE: ${WOO_JETPACK_STORE_URL}
 - hideKeyboard
 - tapOn:
     id: "bottom_button"

--- a/.maestro/flows/login_google.yaml
+++ b/.maestro/flows/login_google.yaml
@@ -8,6 +8,10 @@
 #
 # Preconditions (device/emulator):
 #   - A Google account is already signed in on the device.
+#   - The installed APK was built with the private WooCommerce
+#     google-services.json, not google-services.json-example. The example
+#     OAuth client lets the picker open but Google returns RESULT_CANCELED
+#     after account selection. The smoke runner validates this before launch.
 #   - That Google identity is LINKED on WP.com to an account with access
 #     to ${WOO_JETPACK_STORE_URL}. This is a stronger requirement than "a WP.com
 #     account with the same email exists": WP.com sign-in via Google

--- a/.maestro/flows/login_google.yaml
+++ b/.maestro/flows/login_google.yaml
@@ -1,0 +1,137 @@
+# Smoke Test: Login - Social login (Google)
+# p2: login.social-google
+# P2 ref: Login > Social login - Apple/Google
+#
+# Verifies the "Continue with Google" path on the email screen launches
+# the native Google account picker and that selecting an account reaches
+# the dashboard.
+#
+# Preconditions (device/emulator):
+#   - A Google account is already signed in on the device.
+#   - That Google identity is LINKED on WP.com to an account with access
+#     to ${WOO_STORE_URL}. This is a stronger requirement than "a WP.com
+#     account with the same email exists": WP.com sign-in via Google
+#     uses the Google identity, not the email, so an account created
+#     via email+password will silently fail Google login unless the
+#     owner has explicitly linked Google under WP.com account settings.
+#     Symptom of a missing link: app shows "Logging in" briefly, then
+#     returns to the empty email screen with no visible error.
+#
+# Required env vars:
+#   WOO_STORE_URL                    (any store the linked account accesses)
+appId: com.woocommerce.android.dev
+name: "Login - Social login (Google)"
+tags:
+  - smoke_extended
+  - flaky_quarantine
+  - login
+---
+- launchApp:
+    clearState: true
+
+- extendedWaitUntil:
+    visible: ".*Skip.*|.*Enter your store address.*|.*Log in.*"
+    timeout: 30000
+
+- runFlow:
+    when:
+      visible: "Skip"
+    commands:
+      - tapOn: "Skip"
+
+# Enter store URL to reach the email screen (Google button lives there)
+- extendedWaitUntil:
+    visible:
+      id: "button_login_store"
+    timeout: 15000
+- tapOn:
+    id: "button_login_store"
+    retryTapIfNoChange: true
+
+- extendedWaitUntil:
+    visible:
+      id: "input"
+    timeout: 10000
+- tapOn:
+    id: "input"
+- inputText: ${WOO_STORE_URL}
+- hideKeyboard
+- tapOn:
+    id: "bottom_button"
+    retryTapIfNoChange: true
+
+# Tap "Continue with Google" on the email screen
+# (id: continue_with_google, text: "Continue with Google")
+- extendedWaitUntil:
+    visible:
+      id: "continue_with_google"
+    timeout: 15000
+- tapOn:
+    id: "continue_with_google"
+    retryTapIfNoChange: true
+
+# Native Google account picker (Google Play Services bottom sheet).
+# Content varies by device/Android version. We wait for any recognizable
+# picker text, then tap the first email-looking entry.
+- extendedWaitUntil:
+    visible: ".*Choose an account.*|.*Sign in with Google.*|.*@.*\\..*"
+    timeout: 20000
+
+- takeScreenshot: login_google_account_picker
+
+- tapOn:
+    text: ".*@.*\\..*"
+    index: 0
+    retryTapIfNoChange: true
+
+# Play Services may show a confirmation step after picker selection.
+# The consent UI is a separate activity OUTSIDE the app, so gate each
+# handler on confirming we're still on that activity — otherwise a plain
+# `tapOn: "Continue"` / `"OK"` can fire on the app itself (e.g. hitting
+# the email screen's "Continue with Google" button if we bounced back).
+- runFlow:
+    when:
+      visible: ".*Continue as.*"
+    commands:
+      - tapOn: ".*Continue as.*"
+
+- runFlow:
+    when:
+      visible: ".*Sign in to.*|.*wants to access.*|.*Grant permission.*"
+    commands:
+      - tapOn:
+          text: "Allow|Continue"
+
+# If the WP.com account has access to multiple stores, the app shows
+# a store-picker before the dashboard. Pick whichever one is first —
+# we only need to reach the dashboard, not a specific store.
+- runFlow:
+    when:
+      visible: ".*Choose your store.*|.*Select a store.*|.*Pick a store.*"
+    commands:
+      - tapOn:
+          id: "site_list_item"
+          index: 0
+      - runFlow:
+          when:
+            visible: "Continue"
+          commands:
+            - tapOn: "Continue"
+
+# Verify dashboard loaded (allow generous time for the full auth
+# round-trip: Play Services → Google → WP.com → site fetch → dashboard).
+- extendedWaitUntil:
+    visible: ".*My store.*|.*Manage privacy.*|.*Dashboard.*"
+    timeout: 60000
+
+- runFlow:
+    when:
+      visible: "Save"
+    commands:
+      - tapOn: "Save"
+
+- extendedWaitUntil:
+    visible: ".*My store.*|.*Dashboard.*"
+    timeout: 15000
+
+- takeScreenshot: login_google_success

--- a/.maestro/flows/login_help.yaml
+++ b/.maestro/flows/login_help.yaml
@@ -1,0 +1,63 @@
+# Smoke Test: Login - Help section
+# p2: login.help
+# P2 ref: Login > Help section
+#
+# Verifies the Help action in the login toolbar opens the help screen.
+# The `?` help icon lives in the login toolbar (menu id: help, title
+# "Help" from libs/login/res/menu/menu_login.xml), which is only
+# present once the user has tapped through the prologue and reached
+# the site-address screen — the prologue itself has no toolbar.
+#
+# No credentials required.
+appId: com.woocommerce.android.dev
+name: "Login - Help section"
+tags:
+  - smoke_extended
+  - flaky_quarantine
+  - login
+---
+- launchApp:
+    clearState: true
+
+- extendedWaitUntil:
+    visible: ".*Skip.*|.*Enter your store address.*|.*Log in.*"
+    timeout: 30000
+
+- runFlow:
+    when:
+      visible: "Skip"
+    commands:
+      - tapOn: "Skip"
+
+# Enter the login flow to reach a screen with the toolbar (the prologue
+# has no toolbar, so the help icon is only reachable from here on).
+- extendedWaitUntil:
+    visible:
+      id: "button_login_store"
+    timeout: 15000
+- tapOn:
+    id: "button_login_store"
+    retryTapIfNoChange: true
+
+# Wait for the site-address screen's toolbar to settle
+- extendedWaitUntil:
+    visible:
+      id: "input"
+    timeout: 10000
+
+# Tap the help menu item. The Android menu sets id="@+id/help" and
+# title="Help", so Maestro can locate it by either — prefer the id
+# since the icon has no visible label.
+- tapOn:
+    id: "help"
+    retryTapIfNoChange: true
+
+# Verify the help screen opened. The Zendesk-backed help module shows
+# "Help Center" / "Contact support" / FAQ-style text.
+- extendedWaitUntil:
+    visible: ".*Help Center.*|.*Contact support.*|.*FAQ.*|.*frequently asked.*|.*Zendesk.*"
+    timeout: 15000
+
+- takeScreenshot: login_help_section
+
+- back

--- a/.maestro/flows/login_no_jetpack.yaml
+++ b/.maestro/flows/login_no_jetpack.yaml
@@ -2,17 +2,16 @@
 # p2: login.no-jetpack
 # P2 ref: Login > No Jetpack
 #
-# Logs into a WooCommerce site that does NOT have Jetpack connected,
-# using site credentials (not WP.com), and verifies the post-login
-# dashboard surfaces the "Explore Jetpack" promo card — the app's way
-# of nudging users on non-Jetpack sites toward the install flow.
+# Logs into a WooCommerce site that does NOT have Jetpack connected
+# using site credentials (not WP.com), and verifies the site-credentials
+# path reaches the dashboard.
 #
 # Required env vars:
 #   WOO_NO_JETPACK_SITE_URL                  (any non-Jetpack WP site with WC)
 #   WOO_NO_JETPACK_SITE_ADMIN_USERNAME       (site admin credentials — not WP.com)
 #   WOO_NO_JETPACK_SITE_ADMIN_PASSWORD
 appId: com.woocommerce.android.dev
-name: "Login - No Jetpack (Explore Jetpack banner)"
+name: "Login - No Jetpack via site credentials"
 tags:
   - smoke_extended
   - flaky_quarantine
@@ -110,20 +109,16 @@ tags:
     commands:
       - tapOn: "Save"
 
-# Verify the Jetpack benefits promo banner is visible on the dashboard.
-# Text source: dashboard_jetpack_benefits_banner_*.xml strings
-# ("Get order notifications and more" / "boost store security. Explore
-# Jetpack now."). Matching on the unique "Explore Jetpack" phrasing
-# keeps the assertion stable across minor copy tweaks.
-- scrollUntilVisible:
-    element:
-      text: ".*Get order notifications and more.*|.*Explore Jetpack.*|.*boost store security.*"
-    direction: DOWN
-    timeout: 15000
-    label: "Scroll to Jetpack benefits banner"
-
+# Verify the site-credentials path completed and landed on the store
+# dashboard. The dashboard content for a fresh non-Jetpack site changes
+# with remote feature flags and store setup state, so assert the stable
+# dashboard container instead of a specific promotional card.
 - extendedWaitUntil:
-    visible: ".*Get order notifications and more.*|.*Explore Jetpack.*|.*boost store security.*"
+    visible: "My store"
     timeout: 10000
+
+- assertVisible:
+    id: "dashboard_container"
+    label: "Verify dashboard loaded after no-Jetpack site login"
 
 - takeScreenshot: login_no_jetpack

--- a/.maestro/flows/login_no_jetpack.yaml
+++ b/.maestro/flows/login_no_jetpack.yaml
@@ -1,0 +1,113 @@
+# Smoke Test: Login - No Jetpack
+# p2: login.no-jetpack
+# P2 ref: Login > No Jetpack
+#
+# Logs into a WooCommerce site that does NOT have Jetpack connected,
+# using site credentials (not WP.com), and verifies the post-login
+# dashboard surfaces the "Explore Jetpack" promo card — the app's way
+# of nudging users on non-Jetpack sites toward the install flow.
+#
+# Required env vars:
+#   WOO_JN_SITE_URL                  (any non-Jetpack WP site with WC)
+#   WOO_JN_USERNAME                  (site credentials — not WP.com)
+#   WOO_JN_PASSWORD
+appId: com.woocommerce.android.dev
+name: "Login - No Jetpack (Explore Jetpack banner)"
+tags:
+  - smoke_extended
+  - flaky_quarantine
+  - login
+---
+- launchApp:
+    clearState: true
+
+- extendedWaitUntil:
+    visible: ".*Skip.*|.*Enter your store address.*|.*Log in.*"
+    timeout: 30000
+
+- runFlow:
+    when:
+      visible: "Skip"
+    commands:
+      - tapOn: "Skip"
+
+# Enter JN store URL
+- extendedWaitUntil:
+    visible:
+      id: "button_login_store"
+    timeout: 15000
+- tapOn:
+    id: "button_login_store"
+    retryTapIfNoChange: true
+
+- extendedWaitUntil:
+    visible:
+      id: "input"
+    timeout: 10000
+- tapOn:
+    id: "input"
+- inputText: ${WOO_JN_SITE_URL}
+- hideKeyboard
+- tapOn:
+    id: "bottom_button"
+    retryTapIfNoChange: true
+
+# For a site without Jetpack the app usually routes directly to the
+# site-credentials login screen, skipping the email screen entirely.
+# If it didn't (e.g. the site reports partial Jetpack support), the
+# email screen will show a "Log in with your site credentials" button
+# (id: login_site_creds) that we need to tap first.
+- runFlow:
+    when:
+      visible:
+        id: "login_site_creds"
+    commands:
+      - tapOn:
+          id: "login_site_creds"
+          retryTapIfNoChange: true
+
+# Site-credentials screen shows Username + Password on the SAME screen.
+# This screen is rendered by the libs/login Compose tree, which does
+# NOT apply `testTagsAsResourceId = true` (that's only on the app's
+# WooTheme), so UI nodes expose NO resource IDs to Maestro. Drive it
+# with visible text selectors ("Username", "Password", "Continue"),
+# which are always present as Material TextInputLayout labels.
+- extendedWaitUntil:
+    visible: "Username"
+    timeout: 15000
+- tapOn: "Username"
+- inputText: ${WOO_JN_USERNAME}
+
+# Tap the password label directly — its Material TextInputLayout focuses
+# the associated EditText. Avoid hideKeyboard here: the site-creds screen
+# uses a custom input rail that doesn't expose a standard dismiss action
+# (Maestro errors with "Couldn't hide the keyboard"), and Continue is
+# visible above the IME anyway.
+- tapOn: "Password"
+- inputText: ${WOO_JN_PASSWORD}
+
+- tapOn: "Continue"
+
+# After a successful site-credentials login, the app lands on the
+# dashboard and shows the "Manage privacy" bottom sheet first. Dismiss
+# it (Save accepts the defaults) so the dashboard cards are tappable
+# and visible for the Jetpack-banner assertion below.
+- extendedWaitUntil:
+    visible: ".*Manage privacy.*|.*My store.*"
+    timeout: 60000
+- runFlow:
+    when:
+      visible: ".*Manage privacy.*"
+    commands:
+      - tapOn: "Save"
+
+# Verify the "Explore Jetpack" promo banner is visible on the dashboard.
+# Text source: dashboard_jetpack_benefits_banner_*.xml strings
+# ("Get order notifications and more" / "boost store security. Explore
+# Jetpack now."). Matching on the unique "Explore Jetpack" phrasing
+# keeps the assertion stable across minor copy tweaks.
+- extendedWaitUntil:
+    visible: ".*Explore Jetpack.*|.*boost store security.*"
+    timeout: 30000
+
+- takeScreenshot: login_no_jetpack

--- a/.maestro/flows/login_no_jetpack.yaml
+++ b/.maestro/flows/login_no_jetpack.yaml
@@ -46,7 +46,10 @@ tags:
     timeout: 10000
 - tapOn:
     id: "input"
-- inputText: ${WOO_NO_JETPACK_SITE_URL}
+- runFlow:
+    file: ../subflows/paste_into_focused_field.yaml
+    env:
+      TEXT_TO_PASTE: ${WOO_NO_JETPACK_SITE_URL}
 - hideKeyboard
 - tapOn:
     id: "bottom_button"
@@ -76,7 +79,10 @@ tags:
     visible: "Username"
     timeout: 15000
 - tapOn: "Username"
-- inputText: ${WOO_NO_JETPACK_SITE_ADMIN_USERNAME}
+- runFlow:
+    file: ../subflows/paste_into_focused_field.yaml
+    env:
+      TEXT_TO_PASTE: ${WOO_NO_JETPACK_SITE_ADMIN_USERNAME}
 
 # Tap the password label directly — its Material TextInputLayout focuses
 # the associated EditText. Avoid hideKeyboard here: the site-creds screen
@@ -84,7 +90,10 @@ tags:
 # (Maestro errors with "Couldn't hide the keyboard"), and Continue is
 # visible above the IME anyway.
 - tapOn: "Password"
-- inputText: ${WOO_NO_JETPACK_SITE_ADMIN_PASSWORD}
+- runFlow:
+    file: ../subflows/paste_into_focused_field.yaml
+    env:
+      TEXT_TO_PASTE: ${WOO_NO_JETPACK_SITE_ADMIN_PASSWORD}
 
 - tapOn: "Continue"
 

--- a/.maestro/flows/login_no_jetpack.yaml
+++ b/.maestro/flows/login_no_jetpack.yaml
@@ -8,9 +8,9 @@
 # of nudging users on non-Jetpack sites toward the install flow.
 #
 # Required env vars:
-#   WOO_JN_SITE_URL                  (any non-Jetpack WP site with WC)
-#   WOO_JN_USERNAME                  (site credentials — not WP.com)
-#   WOO_JN_PASSWORD
+#   WOO_NO_JETPACK_SITE_URL                  (any non-Jetpack WP site with WC)
+#   WOO_NO_JETPACK_SITE_ADMIN_USERNAME       (site admin credentials — not WP.com)
+#   WOO_NO_JETPACK_SITE_ADMIN_PASSWORD
 appId: com.woocommerce.android.dev
 name: "Login - No Jetpack (Explore Jetpack banner)"
 tags:
@@ -31,7 +31,7 @@ tags:
     commands:
       - tapOn: "Skip"
 
-# Enter JN store URL
+# Enter no-Jetpack store URL
 - extendedWaitUntil:
     visible:
       id: "button_login_store"
@@ -46,7 +46,7 @@ tags:
     timeout: 10000
 - tapOn:
     id: "input"
-- inputText: ${WOO_JN_SITE_URL}
+- inputText: ${WOO_NO_JETPACK_SITE_URL}
 - hideKeyboard
 - tapOn:
     id: "bottom_button"
@@ -76,7 +76,7 @@ tags:
     visible: "Username"
     timeout: 15000
 - tapOn: "Username"
-- inputText: ${WOO_JN_USERNAME}
+- inputText: ${WOO_NO_JETPACK_SITE_ADMIN_USERNAME}
 
 # Tap the password label directly — its Material TextInputLayout focuses
 # the associated EditText. Avoid hideKeyboard here: the site-creds screen
@@ -84,7 +84,7 @@ tags:
 # (Maestro errors with "Couldn't hide the keyboard"), and Continue is
 # visible above the IME anyway.
 - tapOn: "Password"
-- inputText: ${WOO_JN_PASSWORD}
+- inputText: ${WOO_NO_JETPACK_SITE_ADMIN_PASSWORD}
 
 - tapOn: "Continue"
 
@@ -101,13 +101,20 @@ tags:
     commands:
       - tapOn: "Save"
 
-# Verify the "Explore Jetpack" promo banner is visible on the dashboard.
+# Verify the Jetpack benefits promo banner is visible on the dashboard.
 # Text source: dashboard_jetpack_benefits_banner_*.xml strings
 # ("Get order notifications and more" / "boost store security. Explore
 # Jetpack now."). Matching on the unique "Explore Jetpack" phrasing
 # keeps the assertion stable across minor copy tweaks.
+- scrollUntilVisible:
+    element:
+      text: ".*Get order notifications and more.*|.*Explore Jetpack.*|.*boost store security.*"
+    direction: DOWN
+    timeout: 15000
+    label: "Scroll to Jetpack benefits banner"
+
 - extendedWaitUntil:
-    visible: ".*Explore Jetpack.*|.*boost store security.*"
-    timeout: 30000
+    visible: ".*Get order notifications and more.*|.*Explore Jetpack.*|.*boost store security.*"
+    timeout: 10000
 
 - takeScreenshot: login_no_jetpack

--- a/.maestro/flows/login_no_jetpack.yaml
+++ b/.maestro/flows/login_no_jetpack.yaml
@@ -45,10 +45,7 @@ tags:
     timeout: 10000
 - tapOn:
     id: "input"
-- runFlow:
-    file: ../subflows/paste_into_focused_field.yaml
-    env:
-      TEXT_TO_PASTE: ${WOO_NO_JETPACK_SITE_URL}
+- inputText: ${WOO_NO_JETPACK_SITE_URL}
 - hideKeyboard
 - tapOn:
     id: "bottom_button"
@@ -78,10 +75,7 @@ tags:
     visible: "Username"
     timeout: 15000
 - tapOn: "Username"
-- runFlow:
-    file: ../subflows/paste_into_focused_field.yaml
-    env:
-      TEXT_TO_PASTE: ${WOO_NO_JETPACK_SITE_ADMIN_USERNAME}
+- inputText: ${WOO_NO_JETPACK_SITE_ADMIN_USERNAME}
 
 # Tap the password label directly — its Material TextInputLayout focuses
 # the associated EditText. Avoid hideKeyboard here: the site-creds screen
@@ -89,10 +83,7 @@ tags:
 # (Maestro errors with "Couldn't hide the keyboard"), and Continue is
 # visible above the IME anyway.
 - tapOn: "Password"
-- runFlow:
-    file: ../subflows/paste_into_focused_field.yaml
-    env:
-      TEXT_TO_PASTE: ${WOO_NO_JETPACK_SITE_ADMIN_PASSWORD}
+- inputText: ${WOO_NO_JETPACK_SITE_ADMIN_PASSWORD}
 
 - tapOn: "Continue"
 

--- a/.maestro/flows/login_not_woo_store.yaml
+++ b/.maestro/flows/login_not_woo_store.yaml
@@ -3,13 +3,13 @@
 # P2 ref: Login > Not a Woo store (notawoostore.wordpress.com)
 #
 # Logs into a WordPress site that does NOT have WooCommerce installed
-# using the primary WP.com credentials, and verifies the app shows the
+# using its dedicated WP.com credentials, and verifies the app shows the
 # "not a WooCommerce site" error.
 #
 # Required env vars:
-#   WOO_WPCOM_EMAIL, WOO_WPCOM_PASSWORD
-#                                      (selected WP.com account)
-#   WOO_NOT_A_WOO_STORE_URL          (notawoostore.wordpress.com)
+#   WOO_NOT_A_WOO_STORE_URL
+#   WOO_NOT_A_WOO_STORE_WPCOM_EMAIL
+#   WOO_NOT_A_WOO_STORE_WPCOM_PASSWORD
 appId: com.woocommerce.android.dev
 name: "Login - Not a WooCommerce store error"
 tags:
@@ -58,7 +58,7 @@ tags:
     timeout: 15000
 - tapOn:
     id: "input"
-- inputText: ${WOO_WPCOM_EMAIL}
+- inputText: ${WOO_NOT_A_WOO_STORE_WPCOM_EMAIL}
 - hideKeyboard
 - tapOn:
     id: "login_continue_button"
@@ -91,7 +91,7 @@ tags:
     timeout: 10000
 - tapOn:
     id: "input"
-- inputText: ${WOO_WPCOM_PASSWORD}
+- inputText: ${WOO_NOT_A_WOO_STORE_WPCOM_PASSWORD}
 - hideKeyboard
 - tapOn:
     id: "bottom_button"

--- a/.maestro/flows/login_not_woo_store.yaml
+++ b/.maestro/flows/login_not_woo_store.yaml
@@ -7,7 +7,8 @@
 # "not a WooCommerce site" error.
 #
 # Required env vars:
-#   WOO_EMAIL, WOO_PASSWORD          (shared primary account)
+#   WOO_WPCOM_EMAIL, WOO_WPCOM_PASSWORD
+#                                      (selected WP.com account)
 #   WOO_NOT_A_WOO_STORE_URL          (notawoostore.wordpress.com)
 appId: com.woocommerce.android.dev
 name: "Login - Not a WooCommerce store error"
@@ -57,7 +58,7 @@ tags:
     timeout: 15000
 - tapOn:
     id: "input"
-- inputText: ${WOO_EMAIL}
+- inputText: ${WOO_WPCOM_EMAIL}
 - hideKeyboard
 - tapOn:
     id: "login_continue_button"
@@ -90,7 +91,7 @@ tags:
     timeout: 10000
 - tapOn:
     id: "input"
-- inputText: ${WOO_PASSWORD}
+- inputText: ${WOO_WPCOM_PASSWORD}
 - hideKeyboard
 - tapOn:
     id: "bottom_button"

--- a/.maestro/flows/login_not_woo_store.yaml
+++ b/.maestro/flows/login_not_woo_store.yaml
@@ -2,12 +2,14 @@
 # p2: login.not-woo-store
 # P2 ref: Login > Not a Woo store (notawoostore.wordpress.com)
 #
-# Logs into a WordPress site that does NOT have WooCommerce installed
-# using its dedicated WP.com credentials, and verifies the app shows the
-# "not a WooCommerce site" error.
+# Logs into a WordPress site that does NOT have WooCommerce installed.
+# Site-admin credentials are preferred, with WP.com credentials used when
+# the site routes through WordPress.com authentication instead.
 #
 # Required env vars:
 #   WOO_NOT_A_WOO_STORE_URL
+#   WOO_NOT_A_WOO_STORE_SITE_ADMIN_USERNAME
+#   WOO_NOT_A_WOO_STORE_SITE_ADMIN_PASSWORD
 #   WOO_NOT_A_WOO_STORE_WPCOM_EMAIL
 #   WOO_NOT_A_WOO_STORE_WPCOM_PASSWORD
 appId: com.woocommerce.android.dev
@@ -51,51 +53,77 @@ tags:
     id: "bottom_button"
     retryTapIfNoChange: true
 
-# Enter primary email
+# Wait for either authentication route. A site can route directly to the
+# site-credentials form or expose that path from the WP.com email screen.
 - extendedWaitUntil:
-    visible:
-      id: "login_continue_button"
-    timeout: 15000
-- tapOn:
-    id: "input"
-- inputText: ${WOO_NOT_A_WOO_STORE_WPCOM_EMAIL}
-- hideKeyboard
-- tapOn:
-    id: "login_continue_button"
-    retryTapIfNoChange: true
+    visible: "Username|Email address"
+    timeout: 30000
 
-- runFlow:
-    when:
-      visible: "No thanks"
-    commands:
-      - tapOn: "No thanks"
-
+# Prefer site-admin credentials when the app offers that route explicitly.
 - runFlow:
     when:
       visible:
-        id: "login_enter_password"
+        id: "login_site_creds"
     commands:
       - tapOn:
-          id: "login_enter_password"
+          id: "login_site_creds"
+          retryTapIfNoChange: true
+      - extendedWaitUntil:
+          visible: "Username"
+          timeout: 15000
 
+# Self-hosted sites show Username and Password on the same screen.
 - runFlow:
     when:
-      visible: "No thanks"
+      visible: "Username"
     commands:
-      - tapOn: "No thanks"
+      - tapOn: "Username"
+      - inputText: ${WOO_NOT_A_WOO_STORE_SITE_ADMIN_USERNAME}
+      - tapOn: "Password"
+      - inputText: ${WOO_NOT_A_WOO_STORE_SITE_ADMIN_PASSWORD}
+      - tapOn: "Continue"
 
-# Enter primary password
-- extendedWaitUntil:
-    visible:
-      id: "input"
-    timeout: 10000
-- tapOn:
-    id: "input"
-- inputText: ${WOO_NOT_A_WOO_STORE_WPCOM_PASSWORD}
-- hideKeyboard
-- tapOn:
-    id: "bottom_button"
-    retryTapIfNoChange: true
+# Fall back to WP.com credentials when no site-admin route is available.
+- runFlow:
+    when:
+      visible:
+        id: "login_continue_button"
+    commands:
+      - tapOn:
+          id: "input"
+      - inputText: ${WOO_NOT_A_WOO_STORE_WPCOM_EMAIL}
+      - hideKeyboard
+      - tapOn:
+          id: "login_continue_button"
+          retryTapIfNoChange: true
+      - runFlow:
+          when:
+            visible: "No thanks"
+          commands:
+            - tapOn: "No thanks"
+      - runFlow:
+          when:
+            visible:
+              id: "login_enter_password"
+          commands:
+            - tapOn:
+                id: "login_enter_password"
+      - runFlow:
+          when:
+            visible: "No thanks"
+          commands:
+            - tapOn: "No thanks"
+      - extendedWaitUntil:
+          visible:
+            id: "input"
+          timeout: 10000
+      - tapOn:
+          id: "input"
+      - inputText: ${WOO_NOT_A_WOO_STORE_WPCOM_PASSWORD}
+      - hideKeyboard
+      - tapOn:
+          id: "bottom_button"
+          retryTapIfNoChange: true
 
 # Verify the configured WordPress site is rejected specifically because it
 # does not have WooCommerce. A Jetpack-account error does not prove this P2

--- a/.maestro/flows/login_not_woo_store.yaml
+++ b/.maestro/flows/login_not_woo_store.yaml
@@ -1,0 +1,111 @@
+# Smoke Test: Login - Not a WooCommerce store
+# p2: login.not-woo-store
+# P2 ref: Login > Not a Woo store (notawoostore.wordpress.com)
+#
+# Logs into a WordPress site that does NOT have WooCommerce installed
+# using the primary WP.com credentials, and verifies the app shows the
+# "not a WooCommerce site" error.
+#
+# Required env vars:
+#   WOO_EMAIL, WOO_PASSWORD          (shared primary account)
+#   WOO_NOT_A_WOO_STORE_URL          (notawoostore.wordpress.com)
+appId: com.woocommerce.android.dev
+name: "Login - Not a WooCommerce store error"
+tags:
+  - smoke_extended
+  - flaky_quarantine
+  - login
+---
+- launchApp:
+    clearState: true
+
+- extendedWaitUntil:
+    visible: ".*Skip.*|.*Enter your store address.*|.*Log in.*"
+    timeout: 30000
+
+- runFlow:
+    when:
+      visible: "Skip"
+    commands:
+      - tapOn: "Skip"
+
+# Enter store address
+- extendedWaitUntil:
+    visible:
+      id: "button_login_store"
+    timeout: 15000
+- tapOn:
+    id: "button_login_store"
+    retryTapIfNoChange: true
+
+- extendedWaitUntil:
+    visible:
+      id: "input"
+    timeout: 10000
+- tapOn:
+    id: "input"
+- inputText: ${WOO_NOT_A_WOO_STORE_URL}
+- hideKeyboard
+- tapOn:
+    id: "bottom_button"
+    retryTapIfNoChange: true
+
+# Enter primary email
+- extendedWaitUntil:
+    visible:
+      id: "login_continue_button"
+    timeout: 15000
+- tapOn:
+    id: "input"
+- inputText: ${WOO_EMAIL}
+- hideKeyboard
+- tapOn:
+    id: "login_continue_button"
+    retryTapIfNoChange: true
+
+- runFlow:
+    when:
+      visible: "No thanks"
+    commands:
+      - tapOn: "No thanks"
+
+- runFlow:
+    when:
+      visible:
+        id: "login_enter_password"
+    commands:
+      - tapOn:
+          id: "login_enter_password"
+
+- runFlow:
+    when:
+      visible: "No thanks"
+    commands:
+      - tapOn: "No thanks"
+
+# Enter primary password
+- extendedWaitUntil:
+    visible:
+      id: "input"
+    timeout: 10000
+- tapOn:
+    id: "input"
+- inputText: ${WOO_PASSWORD}
+- hideKeyboard
+- tapOn:
+    id: "bottom_button"
+    retryTapIfNoChange: true
+
+# Verify the app shows an error that prevents proceeding to the store.
+# The configured non-Woo store can trigger one of two strings depending
+# on the account's relationship to the site:
+#   - login_not_woo_store: "It looks like %1$s is not a WooCommerce site."
+#   - login_jetpack_not_connected: "It looks like your account is not
+#     connected to %1$s's Jetpack"
+# Accept either so the test stays useful if the site-to-account mapping
+# changes.
+- extendedWaitUntil:
+    visible: ".*not a WooCommerce site.*|.*not connected to.*Jetpack.*"
+    timeout: 30000
+
+- takeScreenshot: login_not_woo_store

--- a/.maestro/flows/login_not_woo_store.yaml
+++ b/.maestro/flows/login_not_woo_store.yaml
@@ -106,16 +106,11 @@ tags:
     id: "bottom_button"
     retryTapIfNoChange: true
 
-# Verify the app shows an error that prevents proceeding to the store.
-# The configured non-Woo store can trigger one of two strings depending
-# on the account's relationship to the site:
-#   - login_not_woo_store: "It looks like %1$s is not a WooCommerce site."
-#   - login_jetpack_not_connected: "It looks like your account is not
-#     connected to %1$s's Jetpack"
-# Accept either so the test stays useful if the site-to-account mapping
-# changes.
+# Verify the configured WordPress site is rejected specifically because it
+# does not have WooCommerce. A Jetpack-account error does not prove this P2
+# check and must fail so the fixture can be repaired.
 - extendedWaitUntil:
-    visible: ".*not a WooCommerce site.*|.*not connected to.*Jetpack.*"
+    visible: ".*not a WooCommerce site.*"
     timeout: 30000
 
 - takeScreenshot: login_not_woo_store

--- a/.maestro/flows/login_not_woo_store.yaml
+++ b/.maestro/flows/login_not_woo_store.yaml
@@ -45,10 +45,7 @@ tags:
     timeout: 10000
 - tapOn:
     id: "input"
-- runFlow:
-    file: ../subflows/paste_into_focused_field.yaml
-    env:
-      TEXT_TO_PASTE: ${WOO_NOT_A_WOO_STORE_URL}
+- inputText: ${WOO_NOT_A_WOO_STORE_URL}
 - hideKeyboard
 - tapOn:
     id: "bottom_button"
@@ -61,10 +58,7 @@ tags:
     timeout: 15000
 - tapOn:
     id: "input"
-- runFlow:
-    file: ../subflows/paste_into_focused_field.yaml
-    env:
-      TEXT_TO_PASTE: ${WOO_WPCOM_EMAIL}
+- inputText: ${WOO_WPCOM_EMAIL}
 - hideKeyboard
 - tapOn:
     id: "login_continue_button"
@@ -97,10 +91,7 @@ tags:
     timeout: 10000
 - tapOn:
     id: "input"
-- runFlow:
-    file: ../subflows/paste_into_focused_field.yaml
-    env:
-      TEXT_TO_PASTE: ${WOO_WPCOM_PASSWORD}
+- inputText: ${WOO_WPCOM_PASSWORD}
 - hideKeyboard
 - tapOn:
     id: "bottom_button"

--- a/.maestro/flows/login_not_woo_store.yaml
+++ b/.maestro/flows/login_not_woo_store.yaml
@@ -10,6 +10,7 @@
 #   WOO_NOT_A_WOO_STORE_URL
 #   WOO_NOT_A_WOO_STORE_SITE_ADMIN_USERNAME
 #   WOO_NOT_A_WOO_STORE_SITE_ADMIN_PASSWORD
+# Optional WP.com fallback env vars (set both or neither):
 #   WOO_NOT_A_WOO_STORE_WPCOM_EMAIL
 #   WOO_NOT_A_WOO_STORE_WPCOM_PASSWORD
 appId: com.woocommerce.android.dev

--- a/.maestro/flows/login_not_woo_store.yaml
+++ b/.maestro/flows/login_not_woo_store.yaml
@@ -45,7 +45,10 @@ tags:
     timeout: 10000
 - tapOn:
     id: "input"
-- inputText: ${WOO_NOT_A_WOO_STORE_URL}
+- runFlow:
+    file: ../subflows/paste_into_focused_field.yaml
+    env:
+      TEXT_TO_PASTE: ${WOO_NOT_A_WOO_STORE_URL}
 - hideKeyboard
 - tapOn:
     id: "bottom_button"
@@ -58,7 +61,10 @@ tags:
     timeout: 15000
 - tapOn:
     id: "input"
-- inputText: ${WOO_WPCOM_EMAIL}
+- runFlow:
+    file: ../subflows/paste_into_focused_field.yaml
+    env:
+      TEXT_TO_PASTE: ${WOO_WPCOM_EMAIL}
 - hideKeyboard
 - tapOn:
     id: "login_continue_button"
@@ -91,7 +97,10 @@ tags:
     timeout: 10000
 - tapOn:
     id: "input"
-- inputText: ${WOO_WPCOM_PASSWORD}
+- runFlow:
+    file: ../subflows/paste_into_focused_field.yaml
+    env:
+      TEXT_TO_PASTE: ${WOO_WPCOM_PASSWORD}
 - hideKeyboard
 - tapOn:
     id: "bottom_button"

--- a/.maestro/flows/login_not_wp_site.yaml
+++ b/.maestro/flows/login_not_wp_site.yaml
@@ -42,10 +42,7 @@ tags:
     timeout: 10000
 - tapOn:
     id: "input"
-- runFlow:
-    file: ../subflows/paste_into_focused_field.yaml
-    env:
-      TEXT_TO_PASTE: "google.com"
+- inputText: "google.com"
 - tapOn:
     id: "bottom_button"
     retryTapIfNoChange: true

--- a/.maestro/flows/login_not_wp_site.yaml
+++ b/.maestro/flows/login_not_wp_site.yaml
@@ -1,0 +1,58 @@
+# Smoke Test: Login - Not a WordPress site
+# p2: login.not-wp-site
+# P2 ref: Login > Not a WP site (use "Google.com" or any non-WordPress site)
+#
+# Manages its own login flow (does not call the login subflow) because
+# we're validating the pre-login error path. Starts from a fresh state.
+appId: com.woocommerce.android.dev
+name: "Login - Not a WordPress site error"
+tags:
+  - smoke_extended
+  - flaky_quarantine
+  - login
+---
+- launchApp:
+    clearState: true
+
+# Wait for app to finish loading after clearState
+- extendedWaitUntil:
+    visible: ".*Skip.*|.*Enter your store address.*|.*Log in.*"
+    timeout: 30000
+
+# Skip carousel if shown
+- runFlow:
+    when:
+      visible: "Skip"
+    commands:
+      - tapOn: "Skip"
+
+# Tap "Enter your store address"
+- extendedWaitUntil:
+    visible:
+      id: "button_login_store"
+    timeout: 15000
+- tapOn:
+    id: "button_login_store"
+    retryTapIfNoChange: true
+
+# Enter a non-WordPress site URL
+- extendedWaitUntil:
+    visible:
+      id: "input"
+    timeout: 10000
+- tapOn:
+    id: "input"
+- inputText: "google.com"
+- tapOn:
+    id: "bottom_button"
+    retryTapIfNoChange: true
+
+# Verify error message appears
+- extendedWaitUntil:
+    visible: ".*not able to detect a WordPress site.*"
+    timeout: 15000
+
+# Verify the recovery buttons are present
+- assertVisible: "Try another store"
+
+- takeScreenshot: login_not_wp_site

--- a/.maestro/flows/login_not_wp_site.yaml
+++ b/.maestro/flows/login_not_wp_site.yaml
@@ -42,7 +42,10 @@ tags:
     timeout: 10000
 - tapOn:
     id: "input"
-- inputText: "google.com"
+- runFlow:
+    file: ../subflows/paste_into_focused_field.yaml
+    env:
+      TEXT_TO_PASTE: "google.com"
 - tapOn:
     id: "bottom_button"
     retryTapIfNoChange: true

--- a/.maestro/flows/login_successful.yaml
+++ b/.maestro/flows/login_successful.yaml
@@ -3,10 +3,14 @@
 # P2 ref: Login > Jetpack (site address + WP.com credentials)
 #
 # Prerequisites:
-#   - WOO_STORE_URL, WOO_EMAIL, WOO_PASSWORD env vars set
+#   - WOO_JETPACK_STORE_URL, WOO_WPCOM_EMAIL, WOO_WPCOM_PASSWORD env vars set
 #
 # Run:
-#   maestro test -e WOO_EMAIL="..." -e WOO_PASSWORD="..." -e WOO_STORE_URL="..." .maestro/flows/login_successful.yaml
+#   maestro test \
+#     -e WOO_WPCOM_EMAIL="..." \
+#     -e WOO_WPCOM_PASSWORD="..." \
+#     -e WOO_JETPACK_STORE_URL="..." \
+#     .maestro/flows/login_successful.yaml
 appId: com.woocommerce.android.dev
 name: "Login - Successful store login"
 tags:

--- a/.maestro/flows/login_successful.yaml
+++ b/.maestro/flows/login_successful.yaml
@@ -1,0 +1,29 @@
+# Smoke Test: Successful Login via Store Address
+# p2: install.fresh, login.jetpack
+# P2 ref: Login > Jetpack (site address + WP.com credentials)
+#
+# Prerequisites:
+#   - WOO_STORE_URL, WOO_EMAIL, WOO_PASSWORD env vars set
+#
+# Run:
+#   maestro test -e WOO_EMAIL="..." -e WOO_PASSWORD="..." -e WOO_STORE_URL="..." .maestro/flows/login_successful.yaml
+appId: com.woocommerce.android.dev
+name: "Login - Successful store login"
+tags:
+  - smoke_core
+  - login
+---
+# Login
+- runFlow:
+    file: ../subflows/login.yaml
+
+# Verify we landed on the Dashboard
+- assertVisible:
+    id: "dashboard"
+    label: "Verify Dashboard tab is visible after login"
+
+- assertVisible:
+    id: "dashboard_container"
+    label: "Verify Dashboard container loaded"
+
+- takeScreenshot: login_successful

--- a/.maestro/flows/login_wrong_account.yaml
+++ b/.maestro/flows/login_wrong_account.yaml
@@ -43,10 +43,7 @@ tags:
     timeout: 10000
 - tapOn:
     id: "input"
-- runFlow:
-    file: ../subflows/paste_into_focused_field.yaml
-    env:
-      TEXT_TO_PASTE: ${WOO_WRONG_ACCOUNT_STORE_URL}
+- inputText: ${WOO_WRONG_ACCOUNT_STORE_URL}
 - hideKeyboard
 - tapOn:
     id: "bottom_button"
@@ -58,10 +55,7 @@ tags:
     timeout: 15000
 - tapOn:
     id: "input"
-- runFlow:
-    file: ../subflows/paste_into_focused_field.yaml
-    env:
-      TEXT_TO_PASTE: ${WOO_WPCOM_EMAIL}
+- inputText: ${WOO_WPCOM_EMAIL}
 - hideKeyboard
 - tapOn:
     id: "login_continue_button"
@@ -93,10 +87,7 @@ tags:
     timeout: 10000
 - tapOn:
     id: "input"
-- runFlow:
-    file: ../subflows/paste_into_focused_field.yaml
-    env:
-      TEXT_TO_PASTE: ${WOO_WPCOM_PASSWORD}
+- inputText: ${WOO_WPCOM_PASSWORD}
 - hideKeyboard
 - tapOn:
     id: "bottom_button"

--- a/.maestro/flows/login_wrong_account.yaml
+++ b/.maestro/flows/login_wrong_account.yaml
@@ -1,0 +1,102 @@
+# Smoke Test: Login - Wrong account for the store
+# p2: login.wrong-account
+# P2 ref: Login > Wrong account for the store
+#
+# Logs into a WooCommerce store using a WP.com account that does NOT have
+# access to it, and verifies the "account not connected to Jetpack" error.
+#
+# Required env vars:
+#   WOO_EMAIL, WOO_PASSWORD          (shared primary account)
+#   WOO_WRONG_ACCOUNT_STORE_URL      (site the primary account can't access)
+appId: com.woocommerce.android.dev
+name: "Login - Wrong account for the store"
+tags:
+  - smoke_extended
+  - flaky_quarantine
+  - login
+---
+- launchApp:
+    clearState: true
+
+- extendedWaitUntil:
+    visible: ".*Skip.*|.*Enter your store address.*|.*Log in.*"
+    timeout: 30000
+
+- runFlow:
+    when:
+      visible: "Skip"
+    commands:
+      - tapOn: "Skip"
+
+- extendedWaitUntil:
+    visible:
+      id: "button_login_store"
+    timeout: 15000
+- tapOn:
+    id: "button_login_store"
+    retryTapIfNoChange: true
+
+- extendedWaitUntil:
+    visible:
+      id: "input"
+    timeout: 10000
+- tapOn:
+    id: "input"
+- inputText: ${WOO_WRONG_ACCOUNT_STORE_URL}
+- hideKeyboard
+- tapOn:
+    id: "bottom_button"
+    retryTapIfNoChange: true
+
+- extendedWaitUntil:
+    visible:
+      id: "login_continue_button"
+    timeout: 15000
+- tapOn:
+    id: "input"
+- inputText: ${WOO_EMAIL}
+- hideKeyboard
+- tapOn:
+    id: "login_continue_button"
+    retryTapIfNoChange: true
+
+- runFlow:
+    when:
+      visible: "No thanks"
+    commands:
+      - tapOn: "No thanks"
+
+- runFlow:
+    when:
+      visible:
+        id: "login_enter_password"
+    commands:
+      - tapOn:
+          id: "login_enter_password"
+
+- runFlow:
+    when:
+      visible: "No thanks"
+    commands:
+      - tapOn: "No thanks"
+
+- extendedWaitUntil:
+    visible:
+      id: "input"
+    timeout: 10000
+- tapOn:
+    id: "input"
+- inputText: ${WOO_PASSWORD}
+- hideKeyboard
+- tapOn:
+    id: "bottom_button"
+    retryTapIfNoChange: true
+
+# Verify "account not connected" error
+# String: login_jetpack_not_connected =
+#   "It looks like your account is not connected to %1$s's Jetpack"
+- extendedWaitUntil:
+    visible: ".*not connected.*Jetpack.*|.*account.*not connected.*"
+    timeout: 30000
+
+- takeScreenshot: login_wrong_account

--- a/.maestro/flows/login_wrong_account.yaml
+++ b/.maestro/flows/login_wrong_account.yaml
@@ -6,7 +6,8 @@
 # access to it, and verifies the "account not connected to Jetpack" error.
 #
 # Required env vars:
-#   WOO_EMAIL, WOO_PASSWORD          (shared primary account)
+#   WOO_WPCOM_EMAIL, WOO_WPCOM_PASSWORD
+#                                      (selected WP.com account)
 #   WOO_WRONG_ACCOUNT_STORE_URL      (site the primary account can't access)
 appId: com.woocommerce.android.dev
 name: "Login - Wrong account for the store"
@@ -54,7 +55,7 @@ tags:
     timeout: 15000
 - tapOn:
     id: "input"
-- inputText: ${WOO_EMAIL}
+- inputText: ${WOO_WPCOM_EMAIL}
 - hideKeyboard
 - tapOn:
     id: "login_continue_button"
@@ -86,7 +87,7 @@ tags:
     timeout: 10000
 - tapOn:
     id: "input"
-- inputText: ${WOO_PASSWORD}
+- inputText: ${WOO_WPCOM_PASSWORD}
 - hideKeyboard
 - tapOn:
     id: "bottom_button"

--- a/.maestro/flows/login_wrong_account.yaml
+++ b/.maestro/flows/login_wrong_account.yaml
@@ -43,7 +43,10 @@ tags:
     timeout: 10000
 - tapOn:
     id: "input"
-- inputText: ${WOO_WRONG_ACCOUNT_STORE_URL}
+- runFlow:
+    file: ../subflows/paste_into_focused_field.yaml
+    env:
+      TEXT_TO_PASTE: ${WOO_WRONG_ACCOUNT_STORE_URL}
 - hideKeyboard
 - tapOn:
     id: "bottom_button"
@@ -55,7 +58,10 @@ tags:
     timeout: 15000
 - tapOn:
     id: "input"
-- inputText: ${WOO_WPCOM_EMAIL}
+- runFlow:
+    file: ../subflows/paste_into_focused_field.yaml
+    env:
+      TEXT_TO_PASTE: ${WOO_WPCOM_EMAIL}
 - hideKeyboard
 - tapOn:
     id: "login_continue_button"
@@ -87,7 +93,10 @@ tags:
     timeout: 10000
 - tapOn:
     id: "input"
-- inputText: ${WOO_WPCOM_PASSWORD}
+- runFlow:
+    file: ../subflows/paste_into_focused_field.yaml
+    env:
+      TEXT_TO_PASTE: ${WOO_WPCOM_PASSWORD}
 - hideKeyboard
 - tapOn:
     id: "bottom_button"

--- a/.maestro/flows/login_wrong_credentials.yaml
+++ b/.maestro/flows/login_wrong_credentials.yaml
@@ -43,7 +43,7 @@ tags:
     timeout: 10000
 - tapOn:
     id: "input"
-- inputText: ${WOO_STORE_URL}
+- inputText: ${WOO_JETPACK_STORE_URL}
 - tapOn:
     id: "bottom_button"
     retryTapIfNoChange: true
@@ -55,7 +55,7 @@ tags:
     timeout: 15000
 - tapOn:
     id: "input"
-- inputText: ${WOO_EMAIL}
+- inputText: ${WOO_WPCOM_EMAIL}
 - tapOn:
     id: "login_continue_button"
     retryTapIfNoChange: true

--- a/.maestro/flows/login_wrong_credentials.yaml
+++ b/.maestro/flows/login_wrong_credentials.yaml
@@ -43,7 +43,10 @@ tags:
     timeout: 10000
 - tapOn:
     id: "input"
-- inputText: ${WOO_JETPACK_STORE_URL}
+- runFlow:
+    file: ../subflows/paste_into_focused_field.yaml
+    env:
+      TEXT_TO_PASTE: ${WOO_JETPACK_STORE_URL}
 - tapOn:
     id: "bottom_button"
     retryTapIfNoChange: true
@@ -55,7 +58,10 @@ tags:
     timeout: 15000
 - tapOn:
     id: "input"
-- inputText: ${WOO_WPCOM_EMAIL}
+- runFlow:
+    file: ../subflows/paste_into_focused_field.yaml
+    env:
+      TEXT_TO_PASTE: ${WOO_WPCOM_EMAIL}
 - tapOn:
     id: "login_continue_button"
     retryTapIfNoChange: true
@@ -90,7 +96,10 @@ tags:
     timeout: 10000
 - tapOn:
     id: "input"
-- inputText: "definitely_wrong_password_12345"
+- runFlow:
+    file: ../subflows/paste_into_focused_field.yaml
+    env:
+      TEXT_TO_PASTE: "definitely_wrong_password_12345"
 - tapOn:
     id: "bottom_button"
     retryTapIfNoChange: true

--- a/.maestro/flows/login_wrong_credentials.yaml
+++ b/.maestro/flows/login_wrong_credentials.yaml
@@ -43,10 +43,7 @@ tags:
     timeout: 10000
 - tapOn:
     id: "input"
-- runFlow:
-    file: ../subflows/paste_into_focused_field.yaml
-    env:
-      TEXT_TO_PASTE: ${WOO_JETPACK_STORE_URL}
+- inputText: ${WOO_JETPACK_STORE_URL}
 - tapOn:
     id: "bottom_button"
     retryTapIfNoChange: true
@@ -58,10 +55,7 @@ tags:
     timeout: 15000
 - tapOn:
     id: "input"
-- runFlow:
-    file: ../subflows/paste_into_focused_field.yaml
-    env:
-      TEXT_TO_PASTE: ${WOO_WPCOM_EMAIL}
+- inputText: ${WOO_WPCOM_EMAIL}
 - tapOn:
     id: "login_continue_button"
     retryTapIfNoChange: true
@@ -96,10 +90,7 @@ tags:
     timeout: 10000
 - tapOn:
     id: "input"
-- runFlow:
-    file: ../subflows/paste_into_focused_field.yaml
-    env:
-      TEXT_TO_PASTE: "definitely_wrong_password_12345"
+- inputText: "definitely_wrong_password_12345"
 - tapOn:
     id: "bottom_button"
     retryTapIfNoChange: true

--- a/.maestro/flows/login_wrong_credentials.yaml
+++ b/.maestro/flows/login_wrong_credentials.yaml
@@ -1,0 +1,106 @@
+# Smoke Test: Login - Wrong credentials
+# p2: login.wrong-credentials
+# P2 ref: Login > Wrong credentials
+#
+# Manages its own login flow (does not call the login subflow) because
+# we're validating the wrong-password error path. Uses a real email
+# so the account lookup succeeds and the password screen is reached.
+# Credentials are available via MAESTRO_ prefix env vars automatically.
+appId: com.woocommerce.android.dev
+name: "Login - Wrong credentials error"
+tags:
+  - smoke_extended
+  - flaky_quarantine
+  - login
+---
+- launchApp:
+    clearState: true
+
+# Wait for app to finish loading after clearState
+- extendedWaitUntil:
+    visible: ".*Skip.*|.*Enter your store address.*|.*Log in.*"
+    timeout: 30000
+
+# Skip carousel if shown
+- runFlow:
+    when:
+      visible: "Skip"
+    commands:
+      - tapOn: "Skip"
+
+# Enter store address
+- extendedWaitUntil:
+    visible:
+      id: "button_login_store"
+    timeout: 15000
+- tapOn:
+    id: "button_login_store"
+    retryTapIfNoChange: true
+
+- extendedWaitUntil:
+    visible:
+      id: "input"
+    timeout: 10000
+- tapOn:
+    id: "input"
+- inputText: ${WOO_STORE_URL}
+- tapOn:
+    id: "bottom_button"
+    retryTapIfNoChange: true
+
+# Enter email
+- extendedWaitUntil:
+    visible:
+      id: "input"
+    timeout: 15000
+- tapOn:
+    id: "input"
+- inputText: ${WOO_EMAIL}
+- tapOn:
+    id: "login_continue_button"
+    retryTapIfNoChange: true
+
+# Dismiss Google Password Manager if it appears
+- runFlow:
+    when:
+      visible: "No thanks"
+    commands:
+      - tapOn: "No thanks"
+
+# Handle Magic Link screen
+- runFlow:
+    when:
+      visible:
+        id: "login_enter_password"
+    commands:
+      - tapOn:
+          id: "login_enter_password"
+
+# Dismiss Google Password Manager again if it appears on password screen
+- runFlow:
+    when:
+      visible: "No thanks"
+    commands:
+      - tapOn: "No thanks"
+
+# Enter wrong password
+- extendedWaitUntil:
+    visible:
+      id: "input"
+    timeout: 10000
+- tapOn:
+    id: "input"
+- inputText: "definitely_wrong_password_12345"
+- tapOn:
+    id: "bottom_button"
+    retryTapIfNoChange: true
+
+# Verify error message appears. The Woo app shows one of:
+#   - "It looks like this password is incorrect..." (libs/login)
+#   - "It seems the username or password you entered doesn't quite match..." (WooCommerce)
+#   - "The username or password you entered is incorrect" (fallback)
+- extendedWaitUntil:
+    visible: ".*password.*incorrect.*|.*doesn't quite match.*|.*username or password.*incorrect.*"
+    timeout: 15000
+
+- takeScreenshot: login_wrong_credentials

--- a/.maestro/flows/orders_list_and_search.yaml
+++ b/.maestro/flows/orders_list_and_search.yaml
@@ -1,0 +1,87 @@
+# Smoke Test: Orders - List, Pagination, and Search
+# p2: orders.list, orders.pagination, orders.search
+# P2 ref: Orders > Order list (check pagination), Search for an order
+#
+# Verifies:
+#   - Orders list loads with order data
+#   - Pagination works (scroll to load more)
+#   - Search for an order by number or keyword
+appId: com.woocommerce.android.dev
+name: "Orders - List, pagination, and search"
+tags:
+  - smoke_core
+  - orders
+---
+# Reuse the logged-in session — login flows run first and leave the
+# app authenticated. See subflows/ensure_logged_in.yaml.
+- runFlow:
+    file: ../subflows/ensure_logged_in.yaml
+
+# Navigate to Orders
+- runFlow:
+    file: ../subflows/navigate_to_orders.yaml
+
+# Verify orders list loaded
+- assertVisible:
+    id: "ordersList"
+    label: "Orders list is visible"
+
+- assertVisible:
+    id: "orderNum"
+    label: "At least one order number is visible"
+
+# Validate first order has a non-empty number via JavaScript
+- copyTextFrom:
+    id: "orderNum"
+    index: 0
+- evalScript: |
+    var text = maestro.copiedText;
+    if (!text || text.trim() === '') {
+        throw new Error('Order number text is empty');
+    }
+- evalScript: ${output.orderSearchText = maestro.copiedText.trim()}
+
+- takeScreenshot: orders_list
+
+# Test pagination - scroll down
+- scroll
+- scroll
+- scroll
+
+- extendedWaitUntil:
+    visible:
+      id: "orderNum"
+    timeout: 10000
+
+- takeScreenshot: orders_list_scrolled
+
+# Test search against the first visible order from the loaded list.
+- tapOn:
+    id: "menu_search"
+    label: "Open order search"
+
+- extendedWaitUntil:
+    visible:
+      id: "search_src_text"
+    timeout: 10000
+
+- tapOn:
+    id: "search_src_text"
+- inputText: ${output.orderSearchText}
+- pressKey: Enter
+
+# Wait for search results
+- extendedWaitUntil:
+    visible:
+      id: "orderNum"
+    timeout: 15000
+
+- assertVisible:
+    text: "${output.orderSearchText}"
+    label: "Captured order appears in search results"
+
+- takeScreenshot: orders_search_results
+
+# Go back from search
+- back
+- back

--- a/.maestro/flows/orders_list_and_search.yaml
+++ b/.maestro/flows/orders_list_and_search.yaml
@@ -1,14 +1,12 @@
-# Smoke Test: Orders - List, Pagination, and Search
+# Smoke Test: Orders - List and Search
 # p2: orders.list, orders.search
-# P2 probe: orders.pagination (scroll-only; does not prove another API page loaded)
-# P2 ref: Orders > Order list (check pagination), Search for an order
+# P2 ref: Orders > Order list, Search for an order
 #
 # Verifies:
 #   - Orders list loads with order data
-#   - The list remains usable after scrolling toward the pagination boundary
 #   - Search for an order by number or keyword
 appId: com.woocommerce.android.dev
-name: "Orders - List, pagination, and search"
+name: "Orders - List and search"
 tags:
   - smoke_core
   - orders
@@ -43,19 +41,6 @@ tags:
 - evalScript: ${output.orderSearchText = maestro.copiedText.trim()}
 
 - takeScreenshot: orders_list
-
-# Pagination probe only. Without a known order beyond the first API page, this
-# cannot distinguish a loaded second page from scrolling the initial results.
-- scroll
-- scroll
-- scroll
-
-- extendedWaitUntil:
-    visible:
-      id: "orderNum"
-    timeout: 10000
-
-- takeScreenshot: orders_list_scrolled
 
 # Test search against the first visible order from the loaded list.
 - tapOn:

--- a/.maestro/flows/orders_list_and_search.yaml
+++ b/.maestro/flows/orders_list_and_search.yaml
@@ -1,10 +1,11 @@
 # Smoke Test: Orders - List, Pagination, and Search
-# p2: orders.list, orders.pagination, orders.search
+# p2: orders.list, orders.search
+# P2 probe: orders.pagination (scroll-only; does not prove another API page loaded)
 # P2 ref: Orders > Order list (check pagination), Search for an order
 #
 # Verifies:
 #   - Orders list loads with order data
-#   - Pagination works (scroll to load more)
+#   - The list remains usable after scrolling toward the pagination boundary
 #   - Search for an order by number or keyword
 appId: com.woocommerce.android.dev
 name: "Orders - List, pagination, and search"
@@ -43,7 +44,8 @@ tags:
 
 - takeScreenshot: orders_list
 
-# Test pagination - scroll down
+# Pagination probe only. Without a known order beyond the first API page, this
+# cannot distinguish a loaded second page from scrolling the initial results.
 - scroll
 - scroll
 - scroll

--- a/.maestro/flows/products_list_and_sort.yaml
+++ b/.maestro/flows/products_list_and_sort.yaml
@@ -1,12 +1,13 @@
 # Smoke Test: Products - List and Sort
-# p2: products.list, products.pagination, products.sort, products.search
+# p2: products.list, products.sort, products.search
+# P2 probe: products.pagination (scroll-only; does not prove another API page loaded)
 # P2 ref: Products > Product list (check pagination), Sort product list
 #
 # Verifies:
 #   - Products list loads
 #   - Product cards show name, stock status, price, SKU
-#   - Pagination works (scroll to load more)
-#   - Sorting works (by name, date, etc.)
+#   - The list remains usable after scrolling toward the pagination boundary
+#   - Sorting produces different first products for A-to-Z and Z-to-A
 #   - Search for products
 #   - Product filters
 appId: com.woocommerce.android.dev
@@ -46,7 +47,8 @@ tags:
 
 - takeScreenshot: products_list
 
-# Test pagination - scroll down
+# Pagination probe only. A deterministic product beyond the first API page is
+# needed before this can be counted as pagination coverage.
 - scroll
 - scroll
 - scroll
@@ -66,28 +68,57 @@ tags:
     direction: DOWN
     duration: 500
 
-# Test sorting
-- runFlow:
-    when:
-      visible:
-        id: "btn_product_sorting"
-    commands:
-      - tapOn:
-          id: "btn_product_sorting"
-          label: "Open product sorting"
-      - extendedWaitUntil:
-          visible:
-            id: "sortingItem_name"
-          timeout: 10000
-      - takeScreenshot: products_sort_options
-      - tapOn:
-          id: "sortingItem_name"
-          index: 0
-          label: "Select first sort option"
-      - extendedWaitUntil:
-          visible:
-            id: "productsRecycler"
-          timeout: 10000
+# Test sorting with two explicit, opposing choices. Requiring different first
+# products proves the list was reordered instead of only opening the sheet.
+- assertVisible:
+    id: "btn_product_sorting"
+    label: "Require product sorting control"
+- tapOn:
+    id: "btn_product_sorting"
+    label: "Open product sorting"
+- extendedWaitUntil:
+    visible: "Title: A to Z"
+    timeout: 10000
+- takeScreenshot: products_sort_options
+- tapOn:
+    text: "Title: A to Z"
+    label: "Sort products A to Z"
+- extendedWaitUntil:
+    visible: "A to Z"
+    timeout: 15000
+- extendedWaitUntil:
+    visible:
+      id: "productName"
+    timeout: 15000
+- copyTextFrom:
+    id: "productName"
+    index: 0
+- evalScript: ${output.firstProductAscending = maestro.copiedText.trim()}
+
+- tapOn:
+    id: "btn_product_sorting"
+    label: "Reopen product sorting"
+- extendedWaitUntil:
+    visible: "Title: Z to A"
+    timeout: 10000
+- tapOn:
+    text: "Title: Z to A"
+    label: "Sort products Z to A"
+- extendedWaitUntil:
+    visible: "Z to A"
+    timeout: 15000
+- extendedWaitUntil:
+    visible:
+      id: "productName"
+    timeout: 15000
+- copyTextFrom:
+    id: "productName"
+    index: 0
+- evalScript: |
+    var descending = maestro.copiedText.trim();
+    if (!descending || descending === output.firstProductAscending) {
+        throw new Error('Opposing product sorts returned the same first product');
+    }
 
 - takeScreenshot: products_sorted
 

--- a/.maestro/flows/products_list_and_sort.yaml
+++ b/.maestro/flows/products_list_and_sort.yaml
@@ -1,0 +1,138 @@
+# Smoke Test: Products - List and Sort
+# p2: products.list, products.pagination, products.sort, products.search
+# P2 ref: Products > Product list (check pagination), Sort product list
+#
+# Verifies:
+#   - Products list loads
+#   - Product cards show name, stock status, price, SKU
+#   - Pagination works (scroll to load more)
+#   - Sorting works (by name, date, etc.)
+#   - Search for products
+#   - Product filters
+appId: com.woocommerce.android.dev
+name: "Products - List, sort, and search"
+tags:
+  - smoke_core
+  - products
+---
+# Reuse the logged-in session — login flows run first and leave the
+# app authenticated. See subflows/ensure_logged_in.yaml.
+- runFlow:
+    file: ../subflows/ensure_logged_in.yaml
+
+# Navigate to Products
+- runFlow:
+    file: ../subflows/navigate_to_products.yaml
+
+# Verify products list loaded
+- assertVisible:
+    id: "productsRecycler"
+    label: "Products list is visible"
+
+- assertVisible:
+    id: "productName"
+    label: "At least one product name is visible"
+
+# Validate first product has a non-empty name via JavaScript
+- copyTextFrom:
+    id: "productName"
+    index: 0
+- evalScript: |
+    var name = maestro.copiedText;
+    if (!name || name.trim() === '') {
+        throw new Error('Product name is empty — list may not have loaded properly');
+    }
+- evalScript: ${output.productSearchText = maestro.copiedText.trim()}
+
+- takeScreenshot: products_list
+
+# Test pagination - scroll down
+- scroll
+- scroll
+- scroll
+
+- extendedWaitUntil:
+    visible:
+      id: "productName"
+    timeout: 10000
+
+- takeScreenshot: products_list_scrolled
+
+# Scroll back to top
+- swipe:
+    direction: DOWN
+    duration: 500
+- swipe:
+    direction: DOWN
+    duration: 500
+
+# Test sorting
+- runFlow:
+    when:
+      visible:
+        id: "btn_product_sorting"
+    commands:
+      - tapOn:
+          id: "btn_product_sorting"
+          label: "Open product sorting"
+      - extendedWaitUntil:
+          visible:
+            id: "sortingItem_name"
+          timeout: 10000
+      - takeScreenshot: products_sort_options
+      - tapOn:
+          id: "sortingItem_name"
+          index: 0
+          label: "Select first sort option"
+      - extendedWaitUntil:
+          visible:
+            id: "productsRecycler"
+          timeout: 10000
+
+- takeScreenshot: products_sorted
+
+# Test search against the first visible product from the loaded list.
+- tapOn:
+    id: "menu_search"
+    label: "Open product search"
+
+- extendedWaitUntil:
+    visible:
+      id: "search_src_text"
+    timeout: 10000
+
+- tapOn:
+    id: "search_src_text"
+- inputText: ${output.productSearchText}
+- pressKey: Enter
+
+# Wait for search results
+- extendedWaitUntil:
+    visible:
+      id: "productInfoContainer"
+    timeout: 15000
+
+- assertVisible:
+    text: "${output.productSearchText}"
+    label: "Captured product appears in search results"
+
+- takeScreenshot: products_search_results
+
+# Go back from search
+- back
+- back
+
+# Test filters
+- runFlow:
+    when:
+      visible:
+        id: "btn_product_filter"
+    commands:
+      - tapOn:
+          id: "btn_product_filter"
+          label: "Open product filters"
+      - extendedWaitUntil:
+          visible: "Stock status"
+          timeout: 10000
+      - takeScreenshot: products_filters
+      - back

--- a/.maestro/flows/products_list_and_sort.yaml
+++ b/.maestro/flows/products_list_and_sort.yaml
@@ -1,12 +1,10 @@
 # Smoke Test: Products - List and Sort
 # p2: products.list, products.sort, products.search
-# P2 probe: products.pagination (scroll-only; does not prove another API page loaded)
-# P2 ref: Products > Product list (check pagination), Sort product list
+# P2 ref: Products > Product list, Sort product list
 #
 # Verifies:
 #   - Products list loads
 #   - Product cards show name, stock status, price, SKU
-#   - The list remains usable after scrolling toward the pagination boundary
 #   - Sorting produces different first products for A-to-Z and Z-to-A
 #   - Search for products
 #   - Product filters
@@ -46,27 +44,6 @@ tags:
 - evalScript: ${output.productSearchText = maestro.copiedText.trim()}
 
 - takeScreenshot: products_list
-
-# Pagination probe only. A deterministic product beyond the first API page is
-# needed before this can be counted as pagination coverage.
-- scroll
-- scroll
-- scroll
-
-- extendedWaitUntil:
-    visible:
-      id: "productName"
-    timeout: 10000
-
-- takeScreenshot: products_list_scrolled
-
-# Scroll back to top
-- swipe:
-    direction: DOWN
-    duration: 500
-- swipe:
-    direction: DOWN
-    duration: 500
 
 # Test sorting with two explicit, opposing choices. Requiring different first
 # products proves the list was reordered instead of only opening the sheet.

--- a/.maestro/scripts/doctor.py
+++ b/.maestro/scripts/doctor.py
@@ -131,7 +131,12 @@ def referenced_env(flows: list[Path], seed: bool) -> set[str]:
     refs: set[str] = set()
     for flow in flows:
         text = flow.read_text(errors="replace")
-        refs.update(REF_RE.findall(text))
+        flow_refs = set(REF_RE.findall(text))
+        if flow.name == "login_not_woo_store.yaml":
+            flow_refs.difference_update(
+                {"WOO_NOT_A_WOO_STORE_WPCOM_EMAIL", "WOO_NOT_A_WOO_STORE_WPCOM_PASSWORD"}
+            )
+        refs.update(flow_refs)
         if SUBFLOW_LOGIN_RE.search(text):
             refs.update({"WOO_JETPACK_STORE_URL", "WOO_WPCOM_EMAIL", "WOO_WPCOM_PASSWORD"})
     if seed:
@@ -258,6 +263,14 @@ def main() -> int:
         checks.append(Check("fail", "missing required env vars: " + ", ".join("MAESTRO_" + ref for ref in missing)))
     else:
         checks.append(Check("ok", f"all {len(refs)} referenced WOO_* env value(s) are available"))
+
+    if any(flow.name == "login_not_woo_store.yaml" for flow in flows):
+        wpcom_fallback = [
+            has_value(env, candidates_for("WOO_NOT_A_WOO_STORE_WPCOM_EMAIL", store)),
+            has_value(env, candidates_for("WOO_NOT_A_WOO_STORE_WPCOM_PASSWORD", store)),
+        ]
+        if any(wpcom_fallback) and not all(wpcom_fallback):
+            checks.append(Check("fail", "not-Woo-store WP.com fallback requires both email and password"))
 
     jetpack_candidates = candidates_for("WOO_JETPACK_STORE_URL", store)
     no_jetpack_candidates = candidates_for("WOO_NO_JETPACK_SITE_URL", store)

--- a/.maestro/scripts/run-smoke-tests.sh
+++ b/.maestro/scripts/run-smoke-tests.sh
@@ -569,7 +569,7 @@ validate_optional_not_woo_wpcom_env() {
       break
     fi
   done
-  [[ "$selected" == "yes" ]] || return
+  [[ "$selected" == "yes" ]] || return 0
 
   local email="${MAESTRO_WOO_NOT_A_WOO_STORE_WPCOM_EMAIL:-}"
   local password="${MAESTRO_WOO_NOT_A_WOO_STORE_WPCOM_PASSWORD:-}"
@@ -700,6 +700,85 @@ if [[ -n "$APK_PATH" ]]; then
   echo "--- Installing APK"
   adb -s "$DEVICE_SERIAL" install -r -g "$APK_PATH"
 fi
+
+validate_google_login_apk() {
+  local flow google_flow_selected="no"
+  for flow in "${ORDERED_FLOWS[@]}"; do
+    if [[ "$(basename "$flow")" == "login_google.yaml" ]]; then
+      google_flow_selected="yes"
+      break
+    fi
+  done
+  [[ "$google_flow_selected" == "yes" ]] || return 0
+
+  local apk_to_check="$APK_PATH"
+  local pulled_apk="no"
+  if [[ -z "$apk_to_check" ]]; then
+    local installed_apk_path
+    installed_apk_path="$(
+      adb -s "$DEVICE_SERIAL" shell pm path com.woocommerce.android.dev 2>/dev/null |
+        tr -d '\r' |
+        sed -n '1s/^package://p'
+    )"
+    if [[ -z "$installed_apk_path" ]]; then
+      echo "Setup error: com.woocommerce.android.dev is not installed for login_google." >&2
+      exit 1
+    fi
+    apk_to_check="$TMP_DIR/login-google-installed.apk"
+    adb -s "$DEVICE_SERIAL" pull "$installed_apk_path" "$apk_to_check" >/dev/null
+    pulled_apk="yes"
+  fi
+
+  local validation_status=0
+  python3 - "$REPO_ROOT/WooCommerce/google-services.json-example" "$apk_to_check" <<'PY' || validation_status=$?
+import json
+import pathlib
+import sys
+import zipfile
+
+config = json.loads(pathlib.Path(sys.argv[1]).read_text())
+example_client_id = ""
+for client in config.get("client", []):
+    package_name = client.get("client_info", {}).get("android_client_info", {}).get("package_name")
+    if package_name != "com.woocommerce.android.dev":
+        continue
+    for oauth_client in client.get("oauth_client", []):
+        if oauth_client.get("client_type") == 3:
+            example_client_id = oauth_client.get("client_id", "")
+            break
+
+if not example_client_id:
+    raise SystemExit(3)
+
+try:
+    with zipfile.ZipFile(sys.argv[2]) as apk:
+        resources = apk.read("resources.arsc")
+except (KeyError, OSError, zipfile.BadZipFile):
+    raise SystemExit(3)
+
+raise SystemExit(2 if example_client_id.encode() in resources else 0)
+PY
+
+  if [[ "$pulled_apk" == "yes" ]]; then
+    rm -f "$apk_to_check"
+  fi
+
+  if [[ "$validation_status" -eq 2 ]]; then
+    cat >&2 <<'EOF'
+Setup error: login_google cannot run with the example Google OAuth client.
+
+Build or obtain the APK with the private WooCommerce google-services.json,
+then install it or pass it with --apk. For a configured local checkout:
+  ./gradlew :WooCommerce:installWasabiDebug
+EOF
+    exit 1
+  fi
+  if [[ "$validation_status" -ne 0 ]]; then
+    echo "Setup error: could not inspect the APK resources required by login_google." >&2
+    exit 1
+  fi
+}
+validate_google_login_apk
 
 if [[ "$SEED" == "yes" ]]; then
   echo "--- Stale automation orphan sweep"

--- a/.maestro/scripts/run-smoke-tests.sh
+++ b/.maestro/scripts/run-smoke-tests.sh
@@ -532,12 +532,21 @@ if [[ "$STORE" == "shared" && "$SUITE_HAS_DESTRUCTIVE" == "yes" && -z "${CI:-}" 
   exit 1
 fi
 
+is_optional_flow_env_ref() {
+  local flow="$1"
+  local ref="$2"
+  [[ "$(basename "$flow")" == "login_not_woo_store.yaml" ]] &&
+    [[ "$ref" == "WOO_NOT_A_WOO_STORE_WPCOM_EMAIL" ||
+      "$ref" == "WOO_NOT_A_WOO_STORE_WPCOM_PASSWORD" ]]
+}
+
 validate_referenced_env() {
   local missing=()
   local flow ref var
   for flow in "${ORDERED_FLOWS[@]}"; do
     while IFS= read -r ref; do
       [[ -z "$ref" ]] && continue
+      is_optional_flow_env_ref "$flow" "$ref" && continue
       var="MAESTRO_${ref}"
       if [[ -z "${!var:-}" ]]; then
         missing+=("$var")
@@ -551,6 +560,25 @@ validate_referenced_env() {
   fi
 }
 validate_referenced_env
+
+validate_optional_not_woo_wpcom_env() {
+  local flow selected="no"
+  for flow in "${ORDERED_FLOWS[@]}"; do
+    if [[ "$(basename "$flow")" == "login_not_woo_store.yaml" ]]; then
+      selected="yes"
+      break
+    fi
+  done
+  [[ "$selected" == "yes" ]] || return
+
+  local email="${MAESTRO_WOO_NOT_A_WOO_STORE_WPCOM_EMAIL:-}"
+  local password="${MAESTRO_WOO_NOT_A_WOO_STORE_WPCOM_PASSWORD:-}"
+  if [[ -n "$email" && -z "$password" ]] || [[ -z "$email" && -n "$password" ]]; then
+    echo "Missing optional WP.com fallback pair: set both MAESTRO_WOO_NOT_A_WOO_STORE_WPCOM_EMAIL and MAESTRO_WOO_NOT_A_WOO_STORE_WPCOM_PASSWORD, or leave both blank." >&2
+    exit 1
+  fi
+}
+validate_optional_not_woo_wpcom_env
 
 DEVICE_SERIALS=()
 while read -r serial state _rest; do

--- a/.maestro/subflows/ensure_logged_in.yaml
+++ b/.maestro/subflows/ensure_logged_in.yaml
@@ -15,9 +15,10 @@
 #   4. Fallback path — the device was never signed in, the session
 #      was wiped by a previous `clearState`, or WPCom expired the
 #      token: run the login.yaml subflow. It clearStates and
-#      authenticates with the primary Woo credentials
-#      (MAESTRO_WOO_EMAIL / MAESTRO_WOO_PASSWORD /
-#      MAESTRO_WOO_STORE_URL) and lands back on the dashboard.
+#      authenticates with the selected Jetpack-connected store and
+#      WP.com credentials (MAESTRO_WOO_JETPACK_STORE_URL,
+#      MAESTRO_WOO_WPCOM_EMAIL, MAESTRO_WOO_WPCOM_PASSWORD) and
+#      lands back on the dashboard.
 #
 # Why the fallback matters: previously this subflow simply asserted
 # "My store" was visible and timed out (failing the flow) if the

--- a/.maestro/subflows/ensure_logged_in.yaml
+++ b/.maestro/subflows/ensure_logged_in.yaml
@@ -1,0 +1,94 @@
+# Ensure the app is launched with a logged-in session.
+#
+# WPCom triggers extra security screens (magic-link, CAPTCHA) once
+# the same account logs in too many times in a short window. To stay
+# under that threshold, non-login flows MUST reuse the existing
+# session instead of re-authenticating on every run. Only login-
+# specific flows should `clearState: true` + re-login.
+#
+# Behavior:
+#   1. Launch the app WITHOUT clearing state, so the existing
+#      session persists across flows.
+#   2. Wait for either the dashboard OR a welcome-screen signal to
+#      appear.
+#   3. Happy path — dashboard ("My store") is visible: return.
+#   4. Fallback path — the device was never signed in, the session
+#      was wiped by a previous `clearState`, or WPCom expired the
+#      token: run the login.yaml subflow. It clearStates and
+#      authenticates with the primary Woo credentials
+#      (MAESTRO_WOO_EMAIL / MAESTRO_WOO_PASSWORD /
+#      MAESTRO_WOO_STORE_URL) and lands back on the dashboard.
+#
+# Why the fallback matters: previously this subflow simply asserted
+# "My store" was visible and timed out (failing the flow) if the
+# user wasn't logged in. That forced the operator to manually run
+# login_successful.yaml as a prerequisite every time they wanted to
+# kick off a single non-login flow from a cold emulator. Now any
+# flow can be invoked in isolation and it'll self-heal into a
+# logged-in state on first run.
+appId: com.woocommerce.android.dev
+---
+- launchApp:
+    clearState: false
+
+# Wait for either the dashboard OR a welcome-screen signal to
+# appear.
+#
+#   "My store"                   — bottom-nav / top-bar label shown
+#                                  once logged in
+#   "Enter your store address"   — primary welcome-screen CTA
+#   "Log in"                     — welcome-screen alternate CTA
+#   "Skip"                       — intro carousel skip button (the
+#                                  first screen after clearState on
+#                                  some app versions)
+#
+# Matching any of these tells us the app has finished booting. We
+# branch on which one fired.
+- extendedWaitUntil:
+    visible: ".*My store.*|.*Enter your store address.*|.*Log in.*|.*Skip.*"
+    timeout: 45000
+    label: "Wait for dashboard or login welcome screen"
+
+# Dismiss known post-launch modals before deciding whether the session is dirty.
+- runFlow:
+    when:
+      visible: "Save"
+    commands:
+      - tapOn:
+          text: "Save"
+          label: "recovery_dismiss_privacy_dialog"
+
+- runFlow:
+    when:
+      visible: ".*Got it.*"
+    commands:
+      - tapOn:
+          text: ".*Got it.*"
+          label: "recovery_dismiss_got_it_dialog"
+
+- runFlow:
+    when:
+      visible: ".*Not now.*|.*Maybe later.*"
+    commands:
+      - tapOn:
+          text: ".*Not now.*|.*Maybe later.*"
+          label: "recovery_dismiss_optional_prompt"
+
+# Fallback: if we're not on the dashboard, run the full login
+# subflow. login.yaml clearStates + authenticates with the primary
+# Woo account and lands on the dashboard. Running it when we're
+# already on the welcome screen just means the clearState at its
+# top is a no-op-ish re-launch — still idempotent.
+- runFlow:
+    when:
+      notVisible: "My store"
+    commands:
+      - runFlow:
+          file: login.yaml
+
+# Confirm we're on the dashboard, whether we came in already
+# authenticated or via the login fallback.
+- extendedWaitUntil:
+    visible: "My store"
+    timeout: 30000
+    label: "Verify dashboard is reachable"

--- a/.maestro/subflows/login.yaml
+++ b/.maestro/subflows/login.yaml
@@ -1,7 +1,7 @@
 # Reusable login subflow
 # Logs into the WooCommerce app with store URL + email + password.
 #
-# Required env vars: WOO_STORE_URL, WOO_EMAIL, WOO_PASSWORD
+# Required env vars: WOO_JETPACK_STORE_URL, WOO_WPCOM_EMAIL, WOO_WPCOM_PASSWORD
 appId: com.woocommerce.android.dev
 ---
 - launchApp:
@@ -35,7 +35,7 @@ appId: com.woocommerce.android.dev
     timeout: 10000
 - tapOn:
     id: "input"
-- inputText: ${WOO_STORE_URL}
+- inputText: ${WOO_JETPACK_STORE_URL}
 - hideKeyboard
 - tapOn:
     id: "bottom_button"
@@ -48,7 +48,7 @@ appId: com.woocommerce.android.dev
     timeout: 15000
 - tapOn:
     id: "input"
-- inputText: ${WOO_EMAIL}
+- inputText: ${WOO_WPCOM_EMAIL}
 - hideKeyboard
 - tapOn:
     id: "login_continue_button"
@@ -84,7 +84,7 @@ appId: com.woocommerce.android.dev
     timeout: 10000
 - tapOn:
     id: "input"
-- inputText: ${WOO_PASSWORD}
+- inputText: ${WOO_WPCOM_PASSWORD}
 - hideKeyboard
 - tapOn:
     id: "bottom_button"

--- a/.maestro/subflows/login.yaml
+++ b/.maestro/subflows/login.yaml
@@ -1,0 +1,115 @@
+# Reusable login subflow
+# Logs into the WooCommerce app with store URL + email + password.
+#
+# Required env vars: WOO_STORE_URL, WOO_EMAIL, WOO_PASSWORD
+appId: com.woocommerce.android.dev
+---
+- launchApp:
+    clearState: true
+
+# Wait for app to finish loading after clearState (splash screen can take a while)
+- extendedWaitUntil:
+    visible: ".*Skip.*|.*Enter your store address.*|.*Log in.*"
+    timeout: 30000
+
+# Skip the carousel if it appears
+- runFlow:
+    when:
+      visible: "Skip"
+    commands:
+      - tapOn: "Skip"
+
+# Tap "Enter your store address" on the Welcome screen
+- extendedWaitUntil:
+    visible:
+      id: "button_login_store"
+    timeout: 15000
+- tapOn:
+    id: "button_login_store"
+    retryTapIfNoChange: true
+
+# Enter store URL
+- extendedWaitUntil:
+    visible:
+      id: "input"
+    timeout: 10000
+- tapOn:
+    id: "input"
+- inputText: ${WOO_STORE_URL}
+- hideKeyboard
+- tapOn:
+    id: "bottom_button"
+    retryTapIfNoChange: true
+
+# Enter email address
+- extendedWaitUntil:
+    visible:
+      id: "login_continue_button"
+    timeout: 15000
+- tapOn:
+    id: "input"
+- inputText: ${WOO_EMAIL}
+- hideKeyboard
+- tapOn:
+    id: "login_continue_button"
+    retryTapIfNoChange: true
+
+# Dismiss Google Password Manager if it appears
+- runFlow:
+    when:
+      visible: "No thanks"
+    commands:
+      - tapOn: "No thanks"
+
+# Handle Magic Link screen - tap "Enter your password instead"
+- runFlow:
+    when:
+      visible:
+        id: "login_enter_password"
+    commands:
+      - tapOn:
+          id: "login_enter_password"
+
+# Dismiss Google Password Manager again if it appears on password screen
+- runFlow:
+    when:
+      visible: "No thanks"
+    commands:
+      - tapOn: "No thanks"
+
+# Enter password
+- extendedWaitUntil:
+    visible:
+      id: "input"
+    timeout: 10000
+- tapOn:
+    id: "input"
+- inputText: ${WOO_PASSWORD}
+- hideKeyboard
+- tapOn:
+    id: "bottom_button"
+    retryTapIfNoChange: true
+
+# Wait for dashboard to load (or privacy dialog)
+- extendedWaitUntil:
+    visible: ".*My store.*|.*Manage privacy.*"
+    timeout: 30000
+
+# Dismiss privacy dialog if it appears
+- runFlow:
+    when:
+      visible: "Save"
+    commands:
+      - tapOn: "Save"
+
+# Dismiss any store setup or onboarding dialogs
+- runFlow:
+    when:
+      visible: ".*Got it.*"
+    commands:
+      - tapOn: ".*Got it.*"
+
+# Verify dashboard is loaded
+- extendedWaitUntil:
+    visible: "My store"
+    timeout: 10000

--- a/.maestro/subflows/login.yaml
+++ b/.maestro/subflows/login.yaml
@@ -35,10 +35,7 @@ appId: com.woocommerce.android.dev
     timeout: 10000
 - tapOn:
     id: "input"
-- runFlow:
-    file: paste_into_focused_field.yaml
-    env:
-      TEXT_TO_PASTE: ${WOO_JETPACK_STORE_URL}
+- inputText: ${WOO_JETPACK_STORE_URL}
 - hideKeyboard
 - tapOn:
     id: "bottom_button"
@@ -51,10 +48,7 @@ appId: com.woocommerce.android.dev
     timeout: 15000
 - tapOn:
     id: "input"
-- runFlow:
-    file: paste_into_focused_field.yaml
-    env:
-      TEXT_TO_PASTE: ${WOO_WPCOM_EMAIL}
+- inputText: ${WOO_WPCOM_EMAIL}
 - hideKeyboard
 - tapOn:
     id: "login_continue_button"
@@ -90,10 +84,7 @@ appId: com.woocommerce.android.dev
     timeout: 10000
 - tapOn:
     id: "input"
-- runFlow:
-    file: paste_into_focused_field.yaml
-    env:
-      TEXT_TO_PASTE: ${WOO_WPCOM_PASSWORD}
+- inputText: ${WOO_WPCOM_PASSWORD}
 - hideKeyboard
 - tapOn:
     id: "bottom_button"

--- a/.maestro/subflows/login.yaml
+++ b/.maestro/subflows/login.yaml
@@ -35,7 +35,10 @@ appId: com.woocommerce.android.dev
     timeout: 10000
 - tapOn:
     id: "input"
-- inputText: ${WOO_JETPACK_STORE_URL}
+- runFlow:
+    file: paste_into_focused_field.yaml
+    env:
+      TEXT_TO_PASTE: ${WOO_JETPACK_STORE_URL}
 - hideKeyboard
 - tapOn:
     id: "bottom_button"
@@ -48,7 +51,10 @@ appId: com.woocommerce.android.dev
     timeout: 15000
 - tapOn:
     id: "input"
-- inputText: ${WOO_WPCOM_EMAIL}
+- runFlow:
+    file: paste_into_focused_field.yaml
+    env:
+      TEXT_TO_PASTE: ${WOO_WPCOM_EMAIL}
 - hideKeyboard
 - tapOn:
     id: "login_continue_button"
@@ -84,7 +90,10 @@ appId: com.woocommerce.android.dev
     timeout: 10000
 - tapOn:
     id: "input"
-- inputText: ${WOO_WPCOM_PASSWORD}
+- runFlow:
+    file: paste_into_focused_field.yaml
+    env:
+      TEXT_TO_PASTE: ${WOO_WPCOM_PASSWORD}
 - hideKeyboard
 - tapOn:
     id: "bottom_button"

--- a/.maestro/subflows/navigate_to_more_menu.yaml
+++ b/.maestro/subflows/navigate_to_more_menu.yaml
@@ -1,0 +1,9 @@
+# Navigate to the More Menu (Hub) tab
+appId: com.woocommerce.android.dev
+---
+- tapOn:
+    id: "moreMenu"
+- extendedWaitUntil:
+    visible:
+      id: "more_menu_compose_view"
+    timeout: 10000

--- a/.maestro/subflows/navigate_to_orders.yaml
+++ b/.maestro/subflows/navigate_to_orders.yaml
@@ -1,0 +1,9 @@
+# Navigate to the Orders tab
+appId: com.woocommerce.android.dev
+---
+- tapOn:
+    id: "orders"
+- extendedWaitUntil:
+    visible:
+      id: "ordersList"
+    timeout: 15000

--- a/.maestro/subflows/navigate_to_products.yaml
+++ b/.maestro/subflows/navigate_to_products.yaml
@@ -1,0 +1,9 @@
+# Navigate to the Products tab
+appId: com.woocommerce.android.dev
+---
+- tapOn:
+    id: "products"
+- extendedWaitUntil:
+    visible:
+      id: "productsRecycler"
+    timeout: 15000

--- a/.maestro/subflows/paste_into_focused_field.yaml
+++ b/.maestro/subflows/paste_into_focused_field.yaml
@@ -1,9 +1,0 @@
-# Pastes text into the currently focused field using Maestro's internal clipboard.
-#
-# Required env vars:
-#   TEXT_TO_PASTE
-appId: com.woocommerce.android.dev
----
-- setClipboard: ${TEXT_TO_PASTE}
-- pasteText
-- setClipboard: ""

--- a/.maestro/subflows/paste_into_focused_field.yaml
+++ b/.maestro/subflows/paste_into_focused_field.yaml
@@ -1,0 +1,9 @@
+# Pastes text into the currently focused field using Maestro's internal clipboard.
+#
+# Required env vars:
+#   TEXT_TO_PASTE
+appId: com.woocommerce.android.dev
+---
+- setClipboard: ${TEXT_TO_PASTE}
+- pasteText
+- setClipboard: ""


### PR DESCRIPTION
### Description

Adds shared Maestro login/navigation subflows and the first executable Android smoke-test layer. This is stack layer **2 of 8**.

The default `smoke_core` signal introduced here contains four flows:

- successful Jetpack/WP.com login;
- Dashboard stats and date-range switching;
- Orders list and search using a visible order number;
- Products list, opposing sort orders, and search using a visible product name.

The list/search paths intentionally use data already visible in the configured store, so this non-destructive core can run without Woo REST API credentials. Non-login core flows call `ensure_logged_in.yaml` and reuse the existing authenticated session instead of signing in before every flow.

This layer also adds provisional login coverage for help, wrong credentials/account, non-WordPress, non-WooCommerce, no-Jetpack, and Google sign-in. Those paths are tagged `smoke_extended` plus `flaky_quarantine`; they are not part of the release-gating core signal.

### Coverage and validation boundary

- The effective core signal is four flows. The remaining login flows require explicit quarantine inclusion and environment-specific accounts/sites.
- “Fresh install” is not proven by clearing application state alone; the audited coverage-contract correction is applied in #16372.
- Google sign-in requires a device account, a Google identity linked to the relevant WP.com account, and an APK built with the private OAuth configuration.
- No live Maestro flow, login, or store interaction was performed during this PR review.

### Stack

- Integration target: `feature/maestro-smoke-testing-automation`
- Position: **2 of 8**
- Previous: #16196
- Next: #16198
- The complete stack is being assembled and validated on the integration branch before any proposal to merge it into `trunk`.

### Test Steps

1. Run `bash -n .maestro/scripts/run-smoke-tests.sh .maestro/scripts/doctor.sh`.
2. Parse the added YAML workspace and flows with a YAML parser.
3. Run `python3 .maestro/scripts/generate-strings-env.py --check-flow-references`.
4. Run `python3 .maestro/scripts/lint-env.py --file .maestro/env.example --example .maestro/env.example`.
5. With an installed Wasabi debug APK and configured lab-store credentials, run `.maestro/scripts/run-smoke-tests.sh --profile core --device <serial> --no-seed --no-record --no-open`.
6. Confirm the report contains `login_successful`, `dashboard_stats`, `orders_list_and_search`, and `products_list_and_sort`.

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
