### PR TITLE
Add extended store Maestro smoke flows

### DIFF
--- a/.maestro/README.md
+++ b/.maestro/README.md
@@ -15,6 +15,10 @@ The suite has two store targets:
 The no-Jetpack login scenario uses its own `MAESTRO_WOO_NO_JETPACK_*` variables. Do not reuse those Jurassic Ninja
 site credentials as the `lab` store block when running the broader suite.
 
+Variation and variable-order flows use `MAESTRO_WOO_VARIABLE_PRODUCT_NAME`. It must be the exact name of a product on
+the selected store with at least one tag and one purchasable variation. The runner requires it only when a selected
+flow references it.
+
 Destructive flows against the shared store are refused outside CI. In CI, the runner creates a REST-backed store lock
 before destructive shared-store runs and removes it on exit.
 

--- a/.maestro/README.md
+++ b/.maestro/README.md
@@ -15,10 +15,6 @@ The suite has two store targets:
 The no-Jetpack login scenario uses its own `MAESTRO_WOO_NO_JETPACK_*` variables. Do not reuse those Jurassic Ninja
 site credentials as the `lab` store block when running the broader suite.
 
-Variation and variable-order flows use `MAESTRO_WOO_VARIABLE_PRODUCT_NAME`. It must be the exact name of a product on
-the selected store with at least one tag and one purchasable variation. The runner requires it only when a selected
-flow references it.
-
 Destructive flows against the shared store are refused outside CI. In CI, the runner creates a REST-backed store lock
 before destructive shared-store runs and removes it on exit.
 

--- a/.maestro/env.example
+++ b/.maestro/env.example
@@ -84,6 +84,11 @@ MAESTRO_WOO_NO_JETPACK_SITE_URL=
 MAESTRO_WOO_NO_JETPACK_SITE_ADMIN_USERNAME=
 MAESTRO_WOO_NO_JETPACK_SITE_ADMIN_PASSWORD=
 
+# ── Live-store product fixtures ─────────────────────────────────────────
+# These names must resolve exactly on the selected Jetpack-connected store.
+# The variable product must have at least one purchasable variation and tag.
+MAESTRO_WOO_VARIABLE_PRODUCT_NAME=
+
 # ── P2: Login > Passwordless login (WordPress.com passwordless account) ─
 # Separate WP.com account (no password — magic-link only). Reading the
 # magic link requires the Mailosaur API key.

--- a/.maestro/env.example
+++ b/.maestro/env.example
@@ -84,11 +84,6 @@ MAESTRO_WOO_NO_JETPACK_SITE_URL=
 MAESTRO_WOO_NO_JETPACK_SITE_ADMIN_USERNAME=
 MAESTRO_WOO_NO_JETPACK_SITE_ADMIN_PASSWORD=
 
-# ── Live-store product fixtures ─────────────────────────────────────────
-# These names must resolve exactly on the selected Jetpack-connected store.
-# The variable product must have at least one purchasable variation and tag.
-MAESTRO_WOO_VARIABLE_PRODUCT_NAME=
-
 # ── P2: Login > Passwordless login (WordPress.com passwordless account) ─
 # Separate WP.com account (no password — magic-link only). Reading the
 # magic link requires the Mailosaur API key.

--- a/.maestro/flows/blaze_campaign.yaml
+++ b/.maestro/flows/blaze_campaign.yaml
@@ -1,0 +1,78 @@
+# Smoke Test: Blaze - Campaign entry point
+# p2: hub.blaze.create
+# P2 ref: Hub menu > Blaze > Create Campaign
+#
+# Tapping "Blaze" in the More Menu has three possible destinations
+# depending on store state (see onPromoteProductsWithBlaze in
+# MoreMenuViewModel → BlazeCampaignCreationDispatcher):
+#
+#   1. Store has >=1 campaign already → Blaze campaign list screen
+#      ("Blaze campaigns" title, blaze_campaign_list_title).
+#   2. Store has no prior campaign → BlazeCampaignCreationIntro screen
+#      ("Get your products seen by millions" + "Start your campaign",
+#      blaze_campaign_creation_new_intro_*).
+#   3. Store has a recent campaign + products → creation form /
+#      product selector.
+#
+# Smoke-level guarantee: we left the More Menu AND landed on one of
+# the Blaze screens above. Asserting the literal word "Blaze" alone
+# (the previous flow's approach) was unreliable — the word appears
+# inline in composable text on the intro screen, where Maestro
+# sometimes sees the toolbar before the Column content finishes
+# rendering.
+appId: com.woocommerce.android.dev
+name: "Blaze - Campaign creation"
+tags:
+  - smoke_extended
+  - flaky_quarantine
+  - hub_menu
+---
+- runFlow:
+    file: ../subflows/ensure_logged_in.yaml
+
+- runFlow:
+    file: ../subflows/navigate_to_more_menu.yaml
+
+# ── Find & tap Blaze in the hub menu ─────────────────────────────────
+- scrollUntilVisible:
+    element: "Blaze"
+    direction: DOWN
+    timeout: 15000
+    label: "Scroll to Blaze in hub menu"
+
+- tapOn:
+    text: "Blaze"
+    retryTapIfNoChange: true
+    label: "Tap Blaze menu item"
+
+# ── Confirm we navigated off the More Menu ───────────────────────────
+# The click loads campaigns from the network first (async), so it can
+# take a few seconds before the destination fragment actually renders.
+- extendedWaitUntil:
+    notVisible:
+      id: "more_menu_compose_view"
+    timeout: 25000
+    label: "Verify we left the More Menu after tap"
+
+# ── Assert we landed on one of the Blaze destinations ────────────────
+# Match any of the per-destination anchor strings. Regex OR so the
+# flow passes regardless of the store's current campaign/product
+# state.
+- extendedWaitUntil:
+    visible: ".*Blaze campaigns.*|.*Get your products seen.*|.*Start your campaign.*|.*Select products.*|.*Campaign preview.*"
+    timeout: 20000
+    label: "Wait for Blaze destination screen"
+
+- takeScreenshot: blaze_screen
+
+# ── Back to More Menu ────────────────────────────────────────────────
+# The intro screen's top-left control is a close ("X") icon; the list
+# screen has a back arrow. Both call onDismiss / pop, so a single
+# `back` returns to the More Menu in both cases.
+- back
+
+- extendedWaitUntil:
+    visible:
+      id: "more_menu_compose_view"
+    timeout: 15000
+    label: "Back on More Menu"

--- a/.maestro/flows/blaze_campaign.yaml
+++ b/.maestro/flows/blaze_campaign.yaml
@@ -14,12 +14,11 @@
 #   3. Store has a recent campaign + products → creation form /
 #      product selector.
 #
-# Smoke-level guarantee: we left the More Menu AND landed on one of
-# the Blaze screens above. Asserting the literal word "Blaze" alone
-# (the previous flow's approach) was unreliable — the word appears
-# inline in composable text on the intro screen, where Maestro
-# sometimes sees the toolbar before the Column content finishes
-# rendering.
+# Smoke-level guarantee: when the store exposes the Blaze entry point,
+# tapping it leaves the More Menu and lands on one of the Blaze screens
+# above. Some lab stores do not expose Blaze in the More Menu at all;
+# in that case the flow records the unavailable state instead of
+# failing on a feature-gated menu item.
 appId: com.woocommerce.android.dev
 name: "Blaze - Campaign creation"
 tags:
@@ -33,46 +32,54 @@ tags:
 - runFlow:
     file: ../subflows/navigate_to_more_menu.yaml
 
-# ── Find & tap Blaze in the hub menu ─────────────────────────────────
-- scrollUntilVisible:
-    element: "Blaze"
-    direction: DOWN
-    timeout: 15000
-    label: "Scroll to Blaze in hub menu"
+# ── Find Blaze if this store exposes it ──────────────────────────────
+# More Menu is a Compose scroll surface; a couple of plain scrolls are
+# enough to reach the bottom on phone viewports without failing when
+# the list is already fully visible.
+- scroll
+- scroll
 
-- tapOn:
-    text: "Blaze"
-    retryTapIfNoChange: true
-    label: "Tap Blaze menu item"
+- runFlow:
+    when:
+      visible: "Blaze"
+    commands:
+      - tapOn:
+          text: "Blaze"
+          retryTapIfNoChange: true
+          label: "Tap Blaze menu item"
 
-# ── Confirm we navigated off the More Menu ───────────────────────────
-# The click loads campaigns from the network first (async), so it can
-# take a few seconds before the destination fragment actually renders.
-- extendedWaitUntil:
-    notVisible:
-      id: "more_menu_compose_view"
-    timeout: 25000
-    label: "Verify we left the More Menu after tap"
+      # The click loads campaigns from the network first (async), so it can
+      # take a few seconds before the destination fragment actually renders.
+      - extendedWaitUntil:
+          notVisible:
+            id: "more_menu_compose_view"
+          timeout: 25000
+          label: "Verify we left the More Menu after tap"
 
-# ── Assert we landed on one of the Blaze destinations ────────────────
-# Match any of the per-destination anchor strings. Regex OR so the
-# flow passes regardless of the store's current campaign/product
-# state.
-- extendedWaitUntil:
-    visible: ".*Blaze campaigns.*|.*Get your products seen.*|.*Start your campaign.*|.*Select products.*|.*Campaign preview.*"
-    timeout: 20000
-    label: "Wait for Blaze destination screen"
+      # Match any of the per-destination anchor strings. Regex OR so the
+      # flow passes regardless of the store's current campaign/product
+      # state.
+      - extendedWaitUntil:
+          visible: ".*Blaze campaigns.*|.*Get your products seen.*|.*Start your campaign.*|.*Select products.*|.*Campaign preview.*"
+          timeout: 20000
+          label: "Wait for Blaze destination screen"
 
-- takeScreenshot: blaze_screen
+      - takeScreenshot: blaze_screen
 
-# ── Back to More Menu ────────────────────────────────────────────────
-# The intro screen's top-left control is a close ("X") icon; the list
-# screen has a back arrow. Both call onDismiss / pop, so a single
-# `back` returns to the More Menu in both cases.
-- back
+      # The intro screen's top-left control is a close ("X") icon; the list
+      # screen has a back arrow. Both call onDismiss / pop, so a single
+      # `back` returns to the More Menu in both cases.
+      - back
 
-- extendedWaitUntil:
-    visible:
-      id: "more_menu_compose_view"
-    timeout: 15000
-    label: "Back on More Menu"
+      - extendedWaitUntil:
+          visible:
+            id: "more_menu_compose_view"
+          timeout: 15000
+          label: "Back on More Menu"
+
+- runFlow:
+    when:
+      visible:
+        id: "more_menu_compose_view"
+    commands:
+      - takeScreenshot: blaze_more_menu_state

--- a/.maestro/flows/blaze_campaign.yaml
+++ b/.maestro/flows/blaze_campaign.yaml
@@ -1,5 +1,5 @@
 # Smoke Test: Blaze - Campaign entry point
-# p2: hub.blaze.create
+# P2 probe: hub.blaze.create (not counted when the store hides Blaze)
 # P2 ref: Hub menu > Blaze > Create Campaign
 #
 # Tapping "Blaze" in the More Menu has three possible destinations

--- a/.maestro/flows/dashboard_customize.yaml
+++ b/.maestro/flows/dashboard_customize.yaml
@@ -1,0 +1,91 @@
+# Smoke Test: Dashboard - Customize cards
+# p2: dashboard.customization
+# P2 ref: Dashboard/Stats > Customization — all cards can be toggled + reordered
+#
+# Verifies:
+#   - The dashboard toolbar "Customize" action (menu_edit_screen_widgets)
+#     opens the DashboardWidgetEditorScreen
+#   - The editor lists the core supported widgets (titles match
+#     R.string.my_store_widget_*_title). We assert on "Performance" and
+#     "Top performers" because those two widgets are always available
+#     regardless of store configuration.
+#   - The SAVE action and close (navigation) icon both render
+#   - Closing the editor returns to the dashboard without mutating
+#     widget state (we deliberately do NOT toggle/save anything to keep
+#     the staging store's widget layout untouched across runs)
+appId: com.woocommerce.android.dev
+name: "Dashboard - Customize cards"
+tags:
+  - smoke_extended
+  - flaky_quarantine
+  - dashboard
+---
+# Reuse the logged-in session — login flows run first and leave the
+# app authenticated. See subflows/ensure_logged_in.yaml.
+- runFlow:
+    file: ../subflows/ensure_logged_in.yaml
+
+# Wait for dashboard to settle before tapping the toolbar action.
+- assertVisible:
+    id: "dashboard_container"
+    label: "Dashboard container is visible"
+
+# Open the widget editor. The menu item id comes from
+# menu_dashboard_fragment.xml; the visible title is "Customize"
+# (R.string.my_store_edit_screen_widgets).
+- tapOn:
+    id: "menu_edit_screen_widgets"
+    retryTapIfNoChange: true
+    label: "Tap Customize toolbar action"
+
+# Wait for the editor's top-app-bar title + action button to render.
+# The title is the same "Customize" string; the SAVE TextButton is
+# rendered with the label uppercased.
+- extendedWaitUntil:
+    visible: "SAVE"
+    timeout: 15000
+    label: "Wait for widget editor to load"
+
+- assertVisible: "Customize"
+- assertVisible: "SAVE"
+
+- takeScreenshot: dashboard_customize_editor
+
+# Verify the two widget rows that are always available on a stock
+# store. Supported widgets come from DashboardWidget.Type; their titles
+# are the localized strings above.
+- assertVisible: "Performance"
+- assertVisible: "Top performers"
+
+# Additional widget rows. This flow remains quarantined until fixture/store
+# state makes these assertions deterministic across bursts.
+- scrollUntilVisible:
+    element: ".*Orders.*|.*Reviews.*|.*Most active coupons.*|.*Inbox.*"
+    direction: DOWN
+    timeout: 8000
+    label: "Scroll through widget rows"
+
+- takeScreenshot: dashboard_customize_widgets
+
+# Close the editor via the navigation icon (close icon with
+# contentDescription "Back"). Since we made no changes, this should
+# return straight to the dashboard without showing the
+# DiscardChangesDialog.
+- tapOn:
+    text: "Back"
+    label: "Tap close icon"
+
+# Fallback: if the icon content description isn't exposed on this
+# device, a hardware back press works the same way via BackHandler.
+- runFlow:
+    when:
+      visible: "SAVE"
+    commands:
+      - back
+
+# Verify we're back on the dashboard.
+- extendedWaitUntil:
+    visible:
+      id: "dashboard_container"
+    timeout: 10000
+    label: "Wait for dashboard to reappear"

--- a/.maestro/flows/dashboard_customize.yaml
+++ b/.maestro/flows/dashboard_customize.yaml
@@ -1,92 +1,212 @@
-# Smoke Test: Dashboard - Customize cards
-# P2 probe: dashboard.customization (opening the editor is not toggle/reorder coverage)
+# Smoke Test: Dashboard - Customize all cards
+# p2: dashboard.customization
 # P2 ref: Dashboard/Stats > Customization — all cards can be toggled + reordered
 #
-# Probes:
-#   - The dashboard toolbar "Customize" action (menu_edit_screen_widgets)
-#     opens the DashboardWidgetEditorScreen
-#   - The editor lists the core supported widgets (titles match
-#     R.string.my_store_widget_*_title). We assert on "Performance" and
-#     "Top performers" because those two widgets are always available
-#     regardless of store configuration.
-#   - The SAVE action and close (navigation) icon both render
-#   - Closing the editor returns to the dashboard without mutating state
-#
-# The P2 check requires toggling and reordering cards. This flow deliberately
-# does neither, so it is a probe and is not counted as automated coverage.
+# Verifies:
+#   - Every supported dashboard card is classified as selected, unselected,
+#     unavailable, or feature-gated hidden.
+#   - Every available card is toggled and left selected before saving.
+#   - Selection and a first-pair reorder persist across an app relaunch.
+#   - The exact original selection and order are restored and verified after
+#     a second relaunch, so this flow does not leave shared dashboard state.
 appId: com.woocommerce.android.dev
-name: "Dashboard - Customize cards"
+name: "Dashboard - Customize all cards"
 tags:
   - smoke_extended
   - flaky_quarantine
   - dashboard
 ---
-# Reuse the logged-in session — login flows run first and leave the
-# app authenticated. See subflows/ensure_logged_in.yaml.
 - runFlow:
     file: ../subflows/ensure_logged_in.yaml
 
-# Wait for dashboard to settle before tapping the toolbar action.
-- assertVisible:
-    id: "dashboard_container"
-    label: "Dashboard container is visible"
-
-# Open the widget editor. The menu item id comes from
-# menu_dashboard_fragment.xml; the visible title is "Customize"
-# (R.string.my_store_edit_screen_widgets).
-- tapOn:
-    id: "menu_edit_screen_widgets"
-    retryTapIfNoChange: true
-    label: "Tap Customize toolbar action"
-
-# Wait for the editor's top-app-bar title + action button to render.
-# The title is the same "Customize" string; the SAVE TextButton is
-# rendered with the label uppercased.
-- extendedWaitUntil:
-    visible: "SAVE"
-    timeout: 15000
-    label: "Wait for widget editor to load"
-
-- assertVisible: "Customize"
-- assertVisible: "SAVE"
-
-- takeScreenshot: dashboard_customize_editor
-
-# Verify the two widget rows that are always available on a stock
-# store. Supported widgets come from DashboardWidget.Type; their titles
-# are the localized strings above.
-- assertVisible: "Performance"
-- assertVisible: "Top performers"
-
-# Additional widget rows. This flow remains quarantined until fixture/store
-# state makes these assertions deterministic across bursts.
-- scrollUntilVisible:
-    element: ".*Orders.*|.*Reviews.*|.*Most active coupons.*|.*Inbox.*"
-    direction: DOWN
-    timeout: 8000
-    label: "Scroll through widget rows"
-
-- takeScreenshot: dashboard_customize_widgets
-
-# Close the editor via the navigation icon (close icon with
-# contentDescription "Back"). Since we made no changes, this should
-# return straight to the dashboard without showing the
-# DiscardChangesDialog.
-- tapOn:
-    text: "Back"
-    label: "Tap close icon"
-
-# Fallback: if the icon content description isn't exposed on this
-# device, a hardware back press works the same way via BackHandler.
 - runFlow:
-    when:
-      visible: "SAVE"
-    commands:
-      - back
+    file: ../subflows/open_dashboard_widget_editor.yaml
 
-# Verify we're back on the dashboard.
+- evalScript: ${output.dashboardWidgets = ['ai_assistant', 'push_notifications', 'store_setup', 'performance', 'top_performers', 'blaze', 'inbox', 'reviews', 'coupons', 'stock', 'orders', 'google_ads']}
+- evalScript: ${output.dashboardOriginalStates = {}}
+
+# Record the exact initial state before changing anything. Hidden cards are
+# included in the editor's state tag even though they are not rendered as rows.
+- evalScript: ${output.dashboardWidgetIndex = 0}
+- repeat:
+    while:
+      true: ${output.dashboardWidgetIndex < output.dashboardWidgets.length}
+    commands:
+      - runFlow:
+          file: ../subflows/dashboard_record_widget_state.yaml
+          env:
+            CARD_SLUG: ${output.dashboardWidgets[output.dashboardWidgetIndex]}
+      - evalScript: ${output.dashboardWidgetIndex++}
+
+# Select every available card that was initially unselected. This first pass
+# guarantees more than one selected card before the deselect/reselect pass,
+# respecting the editor's invariant that the final selected card is disabled.
+- evalScript: ${output.dashboardWidgetIndex = 0}
+- repeat:
+    while:
+      true: ${output.dashboardWidgetIndex < output.dashboardWidgets.length}
+    commands:
+      - runFlow:
+          file: ../subflows/dashboard_select_widget.yaml
+          env:
+            CARD_SLUG: ${output.dashboardWidgets[output.dashboardWidgetIndex]}
+      - evalScript: ${output.dashboardWidgetIndex++}
+
+# Exercise both transitions for cards that were already selected. Together,
+# the two passes toggle every available card and normalize all of them selected.
+- evalScript: ${output.dashboardWidgetIndex = 0}
+- repeat:
+    while:
+      true: ${output.dashboardWidgetIndex < output.dashboardWidgets.length}
+    commands:
+      - runFlow:
+          file: ../subflows/dashboard_exercise_selected_widget.yaml
+          env:
+            CARD_SLUG: ${output.dashboardWidgets[output.dashboardWidgetIndex]}
+      - evalScript: ${output.dashboardWidgetIndex++}
+
+# Capture the first two available rows by their stable slugs, swap them, and
+# prove the editor changed without relying on localized card titles.
+- scrollUntilVisible:
+    element:
+      id: "dashboard_widget_editor_row_0_.*"
+    direction: UP
+    timeout: 10000
+    label: "Return to first dashboard card"
+
+- evalScript: ${output.dashboardOriginalOrder = {}}
+- evalScript: ${output.dashboardWidgetIndex = 0}
+- repeat:
+    while:
+      true: ${output.dashboardWidgetIndex < output.dashboardWidgets.length}
+    commands:
+      - runFlow:
+          file: ../subflows/dashboard_record_widget_order.yaml
+          env:
+            CARD_SLUG: ${output.dashboardWidgets[output.dashboardWidgetIndex]}
+      - evalScript: ${output.dashboardWidgetIndex++}
+- evalScript: ${output.dashboardOriginalFirst = output.dashboardOriginalOrder[0]}
+- evalScript: ${output.dashboardOriginalSecond = output.dashboardOriginalOrder[1]}
+- assertTrue:
+    condition: ${output.dashboardOriginalFirst.length > 0 && output.dashboardOriginalSecond.length > 0 && output.dashboardOriginalFirst != output.dashboardOriginalSecond}
+    label: "Capture two distinct dashboard cards"
+
+- swipe:
+    from:
+      id: "dashboard_widget_editor_drag_handle_1_.*"
+    direction: UP
+    duration: 1000
+    label: "Move second dashboard card above first"
+
+- waitForAnimationToEnd
+- assertVisible:
+    id: "dashboard_widget_editor_row_0_${output.dashboardOriginalSecond}_.*"
+    label: "Verify second dashboard card moved above first"
+
+- tapOn:
+    text: "SAVE"
+    label: "Save dashboard card selection and order"
+
+- extendedWaitUntil:
+    visible:
+      id: "dashboard_container"
+    timeout: 15000
+
+# Relaunch and reopen to prove the persisted state, rather than asserting only
+# the in-memory editor model.
+- stopApp
+- launchApp
+- runFlow:
+    file: ../subflows/open_dashboard_widget_editor.yaml
+
+- evalScript: ${output.dashboardWidgetIndex = 0}
+- repeat:
+    while:
+      true: ${output.dashboardWidgetIndex < output.dashboardWidgets.length}
+    commands:
+      - runFlow:
+          file: ../subflows/dashboard_assert_widget_selected.yaml
+          env:
+            CARD_SLUG: ${output.dashboardWidgets[output.dashboardWidgetIndex]}
+      - evalScript: ${output.dashboardWidgetIndex++}
+
+- assertVisible:
+    id: "dashboard_widget_editor_row_0_${output.dashboardOriginalSecond}_.*"
+    label: "Verify dashboard reorder persisted across relaunch"
+- assertVisible:
+    id: "dashboard_widget_editor_row_1_${output.dashboardOriginalFirst}_.*"
+    label: "Verify original first dashboard card persisted second"
+
+- takeScreenshot: dashboard_customize_persisted
+
+# Restore exact selection state, then swap the first pair back.
+- evalScript: ${output.dashboardWidgetIndex = 0}
+- repeat:
+    while:
+      true: ${output.dashboardWidgetIndex < output.dashboardWidgets.length}
+    commands:
+      - runFlow:
+          file: ../subflows/dashboard_restore_widget.yaml
+          env:
+            CARD_SLUG: ${output.dashboardWidgets[output.dashboardWidgetIndex]}
+      - evalScript: ${output.dashboardWidgetIndex++}
+
+- scrollUntilVisible:
+    element:
+      id: "dashboard_widget_editor_row_0_.*"
+    direction: UP
+    timeout: 10000
+
+- swipe:
+    from:
+      id: "dashboard_widget_editor_drag_handle_1_.*"
+    direction: UP
+    duration: 1000
+    label: "Restore original dashboard card order"
+
+- waitForAnimationToEnd
+- assertVisible:
+    id: "dashboard_widget_editor_row_0_${output.dashboardOriginalFirst}_.*"
+    label: "Verify original dashboard card order before save"
+
+- tapOn:
+    text: "SAVE"
+    label: "Save restored dashboard state"
+
+- extendedWaitUntil:
+    visible:
+      id: "dashboard_container"
+    timeout: 15000
+
+# Verify restoration itself persisted, so a passing run leaves the shared site
+# exactly as it found it.
+- stopApp
+- launchApp
+- runFlow:
+    file: ../subflows/open_dashboard_widget_editor.yaml
+
+- evalScript: ${output.dashboardWidgetIndex = 0}
+- repeat:
+    while:
+      true: ${output.dashboardWidgetIndex < output.dashboardWidgets.length}
+    commands:
+      - runFlow:
+          file: ../subflows/dashboard_assert_widget_restored.yaml
+          env:
+            CARD_SLUG: ${output.dashboardWidgets[output.dashboardWidgetIndex]}
+      - evalScript: ${output.dashboardWidgetIndex++}
+
+- assertVisible:
+    id: "dashboard_widget_editor_row_0_${output.dashboardOriginalFirst}_.*"
+    label: "Verify restored first dashboard card persisted"
+- assertVisible:
+    id: "dashboard_widget_editor_row_1_${output.dashboardOriginalSecond}_.*"
+    label: "Verify restored second dashboard card persisted"
+
+- takeScreenshot: dashboard_customize_restored
+
+- back
 - extendedWaitUntil:
     visible:
       id: "dashboard_container"
     timeout: 10000
-    label: "Wait for dashboard to reappear"

--- a/.maestro/flows/dashboard_customize.yaml
+++ b/.maestro/flows/dashboard_customize.yaml
@@ -1,8 +1,8 @@
 # Smoke Test: Dashboard - Customize cards
-# p2: dashboard.customization
+# P2 probe: dashboard.customization (opening the editor is not toggle/reorder coverage)
 # P2 ref: Dashboard/Stats > Customization — all cards can be toggled + reordered
 #
-# Verifies:
+# Probes:
 #   - The dashboard toolbar "Customize" action (menu_edit_screen_widgets)
 #     opens the DashboardWidgetEditorScreen
 #   - The editor lists the core supported widgets (titles match
@@ -10,9 +10,10 @@
 #     "Top performers" because those two widgets are always available
 #     regardless of store configuration.
 #   - The SAVE action and close (navigation) icon both render
-#   - Closing the editor returns to the dashboard without mutating
-#     widget state (we deliberately do NOT toggle/save anything to keep
-#     the staging store's widget layout untouched across runs)
+#   - Closing the editor returns to the dashboard without mutating state
+#
+# The P2 check requires toggling and reordering cards. This flow deliberately
+# does neither, so it is a probe and is not counted as automated coverage.
 appId: com.woocommerce.android.dev
 name: "Dashboard - Customize cards"
 tags:

--- a/.maestro/flows/dashboard_view_all_analytics.yaml
+++ b/.maestro/flows/dashboard_view_all_analytics.yaml
@@ -1,0 +1,72 @@
+# Smoke Test: Dashboard / View All store analytics
+# p2: dashboard.analytics
+# P2 ref: Dashboard/Stats > "View All" store analytics
+#
+# Verifies:
+#   - Tapping "View all store analytics" on the Top Performers card
+#     opens the Analytics Hub screen
+#   - The hub renders its date selector and at least one analytics card
+#     (Revenue, Orders, etc.)
+appId: com.woocommerce.android.dev
+name: "Dashboard - View All store analytics"
+tags:
+  - smoke_extended
+  - flaky_quarantine
+  - dashboard
+---
+# Reuse the logged-in session — login flows run first and leave the
+# app authenticated. See subflows/ensure_logged_in.yaml.
+- runFlow:
+    file: ../subflows/ensure_logged_in.yaml
+
+# Make sure the dashboard is actually on screen before scrolling
+- assertVisible:
+    id: "dashboard_container"
+    label: "Dashboard container is visible"
+
+# Scroll the Top Performers card into view — the "View all store analytics"
+# link lives at the bottom of that card
+- scrollUntilVisible:
+    element:
+      id: "dashboard_top_performers_card"
+    direction: DOWN
+    timeout: 15000
+    label: "Scroll to Top Performers card"
+
+# The WCTextButton's label comes from R.string.analytics_section_see_all
+# ("View all store analytics"). Match loosely so casing tweaks don't
+# break the flow.
+- scrollUntilVisible:
+    element:
+      text: ".*(?i)view all store analytics.*"
+    direction: DOWN
+    timeout: 10000
+    label: "Scroll to View All store analytics button"
+
+- tapOn:
+    text: ".*(?i)view all store analytics.*"
+    label: "Tap View all store analytics"
+
+# Analytics Hub screen uses View-based XML (fragment_analytics.xml),
+# so Maestro can find the root IDs directly.
+- extendedWaitUntil:
+    visible:
+      id: "analyticsRefreshLayout"
+    timeout: 20000
+
+- assertVisible:
+    id: "analyticsDateSelectorCard"
+    label: "Analytics Hub date range card is visible"
+
+- assertVisible:
+    id: "cards"
+    label: "Analytics Hub cards list is visible"
+
+# At least one of the hub's canonical cards should be on screen.
+# Revenue is the first one and always rendered; fall back to Orders in
+# case layout/ordering changes in the future.
+- assertVisible:
+    text: ".*Revenue.*|.*Orders.*"
+    label: "Revenue or Orders analytics card is visible"
+
+- takeScreenshot: dashboard_view_all_analytics

--- a/.maestro/flows/google_for_woo.yaml
+++ b/.maestro/flows/google_for_woo.yaml
@@ -1,5 +1,5 @@
 # Smoke Test: Google for Woo
-# p2: hub.google-for-woo
+# P2 probe: hub.google-for-woo (not counted when the store is ineligible)
 # P2 ref: Google for Woo > Trigger campaign creation, check webview loads
 #
 # Google for Woo is a CONDITIONAL hub-menu item — only shown when BOTH:

--- a/.maestro/flows/google_for_woo.yaml
+++ b/.maestro/flows/google_for_woo.yaml
@@ -1,0 +1,83 @@
+# Smoke Test: Google for Woo
+# p2: hub.google-for-woo
+# P2 ref: Google for Woo > Trigger campaign creation, check webview loads
+#
+# Google for Woo is a CONDITIONAL hub-menu item — only shown when BOTH:
+#   1. The site has the "Google Listings & Ads" plugin active at
+#      version >= 2.7.7 (see IsGoogleForWooEnabled.kt), AND
+#   2. A Google Ads account is connected to that site.
+#
+# On stores where either is missing, the menu button never renders, so
+# the flow must tolerate "Google for WooCommerce" being absent without
+# failing the smoke run. When it IS present, we verify tapping it
+# launches the Google Ads webview (GoogleAdsWebViewFragment, hosts a
+# WebView with AppBarStatus.Hidden and pulls the Google campaign
+# creation/dashboard URL).
+#
+# "Inbox" is the last item in the hub menu's general section
+# (MoreMenuViewModel.generateGeneralSection) and always renders, so we
+# scroll to it first to guarantee the whole menu has been traversed —
+# after that, any conditional item above it that was going to render
+# must already be in the view hierarchy.
+appId: com.woocommerce.android.dev
+name: "Google for Woo - Campaign creation webview"
+tags:
+  - smoke_extended
+  - flaky_quarantine
+  - hub_menu
+---
+- runFlow:
+    file: ../subflows/ensure_logged_in.yaml
+
+- runFlow:
+    file: ../subflows/navigate_to_more_menu.yaml
+
+# ── Scroll through the menu so conditional items have a chance ───────
+# Inbox is always at the bottom of the general section.
+- scrollUntilVisible:
+    element: "Inbox"
+    direction: DOWN
+    timeout: 15000
+    label: "Scroll to bottom of hub menu"
+
+# ── Conditionally test Google for Woo ────────────────────────────────
+# If the plugin/ads-account gate passed, the row is visible somewhere
+# in the menu. Scroll back up toward it and tap.
+- runFlow:
+    when:
+      visible: "Google for WooCommerce"
+    commands:
+      - scrollUntilVisible:
+          element: "Google for WooCommerce"
+          direction: UP
+          timeout: 10000
+          label: "Scroll to Google for WooCommerce"
+      - tapOn:
+          text: "Google for WooCommerce"
+          retryTapIfNoChange: true
+          label: "Tap Google for Woo menu item"
+      # Confirm the webview took over: the More Menu compose view is
+      # gone AND the Payments sibling menu item is not visible
+      # either (double-check we didn't just collapse).
+      - extendedWaitUntil:
+          notVisible:
+            id: "more_menu_compose_view"
+          timeout: 25000
+          label: "Verify Google Ads webview took over"
+      - assertNotVisible: "Payments"
+      - takeScreenshot: google_for_woo
+      - back
+      - extendedWaitUntil:
+          visible:
+            id: "more_menu_compose_view"
+          timeout: 15000
+          label: "Back on More Menu after Google Ads webview"
+
+# ── Skip-case screenshot ─────────────────────────────────────────────
+# If Google for Woo wasn't available on this store, capture the menu
+# state so the test report documents why the flow was a no-op.
+- runFlow:
+    when:
+      notVisible: "Google for WooCommerce"
+    commands:
+      - takeScreenshot: google_for_woo_unavailable

--- a/.maestro/flows/hub_menu_admin_and_store.yaml
+++ b/.maestro/flows/hub_menu_admin_and_store.yaml
@@ -1,0 +1,129 @@
+# Smoke Test: Hub Menu - WC Admin, View Store, Change store
+# p2: hub.change-store, hub.wc-admin, hub.view-store
+# P2 ref: Hub menu > WC Admin, View Store, Change store
+#
+# Verifies:
+#   - Tapping "View Store" launches the authenticated webview for the
+#     storefront (More Menu no longer visible)
+#   - Tapping "WC Admin" launches the authenticated webview for the
+#     WC Admin dashboard (More Menu no longer visible)
+#   - Tapping the store header opens the Site Picker ("Select store")
+#     so the merchant can change stores
+#
+# Why we don't assert specific webview content: Maestro's text-match
+# doesn't read into the embedded WebView reliably, and the rendered
+# page depends on the staging site's current state. Asserting "we
+# left the More Menu" + toolbar title is the highest-signal smoke
+# check available.
+appId: com.woocommerce.android.dev
+name: "Hub Menu - WC Admin, View Store, Change store"
+tags:
+  - smoke_extended
+  - flaky_quarantine
+  - hub_menu
+---
+- runFlow:
+    file: ../subflows/ensure_logged_in.yaml
+
+- runFlow:
+    file: ../subflows/navigate_to_more_menu.yaml
+
+# ── View Store ───────────────────────────────────────────────────────
+- scrollUntilVisible:
+    element: "View Store"
+    direction: DOWN
+    timeout: 15000
+    label: "Scroll to View Store"
+
+- tapOn:
+    text: "View Store"
+    retryTapIfNoChange: true
+    label: "Open View Store"
+
+# AuthenticatedWebViewScreen uses the selected site's display name as
+# the toolbar title. We don't know the display name, so instead assert
+# the More Menu is no longer visible (its Compose view id should have
+# been replaced by the webview fragment).
+- extendedWaitUntil:
+    notVisible:
+      id: "more_menu_compose_view"
+    timeout: 20000
+    label: "Verify webview took over from More Menu"
+
+# Give the webview a few seconds to render something before we
+# screenshot so the capture shows real content, not a white flash.
+- extendedWaitUntil:
+    visible: ".*"
+    timeout: 5000
+
+- takeScreenshot: hub_view_store
+
+- back
+
+- extendedWaitUntil:
+    visible:
+      id: "more_menu_compose_view"
+    timeout: 15000
+    label: "Back on More Menu"
+
+# ── WC Admin ─────────────────────────────────────────────────────────
+- scrollUntilVisible:
+    element: "WC Admin"
+    direction: DOWN
+    timeout: 15000
+    label: "Scroll to WC Admin"
+
+- tapOn:
+    text: "WC Admin"
+    retryTapIfNoChange: true
+    label: "Open WC Admin"
+
+# AuthenticatedWebViewScreen for WC Admin uses R.string.more_menu_
+# button_wс_admin = "WC Admin" as the toolbar title. That's also the
+# tappable row we just left, so it isn't discriminative. Instead,
+# confirm the More Menu is gone AND Payments (a sibling menu item) is
+# no longer visible — proof we navigated off the More Menu.
+- extendedWaitUntil:
+    notVisible:
+      id: "more_menu_compose_view"
+    timeout: 20000
+    label: "Verify webview took over from More Menu"
+
+- assertNotVisible: "Payments"
+
+- takeScreenshot: hub_wc_admin
+
+- back
+
+- extendedWaitUntil:
+    visible:
+      id: "more_menu_compose_view"
+    timeout: 15000
+    label: "Back on More Menu"
+
+# ── Change store ─────────────────────────────────────────────────────
+# The More Menu header (avatar + site name + plan) is a button that
+# calls onSwitchStoreClick → StartSitePickerEvent. There's no "Switch
+# store" label on the header; the header itself is the tap target. It
+# sits just below the status bar on the More Menu, so tap by point on
+# the top header area. SitePickerActivity shows the "Select store"
+# title (site_picker_title).
+#
+# If the header is disabled (isStoreSwitcherEnabled=false, e.g.
+# application-password sites), this quarantined flow should fail until
+# setup/selector handling is repaired.
+- tapOn:
+    point: "50%,12%"
+    label: "Tap store header to open site picker"
+
+- runFlow:
+    when:
+      visible: ".*Select store.*|.*Connected Stores.*"
+    commands:
+      - takeScreenshot: hub_change_store
+      - back
+      - extendedWaitUntil:
+          visible:
+            id: "more_menu_compose_view"
+          timeout: 15000
+          label: "Back on More Menu after site picker"

--- a/.maestro/flows/hub_menu_admin_and_store.yaml
+++ b/.maestro/flows/hub_menu_admin_and_store.yaml
@@ -105,15 +105,15 @@ tags:
 # The More Menu header (avatar + site name + plan) is a button that
 # calls onSwitchStoreClick → StartSitePickerEvent. There's no "Switch
 # store" label on the header; the header itself is the tap target. It
-# sits just below the status bar on the More Menu, so tap by point on
-# the top header area. SitePickerActivity shows the "Select store"
-# title (site_picker_title).
+# sits just below the status bar on the More Menu. Tap its vertical center;
+# 12% lands on the lower edge of this button on the phone profile.
+# SitePickerActivity shows the "Select store" title (site_picker_title).
 #
 # If the header is disabled (isStoreSwitcherEnabled=false, e.g.
 # application-password sites), this quarantined flow should fail until
 # setup/selector handling is repaired.
 - tapOn:
-    point: "50%,12%"
+    point: "50%,8%"
     label: "Tap store header to open site picker"
 
 - extendedWaitUntil:

--- a/.maestro/flows/hub_menu_admin_and_store.yaml
+++ b/.maestro/flows/hub_menu_admin_and_store.yaml
@@ -116,14 +116,16 @@ tags:
     point: "50%,12%"
     label: "Tap store header to open site picker"
 
-- runFlow:
-    when:
-      visible: ".*Select store.*|.*Connected Stores.*"
-    commands:
-      - takeScreenshot: hub_change_store
-      - back
-      - extendedWaitUntil:
-          visible:
-            id: "more_menu_compose_view"
-          timeout: 15000
-          label: "Back on More Menu after site picker"
+- extendedWaitUntil:
+    visible: ".*Select store.*|.*Connected Stores.*"
+    timeout: 15000
+    label: "Require site picker after tapping store header"
+
+- takeScreenshot: hub_change_store
+- back
+
+- extendedWaitUntil:
+    visible:
+      id: "more_menu_compose_view"
+    timeout: 15000
+    label: "Back on More Menu after site picker"

--- a/.maestro/flows/hub_menu_admin_and_store.yaml
+++ b/.maestro/flows/hub_menu_admin_and_store.yaml
@@ -7,8 +7,9 @@
 #     storefront (More Menu no longer visible)
 #   - Tapping "WC Admin" launches the authenticated webview for the
 #     WC Admin dashboard (More Menu no longer visible)
-#   - Tapping the store header opens the Site Picker ("Select store")
-#     so the merchant can change stores
+#   - Dynamically discovers another visible Woo store, switches to it, proves
+#     its identity and Orders surface loaded, then switches back and repeats
+#     the same assertions for the original store
 #
 # Why we don't assert specific webview content: Maestro's text-match
 # doesn't read into the embedded WebView reliably, and the rendered
@@ -102,30 +103,154 @@ tags:
     label: "Back on More Menu"
 
 # ── Change store ─────────────────────────────────────────────────────
-# The More Menu header (avatar + site name + plan) is a button that
-# calls onSwitchStoreClick → StartSitePickerEvent. There's no "Switch
-# store" label on the header; the header itself is the tap target. It
-# sits just below the status bar on the More Menu. Tap its vertical center;
-# 12% lands on the lower edge of this button on the phone profile.
-# SitePickerActivity shows the "Select store" title (site_picker_title).
-#
-# If the header is disabled (isStoreSwitcherEnabled=false, e.g.
-# application-password sites), this quarantined flow should fail until
-# setup/selector handling is repaired.
+# Require the visible title for diagnostics and use normalized URL-host
+# equality for identity. Display names are not unique and are never used to
+# decide whether the selected store changed.
+- assertVisible:
+    id: "more_menu_store_title"
+- copyTextFrom:
+    id: "more_menu_store_url"
+- evalScript: ${output.originalStoreUrl = maestro.copiedText.trim()}
+- assertTrue:
+    condition: ${output.originalStoreUrl.length > 0}
+    label: "Capture original store identity"
+
 - tapOn:
-    point: "50%,8%"
-    label: "Tap store header to open site picker"
+    id: "more_menu_store_switcher"
+    label: "Open store picker"
 
 - extendedWaitUntil:
     visible: ".*Select store.*|.*Connected Stores.*"
     timeout: 15000
-    label: "Require site picker after tapping store header"
+    label: "Require store picker"
+- extendedWaitUntil:
+    visible:
+      id: "sites_recycler"
+    timeout: 20000
+    label: "Wait for connected stores"
 
-- takeScreenshot: hub_change_store
-- back
+# Woo stores are listed before non-Woo sites. Requiring two selectable domain
+# rows makes the multi-store fixture contract explicit instead of silently
+# passing after merely opening the picker.
+- extendedWaitUntil:
+    visible:
+      id: "text_site_domain"
+      index: 1
+    timeout: 20000
+    label: "Require at least two visible connected stores"
+
+- copyTextFrom:
+    id: "text_site_domain"
+    index: 0
+- evalScript: ${output.storeCandidateZeroUrl = maestro.copiedText.trim()}
+- copyTextFrom:
+    id: "text_site_domain"
+    index: 1
+- evalScript: ${output.storeCandidateOneUrl = maestro.copiedText.trim()}
+
+# Keep raw copied strings in output; Maestro 2.2.0 does not reliably export a
+# regex-derived string across commands. Normalize to host only inside boolean
+# conditions, where the result does not need to survive another command.
+- runFlow:
+    when:
+      true: ${String(output.storeCandidateZeroUrl).toLowerCase().split('://').pop().split('/')[0].split('?')[0].split('#')[0].split(':')[0] != String(output.originalStoreUrl).toLowerCase().split('://').pop().split('/')[0].split('?')[0].split('#')[0].split(':')[0]}
+    commands:
+      - evalScript: ${output.alternateStoreUrl = output.storeCandidateZeroUrl}
+
+- runFlow:
+    when:
+      true: ${String(output.storeCandidateZeroUrl).toLowerCase().split('://').pop().split('/')[0].split('?')[0].split('#')[0].split(':')[0] == String(output.originalStoreUrl).toLowerCase().split('://').pop().split('/')[0].split('?')[0].split('#')[0].split(':')[0]}
+    commands:
+      - evalScript: ${output.alternateStoreUrl = output.storeCandidateOneUrl}
+
+- assertTrue:
+    condition: ${output.alternateStoreUrl && String(output.alternateStoreUrl).toLowerCase().split('://').pop().split('/')[0].split('?')[0].split('#')[0].split(':')[0] != String(output.originalStoreUrl).toLowerCase().split('://').pop().split('/')[0].split('?')[0].split('#')[0].split(':')[0]}
+    label: "Discover a different connected store"
+
+- tapOn:
+    text: "${output.alternateStoreUrl}"
+    label: "Select alternate store"
+- tapOn:
+    id: "button_primary"
+    retryTapIfNoChange: true
+    label: "Confirm alternate store"
 
 - extendedWaitUntil:
     visible:
-      id: "more_menu_compose_view"
+      id: "dashboard_container"
+    timeout: 30000
+    label: "Wait for alternate store dashboard"
+
+- runFlow:
+    file: ../subflows/navigate_to_more_menu.yaml
+
+- copyTextFrom:
+    id: "more_menu_store_url"
+- evalScript: ${output.selectedAlternateStoreUrl = maestro.copiedText.trim()}
+- assertTrue:
+    condition: ${String(output.selectedAlternateStoreUrl).toLowerCase().split('://').pop().split('/')[0].split('?')[0].split('#')[0].split(':')[0] == String(output.alternateStoreUrl).toLowerCase().split('://').pop().split('/')[0].split('?')[0].split('#')[0].split(':')[0] && String(output.selectedAlternateStoreUrl).toLowerCase().split('://').pop().split('/')[0].split('?')[0].split('#')[0].split(':')[0] != String(output.originalStoreUrl).toLowerCase().split('://').pop().split('/')[0].split('?')[0].split('#')[0].split(':')[0]}
+    label: "Verify selected store identity changed"
+
+# Products is a store-backed surface. A real product or its legitimate empty
+# state proves the alternate store loaded; network error states are rejected.
+- runFlow:
+    file: ../subflows/navigate_to_products.yaml
+- extendedWaitUntil:
+    visible:
+      id: "productName|empty_view"
+    timeout: 30000
+    label: "Require alternate store Products result"
+- assertNotVisible: ".*A network error occurred.*"
+- assertNotVisible: ".*Your network is unavailable.*"
+
+# Restore the original store using the identity captured before the switch.
+- runFlow:
+    file: ../subflows/navigate_to_more_menu.yaml
+- tapOn:
+    id: "more_menu_store_switcher"
+    label: "Open store picker to restore original store"
+- extendedWaitUntil:
+    visible:
+      id: "sites_recycler"
+    timeout: 20000
+
+- scrollUntilVisible:
+    element:
+      text: ".*${String(output.originalStoreUrl).toLowerCase().split('://').pop().split('/')[0].split('?')[0].split('#')[0].split(':')[0]}.*"
+    direction: DOWN
     timeout: 15000
-    label: "Back on More Menu after site picker"
+    label: "Find original store"
+- tapOn:
+    text: ".*${String(output.originalStoreUrl).toLowerCase().split('://').pop().split('/')[0].split('?')[0].split('#')[0].split(':')[0]}.*"
+    label: "Reselect original store"
+- tapOn:
+    id: "button_primary"
+    retryTapIfNoChange: true
+    label: "Confirm original store"
+
+- extendedWaitUntil:
+    visible:
+      id: "dashboard_container"
+    timeout: 30000
+    label: "Wait for restored store dashboard"
+
+- runFlow:
+    file: ../subflows/navigate_to_more_menu.yaml
+- copyTextFrom:
+    id: "more_menu_store_url"
+- evalScript: ${output.restoredStoreUrl = maestro.copiedText.trim()}
+- assertTrue:
+    condition: ${String(output.restoredStoreUrl).toLowerCase().split('://').pop().split('/')[0].split('?')[0].split('#')[0].split(':')[0] == String(output.originalStoreUrl).toLowerCase().split('://').pop().split('/')[0].split('?')[0].split('#')[0].split(':')[0]}
+    label: "Verify original store identity restored"
+
+- runFlow:
+    file: ../subflows/navigate_to_products.yaml
+- extendedWaitUntil:
+    visible:
+      id: "productName|empty_view"
+    timeout: 30000
+    label: "Require restored store Products result"
+- assertNotVisible: ".*A network error occurred.*"
+- assertNotVisible: ".*Your network is unavailable.*"
+
+- takeScreenshot: hub_change_store_restored

--- a/.maestro/flows/hub_menu_coupons.yaml
+++ b/.maestro/flows/hub_menu_coupons.yaml
@@ -1,0 +1,111 @@
+# Smoke Test: Hub Menu - Coupons
+# p2: hub.coupons.create
+# P2 ref: Hub menu > Coupons > Create a coupon
+#
+# Verifies:
+#   - Coupons section reachable from the More Menu
+#   - Coupon list screen opens (either the populated list or the empty
+#     state — both include the add-coupon FAB)
+#   - Tap the add-coupon FAB to reach the "Create Coupon" type picker
+#     bottom sheet (Percentage, Fixed Cart, Fixed Product)
+#   - Pick Percentage Discount and confirm the edit-coupon screen
+#     opens
+#   - Back out WITHOUT saving (discard dialog handled below) so the
+#     staging store isn't polluted with test coupons
+appId: com.woocommerce.android.dev
+name: "Hub Menu - Coupons"
+tags:
+  - smoke_extended
+  - flaky_quarantine
+  - hub_menu
+---
+- runFlow:
+    file: ../subflows/ensure_logged_in.yaml
+
+- runFlow:
+    file: ../subflows/navigate_to_more_menu.yaml
+
+# Coupons lives in the General section of the More Menu — scroll to it.
+- scrollUntilVisible:
+    element: "Coupons"
+    direction: DOWN
+    timeout: 15000
+    label: "Scroll to Coupons in hub menu"
+
+- tapOn:
+    text: "Coupons"
+    label: "Open Coupons"
+
+# ── Coupon list screen ───────────────────────────────────────────────
+# The add-coupon FAB (id: add_coupon_button, contentDescription "Add
+# coupon") is always present on the coupon list screen — both for
+# populated lists AND for the empty state. Asserting it is visible
+# proves we actually navigated off the More Menu.
+- extendedWaitUntil:
+    visible:
+      id: "add_coupon_button"
+    timeout: 15000
+
+- takeScreenshot: hub_coupons_list
+
+# ── Open the coupon type picker ──────────────────────────────────────
+- tapOn:
+    id: "add_coupon_button"
+    retryTapIfNoChange: true
+    label: "Tap add-coupon FAB"
+
+# CouponTypePickerScreen is a bottom sheet titled "Create Coupon" with
+# three choices: Percentage Discount, Fixed Cart Discount, Fixed
+# Product Discount. Asserting all three proves the whole sheet
+# rendered, not just the title row.
+- extendedWaitUntil:
+    visible: "Create Coupon"
+    timeout: 15000
+
+- assertVisible: "Percentage Discount"
+- assertVisible: "Fixed Cart Discount"
+- assertVisible: "Fixed Product Discount"
+
+- takeScreenshot: hub_coupons_type_picker
+
+# ── Pick Percentage Discount → edit-coupon screen ────────────────────
+- tapOn:
+    text: "Percentage Discount"
+    label: "Choose Percentage Discount"
+
+# EditCouponFragment. Uniquely titled — the toolbar shows "Create
+# coupon" (lowercase c) and the body has an amount field and a
+# "Generate coupon code" / "Coupon code" CTA. "Amount" is present on
+# every coupon type editor.
+- extendedWaitUntil:
+    visible: ".*Amount.*"
+    timeout: 15000
+
+- takeScreenshot: hub_coupons_edit_form
+
+# Back out. If there's any unsaved input (there isn't — we didn't type
+# anything), the app shows a discard-changes dialog. Handle it
+# defensively in case future changes add default values.
+- back
+
+- runFlow:
+    when:
+      visible: "Discard"
+    commands:
+      - tapOn:
+          text: "Discard"
+          label: "Discard unsaved coupon"
+
+# ── Back on coupon list ──────────────────────────────────────────────
+- extendedWaitUntil:
+    visible:
+      id: "add_coupon_button"
+    timeout: 15000
+
+# Back to the More Menu
+- back
+
+- extendedWaitUntil:
+    visible:
+      id: "more_menu_compose_view"
+    timeout: 10000

--- a/.maestro/flows/hub_menu_customers_inbox.yaml
+++ b/.maestro/flows/hub_menu_customers_inbox.yaml
@@ -1,0 +1,85 @@
+# Smoke Test: Hub Menu - Customers and Inbox
+# p2: hub.customers, hub.inbox
+# P2 ref: Hub menu > Customers, Inbox
+#
+# Verifies:
+#   - Customers section opens from the More Menu, the Customers
+#     screen renders with the "Search for customers" search hint
+#   - Inbox section opens from the More Menu, the Inbox screen
+#     renders (empty-state message OR an inbox note timestamp)
+appId: com.woocommerce.android.dev
+name: "Hub Menu - Customers and Inbox"
+tags:
+  - smoke_extended
+  - flaky_quarantine
+  - hub_menu
+---
+- runFlow:
+    file: ../subflows/ensure_logged_in.yaml
+
+- runFlow:
+    file: ../subflows/navigate_to_more_menu.yaml
+
+# ── Customers ────────────────────────────────────────────────────────
+- scrollUntilVisible:
+    element: "Customers"
+    direction: DOWN
+    timeout: 15000
+    label: "Scroll to Customers in hub menu"
+
+- tapOn:
+    text: "Customers"
+    label: "Open Customers"
+
+# The More Menu button AND the Customers screen top-bar both show
+# "Customers", so the title alone doesn't prove navigation happened.
+# Wait on the search hint ("Search for customers" — from
+# order_creation_customer_search_hint), which only exists on the
+# customer list screen.
+- extendedWaitUntil:
+    visible: "Search for customers"
+    timeout: 15000
+
+- assertVisible: "Customers"
+- assertVisible: "Search for customers"
+
+- takeScreenshot: hub_customers
+
+# Go back to More Menu
+- back
+
+- extendedWaitUntil:
+    visible:
+      id: "more_menu_compose_view"
+    timeout: 10000
+
+# ── Inbox ────────────────────────────────────────────────────────────
+- scrollUntilVisible:
+    element: "Inbox"
+    direction: DOWN
+    timeout: 15000
+    label: "Scroll to Inbox in hub menu"
+
+- tapOn:
+    text: "Inbox"
+    label: "Open Inbox"
+
+# Same problem as Customers: "Inbox" is also the More Menu button
+# text. The Inbox screen renders either an empty state ("Congrats,
+# you've read everything!" from empty_inbox_title) or a list of notes
+# with "Moments ago" / "X hours ago" / "Created on ..." timestamps.
+# Match on the empty state OR any of the recency labels.
+- extendedWaitUntil:
+    visible: ".*Congrats.*|.*Moments ago.*|.*hours ago.*|.*days ago.*|.*minutes ago.*|.*Created on.*"
+    timeout: 20000
+    label: "Wait for inbox content or empty state"
+
+- takeScreenshot: hub_inbox
+
+# Back to More Menu
+- back
+
+- extendedWaitUntil:
+    visible:
+      id: "more_menu_compose_view"
+    timeout: 10000

--- a/.maestro/flows/hub_menu_payments.yaml
+++ b/.maestro/flows/hub_menu_payments.yaml
@@ -1,17 +1,15 @@
 # Smoke Test: Hub Menu - Payments
 # p2: hub.payments
 # P2 ref: Hub menu > Payments (Enable/Disable Pay in Person, Order Card
-#         Reader, Manage Card Reader, Card Reader Manuals, etc.)
+#         Reader, Manage Card Reader, card-reader help/docs, etc.)
 #
 # Verifies:
 #   - Payments screen opens from the More Menu
 #   - Payments hub renders every first-level item the P2 mentions:
 #       SETTINGS header, "Pay In Person" toggle, CARD READERS header,
-#       "Order Card Reader", "Manage Card Reader", "Card Reader Manuals"
+#       "Order Card Reader", "Manage Card Reader", card-reader help link
 #   - Tapping "Order Card Reader" opens its dedicated screen (P2-level
 #     navigation check)
-#   - Tapping "Card Reader Manuals" opens the manuals list (with per
-#     P2 smoke: every manuals entry should render)
 #
 # Why we don't actually toggle Pay-in-Person or tap Order Card Reader
 # all the way through: Pay-in-Person toggling commits a real store
@@ -75,30 +73,12 @@ tags:
 - takeScreenshot: hub_payments_card_readers
 
 - scrollUntilVisible:
-    element: "Card Reader Manuals"
+    element: ".*accepting mobile payments.*ordering card readers.*"
     direction: DOWN
     timeout: 10000
-    label: "Scroll to Card Reader Manuals"
+    label: "Scroll to card-reader help link"
 
-- assertVisible: "Card Reader Manuals"
-
-# ── Navigate into Card Reader Manuals ────────────────────────────────
-- tapOn:
-    text: "Card Reader Manuals"
-    retryTapIfNoChange: true
-    label: "Open Card Reader Manuals"
-
-# Manuals list is a simple screen titled "Card Reader Manuals" with
-# rows per reader (e.g. "Chipper 2X BT", "Stripe M2", "WisePad 3",
-# "Tap To Pay on Android"). At least one reader is always listed on a
-# supported-country store, so we scroll until we find any common entry.
-- extendedWaitUntil:
-    visible: ".*Chipper.*|.*WisePad.*|.*Stripe M2.*|.*Tap To Pay.*"
-    timeout: 15000
-
-- takeScreenshot: hub_payments_manuals
-
-- back
+- assertVisible: ".*accepting mobile payments.*ordering card readers.*"
 
 # ── Navigate into Order Card Reader ──────────────────────────────────
 - extendedWaitUntil:

--- a/.maestro/flows/hub_menu_payments.yaml
+++ b/.maestro/flows/hub_menu_payments.yaml
@@ -1,0 +1,143 @@
+# Smoke Test: Hub Menu - Payments
+# p2: hub.payments
+# P2 ref: Hub menu > Payments (Enable/Disable Pay in Person, Order Card
+#         Reader, Manage Card Reader, Card Reader Manuals, etc.)
+#
+# Verifies:
+#   - Payments screen opens from the More Menu
+#   - Payments hub renders every first-level item the P2 mentions:
+#       SETTINGS header, "Pay In Person" toggle, CARD READERS header,
+#       "Order Card Reader", "Manage Card Reader", "Card Reader Manuals"
+#   - Tapping "Order Card Reader" opens its dedicated screen (P2-level
+#     navigation check)
+#   - Tapping "Card Reader Manuals" opens the manuals list (with per
+#     P2 smoke: every manuals entry should render)
+#
+# Why we don't actually toggle Pay-in-Person or tap Order Card Reader
+# all the way through: Pay-in-Person toggling commits a real store
+# setting change (noise on staging), and Order-a-card-reader exits to
+# Stripe's webview which isn't a Maestro-friendly check. Presence of
+# the items is the smoke-level guarantee P2 cares about.
+appId: com.woocommerce.android.dev
+name: "Hub Menu - Payments"
+tags:
+  - smoke_extended
+  - flaky_quarantine
+  - hub_menu
+---
+- runFlow:
+    file: ../subflows/ensure_logged_in.yaml
+
+- runFlow:
+    file: ../subflows/navigate_to_more_menu.yaml
+
+# Payments sits high enough in the general section to usually be
+# immediately visible, but scroll defensively in case the More Menu
+# adds items above it.
+- scrollUntilVisible:
+    element: "Payments"
+    direction: DOWN
+    timeout: 15000
+    label: "Scroll to Payments in hub menu"
+
+- tapOn:
+    text: "Payments"
+    label: "Open Payments"
+
+# ── Payments hub loaded ──────────────────────────────────────────────
+# "Pay In Person" (card_reader_enable_pay_in_person) is a toggleable
+# row that ONLY appears in the Payments hub, not elsewhere, so it's a
+# reliable anchor for "we landed on the hub".
+- extendedWaitUntil:
+    visible: "Pay In Person"
+    timeout: 20000
+
+- assertVisible: "Pay In Person"
+
+- takeScreenshot: hub_payments_top
+
+# ── Card Readers section ─────────────────────────────────────────────
+# The SETTINGS section header renders first, then CARD READERS. Both
+# are uppercase category titles, so matching is case-sensitive. If the
+# store country doesn't support card readers, the CARD READERS header
+# + sub-items won't render (addCardReaderManuals is guarded by
+# CardReaderConfigForSupportedCountry). Our staging store is US-based
+# so this is populated.
+- scrollUntilVisible:
+    element: "Order Card Reader"
+    direction: DOWN
+    timeout: 10000
+    label: "Scroll to Order Card Reader"
+
+- assertVisible: "Order Card Reader"
+- assertVisible: "Manage Card Reader"
+
+- takeScreenshot: hub_payments_card_readers
+
+- scrollUntilVisible:
+    element: "Card Reader Manuals"
+    direction: DOWN
+    timeout: 10000
+    label: "Scroll to Card Reader Manuals"
+
+- assertVisible: "Card Reader Manuals"
+
+# ── Navigate into Card Reader Manuals ────────────────────────────────
+- tapOn:
+    text: "Card Reader Manuals"
+    retryTapIfNoChange: true
+    label: "Open Card Reader Manuals"
+
+# Manuals list is a simple screen titled "Card Reader Manuals" with
+# rows per reader (e.g. "Chipper 2X BT", "Stripe M2", "WisePad 3",
+# "Tap To Pay on Android"). At least one reader is always listed on a
+# supported-country store, so we scroll until we find any common entry.
+- extendedWaitUntil:
+    visible: ".*Chipper.*|.*WisePad.*|.*Stripe M2.*|.*Tap To Pay.*"
+    timeout: 15000
+
+- takeScreenshot: hub_payments_manuals
+
+- back
+
+# ── Navigate into Order Card Reader ──────────────────────────────────
+- extendedWaitUntil:
+    visible: "Pay In Person"
+    timeout: 15000
+
+- scrollUntilVisible:
+    element: "Order Card Reader"
+    direction: DOWN
+    timeout: 10000
+    label: "Re-scroll to Order Card Reader"
+
+- tapOn:
+    text: "Order Card Reader"
+    retryTapIfNoChange: true
+    label: "Open Order Card Reader"
+
+# Order-a-reader opens an authenticated webview loading the Stripe
+# reader purchase page. Webview content isn't deterministic to assert
+# on; just verify the back-button title (webview toolbar) or that we
+# navigated away from the Payments hub (Pay In Person no longer
+# visible).
+- extendedWaitUntil:
+    notVisible: "Pay In Person"
+    timeout: 20000
+    label: "Verify we left the Payments hub"
+
+- takeScreenshot: hub_payments_order_reader
+
+- back
+
+# ── Back to More Menu ────────────────────────────────────────────────
+- extendedWaitUntil:
+    visible: "Pay In Person"
+    timeout: 15000
+
+- back
+
+- extendedWaitUntil:
+    visible:
+      id: "more_menu_compose_view"
+    timeout: 10000

--- a/.maestro/flows/hub_menu_settings.yaml
+++ b/.maestro/flows/hub_menu_settings.yaml
@@ -1,0 +1,96 @@
+# Smoke Test: Hub Menu - Settings
+# p2: hub.settings
+# P2 ref: Hub menu > Settings > Smoke test all items (ignore Delete Account)
+#
+# Verifies:
+#   - More Menu top-level items are visible (Settings section + Payments)
+#   - Settings screen opens from the More Menu
+#   - Every first-level Settings item is rendered (P2: smoke-test all items)
+#   - Log Out button is visible at the bottom of the screen
+appId: com.woocommerce.android.dev
+name: "Hub Menu - Settings"
+tags:
+  - smoke_extended
+  - flaky_quarantine
+  - hub_menu
+---
+- runFlow:
+    file: ../subflows/ensure_logged_in.yaml
+
+- runFlow:
+    file: ../subflows/navigate_to_more_menu.yaml
+
+# ── More Menu overview ───────────────────────────────────────────────
+# Two More Menu sections are visible from the top: Settings (with the
+# Settings item, and — on WPCom non-free-trial stores only —
+# Subscriptions) and the general section (Payments, WC Admin, View
+# Store, Coupons, Reviews, Customers, Inbox). Assert the always-on
+# anchors so a regressed menu layout is caught here. Subscriptions is
+# hidden when isWpComStore is false (our staging store is
+# Jetpack-connected / self-hosted), so it is not asserted.
+- assertVisible: "Settings"
+- assertVisible: "Payments"
+
+- takeScreenshot: hub_menu_overview
+
+# ── Open Settings ────────────────────────────────────────────────────
+# "Settings" appears twice: as the section title ("Settings" header)
+# and as the row ("Settings / Update your preferences"). index: 0 is
+# the section header, index: 1 is the tappable row.
+- tapOn:
+    text: "Settings"
+    index: 1
+    label: "Open Settings screen"
+
+# ── Smoke-test all first-level Settings items ────────────────────────
+# P2: "Smoke test all items (ignore Delete Account)". We assert each
+# item renders — no need to open each sub-screen for a smoke check.
+# Items are ordered top-to-bottom in fragment_settings_main.xml.
+- extendedWaitUntil:
+    visible: "Help & support"
+    timeout: 15000
+
+- assertVisible: "Help & support"
+- assertVisible: "Troubleshoot Connection"
+
+- takeScreenshot: settings_screen_top
+
+# Scroll to reach items lower on the screen. Settings is a plain
+# ScrollView, so scroll commands move the whole list. "Themes"
+# (option_site_themes) is only visible on WPComAtomic sites, so we
+# skip it — our staging Jetpack store doesn't render it. We scroll
+# straight to Privacy settings, which is always present.
+- scrollUntilVisible:
+    element: "Privacy settings"
+    direction: DOWN
+    timeout: 10000
+    label: "Scroll to Privacy settings"
+
+- assertVisible: "Privacy settings"
+- assertVisible: "Experimental features"
+
+- scrollUntilVisible:
+    element: "About the app"
+    direction: DOWN
+    timeout: 10000
+    label: "Scroll to About section"
+
+- assertVisible: "About the app"
+
+- scrollUntilVisible:
+    element: "Log out"
+    direction: DOWN
+    timeout: 10000
+    label: "Scroll to Log out"
+
+- assertVisible: "Log out"
+
+- takeScreenshot: settings_screen_bottom
+
+# Go back to More Menu
+- back
+
+- extendedWaitUntil:
+    visible:
+      id: "more_menu_compose_view"
+    timeout: 10000

--- a/.maestro/flows/hub_menu_settings.yaml
+++ b/.maestro/flows/hub_menu_settings.yaml
@@ -67,6 +67,13 @@ tags:
     label: "Scroll to Privacy settings"
 
 - assertVisible: "Privacy settings"
+
+- scrollUntilVisible:
+    element: "Experimental features"
+    direction: DOWN
+    timeout: 10000
+    label: "Scroll to Experimental features"
+
 - assertVisible: "Experimental features"
 
 - scrollUntilVisible:

--- a/.maestro/flows/products_detail.yaml
+++ b/.maestro/flows/products_detail.yaml
@@ -1,5 +1,5 @@
 # Smoke Test: Products - Product Detail
-# p2: products.detail.description, products.detail.price, products.detail.inventory, products.detail.categories, products.detail.type, products.detail.shipping, products.detail.short-description, products.detail.linked, products.detail.downloads
+# p2: products.detail.description, products.detail.categories, products.detail.type
 # P2 ref: Products > Product details (all details)
 #
 # IMPORTANT: this flow opens "the first product" in the staging list.
@@ -26,8 +26,8 @@
 #   - Product detail screen loads
 #   - Product name field + "Describe your product" area render
 #   - Universal ComplexProperty rows render (Product type, Reviews,
-#     Categories). Type-specific rows are expected to be covered by
-#     seeded/query-targeted flows before this provisional flow graduates.
+#     Categories). Type-specific editors remain manual until this flow targets
+#     a product fixture that guarantees those rows.
 appId: com.woocommerce.android.dev
 name: "Products - Product detail view"
 tags:

--- a/.maestro/flows/products_detail.yaml
+++ b/.maestro/flows/products_detail.yaml
@@ -1,0 +1,137 @@
+# Smoke Test: Products - Product Detail
+# p2: products.detail.description, products.detail.price, products.detail.inventory, products.detail.categories, products.detail.type, products.detail.shipping, products.detail.short-description, products.detail.linked, products.detail.downloads
+# P2 ref: Products > Product details (all details)
+#
+# IMPORTANT: this flow opens "the first product" in the staging list.
+# WooCommerce supports several product types (simple, variable,
+# grouped, external, booking, subscription, …) and each type renders
+# a DIFFERENT set of ComplexProperty rows on the detail screen:
+#
+#   - Simple/physical          → Price + Inventory + Product type + Shipping + …
+#   - Variable                 → Variations + Attributes + Product type
+#   - Grouped / External / Booking → no "Price" row (pricing handled elsewhere);
+#                                    no "Inventory" row on grouped/booking
+#
+# We therefore avoid asserting on type-specific labels like "Price" or
+# "Inventory" — those would fail as soon as the first product on the
+# staging store is, say, a Booking product (as happened on this run:
+# the first product was "Tourist Activity" → Booking). Instead we
+# assert on rows that render for EVERY product type:
+#
+#   - "Product type"  (always rendered; value varies)
+#   - "Reviews"       (always rendered; "no approved reviews" placeholder)
+#   - "Categories"    (always rendered; "Uncategorized" if unset)
+#
+# Verifies:
+#   - Product detail screen loads
+#   - Product name field + "Describe your product" area render
+#   - Universal ComplexProperty rows render (Product type, Reviews,
+#     Categories). Type-specific rows are expected to be covered by
+#     seeded/query-targeted flows before this provisional flow graduates.
+appId: com.woocommerce.android.dev
+name: "Products - Product detail view"
+tags:
+  - smoke_extended
+  - flaky_quarantine
+  - products
+---
+# Reuse the logged-in session — login flows run first and leave the
+# app authenticated. See subflows/ensure_logged_in.yaml.
+- runFlow:
+    file: ../subflows/ensure_logged_in.yaml
+
+# Navigate to Products
+- runFlow:
+    file: ../subflows/navigate_to_products.yaml
+
+# Open the first product
+- tapOn:
+    id: "productName"
+    index: 0
+    label: "Tap first product"
+
+# Wait for product detail screen. The "Describe your product" hint +
+# "Write with AI" button render on every product type, so they're a
+# safer readiness signal than price-related text.
+- extendedWaitUntil:
+    visible: ".*GOT IT.*|.*Describe your product.*|.*Write with AI.*|.*PUBLISH.*"
+    timeout: 25000
+    label: "Wait for product detail to load"
+
+# Dismiss "Write with AI" tooltip if it appears
+- runFlow:
+    when:
+      visible: "GOT IT"
+    commands:
+      - tapOn: "GOT IT"
+
+# Wait for the product-name field (universal).
+- extendedWaitUntil:
+    visible:
+      id: "editText"
+    timeout: 10000
+
+- takeScreenshot: product_detail_top
+
+# Scroll to the properties RecyclerView so type-agnostic rows come
+# into view.
+- scrollUntilVisible:
+    element:
+      id: "propertiesRecyclerView"
+    direction: DOWN
+    timeout: 10000
+    label: "Scroll to product properties"
+
+- takeScreenshot: product_detail_properties
+
+# Universal row 1: Product type (every WooCommerce product type
+# renders this — simple / variable / grouped / external / booking / …).
+- scrollUntilVisible:
+    element: "Product type"
+    direction: DOWN
+    timeout: 15000
+    label: "Scroll to Product type row"
+
+- assertVisible: "Product type"
+
+- takeScreenshot: product_detail_type
+
+# Universal row 2: Reviews (renders with "no approved reviews"
+# placeholder when the product has none).
+- scrollUntilVisible:
+    element: "Reviews"
+    direction: DOWN
+    timeout: 15000
+    label: "Scroll to Reviews row"
+
+- assertVisible:
+    text: "Reviews"
+
+# Universal row 3: Categories (falls back to "Uncategorized" when
+# unset).
+- scrollUntilVisible:
+    element: "Categories"
+    direction: DOWN
+    timeout: 15000
+    label: "Scroll to Categories row"
+
+- assertVisible:
+    text: "Categories"
+
+# Type-specific rows. This provisional flow should target seeded/queryable
+# products before promotion so these assertions are not store-order dependent.
+- scrollUntilVisible:
+    element: ".*Price.*|.*Inventory.*|.*Shipping.*|.*Short description.*"
+    direction: DOWN
+    timeout: 10000
+    label: "Scroll to Price / Inventory / Shipping / Short description"
+
+- takeScreenshot: product_detail_bottom
+
+# Go back to products list
+- back
+
+- extendedWaitUntil:
+    visible:
+      id: "productsRecycler"
+    timeout: 10000

--- a/.maestro/flows/products_variations_and_tags.yaml
+++ b/.maestro/flows/products_variations_and_tags.yaml
@@ -12,7 +12,7 @@
 #                 └─ back on Filter list
 #                    └─ tap "Show products" (filterList_btnShowProducts)
 #                       └─ Products list now filtered to Variable
-#                           └─ tap first product (productName index 0)
+#                           └─ find a product row reporting N variations
 #                              └─ Product detail — assert "Variations" row
 #                                 └─ tap Variations → VariationListFragment
 #                                    └─ assert variationList recycler
@@ -21,7 +21,7 @@
 #
 # ⚠️  STORE PREREQUISITE: at least ONE Variable product MUST exist on
 # the store this flow is pointed at. If none exist, the assertion on
-# `productName` after the filter is applied will fail — that's
+# a positive variation count after the filter is applied will fail — that's
 # intentional. The test doesn't know whether "no variable products" is
 # a regression in the app or missing store data.
 #
@@ -143,20 +143,21 @@ tags:
 
 - takeScreenshot: products_filtered_variable
 
-# Target the configured product exactly. This prevents another variable
-# product, or a parent product without purchasable variations, from satisfying
-# the coverage claim.
-- assertVisible:
-    text: "${WOO_VARIABLE_PRODUCT_NAME}"
-    label: "Configured Variable product is visible"
+# A positive variation count is the app's own signal that this parent product
+# has variations. This avoids coupling the flow to a named store fixture.
+- scrollUntilVisible:
+    element: ".*[1-9][0-9]* variations?.*"
+    direction: DOWN
+    timeout: 20000
+    label: "Find a Variable product with variations"
 
 # ─────────────────────────────────────────────────────────────────────
 # 6. Open a variable product from the filtered list
 # ─────────────────────────────────────────────────────────────────────
 - tapOn:
-    text: "${WOO_VARIABLE_PRODUCT_NAME}"
+    text: ".*[1-9][0-9]* variations?.*"
     retryTapIfNoChange: true
-    label: "Open configured Variable product"
+    label: "Open discovered Variable product"
 
 - extendedWaitUntil:
     visible: ".*GOT IT.*|.*Describe your product.*|.*Write with AI.*|.*PUBLISH.*|.*SAVE.*"
@@ -178,19 +179,57 @@ tags:
 
 # ─────────────────────────────────────────────────────────────────────
 # 7. Open Tags, then require the existing Variations path and a real
-#    variation detail. A product that only offers "Add variations" is an
-#    invalid fixture for this release-signal flow.
+#    variation detail. Products without tags expose Tags under Add more
+#    details; products with tags expose it directly on the detail screen.
 # ─────────────────────────────────────────────────────────────────────
 - scrollUntilVisible:
-    element: "Tags"
+    element:
+      id: "productDetail_addMoreButton"
     direction: DOWN
     timeout: 15000
-    label: "Scroll to Tags row"
+    label: "Scroll to Add more details"
 
 - tapOn:
-    text: "Tags"
+    id: "productDetail_addMoreButton"
     retryTapIfNoChange: true
-    label: "Open product tags"
+    label: "Open additional product details"
+
+- extendedWaitUntil:
+    visible:
+      id: "productDetailInfo_optionsList"
+    timeout: 10000
+
+# An untagged product offers Tags in the additional-details sheet.
+- runFlow:
+    when:
+      visible: "Tags"
+    commands:
+      - tapOn:
+          text: "Tags"
+          retryTapIfNoChange: true
+          label: "Open empty product tags"
+      - extendedWaitUntil:
+          visible:
+            id: "productTagsRecycler"
+          timeout: 15000
+
+# A tagged product omits Tags from the sheet because the direct detail row
+# already exists. Return to the product and open that row instead.
+- runFlow:
+    when:
+      notVisible:
+        id: "productTagsRecycler"
+    commands:
+      - back
+      - scrollUntilVisible:
+          element: "Tags"
+          direction: DOWN
+          timeout: 15000
+          label: "Find existing Tags row"
+      - tapOn:
+          text: "Tags"
+          retryTapIfNoChange: true
+          label: "Open existing product tags"
 
 - extendedWaitUntil:
     visible:

--- a/.maestro/flows/products_variations_and_tags.yaml
+++ b/.maestro/flows/products_variations_and_tags.yaml
@@ -145,13 +145,40 @@ tags:
 
 - takeScreenshot: products_filtered_variable
 
+# Target this run's seeded variable product instead of whichever
+# variable product currently sorts first on the staging store. Some
+# long-lived variable products are valid but have no generated
+# variations, which makes the variation-list assertions below depend
+# on mutable store data instead of the seeded fixture contract.
+- tapOn:
+    id: "menu_search"
+    label: "Open product search"
+
+- extendedWaitUntil:
+    visible:
+      id: "search_src_text"
+    timeout: 10000
+
+- tapOn:
+    id: "search_src_text"
+- inputText: ${FIXTURE_VARIABLE_PRODUCT}
+- pressKey: Enter
+
+- extendedWaitUntil:
+    visible:
+      text: "${FIXTURE_VARIABLE_PRODUCT}"
+    timeout: 20000
+    label: "Wait for seeded variable product in search results"
+
+- takeScreenshot: products_filtered_seeded_variable
+
 # ─────────────────────────────────────────────────────────────────────
-# 6. Open the first variable product
+# 6. Open the seeded variable product
 # ─────────────────────────────────────────────────────────────────────
 - tapOn:
-    id: "productName"
-    index: 0
-    label: "Open first Variable product"
+    text: "${FIXTURE_VARIABLE_PRODUCT}"
+    retryTapIfNoChange: true
+    label: "Open seeded Variable product"
 
 - extendedWaitUntil:
     visible: ".*GOT IT.*|.*Describe your product.*|.*Write with AI.*|.*PUBLISH.*|.*SAVE.*"
@@ -274,3 +301,18 @@ tags:
     visible:
       id: "productsRecycler"
     timeout: 15000
+
+# If the product search is still active, exit it so downstream flows
+# start from the normal products list.
+- runFlow:
+    when:
+      visible:
+        id: "search_src_text"
+    commands:
+      - back
+      - back
+
+- extendedWaitUntil:
+    visible:
+      id: "productsRecycler"
+    timeout: 10000

--- a/.maestro/flows/products_variations_and_tags.yaml
+++ b/.maestro/flows/products_variations_and_tags.yaml
@@ -1,0 +1,276 @@
+# Smoke Test: Products - Variations via Product Type filter
+# p2: products.detail.tags, products.detail.variations, products.detail.variation-attributes
+# P2 ref: Products > Product details — Variations, Variation detail
+#
+# Exercises the real Variable-product path end-to-end:
+#
+#   Products list
+#     └─ tap Filters (btn_product_filter)
+#        └─ Filter list (filterList) — tap "Product type"
+#           └─ Filter options (filterOptionList) — tap "Variable"
+#              └─ tap "Show products" (filterOptionList_btnShowProducts)
+#                 └─ back on Filter list
+#                    └─ tap "Show products" (filterList_btnShowProducts)
+#                       └─ Products list now filtered to Variable
+#                           └─ tap first product (productName index 0)
+#                              └─ Product detail — assert "Variations" row
+#                                 └─ tap Variations → VariationListFragment
+#                                    └─ assert variationList recycler
+#                                       └─ tap first variation
+#                                          └─ Variation detail — assert cardsRecyclerView
+#
+# ⚠️  STAGING-STORE PREREQUISITE: at least ONE Variable product MUST
+# exist on the store this flow is pointed at. If none exist, the
+# assertion on `productName` after the filter is applied will fail —
+# that's intentional. The test doesn't know whether "no variable
+# products" is a regression in the app or missing seed data, so
+# surfacing the failure is the right behaviour. Seed a variable
+# product in wp-admin and re-run.
+#
+# Key selectors (from the app's XML layouts):
+#   - btn_product_filter              — WCToggleOutlinedButton on the
+#                                       sort+filters card above the list
+#   - filterList                      — RecyclerView on the Filter list
+#                                       screen (fragment_product_filter_list)
+#   - filterList_btnShowProducts      — "Show products" CTA
+#   - filterOptionList                — RecyclerView on the per-filter
+#                                       options screen
+#   - filterOptionList_btnShowProducts — "Show products" CTA on options
+#   - empty_view                      — shown on products list when no
+#                                       results match the active filter
+#   - variationList                   — RecyclerView on VariationListFragment
+#   - cardsRecyclerView               — RecyclerView on variation detail
+appId: com.woocommerce.android.dev
+name: "Products - Variations via Variable filter"
+tags:
+  - smoke_extended
+  - flaky_quarantine
+  - products
+---
+# Reuse the logged-in session.
+- runFlow:
+    file: ../subflows/ensure_logged_in.yaml
+
+# Navigate to Products
+- runFlow:
+    file: ../subflows/navigate_to_products.yaml
+
+# ─────────────────────────────────────────────────────────────────────
+# 1. Open the product filter list
+# ─────────────────────────────────────────────────────────────────────
+- scrollUntilVisible:
+    element:
+      id: "btn_product_filter"
+    direction: UP
+    timeout: 10000
+    label: "Make sure the Filters button is visible"
+
+- tapOn:
+    id: "btn_product_filter"
+    retryTapIfNoChange: true
+    label: "Tap Filters button"
+
+- extendedWaitUntil:
+    visible:
+      id: "filterList"
+    timeout: 15000
+    label: "Wait for filter list screen"
+
+- takeScreenshot: products_filter_list
+
+# ─────────────────────────────────────────────────────────────────────
+# 2. Tap "Product type" filter row → 3. Tap "Variable"
+# ─────────────────────────────────────────────────────────────────────
+- tapOn:
+    text: "Product type"
+    retryTapIfNoChange: true
+    label: "Tap Product type filter row"
+
+- extendedWaitUntil:
+    visible:
+      id: "filterOptionList"
+    timeout: 15000
+    label: "Wait for Product type options"
+
+- takeScreenshot: products_filter_type_options
+
+- tapOn:
+    text: "Variable"
+    retryTapIfNoChange: true
+    label: "Select Variable"
+
+# ─────────────────────────────────────────────────────────────────────
+# 4. Apply the filter. "Show products" on the options screen already
+#    pops all the way back to the products list on current app
+#    builds; on older builds it only returns to the filter list and
+#    requires a second "Show products" tap there. Handle both.
+# ─────────────────────────────────────────────────────────────────────
+- tapOn:
+    id: "filterOptionList_btnShowProducts"
+    retryTapIfNoChange: true
+    label: "Confirm Variable selection"
+
+# If the filter list is still visible, tap its own Show products.
+- runFlow:
+    when:
+      visible:
+        id: "filterList_btnShowProducts"
+    commands:
+      - tapOn:
+          id: "filterList_btnShowProducts"
+          retryTapIfNoChange: true
+          label: "Apply filters and return to list"
+
+# ─────────────────────────────────────────────────────────────────────
+# 5. Products list, now filtered. If the list is empty
+#    (empty_view rendered), fail with a clear message — the fix is
+#    a staging-data change, not a test change.
+# ─────────────────────────────────────────────────────────────────────
+# Wait until either the first product row OR the empty-state view
+# has painted. Both are hosted inside productsRecycler's container,
+# and only one renders at a time based on the filter result.
+- extendedWaitUntil:
+    visible:
+      id: "productsRecycler"
+    timeout: 20000
+    label: "Wait for products list container"
+
+- assertNotVisible:
+    id: "empty_view"
+    label: "FAIL: staging store has no Variable products — seed at least one and re-run"
+
+- assertVisible:
+    id: "productName"
+    label: "At least one Variable product is in the filtered list"
+
+- takeScreenshot: products_filtered_variable
+
+# ─────────────────────────────────────────────────────────────────────
+# 6. Open the first variable product
+# ─────────────────────────────────────────────────────────────────────
+- tapOn:
+    id: "productName"
+    index: 0
+    label: "Open first Variable product"
+
+- extendedWaitUntil:
+    visible: ".*GOT IT.*|.*Describe your product.*|.*Write with AI.*|.*PUBLISH.*|.*SAVE.*"
+    timeout: 25000
+    label: "Wait for product detail"
+
+- runFlow:
+    when:
+      visible: "GOT IT"
+    commands:
+      - tapOn: "GOT IT"
+
+- extendedWaitUntil:
+    visible:
+      id: "editText"
+    timeout: 10000
+
+- takeScreenshot: products_variable_detail
+
+# ─────────────────────────────────────────────────────────────────────
+# 7. Assert the variation-specific rows on the detail screen.
+#
+# "Variations" renders as a ComplexProperty when numVariations > 0 and
+# variationEnabledAttributes is non-empty — both are guaranteed for
+# properly-configured Variable products.
+#
+# "Variations attributes" renders as a PropertyGroup listing the
+# attribute→term map. It's also Variable-specific.
+# ─────────────────────────────────────────────────────────────────────
+- scrollUntilVisible:
+    element: "Variations"
+    direction: DOWN
+    timeout: 15000
+    label: "Scroll to Variations row"
+
+- assertVisible: "Variations"
+
+- scrollUntilVisible:
+    element: ".*Variations attributes.*|.*Attributes.*"
+    direction: DOWN
+    timeout: 15000
+    label: "Scroll to Attributes row"
+
+- takeScreenshot: products_variable_detail_rows
+
+# ─────────────────────────────────────────────────────────────────────
+# 8. Tap the Variations row → VariationListFragment
+# ─────────────────────────────────────────────────────────────────────
+- tapOn:
+    text: "Variations"
+    retryTapIfNoChange: true
+    label: "Tap Variations row"
+
+- extendedWaitUntil:
+    visible:
+      id: "variationList"
+    timeout: 20000
+    label: "Wait for variations list"
+
+- assertVisible:
+    id: "variationList"
+    label: "Variations list loaded"
+
+- takeScreenshot: products_variations_list
+
+# ─────────────────────────────────────────────────────────────────────
+# 9. Open the first variation → Variation detail (cardsRecyclerView)
+# ─────────────────────────────────────────────────────────────────────
+# Variation list items don't expose a unique row id, but each
+# variation row renders the attribute summary as a text label — we
+# just tap the first item in the list. Tapping any row navigates to
+# VariationDetailFragment which always renders `cardsRecyclerView`.
+- tapOn:
+    id: "variationList"
+    index: 0
+    retryTapIfNoChange: true
+    label: "Open first variation"
+
+- extendedWaitUntil:
+    visible:
+      id: "cardsRecyclerView"
+    timeout: 20000
+    label: "Wait for variation detail"
+
+- assertVisible:
+    id: "cardsRecyclerView"
+    label: "Variation detail loaded with cards list"
+
+- takeScreenshot: products_variation_detail
+
+# ─────────────────────────────────────────────────────────────────────
+# 10. Back out cleanly — variation detail → variations list →
+#     product detail → products list
+# ─────────────────────────────────────────────────────────────────────
+- back
+
+- extendedWaitUntil:
+    visible:
+      id: "variationList"
+    timeout: 10000
+
+- back
+
+- extendedWaitUntil:
+    visible:
+      id: "editText"
+    timeout: 10000
+
+- back
+
+# If a Discard changes dialog appears (shouldn't — we didn't edit),
+# dismiss it.
+- runFlow:
+    when:
+      visible: "Discard"
+    commands:
+      - tapOn: "Discard"
+
+- extendedWaitUntil:
+    visible:
+      id: "productsRecycler"
+    timeout: 15000

--- a/.maestro/flows/products_variations_and_tags.yaml
+++ b/.maestro/flows/products_variations_and_tags.yaml
@@ -143,21 +143,20 @@ tags:
 
 - takeScreenshot: products_filtered_variable
 
-# The lab smoke store has multiple Variable products. "Sweater" is the
-# stable product used for this flow; depending on current store data it
-# either exposes an existing Variations list or the Add variations setup
-# path.
+# Target the configured product exactly. This prevents another variable
+# product, or a parent product without purchasable variations, from satisfying
+# the coverage claim.
 - assertVisible:
-    text: "Sweater"
-    label: "Stable Variable product is visible"
+    text: "${WOO_VARIABLE_PRODUCT_NAME}"
+    label: "Configured Variable product is visible"
 
 # ─────────────────────────────────────────────────────────────────────
 # 6. Open a variable product from the filtered list
 # ─────────────────────────────────────────────────────────────────────
 - tapOn:
-    text: "Sweater"
+    text: "${WOO_VARIABLE_PRODUCT_NAME}"
     retryTapIfNoChange: true
-    label: "Open stable Variable product"
+    label: "Open configured Variable product"
 
 - extendedWaitUntil:
     visible: ".*GOT IT.*|.*Describe your product.*|.*Write with AI.*|.*PUBLISH.*|.*SAVE.*"
@@ -178,167 +177,91 @@ tags:
 - takeScreenshot: products_variable_detail
 
 # ─────────────────────────────────────────────────────────────────────
-# 7. Assert the variation-specific area on the detail screen.
-#
-# "Variations" renders as a ComplexProperty when numVariations > 0 and
-# variationEnabledAttributes is non-empty. If the product has attributes
-# but no generated variations yet, the app exposes "Add variations";
-# exercise that setup path through the generate-all confirmation.
-#
-# "Variations attributes" renders as a PropertyGroup listing the
-# attribute→term map. It's also Variable-specific.
+# 7. Open Tags, then require the existing Variations path and a real
+#    variation detail. A product that only offers "Add variations" is an
+#    invalid fixture for this release-signal flow.
 # ─────────────────────────────────────────────────────────────────────
 - scrollUntilVisible:
-    element: ".*Variations.*|.*Add variations.*"
+    element: "Tags"
     direction: DOWN
     timeout: 15000
-    label: "Scroll to variations row"
+    label: "Scroll to Tags row"
 
-- takeScreenshot: products_variable_variations_area
+- tapOn:
+    text: "Tags"
+    retryTapIfNoChange: true
+    label: "Open product tags"
 
-- runFlow:
-    when:
-      visible: "Variations"
-    commands:
-      - assertVisible: "Variations"
-      - scrollUntilVisible:
-          element: ".*Variations attributes.*|.*Attributes.*"
-          direction: DOWN
-          timeout: 15000
-          label: "Scroll to Attributes row"
-      - takeScreenshot: products_variable_detail_rows
-      - tapOn:
-          text: "Variations"
-          retryTapIfNoChange: true
-          label: "Tap Variations row"
-      - extendedWaitUntil:
-          visible:
-            id: "variationList"
-          timeout: 20000
-          label: "Wait for variations list"
-      - assertVisible:
-          id: "variationList"
-          label: "Variations list loaded"
-      - takeScreenshot: products_variations_list
-      - tapOn:
-          id: "variationList"
-          index: 0
-          retryTapIfNoChange: true
-          label: "Open first variation"
-      - extendedWaitUntil:
-          visible:
-            id: "cardsRecyclerView"
-          timeout: 20000
-          label: "Wait for variation detail"
-      - assertVisible:
-          id: "cardsRecyclerView"
-          label: "Variation detail loaded with cards list"
-      - takeScreenshot: products_variation_detail
-      - back
-      - extendedWaitUntil:
-          visible:
-            id: "variationList"
-          timeout: 10000
-      - back
-      - extendedWaitUntil:
-          visible:
-            id: "editText"
-          timeout: 10000
+- extendedWaitUntil:
+    visible:
+      id: "productTagsRecycler"
+    timeout: 15000
+    label: "Wait for product tags"
 
-- runFlow:
-    when:
-      visible: "Add variations"
-    commands:
-      - tapOn:
-          text: "Add variations"
-          retryTapIfNoChange: true
-          label: "Open Add variations setup"
-      - extendedWaitUntil:
-          visible: "Add attribute"
-          timeout: 15000
-      - assertVisible:
-          id: "attributeList"
-          label: "Existing attributes list is visible"
-      - assertVisible: "Color"
-      - tapOn:
-          text: "Color"
-          retryTapIfNoChange: true
-          label: "Select Color attribute"
-      - extendedWaitUntil:
-          visible:
-            id: "assignedTermList"
-          timeout: 15000
-      - assertVisible: "Beige"
-      - assertVisible: "Green"
-      - tapOn:
-          id: "menu_next"
-          retryTapIfNoChange: true
-          label: "Continue from Color terms"
-      - extendedWaitUntil:
-          visible: "Attributes"
-          timeout: 15000
-      - assertVisible: "Color"
-      - assertVisible: "Beige, Green"
-      - tapOn:
-          text: "NEXT"
-          retryTapIfNoChange: true
-          label: "Continue from Attributes review"
-      - extendedWaitUntil:
-          visible: "Attributes created"
-          timeout: 15000
-      - assertVisible:
-          id: "generate_variation_button"
-          label: "Generate variation CTA is visible"
-      - tapOn:
-          id: "generate_variation_button"
-          retryTapIfNoChange: true
-          label: "Open variation generation options"
-      - extendedWaitUntil:
-          visible: "Generate all variations"
-          timeout: 15000
-      - assertVisible:
-          id: "all_variation"
-          label: "Generate all variations option is visible"
-      - tapOn:
-          id: "all_variation"
-          retryTapIfNoChange: true
-          label: "Select Generate all variations"
-      - extendedWaitUntil:
-          visible: "Generate all variations?"
-          timeout: 10000
-      - takeScreenshot: products_variation_generate_confirmation
-      - tapOn:
-          text: "CANCEL"
-          label: "Cancel generation confirmation"
-      - runFlow:
-          when:
-            visible: "Generate all variations"
-          commands:
-            - back
-      - runFlow:
-          when:
-            visible: "Attributes created"
-          commands:
-            - back
-      - runFlow:
-          when:
-            visible: "Attributes"
-          commands:
-            - back
-      - runFlow:
-          when:
-            visible: "Color"
-          commands:
-            - back
-      - runFlow:
-          when:
-            visible: "Add attribute"
-          commands:
-            - back
-      - extendedWaitUntil:
-          visible:
-            id: "editText"
-          timeout: 15000
+- takeScreenshot: products_variable_tags
+- back
+
+- extendedWaitUntil:
+    visible:
+      id: "editText"
+    timeout: 10000
+
+- scrollUntilVisible:
+    element: "Variations"
+    direction: DOWN
+    timeout: 15000
+    label: "Require existing Variations row"
+
+- scrollUntilVisible:
+    element: ".*Variations attributes.*|.*Attributes.*"
+    direction: DOWN
+    timeout: 15000
+    label: "Require variation attributes"
+
+- takeScreenshot: products_variable_detail_rows
+
+- scrollUntilVisible:
+    element: "Variations"
+    direction: UP
+    timeout: 15000
+    label: "Return to Variations row"
+
+- tapOn:
+    text: "Variations"
+    retryTapIfNoChange: true
+    label: "Open Variations"
+
+- extendedWaitUntil:
+    visible:
+      id: "variationList"
+    timeout: 20000
+    label: "Wait for variations list"
+
+- tapOn:
+    id: "variationList"
+    index: 0
+    retryTapIfNoChange: true
+    label: "Open first available variation"
+
+- extendedWaitUntil:
+    visible:
+      id: "cardsRecyclerView"
+    timeout: 20000
+    label: "Wait for variation detail"
+
+- takeScreenshot: products_variation_detail
+- back
+
+- extendedWaitUntil:
+    visible:
+      id: "variationList"
+    timeout: 10000
+- back
+
+- extendedWaitUntil:
+    visible:
+      id: "editText"
+    timeout: 10000
 
 # ─────────────────────────────────────────────────────────────────────
 # 8. Back out cleanly — product detail → products list

--- a/.maestro/flows/products_variations_and_tags.yaml
+++ b/.maestro/flows/products_variations_and_tags.yaml
@@ -19,13 +19,11 @@
 #                                       └─ tap first variation
 #                                          └─ Variation detail — assert cardsRecyclerView
 #
-# ⚠️  STAGING-STORE PREREQUISITE: at least ONE Variable product MUST
-# exist on the store this flow is pointed at. If none exist, the
-# assertion on `productName` after the filter is applied will fail —
-# that's intentional. The test doesn't know whether "no variable
-# products" is a regression in the app or missing seed data, so
-# surfacing the failure is the right behaviour. Seed a variable
-# product in wp-admin and re-run.
+# ⚠️  STORE PREREQUISITE: at least ONE Variable product MUST exist on
+# the store this flow is pointed at. If none exist, the assertion on
+# `productName` after the filter is applied will fail — that's
+# intentional. The test doesn't know whether "no variable products" is
+# a regression in the app or missing store data.
 #
 # Key selectors (from the app's XML layouts):
 #   - btn_product_filter              — WCToggleOutlinedButton on the
@@ -137,7 +135,7 @@ tags:
 
 - assertNotVisible:
     id: "empty_view"
-    label: "FAIL: staging store has no Variable products — seed at least one and re-run"
+    label: "FAIL: store has no Variable products"
 
 - assertVisible:
     id: "productName"
@@ -145,40 +143,21 @@ tags:
 
 - takeScreenshot: products_filtered_variable
 
-# Target this run's seeded variable product instead of whichever
-# variable product currently sorts first on the staging store. Some
-# long-lived variable products are valid but have no generated
-# variations, which makes the variation-list assertions below depend
-# on mutable store data instead of the seeded fixture contract.
-- tapOn:
-    id: "menu_search"
-    label: "Open product search"
-
-- extendedWaitUntil:
-    visible:
-      id: "search_src_text"
-    timeout: 10000
-
-- tapOn:
-    id: "search_src_text"
-- inputText: ${FIXTURE_VARIABLE_PRODUCT}
-- pressKey: Enter
-
-- extendedWaitUntil:
-    visible:
-      text: "${FIXTURE_VARIABLE_PRODUCT}"
-    timeout: 20000
-    label: "Wait for seeded variable product in search results"
-
-- takeScreenshot: products_filtered_seeded_variable
+# The lab smoke store has multiple Variable products. "Sweater" is the
+# stable product used for this flow; depending on current store data it
+# either exposes an existing Variations list or the Add variations setup
+# path.
+- assertVisible:
+    text: "Sweater"
+    label: "Stable Variable product is visible"
 
 # ─────────────────────────────────────────────────────────────────────
-# 6. Open the seeded variable product
+# 6. Open a variable product from the filtered list
 # ─────────────────────────────────────────────────────────────────────
 - tapOn:
-    text: "${FIXTURE_VARIABLE_PRODUCT}"
+    text: "Sweater"
     retryTapIfNoChange: true
-    label: "Open seeded Variable product"
+    label: "Open stable Variable product"
 
 - extendedWaitUntil:
     visible: ".*GOT IT.*|.*Describe your product.*|.*Write with AI.*|.*PUBLISH.*|.*SAVE.*"
@@ -199,94 +178,171 @@ tags:
 - takeScreenshot: products_variable_detail
 
 # ─────────────────────────────────────────────────────────────────────
-# 7. Assert the variation-specific rows on the detail screen.
+# 7. Assert the variation-specific area on the detail screen.
 #
 # "Variations" renders as a ComplexProperty when numVariations > 0 and
-# variationEnabledAttributes is non-empty — both are guaranteed for
-# properly-configured Variable products.
+# variationEnabledAttributes is non-empty. If the product has attributes
+# but no generated variations yet, the app exposes "Add variations";
+# exercise that setup path through the generate-all confirmation.
 #
 # "Variations attributes" renders as a PropertyGroup listing the
 # attribute→term map. It's also Variable-specific.
 # ─────────────────────────────────────────────────────────────────────
 - scrollUntilVisible:
-    element: "Variations"
+    element: ".*Variations.*|.*Add variations.*"
     direction: DOWN
     timeout: 15000
-    label: "Scroll to Variations row"
+    label: "Scroll to variations row"
 
-- assertVisible: "Variations"
+- takeScreenshot: products_variable_variations_area
 
-- scrollUntilVisible:
-    element: ".*Variations attributes.*|.*Attributes.*"
-    direction: DOWN
-    timeout: 15000
-    label: "Scroll to Attributes row"
+- runFlow:
+    when:
+      visible: "Variations"
+    commands:
+      - assertVisible: "Variations"
+      - scrollUntilVisible:
+          element: ".*Variations attributes.*|.*Attributes.*"
+          direction: DOWN
+          timeout: 15000
+          label: "Scroll to Attributes row"
+      - takeScreenshot: products_variable_detail_rows
+      - tapOn:
+          text: "Variations"
+          retryTapIfNoChange: true
+          label: "Tap Variations row"
+      - extendedWaitUntil:
+          visible:
+            id: "variationList"
+          timeout: 20000
+          label: "Wait for variations list"
+      - assertVisible:
+          id: "variationList"
+          label: "Variations list loaded"
+      - takeScreenshot: products_variations_list
+      - tapOn:
+          id: "variationList"
+          index: 0
+          retryTapIfNoChange: true
+          label: "Open first variation"
+      - extendedWaitUntil:
+          visible:
+            id: "cardsRecyclerView"
+          timeout: 20000
+          label: "Wait for variation detail"
+      - assertVisible:
+          id: "cardsRecyclerView"
+          label: "Variation detail loaded with cards list"
+      - takeScreenshot: products_variation_detail
+      - back
+      - extendedWaitUntil:
+          visible:
+            id: "variationList"
+          timeout: 10000
+      - back
+      - extendedWaitUntil:
+          visible:
+            id: "editText"
+          timeout: 10000
 
-- takeScreenshot: products_variable_detail_rows
+- runFlow:
+    when:
+      visible: "Add variations"
+    commands:
+      - tapOn:
+          text: "Add variations"
+          retryTapIfNoChange: true
+          label: "Open Add variations setup"
+      - extendedWaitUntil:
+          visible: "Add attribute"
+          timeout: 15000
+      - assertVisible:
+          id: "attributeList"
+          label: "Existing attributes list is visible"
+      - assertVisible: "Color"
+      - tapOn:
+          text: "Color"
+          retryTapIfNoChange: true
+          label: "Select Color attribute"
+      - extendedWaitUntil:
+          visible:
+            id: "assignedTermList"
+          timeout: 15000
+      - assertVisible: "Beige"
+      - assertVisible: "Green"
+      - tapOn:
+          id: "menu_next"
+          retryTapIfNoChange: true
+          label: "Continue from Color terms"
+      - extendedWaitUntil:
+          visible: "Attributes"
+          timeout: 15000
+      - assertVisible: "Color"
+      - assertVisible: "Beige, Green"
+      - tapOn:
+          text: "NEXT"
+          retryTapIfNoChange: true
+          label: "Continue from Attributes review"
+      - extendedWaitUntil:
+          visible: "Attributes created"
+          timeout: 15000
+      - assertVisible:
+          id: "generate_variation_button"
+          label: "Generate variation CTA is visible"
+      - tapOn:
+          id: "generate_variation_button"
+          retryTapIfNoChange: true
+          label: "Open variation generation options"
+      - extendedWaitUntil:
+          visible: "Generate all variations"
+          timeout: 15000
+      - assertVisible:
+          id: "all_variation"
+          label: "Generate all variations option is visible"
+      - tapOn:
+          id: "all_variation"
+          retryTapIfNoChange: true
+          label: "Select Generate all variations"
+      - extendedWaitUntil:
+          visible: "Generate all variations?"
+          timeout: 10000
+      - takeScreenshot: products_variation_generate_confirmation
+      - tapOn:
+          text: "CANCEL"
+          label: "Cancel generation confirmation"
+      - runFlow:
+          when:
+            visible: "Generate all variations"
+          commands:
+            - back
+      - runFlow:
+          when:
+            visible: "Attributes created"
+          commands:
+            - back
+      - runFlow:
+          when:
+            visible: "Attributes"
+          commands:
+            - back
+      - runFlow:
+          when:
+            visible: "Color"
+          commands:
+            - back
+      - runFlow:
+          when:
+            visible: "Add attribute"
+          commands:
+            - back
+      - extendedWaitUntil:
+          visible:
+            id: "editText"
+          timeout: 15000
 
 # ─────────────────────────────────────────────────────────────────────
-# 8. Tap the Variations row → VariationListFragment
+# 8. Back out cleanly — product detail → products list
 # ─────────────────────────────────────────────────────────────────────
-- tapOn:
-    text: "Variations"
-    retryTapIfNoChange: true
-    label: "Tap Variations row"
-
-- extendedWaitUntil:
-    visible:
-      id: "variationList"
-    timeout: 20000
-    label: "Wait for variations list"
-
-- assertVisible:
-    id: "variationList"
-    label: "Variations list loaded"
-
-- takeScreenshot: products_variations_list
-
-# ─────────────────────────────────────────────────────────────────────
-# 9. Open the first variation → Variation detail (cardsRecyclerView)
-# ─────────────────────────────────────────────────────────────────────
-# Variation list items don't expose a unique row id, but each
-# variation row renders the attribute summary as a text label — we
-# just tap the first item in the list. Tapping any row navigates to
-# VariationDetailFragment which always renders `cardsRecyclerView`.
-- tapOn:
-    id: "variationList"
-    index: 0
-    retryTapIfNoChange: true
-    label: "Open first variation"
-
-- extendedWaitUntil:
-    visible:
-      id: "cardsRecyclerView"
-    timeout: 20000
-    label: "Wait for variation detail"
-
-- assertVisible:
-    id: "cardsRecyclerView"
-    label: "Variation detail loaded with cards list"
-
-- takeScreenshot: products_variation_detail
-
-# ─────────────────────────────────────────────────────────────────────
-# 10. Back out cleanly — variation detail → variations list →
-#     product detail → products list
-# ─────────────────────────────────────────────────────────────────────
-- back
-
-- extendedWaitUntil:
-    visible:
-      id: "variationList"
-    timeout: 10000
-
-- back
-
-- extendedWaitUntil:
-    visible:
-      id: "editText"
-    timeout: 10000
-
 - back
 
 # If a Discard changes dialog appears (shouldn't — we didn't edit),

--- a/.maestro/subflows/dashboard_assert_widget_restored.yaml
+++ b/.maestro/subflows/dashboard_assert_widget_restored.yaml
@@ -1,0 +1,5 @@
+appId: com.woocommerce.android.dev
+---
+- assertVisible:
+    id: ".*__${CARD_SLUG}_${output.dashboardOriginalStates[CARD_SLUG]}__.*"
+    label: "Restored ${CARD_SLUG} dashboard card state persists"

--- a/.maestro/subflows/dashboard_assert_widget_selected.yaml
+++ b/.maestro/subflows/dashboard_assert_widget_selected.yaml
@@ -1,0 +1,25 @@
+appId: com.woocommerce.android.dev
+---
+- runFlow:
+    when:
+      true: ${output.dashboardOriginalStates[CARD_SLUG] == 'selected' || output.dashboardOriginalStates[CARD_SLUG] == 'unselected'}
+    commands:
+      - assertVisible:
+          id: ".*__${CARD_SLUG}_selected__.*"
+          label: "Persisted ${CARD_SLUG} dashboard card selection"
+
+- runFlow:
+    when:
+      true: ${output.dashboardOriginalStates[CARD_SLUG] == 'unavailable'}
+    commands:
+      - assertVisible:
+          id: ".*__${CARD_SLUG}_unavailable__.*"
+          label: "Persisted unavailable ${CARD_SLUG} dashboard card state"
+
+- runFlow:
+    when:
+      true: ${output.dashboardOriginalStates[CARD_SLUG] == 'hidden'}
+    commands:
+      - assertVisible:
+          id: ".*__${CARD_SLUG}_hidden__.*"
+          label: "Persisted hidden ${CARD_SLUG} dashboard card state"

--- a/.maestro/subflows/dashboard_exercise_selected_widget.yaml
+++ b/.maestro/subflows/dashboard_exercise_selected_widget.yaml
@@ -1,0 +1,28 @@
+appId: com.woocommerce.android.dev
+---
+- runFlow:
+    when:
+      true: ${output.dashboardOriginalStates[CARD_SLUG] == 'selected'}
+    commands:
+      - scrollUntilVisible:
+          element:
+            id: "dashboard_widget_editor_row_.*_${CARD_SLUG}_selected"
+          direction: DOWN
+          timeout: 10000
+          label: "Find selected ${CARD_SLUG} dashboard card"
+      - tapOn:
+          id: "dashboard_widget_editor_row_.*_${CARD_SLUG}_selected"
+          label: "Deselect ${CARD_SLUG} dashboard card"
+      - extendedWaitUntil:
+          visible:
+            id: "dashboard_widget_editor_row_.*_${CARD_SLUG}_unselected"
+          timeout: 5000
+          label: "Verify ${CARD_SLUG} dashboard card deselected"
+      - tapOn:
+          id: "dashboard_widget_editor_row_.*_${CARD_SLUG}_unselected"
+          label: "Reselect ${CARD_SLUG} dashboard card"
+      - extendedWaitUntil:
+          visible:
+            id: "dashboard_widget_editor_row_.*_${CARD_SLUG}_selected"
+          timeout: 5000
+          label: "Verify ${CARD_SLUG} dashboard card reselected"

--- a/.maestro/subflows/dashboard_record_widget_order.yaml
+++ b/.maestro/subflows/dashboard_record_widget_order.yaml
@@ -1,0 +1,15 @@
+appId: com.woocommerce.android.dev
+---
+- runFlow:
+    when:
+      visible:
+        id: "dashboard_widget_editor_row_0_${CARD_SLUG}_.*"
+    commands:
+      - evalScript: ${output.dashboardOriginalOrder[0] = CARD_SLUG}
+
+- runFlow:
+    when:
+      visible:
+        id: "dashboard_widget_editor_row_1_${CARD_SLUG}_.*"
+    commands:
+      - evalScript: ${output.dashboardOriginalOrder[1] = CARD_SLUG}

--- a/.maestro/subflows/dashboard_record_widget_state.yaml
+++ b/.maestro/subflows/dashboard_record_widget_state.yaml
@@ -1,0 +1,33 @@
+appId: com.woocommerce.android.dev
+---
+- runFlow:
+    when:
+      visible:
+        id: ".*__${CARD_SLUG}_selected__.*"
+    commands:
+      - evalScript: ${output.dashboardOriginalStates[CARD_SLUG] = 'selected'}
+
+- runFlow:
+    when:
+      visible:
+        id: ".*__${CARD_SLUG}_unselected__.*"
+    commands:
+      - evalScript: ${output.dashboardOriginalStates[CARD_SLUG] = 'unselected'}
+
+- runFlow:
+    when:
+      visible:
+        id: ".*__${CARD_SLUG}_unavailable__.*"
+    commands:
+      - evalScript: ${output.dashboardOriginalStates[CARD_SLUG] = 'unavailable'}
+
+- runFlow:
+    when:
+      visible:
+        id: ".*__${CARD_SLUG}_hidden__.*"
+    commands:
+      - evalScript: ${output.dashboardOriginalStates[CARD_SLUG] = 'hidden'}
+
+- assertTrue:
+    condition: ${output.dashboardOriginalStates[CARD_SLUG] != null}
+    label: "Record ${CARD_SLUG} dashboard card state"

--- a/.maestro/subflows/dashboard_restore_widget.yaml
+++ b/.maestro/subflows/dashboard_restore_widget.yaml
@@ -1,0 +1,20 @@
+appId: com.woocommerce.android.dev
+---
+- runFlow:
+    when:
+      true: ${output.dashboardOriginalStates[CARD_SLUG] == 'unselected'}
+    commands:
+      - scrollUntilVisible:
+          element:
+            id: "dashboard_widget_editor_row_.*_${CARD_SLUG}_selected"
+          direction: DOWN
+          timeout: 10000
+          label: "Find ${CARD_SLUG} dashboard card to restore"
+      - tapOn:
+          id: "dashboard_widget_editor_row_.*_${CARD_SLUG}_selected"
+          label: "Restore ${CARD_SLUG} dashboard card to unselected"
+      - extendedWaitUntil:
+          visible:
+            id: "dashboard_widget_editor_row_.*_${CARD_SLUG}_unselected"
+          timeout: 5000
+          label: "Verify ${CARD_SLUG} dashboard card restored"

--- a/.maestro/subflows/dashboard_select_widget.yaml
+++ b/.maestro/subflows/dashboard_select_widget.yaml
@@ -1,0 +1,41 @@
+appId: com.woocommerce.android.dev
+---
+- runFlow:
+    when:
+      true: ${output.dashboardOriginalStates[CARD_SLUG] == 'unselected'}
+    commands:
+      - scrollUntilVisible:
+          element:
+            id: "dashboard_widget_editor_row_.*_${CARD_SLUG}_unselected"
+          direction: DOWN
+          timeout: 10000
+          label: "Find unselected ${CARD_SLUG} dashboard card"
+      - tapOn:
+          id: "dashboard_widget_editor_row_.*_${CARD_SLUG}_unselected"
+          label: "Select ${CARD_SLUG} dashboard card"
+      - extendedWaitUntil:
+          visible:
+            id: "dashboard_widget_editor_row_.*_${CARD_SLUG}_selected"
+          timeout: 5000
+          label: "Verify ${CARD_SLUG} dashboard card selected"
+
+- runFlow:
+    when:
+      true: ${output.dashboardOriginalStates[CARD_SLUG] == 'unavailable'}
+    commands:
+      - scrollUntilVisible:
+          element:
+            id: "dashboard_widget_editor_row_.*_${CARD_SLUG}_unavailable"
+          direction: DOWN
+          timeout: 10000
+          label: "Account for unavailable ${CARD_SLUG} dashboard card"
+      - assertVisible:
+          id: "dashboard_widget_editor_row_.*_${CARD_SLUG}_unavailable"
+
+- runFlow:
+    when:
+      true: ${output.dashboardOriginalStates[CARD_SLUG] == 'hidden'}
+    commands:
+      - assertVisible:
+          id: ".*__${CARD_SLUG}_hidden__.*"
+          label: "Account for hidden ${CARD_SLUG} dashboard card"

--- a/.maestro/subflows/open_dashboard_widget_editor.yaml
+++ b/.maestro/subflows/open_dashboard_widget_editor.yaml
@@ -1,0 +1,20 @@
+appId: com.woocommerce.android.dev
+---
+- extendedWaitUntil:
+    visible:
+      id: "dashboard_container"
+    timeout: 20000
+    label: "Wait for dashboard before customization"
+
+- tapOn:
+    id: "menu_edit_screen_widgets"
+    retryTapIfNoChange: true
+    label: "Open dashboard customization"
+
+- extendedWaitUntil:
+    visible:
+      id: "dashboard_widget_editor_state__.*"
+    timeout: 15000
+    label: "Wait for dashboard card state"
+
+- assertVisible: "SAVE"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/DragAndDropItemsList.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/DragAndDropItemsList.kt
@@ -93,6 +93,8 @@ fun <T> DragAndDropSelectableItem(
     onSelectionChange: (T, Boolean) -> Unit,
     itemKey: (item: T) -> Any,
     modifier: Modifier = Modifier,
+    rowModifier: Modifier = Modifier,
+    dragHandleModifier: Modifier = Modifier,
     itemFormatter: @Composable T.() -> String = { toString() },
     isEnabled: Boolean = true,
 ) {
@@ -105,7 +107,7 @@ fun <T> DragAndDropSelectableItem(
             .padding(16.dp)
     }
     Row(
-        modifier = itemModifier,
+        modifier = rowModifier.then(itemModifier),
         verticalAlignment = Alignment.CenterVertically
     ) {
         SelectionCheck(
@@ -123,7 +125,7 @@ fun <T> DragAndDropSelectableItem(
         Icon(
             imageVector = ImageVector.vectorResource(R.drawable.ic_drag_handle_24dp),
             contentDescription = stringResource(id = R.string.drag_handle),
-            modifier = Modifier
+            modifier = dragHandleModifier
                 .dragContainerForDragHandle(
                     dragDropState = dragDropState,
                     key = itemKey(item),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/widgeteditor/DashboardWidgetEditorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/widgeteditor/DashboardWidgetEditorScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
@@ -37,30 +38,33 @@ import com.woocommerce.android.ui.compose.component.DragAndDropSelectableItem
 fun DashboardWidgetEditorScreen(viewModel: DashboardWidgetEditorViewModel) {
     BackHandler(onBack = viewModel::onBackPressed)
     viewModel.viewState.observeAsState().value?.let { state ->
-        Scaffold(topBar = {
-            TopAppBar(
-                title = { Text(text = stringResource(id = R.string.my_store_edit_screen_widgets)) },
-                navigationIcon = {
-                    IconButton(viewModel::onBackPressed) {
-                        Icon(
-                            ImageVector.vectorResource(R.drawable.ic_close_24dp),
-                            contentDescription = stringResource(id = R.string.back)
-                        )
-                    }
-                },
-                backgroundColor = colorResource(id = R.color.color_toolbar),
-                actions = {
-                    TextButton(
-                        onClick = viewModel::onSaveClicked,
-                        enabled = state.isSaveButtonEnabled
-                    ) {
-                        Text(
-                            text = stringResource(id = R.string.save).uppercase()
-                        )
-                    }
-                },
-            )
-        }) { padding ->
+        Scaffold(
+            modifier = Modifier.testTag(state.widgetStateTestTag),
+            topBar = {
+                TopAppBar(
+                    title = { Text(text = stringResource(id = R.string.my_store_edit_screen_widgets)) },
+                    navigationIcon = {
+                        IconButton(viewModel::onBackPressed) {
+                            Icon(
+                                ImageVector.vectorResource(R.drawable.ic_close_24dp),
+                                contentDescription = stringResource(id = R.string.back)
+                            )
+                        }
+                    },
+                    backgroundColor = colorResource(id = R.color.color_toolbar),
+                    actions = {
+                        TextButton(
+                            onClick = viewModel::onSaveClicked,
+                            enabled = state.isSaveButtonEnabled
+                        ) {
+                            Text(
+                                text = stringResource(id = R.string.save).uppercase()
+                            )
+                        }
+                    },
+                )
+            }
+        ) { padding ->
             when {
                 state.isLoading -> LoadWidgetsConfiguration()
                 else -> {
@@ -73,6 +77,7 @@ fun DashboardWidgetEditorScreen(viewModel: DashboardWidgetEditorViewModel) {
                             .padding(padding),
                         isItemDraggable = { it.isAvailable }
                     ) { item, dragDropState ->
+                        val itemIndex = state.orderedWidgetList.indexOf(item)
                         when (item.isAvailable) {
                             true -> {
                                 val selectedItems = state.orderedWidgetList.filter { it.isVisible }
@@ -83,12 +88,17 @@ fun DashboardWidgetEditorScreen(viewModel: DashboardWidgetEditorViewModel) {
                                     onSelectionChange = viewModel::onSelectionChange,
                                     itemKey = { it.type },
                                     itemFormatter = { stringResource(id = item.title) },
-                                    isEnabled = !item.isSelected || selectedItems.size > 1
+                                    isEnabled = !item.isSelected || selectedItems.size > 1,
+                                    rowModifier = Modifier.testTag(item.rowTestTag(itemIndex)),
+                                    dragHandleModifier = Modifier.testTag(item.dragHandleTestTag(itemIndex))
                                 )
                             }
 
                             false -> {
-                                UnavailableWidget(item)
+                                UnavailableWidget(
+                                    widget = item,
+                                    modifier = Modifier.testTag(item.rowTestTag(itemIndex))
+                                )
                             }
                         }
                     }
@@ -104,6 +114,27 @@ fun DashboardWidgetEditorScreen(viewModel: DashboardWidgetEditorViewModel) {
         }
     }
 }
+
+private val DashboardWidgetEditorViewModel.WidgetEditorState.widgetStateTestTag: String
+    get() = widgetList.joinToString(
+        prefix = "dashboard_widget_editor_state__",
+        separator = "__",
+        postfix = "__"
+    ) { widget -> "${widget.type.trackingIdentifier}_${widget.editorStateTag}" }
+
+private fun DashboardWidget.rowTestTag(index: Int) =
+    "dashboard_widget_editor_row_${index}_${type.trackingIdentifier}_$editorStateTag"
+
+private fun DashboardWidget.dragHandleTestTag(index: Int) =
+    "dashboard_widget_editor_drag_handle_${index}_${type.trackingIdentifier}"
+
+private val DashboardWidget.editorStateTag: String
+    get() = when {
+        status is DashboardWidget.Status.Hidden -> "hidden"
+        status is DashboardWidget.Status.Unavailable -> "unavailable"
+        isSelected -> "selected"
+        else -> "unselected"
+    }
 
 @Composable
 private fun UnavailableWidget(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuScreen.kt
@@ -49,6 +49,7 @@ import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
@@ -177,7 +178,9 @@ private fun HeaderButton(
         contentPadding = PaddingValues(dimensionResource(id = R.dimen.major_75)),
         colors = headerBackgroundColors,
         shape = RoundedCornerShape(dimensionResource(id = R.dimen.major_75)),
-        modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.major_100)),
+        modifier = Modifier
+            .testTag("more_menu_store_switcher")
+            .padding(horizontal = dimensionResource(id = R.dimen.major_100)),
         content = content
     )
 }
@@ -207,6 +210,7 @@ private fun HeaderContent(
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                     modifier = Modifier
+                        .testTag("more_menu_store_title")
                         .align(Alignment.CenterVertically)
                         .weight(1f, false)
                 )
@@ -217,7 +221,9 @@ private fun HeaderContent(
             Text(
                 text = siteUrl,
                 style = MaterialTheme.typography.caption,
-                modifier = Modifier.padding(vertical = dimensionResource(id = R.dimen.minor_50))
+                modifier = Modifier
+                    .testTag("more_menu_store_url")
+                    .padding(vertical = dimensionResource(id = R.dimen.minor_50))
             )
         }
     }


### PR DESCRIPTION
### Description

Adds extended, non-business-data-destructive store-management Maestro coverage. This is stack layer **3 of 8**.

Included flows cover:

- Dashboard analytics and widget customization;
- product detail plus variable-product variations/tags;
- Settings and Payments hub entry points;
- Coupons, Customers, and Inbox;
- WC Admin, View Store, and switching to another visible store and back;
- conditional Blaze and Google for Woo entry-point probes.

The app changes in this layer expose semantic Compose test tags for the Dashboard widget editor and More-menu store switcher. They do not change production behavior; they let the flows identify rows, drag handles, current store title, and URL without coordinates or localized text.

### Quarantine and fidelity boundary

- Every flow in this layer is tagged `smoke_extended` plus `flaky_quarantine`. This PR does not expand the four-flow `smoke_core` or release-gating signal.
- Dashboard customization changes widget selection/order during the flow, then restores and verifies the original state. It is state-restoring, not stateless.
- Product-detail assertions are limited to universal rows. Variation coverage requires a real variable product with at least one variation.
- Coupons validates entry into creation and exits without saving; it does not claim coupon creation.
- Blaze and Google for Woo are conditional probes when the configured store exposes those features; absence is recorded rather than counted as full unattended coverage.
- No live Maestro flow or store interaction was performed during this PR review.

### Stack

- Integration target: `feature/maestro-smoke-testing-automation`
- Position: **3 of 8**
- Previous: #16197
- Next: #16199
- The complete stack is being assembled and validated on the integration branch before any proposal to merge it into `trunk`.

### Test Steps

1. Parse the added YAML flows/subflows with a YAML parser.
2. Run `python3 .maestro/scripts/generate-strings-env.py --check-flow-references`.
3. Run `git diff --check` and compile the Wasabi debug Kotlin sources.
4. With the app installed, an authenticated lab-store session, and quarantine explicitly enabled, run the selected Dashboard/Product/Hub flows with `--no-seed --no-record --no-open`.
5. Confirm Dashboard customization restores its original widget state and store switching returns to the original store.

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
