### PR TITLE
Add destructive Maestro smoke flows

### DIFF
--- a/.maestro/README.md
+++ b/.maestro/README.md
@@ -15,6 +15,9 @@ The suite has two store targets:
 The no-Jetpack login scenario uses its own `MAESTRO_WOO_NO_JETPACK_*` variables. Do not reuse those Jurassic Ninja
 site credentials as the `lab` store block when running the broader suite.
 
+`orders_create.yaml` also requires `MAESTRO_WOO_EXISTING_CUSTOMER_EMAIL`, which must identify an existing customer on
+the selected store. The flow edits that customer's order-local details; use a disposable test-store customer.
+
 Destructive flows against the shared store are refused outside CI. In CI, the runner creates a REST-backed store lock
 before destructive shared-store runs and removes it on exit.
 

--- a/.maestro/README.md
+++ b/.maestro/README.md
@@ -46,6 +46,15 @@ Run the pre-flight doctor when setting up a machine, changing credentials, or pr
 .maestro/scripts/doctor.sh --profile phone-full --store lab --device emulator-5554
 ```
 
+### Store data prerequisites
+
+`orders_create` selects an existing live-store customer and edits only the customer copy attached to the order draft.
+The app creates that `Order.Customer` in `OrderCreateEditCustomerAddFragment` and
+`OrderCreateEditViewModel.onCustomerEdited` replaces only `orderDraft.customer`; it does not update the store customer.
+The flow captures the selected email, verifies it on the draft, verifies the edited marker on the persisted order,
+then searches the customer list again and requires the original email to be unchanged. The configured store must have
+at least two existing customers with email addresses; missing data fails as an explicit prerequisite.
+
 ## Running
 
 Default local run: lab store, `smoke_core` only, quarantine excluded.

--- a/.maestro/README.md
+++ b/.maestro/README.md
@@ -15,9 +15,6 @@ The suite has two store targets:
 The no-Jetpack login scenario uses its own `MAESTRO_WOO_NO_JETPACK_*` variables. Do not reuse those Jurassic Ninja
 site credentials as the `lab` store block when running the broader suite.
 
-`orders_create.yaml` also requires `MAESTRO_WOO_EXISTING_CUSTOMER_EMAIL`, which must identify an existing customer on
-the selected store. The flow edits that customer's order-local details; use a disposable test-store customer.
-
 Destructive flows against the shared store are refused outside CI. In CI, the runner creates a REST-backed store lock
 before destructive shared-store runs and removes it on exit.
 

--- a/.maestro/env.example
+++ b/.maestro/env.example
@@ -84,10 +84,6 @@ MAESTRO_WOO_NO_JETPACK_SITE_URL=
 MAESTRO_WOO_NO_JETPACK_SITE_ADMIN_USERNAME=
 MAESTRO_WOO_NO_JETPACK_SITE_ADMIN_PASSWORD=
 
-# ── Live-store product fixtures ─────────────────────────────────────────
-# Existing customer selected and edited by orders_create.yaml.
-MAESTRO_WOO_EXISTING_CUSTOMER_EMAIL=
-
 # ── P2: Login > Passwordless login (WordPress.com passwordless account) ─
 # Separate WP.com account (no password — magic-link only). Reading the
 # magic link requires the Mailosaur API key.

--- a/.maestro/env.example
+++ b/.maestro/env.example
@@ -84,6 +84,10 @@ MAESTRO_WOO_NO_JETPACK_SITE_URL=
 MAESTRO_WOO_NO_JETPACK_SITE_ADMIN_USERNAME=
 MAESTRO_WOO_NO_JETPACK_SITE_ADMIN_PASSWORD=
 
+# ── Live-store product fixtures ─────────────────────────────────────────
+# Existing customer selected and edited by orders_create.yaml.
+MAESTRO_WOO_EXISTING_CUSTOMER_EMAIL=
+
 # ── P2: Login > Passwordless login (WordPress.com passwordless account) ─
 # Separate WP.com account (no password — magic-link only). Reading the
 # magic link requires the Mailosaur API key.

--- a/.maestro/flows/hub_menu_coupons.yaml
+++ b/.maestro/flows/hub_menu_coupons.yaml
@@ -92,10 +92,7 @@ tags:
 - tapOn:
     id: "edit_coupon_code_input"
 - eraseText
-- runFlow:
-    file: ../subflows/paste_into_focused_field.yaml
-    env:
-      TEXT_TO_PASTE: SUITE-${SUITE_RUN_ID}-UI
+- inputText: SUITE-${SUITE_RUN_ID}-UI
 - hideKeyboard
 
 - tapOn:

--- a/.maestro/flows/hub_menu_coupons.yaml
+++ b/.maestro/flows/hub_menu_coupons.yaml
@@ -10,14 +10,14 @@
 #     bottom sheet (Percentage, Fixed Cart, Fixed Product)
 #   - Pick Percentage Discount and confirm the edit-coupon screen
 #     opens
-#   - Back out WITHOUT saving (discard dialog handled below) so the
-#     staging store isn't polluted with test coupons
+#   - Create a run-scoped coupon and verify it appears in the list
 appId: com.woocommerce.android.dev
 name: "Hub Menu - Coupons"
 tags:
   - smoke_extended
   - flaky_quarantine
   - hub_menu
+  - destructive
 ---
 - runFlow:
     file: ../subflows/ensure_logged_in.yaml
@@ -83,24 +83,42 @@ tags:
 
 - takeScreenshot: hub_coupons_edit_form
 
-# Back out. If there's any unsaved input (there isn't — we didn't type
-# anything), the app shows a discard-changes dialog. Handle it
-# defensively in case future changes add default values.
-- back
+- tapOn:
+    id: "edit_coupon_amount_input"
+- eraseText
+- inputText: "10"
+- hideKeyboard
 
+- tapOn:
+    id: "edit_coupon_code_input"
+- eraseText
 - runFlow:
-    when:
-      visible: "Discard"
-    commands:
-      - tapOn:
-          text: "Discard"
-          label: "Discard unsaved coupon"
+    file: ../subflows/paste_into_focused_field.yaml
+    env:
+      TEXT_TO_PASTE: SUITE-${SUITE_RUN_ID}-UI
+- hideKeyboard
+
+- tapOn:
+    id: "edit_coupon_save_button"
+    retryTapIfNoChange: true
+    label: "Create run-scoped coupon"
 
 # ── Back on coupon list ──────────────────────────────────────────────
 - extendedWaitUntil:
     visible:
       id: "add_coupon_button"
-    timeout: 15000
+    timeout: 30000
+
+- extendedWaitUntil:
+    visible: ".*${SUITE_RUN_ID}.*"
+    timeout: 30000
+    label: "Wait for created coupon"
+
+- assertVisible:
+    text: ".*${SUITE_RUN_ID}.*"
+    label: "Created coupon is visible in the list"
+
+- takeScreenshot: hub_coupons_created
 
 # Back to the More Menu
 - back

--- a/.maestro/flows/orders_cash_payment.yaml
+++ b/.maestro/flows/orders_cash_payment.yaml
@@ -3,18 +3,17 @@
 # P2 ref: Orders > Collect payment using cash on delivery
 #
 # Verifies:
-#   - Filter the orders list by "Processing" status
-#   - Open a processing order
+#   - Search locates this run's seeded pending-payment order
 #   - Tap "Collect Payment" in the payment info section
 #   - Pick the "Cash" option on the Select Payment Method screen
 #   - Change Due Calculator opens with the order total pre-filled
 #   - Tap "Mark Order as Complete" to record the cash payment
 #   - Returns to the order detail/list with the order marked completed
 #
-# Note: unlike mark-complete, the cash-payment flow has no undo — the
-# order stays Completed with a "Cash on Delivery" gateway recorded.
-# The staging store has plenty of processing orders, so one-per-run is
-# acceptable for smoke purposes.
+# Note: the cash-payment flow has no undo — the order stays Completed
+# with a "Cash on Delivery" gateway recorded. It therefore only ever
+# consumes a seeded fixture order (located via ${SUITE_RUN_ID} search),
+# never an arbitrary order from the shared store's list.
 appId: com.woocommerce.android.dev
 name: "Orders - Collect cash payment"
 tags:
@@ -29,62 +28,36 @@ tags:
 - runFlow:
     file: ../subflows/navigate_to_orders.yaml
 
-# ── Filter by Pending payment status ──────────────────────────────────
-# "Processing" orders on this store have already been paid (the payment
-# info shows "Payment complete."), so the Collect Payment button is
-# hidden. "Pending payment" orders are awaiting payment and expose the
-# collect-payment action that the cash flow tests. Clear any
-# previously-applied filters first to avoid cross-test contamination.
+# ── Find this run's seeded pending-payment order ──────────────────────
+# Fixtures are located by query, never by list position — on the shared
+# store the first pending order can be a manual tester's real order, and
+# this flow's cash payment has no undo. Searching the suite run id only
+# surfaces automation-owned orders (seeded billing name is the run id);
+# a "Pending payment" row is a seeded COD fixture that still exposes the
+# Collect Payment action. If attempt 1 consumed pending-order-1, the
+# retry finds pending-order-2 through the same query.
 - tapOn:
-    id: "btn_order_filter"
-    label: "Open filters"
-
-- runFlow:
-    when:
-      visible: ".*Clear.*"
-    commands:
-      - tapOn:
-          text: ".*Clear.*"
-          label: "Clear existing filters"
-
-- extendedWaitUntil:
-    visible: "Order Status"
-    timeout: 10000
-
-- tapOn:
-    text: "Order Status"
-    label: "Open status filter"
-
-- extendedWaitUntil:
-    visible: ".*Pending payment.*"
-    timeout: 10000
-
-- tapOn:
-    text: ".*Pending payment.*"
-    label: "Select Pending payment status"
-
-- tapOn:
-    id: "showOrdersButton"
-    label: "Apply filter"
+    id: "menu_search"
+    label: "Open order search"
 
 - extendedWaitUntil:
     visible:
-      id: "ordersList"
-    timeout: 15000
+      id: "search_src_text"
+    timeout: 10000
 
-# Pull-to-refresh the list so the status filter reflects the latest
-# server state (stale cache can leave a just-completed order at index 0).
-- swipe:
-    from:
-      id: "ordersList"
-    direction: DOWN
-    duration: 800
-
-# ── Open the first pending-payment order ──────────────────────────────
 - tapOn:
-    id: "orderNum"
-    index: 0
-    label: "Open first pending-payment order"
+    id: "search_src_text"
+- inputText: ${SUITE_RUN_ID}
+- pressKey: Enter
+
+- extendedWaitUntil:
+    visible: ".*Pending payment.*"
+    timeout: 20000
+    label: "Wait for a seeded pending-payment order in results"
+
+- tapOn:
+    text: ".*Pending payment.*"
+    label: "Open this run's pending-payment order"
 
 - extendedWaitUntil:
     visible:
@@ -161,22 +134,14 @@ tags:
 
 - takeScreenshot: orders_after_cash_payment
 
-# ── Clear the filter so future runs start from an unfiltered list ────
-- tapOn:
-    id: "btn_order_filter"
-    label: "Re-open filters to clear"
-
+# ── Exit search if still active so downstream flows start clean ──────
 - runFlow:
     when:
-      visible: ".*Clear.*"
+      visible:
+        id: "search_src_text"
     commands:
-      - tapOn:
-          text: ".*Clear.*"
-          label: "Clear filters"
-
-- tapOn:
-    id: "showOrdersButton"
-    label: "Apply cleared filter"
+      - back
+      - back
 
 - extendedWaitUntil:
     visible:

--- a/.maestro/flows/orders_cash_payment.yaml
+++ b/.maestro/flows/orders_cash_payment.yaml
@@ -3,7 +3,7 @@
 # P2 ref: Orders > Collect payment using cash on delivery
 #
 # Verifies:
-#   - Search locates this run's seeded pending-payment order
+#   - Create a fresh unpaid order through the app UI
 #   - Tap "Collect Payment" in the payment info section
 #   - Pick the "Cash" option on the Select Payment Method screen
 #   - Change Due Calculator opens with the order total pre-filled
@@ -11,9 +11,9 @@
 #   - Returns to the order detail/list with the order marked completed
 #
 # Note: the cash-payment flow has no undo — the order stays Completed
-# with a "Cash on Delivery" gateway recorded. It therefore only ever
-# consumes a seeded fixture order (located via ${SUITE_RUN_ID} search),
-# never an arbitrary order from the shared store's list.
+# with a "Cash on Delivery" gateway recorded. It therefore creates its
+# own pending-payment order first instead of consuming an arbitrary row
+# from the shared store.
 appId: com.woocommerce.android.dev
 name: "Orders - Collect cash payment"
 tags:
@@ -28,41 +28,59 @@ tags:
 - runFlow:
     file: ../subflows/navigate_to_orders.yaml
 
-# ── Find this run's seeded pending-payment order ──────────────────────
-# Fixtures are located by query, never by list position — on the shared
-# store the first pending order can be a manual tester's real order, and
-# this flow's cash payment has no undo. Searching the suite run id only
-# surfaces automation-owned orders (seeded billing name is the run id);
-# a "Pending payment" row is a seeded COD fixture that still exposes the
-# Collect Payment action. If attempt 1 consumed pending-order-1, the
-# retry finds pending-order-2 through the same query.
+# ── Create a fresh pending-payment order ──────────────────────────────
 - tapOn:
-    id: "menu_search"
-    label: "Open order search"
+    id: "createOrderButton"
+    retryTapIfNoChange: true
+    label: "Tap Create Order FAB"
 
 - extendedWaitUntil:
-    visible:
-      id: "search_src_text"
-    timeout: 10000
+    visible: "Add products"
+    timeout: 15000
 
 - tapOn:
-    id: "search_src_text"
-- inputText: ${SUITE_RUN_ID}
-- pressKey: Enter
+    text: "Add products"
+    label: "Tap Add products"
 
 - extendedWaitUntil:
-    visible: ".*Pending payment.*"
-    timeout: 20000
-    label: "Wait for a seeded pending-payment order in results"
+    visible: ".*Search Products.*"
+    timeout: 15000
 
 - tapOn:
-    text: ".*Pending payment.*"
-    label: "Open this run's pending-payment order"
+    point: "50%,30%"
+    label: "Tap first product row"
+
+- extendedWaitUntil:
+    visible: ".*Select \\d+ Product.*"
+    timeout: 15000
+
+- tapOn:
+    text: ".*Select \\d+ Product.*"
+    label: "Confirm product selection"
+
+- extendedWaitUntil:
+    visible: "New order"
+    timeout: 15000
+
+- takeScreenshot: cash_payment_order_ready_to_create
+
+# The toolbar Create action submits the order without starting the
+# payment flow. That leaves a safe automation-owned Pending payment
+# order whose detail screen exposes Collect Payment.
+- tapOn:
+    id: "menu_create"
+    retryTapIfNoChange: true
+    label: "Create pending-payment order"
 
 - extendedWaitUntil:
     visible:
       id: "orderDetail_container"
     timeout: 15000
+
+- extendedWaitUntil:
+    visible: ".*Pending payment.*"
+    timeout: 20000
+    label: "Wait for pending-payment order detail"
 
 - takeScreenshot: order_detail_before_collect
 
@@ -133,15 +151,6 @@ tags:
     timeout: 30000
 
 - takeScreenshot: orders_after_cash_payment
-
-# ── Exit search if still active so downstream flows start clean ──────
-- runFlow:
-    when:
-      visible:
-        id: "search_src_text"
-    commands:
-      - back
-      - back
 
 - extendedWaitUntil:
     visible:

--- a/.maestro/flows/orders_cash_payment.yaml
+++ b/.maestro/flows/orders_cash_payment.yaml
@@ -1,0 +1,184 @@
+# Smoke Test: Orders - Collect cash (Cash on Delivery) payment
+# p2: orders.collect-payment.cash
+# P2 ref: Orders > Collect payment using cash on delivery
+#
+# Verifies:
+#   - Filter the orders list by "Processing" status
+#   - Open a processing order
+#   - Tap "Collect Payment" in the payment info section
+#   - Pick the "Cash" option on the Select Payment Method screen
+#   - Change Due Calculator opens with the order total pre-filled
+#   - Tap "Mark Order as Complete" to record the cash payment
+#   - Returns to the order detail/list with the order marked completed
+#
+# Note: unlike mark-complete, the cash-payment flow has no undo — the
+# order stays Completed with a "Cash on Delivery" gateway recorded.
+# The staging store has plenty of processing orders, so one-per-run is
+# acceptable for smoke purposes.
+appId: com.woocommerce.android.dev
+name: "Orders - Collect cash payment"
+tags:
+  - smoke_extended
+  - flaky_quarantine
+  - orders
+  - destructive
+---
+- runFlow:
+    file: ../subflows/ensure_logged_in.yaml
+
+- runFlow:
+    file: ../subflows/navigate_to_orders.yaml
+
+# ── Filter by Pending payment status ──────────────────────────────────
+# "Processing" orders on this store have already been paid (the payment
+# info shows "Payment complete."), so the Collect Payment button is
+# hidden. "Pending payment" orders are awaiting payment and expose the
+# collect-payment action that the cash flow tests. Clear any
+# previously-applied filters first to avoid cross-test contamination.
+- tapOn:
+    id: "btn_order_filter"
+    label: "Open filters"
+
+- runFlow:
+    when:
+      visible: ".*Clear.*"
+    commands:
+      - tapOn:
+          text: ".*Clear.*"
+          label: "Clear existing filters"
+
+- extendedWaitUntil:
+    visible: "Order Status"
+    timeout: 10000
+
+- tapOn:
+    text: "Order Status"
+    label: "Open status filter"
+
+- extendedWaitUntil:
+    visible: ".*Pending payment.*"
+    timeout: 10000
+
+- tapOn:
+    text: ".*Pending payment.*"
+    label: "Select Pending payment status"
+
+- tapOn:
+    id: "showOrdersButton"
+    label: "Apply filter"
+
+- extendedWaitUntil:
+    visible:
+      id: "ordersList"
+    timeout: 15000
+
+# Pull-to-refresh the list so the status filter reflects the latest
+# server state (stale cache can leave a just-completed order at index 0).
+- swipe:
+    from:
+      id: "ordersList"
+    direction: DOWN
+    duration: 800
+
+# ── Open the first pending-payment order ──────────────────────────────
+- tapOn:
+    id: "orderNum"
+    index: 0
+    label: "Open first pending-payment order"
+
+- extendedWaitUntil:
+    visible:
+      id: "orderDetail_container"
+    timeout: 15000
+
+- takeScreenshot: order_detail_before_collect
+
+# ── Collect Payment → Cash ───────────────────────────────────────────
+- scrollUntilVisible:
+    element:
+      id: "paymentInfo_collectCardPresentPaymentButton"
+    direction: DOWN
+    timeout: 15000
+    label: "Scroll to Collect Payment button"
+
+- tapOn:
+    id: "paymentInfo_collectCardPresentPaymentButton"
+    retryTapIfNoChange: true
+    label: "Tap Collect Payment"
+
+# Occasional flake: on the first tap the button visibly depresses but
+# the SelectPaymentMethod fragment never presents. Observed after the
+# orders_mark_complete flow runs earlier in the suite — the app's back
+# stack is transiently non-ideal. Give the normal path 10s, and if the
+# sheet still hasn't appeared, tap again (the first tap was lost). On
+# the happy path the second tap is a no-op because the button is no
+# longer part of the current screen.
+- runFlow:
+    when:
+      notVisible: ".*Take payment.*|.*Cash.*"
+    commands:
+      - extendedWaitUntil:
+          visible: ".*Take payment.*|.*Cash.*"
+          timeout: 10000
+
+- runFlow:
+    when:
+      notVisible: ".*Take payment.*|.*Cash.*"
+    commands:
+      - tapOn:
+          id: "paymentInfo_collectCardPresentPaymentButton"
+          retryTapIfNoChange: true
+          label: "Retry Collect Payment tap (first was lost)"
+
+- extendedWaitUntil:
+    visible: ".*Take payment.*|.*Cash.*"
+    timeout: 30000
+
+- takeScreenshot: select_payment_method
+
+- tapOn:
+    text: "Cash"
+    retryTapIfNoChange: true
+    label: "Select Cash payment method"
+
+# ── Change Due Calculator ────────────────────────────────────────────
+- extendedWaitUntil:
+    visible: ".*Mark Order as Complete.*"
+    timeout: 15000
+
+- takeScreenshot: change_due_calculator
+
+- tapOn:
+    text: ".*Mark Order as Complete.*"
+    retryTapIfNoChange: true
+    label: "Mark order as complete with cash"
+
+# ── Verify order is marked completed and we returned to the list ─────
+- extendedWaitUntil:
+    visible:
+      id: "ordersList"
+    timeout: 30000
+
+- takeScreenshot: orders_after_cash_payment
+
+# ── Clear the filter so future runs start from an unfiltered list ────
+- tapOn:
+    id: "btn_order_filter"
+    label: "Re-open filters to clear"
+
+- runFlow:
+    when:
+      visible: ".*Clear.*"
+    commands:
+      - tapOn:
+          text: ".*Clear.*"
+          label: "Clear filters"
+
+- tapOn:
+    id: "showOrdersButton"
+    label: "Apply cleared filter"
+
+- extendedWaitUntil:
+    visible:
+      id: "ordersList"
+    timeout: 10000

--- a/.maestro/flows/orders_create.yaml
+++ b/.maestro/flows/orders_create.yaml
@@ -33,6 +33,9 @@ tags:
 - runFlow:
     file: ../subflows/ensure_logged_in.yaml
 
+- runFlow:
+    file: ../subflows/ensure_configured_woo_store.yaml
+
 # Navigate to Orders
 - runFlow:
     file: ../subflows/navigate_to_orders.yaml
@@ -137,9 +140,63 @@ tags:
     timeout: 15000
     label: "Wait for selected variation in parent selector"
 
+# Keep the selected variation, switch the selector to Simple products, and
+# select another purchasable line item. Filtering by a different product type
+# guarantees the second item cannot be the selected variation or its parent.
+- tapOn:
+    text: "Filter.*"
+    retryTapIfNoChange: true
+    label: "Reopen product selector filters"
+
+- extendedWaitUntil:
+    visible:
+      id: "filterList"
+    timeout: 15000
+
+- tapOn:
+    text: "Product type"
+    retryTapIfNoChange: true
+    label: "Change Product type filter"
+
+- extendedWaitUntil:
+    visible:
+      id: "filterOptionList"
+    timeout: 15000
+
+- tapOn:
+    text: "Simple"
+    retryTapIfNoChange: true
+    label: "Select Simple products"
+
+- tapOn:
+    id: "filterOptionList_btnShowProducts"
+    retryTapIfNoChange: true
+    label: "Confirm Simple product filter"
+
+- runFlow:
+    when:
+      visible:
+        id: "filterList_btnShowProducts"
+    commands:
+      - tapOn:
+          id: "filterList_btnShowProducts"
+          retryTapIfNoChange: true
+          label: "Apply Simple product filter"
+
+- extendedWaitUntil:
+    visible:
+      id: "product_selector_product_item"
+    timeout: 20000
+    label: "Require a purchasable Simple product"
+
+- tapOn:
+    id: "product_selector_product_item"
+    index: 0
+    label: "Select a distinct Simple product"
+
 - tapOn:
     id: "product_selector_done_button"
-    label: "Confirm product selection"
+    label: "Confirm both product selections"
 
 # Back on order creation
 - extendedWaitUntil:
@@ -148,15 +205,26 @@ tags:
 
 - assertVisible:
     id: "order_product_card"
-    label: "Selected product is present in the order"
+    index: 0
+    label: "First selected line item is present in the order"
+
+- assertVisible:
+    id: "order_product_card"
+    index: 1
+    label: "Second selected line item is present in the order"
+
+- assertVisible:
+    text: ".*⦁.*"
+    label: "A selected line item exposes real variation attributes"
 
 - takeScreenshot: order_create_with_product
 
 # ── Adjust quantity and apply a product discount ─────────────────────
 - tapOn:
     id: "order_product_card"
+    index: 0
     retryTapIfNoChange: true
-    label: "Expand selected product"
+    label: "Expand first selected product"
 
 - extendedWaitUntil:
     visible: "Order count"
@@ -602,6 +670,23 @@ tags:
     visible:
       id: "orderDetail_container"
     timeout: 20000
+- scrollUntilVisible:
+    element:
+      id: "productInfo_name"
+    direction: DOWN
+    timeout: 15000
+    label: "Find persisted order line items"
+- assertVisible:
+    id: "productInfo_name"
+    index: 0
+    label: "First line item persisted on the completed order"
+- assertVisible:
+    id: "productInfo_name"
+    index: 1
+    label: "Second line item persisted on the completed order"
+- assertVisible:
+    text: ".*⦁.*"
+    label: "Persisted order retains the selected variation attributes"
 - scrollUntilVisible:
     element: ".*SmokeTest-${SUITE_RUN_ID}.*"
     direction: DOWN

--- a/.maestro/flows/orders_create.yaml
+++ b/.maestro/flows/orders_create.yaml
@@ -324,6 +324,7 @@ tags:
 - scrollUntilVisible:
     element: "Add note"
     direction: DOWN
+    centerElement: true
     timeout: 10000
     label: "Scroll to notes button in customer section"
 
@@ -365,6 +366,7 @@ tags:
 - scrollUntilVisible:
     element: "Add customer details"
     direction: DOWN
+    centerElement: true
     timeout: 10000
     label: "Scroll to customer section"
 
@@ -407,6 +409,7 @@ tags:
 - scrollUntilVisible:
     element: "Edit customer details"
     direction: DOWN
+    centerElement: true
     timeout: 10000
     label: "Verify the existing customer is attached"
 
@@ -416,6 +419,7 @@ tags:
 - scrollUntilVisible:
     element: "Edit customer details"
     direction: DOWN
+    centerElement: true
     timeout: 10000
     label: "Scroll to customer section"
 
@@ -461,6 +465,7 @@ tags:
 - scrollUntilVisible:
     element: "Edit customer details"
     direction: DOWN
+    centerElement: true
     timeout: 10000
 - tapOn:
     text: "Edit customer details"
@@ -582,6 +587,7 @@ tags:
 - scrollUntilVisible:
     element: "Add customer details"
     direction: DOWN
+    centerElement: true
     timeout: 15000
     label: "Reach customer picker in fresh order"
 - tapOn:

--- a/.maestro/flows/orders_create.yaml
+++ b/.maestro/flows/orders_create.yaml
@@ -60,27 +60,18 @@ tags:
 
 - takeScreenshot: order_create_product_selector
 
-# Search for the configured variable product. The runner requires this value
-# only when the flow is selected.
-- tapOn:
-    text: ".*Search Products.*"
-    label: "Focus product search"
-
-- runFlow:
-    file: ../subflows/paste_into_focused_field.yaml
-    env:
-      TEXT_TO_PASTE: ${WOO_VARIABLE_PRODUCT_NAME}
-- hideKeyboard
-
-- extendedWaitUntil:
-    visible: "${WOO_VARIABLE_PRODUCT_NAME}"
-    timeout: 20000
-    label: "Wait for configured variable product"
+# Product rows report their variation count. Find one dynamically so order
+# coverage does not depend on a product name configured outside the app.
+- scrollUntilVisible:
+    element: ".*[1-9][0-9]* variations?.*"
+    direction: DOWN
+    timeout: 30000
+    label: "Find a Variable product with variations"
 
 - tapOn:
-    id: "product_selector_product_item"
-    index: 0
-    label: "Open variable product variations"
+    text: ".*[1-9][0-9]* variations?.*"
+    retryTapIfNoChange: true
+    label: "Open discovered Variable product"
 
 # Requiring a tagged variation row prevents a simple product, the parent row,
 # or the product selector's Clear Selection label from satisfying this check.
@@ -119,16 +110,16 @@ tags:
     timeout: 15000
 
 - assertVisible:
-    text: "${WOO_VARIABLE_PRODUCT_NAME}"
-    label: "Selected variable product is present in the order"
+    id: "order_product_card"
+    label: "Selected variation is present in the order"
 
 - takeScreenshot: order_create_with_product
 
 # ── Adjust quantity and apply a product discount ─────────────────────
 - tapOn:
-    text: "${WOO_VARIABLE_PRODUCT_NAME}"
+    id: "order_product_card"
     retryTapIfNoChange: true
-    label: "Expand selected variable product"
+    label: "Expand selected variation"
 
 - extendedWaitUntil:
     visible: "Order count"

--- a/.maestro/flows/orders_create.yaml
+++ b/.maestro/flows/orders_create.yaml
@@ -60,18 +60,57 @@ tags:
 
 - takeScreenshot: order_create_product_selector
 
-# Tap the first product row - product items sit below the search field
+# Search for the configured variable product. The runner requires this value
+# only when the flow is selected.
 - tapOn:
-    point: "50%,30%"
-    label: "Tap first product row"
+    text: ".*Search Products.*"
+    label: "Focus product search"
 
-# Confirm selection (regex matches "Select 1 Product" or "Select N Products")
+- runFlow:
+    file: ../subflows/paste_into_focused_field.yaml
+    env:
+      TEXT_TO_PASTE: ${WOO_VARIABLE_PRODUCT_NAME}
+- hideKeyboard
+
 - extendedWaitUntil:
-    visible: ".*Select \\d+ Product.*"
-    timeout: 15000
+    visible: "${WOO_VARIABLE_PRODUCT_NAME}"
+    timeout: 20000
+    label: "Wait for configured variable product"
 
 - tapOn:
-    text: ".*Select \\d+ Product.*"
+    id: "product_selector_product_item"
+    index: 0
+    label: "Open variable product variations"
+
+# Requiring a tagged variation row prevents a simple product, the parent row,
+# or the product selector's Clear Selection label from satisfying this check.
+- extendedWaitUntil:
+    visible:
+      id: "product_selector_variation_item"
+    timeout: 20000
+    label: "Require purchasable variation rows"
+
+- assertNotVisible:
+    text: ".*Search Products.*"
+    label: "Product search is replaced by variation selector"
+
+- tapOn:
+    id: "product_selector_variation_item"
+    index: 0
+    label: "Select first available variation"
+
+# Variation selection is returned to the parent selector on Back. The parent
+# Done button is tagged separately so this cannot tap a stale text match.
+- back
+
+- extendedWaitUntil:
+    visible:
+      id: "product_selector_done_button"
+    timeout: 15000
+    label: "Wait for selected variation in parent selector"
+
+- tapOn:
+    id: "product_selector_done_button"
     label: "Confirm product selection"
 
 # Back on order creation
@@ -79,7 +118,80 @@ tags:
     visible: "New order"
     timeout: 15000
 
+- assertVisible:
+    text: "${WOO_VARIABLE_PRODUCT_NAME}"
+    label: "Selected variable product is present in the order"
+
 - takeScreenshot: order_create_with_product
+
+# ── Adjust quantity and apply a product discount ─────────────────────
+- tapOn:
+    text: "${WOO_VARIABLE_PRODUCT_NAME}"
+    retryTapIfNoChange: true
+    label: "Expand selected variable product"
+
+- extendedWaitUntil:
+    visible: "Order count"
+    timeout: 10000
+
+- tapOn:
+    text: "Increase product quantity"
+    retryTapIfNoChange: true
+    label: "Increase product quantity"
+
+- assertVisible:
+    text: ".*2 ×.*|.*2 x.*"
+    label: "Quantity increased to two"
+
+- tapOn:
+    text: "Decrease product quantity"
+    retryTapIfNoChange: true
+    label: "Decrease product quantity"
+
+- assertVisible:
+    text: ".*1 ×.*|.*1 x.*"
+    label: "Quantity decreased to one"
+
+- tapOn:
+    text: "Add discount"
+    retryTapIfNoChange: true
+    label: "Open product discount"
+
+- extendedWaitUntil:
+    visible: "Discount"
+    timeout: 15000
+
+# Use a percentage so the fixture's price cannot make the discount invalid.
+- tapOn:
+    text: "%"
+    label: "Use percentage discount"
+- eraseText: 100
+- inputText: "10"
+- hideKeyboard
+
+- assertVisible:
+    text: "Calculated Amount"
+    label: "Percentage discount is calculated"
+- assertNotVisible: "Discount cannot be greater than the price"
+
+- tapOn:
+    text: "Done"
+    retryTapIfNoChange: true
+    label: "Save product discount"
+
+- extendedWaitUntil:
+    visible: "New order"
+    timeout: 15000
+
+- assertVisible:
+    id: "order_product_discount_amount"
+    label: "Product discount is reflected in the order"
+- copyTextFrom:
+    id: "order_product_discount_amount"
+- evalScript: |
+    if (!maestro.copiedText || maestro.copiedText.trim().charAt(0) !== '-') {
+        throw new Error('Product discount amount is missing from the order');
+    }
 
 # ── Add a custom amount (fixed, with a name) ──────────────────────────
 - scrollUntilVisible:
@@ -158,6 +270,65 @@ tags:
 
 - takeScreenshot: order_create_with_custom_amount
 
+# ── Add shipping ─────────────────────────────────────────────────────
+- scrollUntilVisible:
+    element:
+      id: "add_shipping_button"
+    direction: DOWN
+    timeout: 10000
+    label: "Scroll to Add shipping"
+
+- tapOn:
+    id: "add_shipping_button"
+    retryTapIfNoChange: true
+    label: "Open Add shipping"
+
+- extendedWaitUntil:
+    visible:
+      id: "order_shipping_amount_input"
+    timeout: 15000
+
+- tapOn:
+    id: "order_shipping_amount_input"
+- inputText: "500"
+- hideKeyboard
+
+- tapOn:
+    id: "order_shipping_name_input"
+- runFlow:
+    file: ../subflows/paste_into_focused_field.yaml
+    env:
+      TEXT_TO_PASTE: Maestro shipping ${SUITE_RUN_ID}
+- hideKeyboard
+
+- tapOn:
+    id: "order_shipping_save_button"
+    retryTapIfNoChange: true
+    label: "Save shipping line"
+
+- extendedWaitUntil:
+    visible: "New order"
+    timeout: 15000
+
+- assertVisible:
+    text: "Maestro shipping ${SUITE_RUN_ID}"
+    label: "Shipping line is present in the order"
+
+- takeScreenshot: order_create_with_shipping
+
+# The first shipping line can trigger a feedback overlay that intercepts the
+# customer and note controls underneath it.
+- runFlow:
+    when:
+      visible: "Shipping added!"
+    commands:
+      - tapOn:
+          text: "Close"
+          label: "Dismiss shipping feedback"
+      - extendedWaitUntil:
+          notVisible: "Shipping added!"
+          timeout: 5000
+
 # ── Add a customer-facing note ────────────────────────────────────────
 # Added BEFORE the customer on purpose: when both customer and note are
 # empty, the "Add note" button lives in customer_section (via
@@ -203,9 +374,8 @@ tags:
     label: "Customer note visible in creation screen"
 
 # ── Add a customer ────────────────────────────────────────────────────
-# Uses the search flow to verify it works, then falls back to "Add
-# details manually" so the flow doesn't depend on the staging store
-# containing a matching customer.
+# Select an existing customer by its exact configured email. Manual customer
+# entry does not satisfy the P2 existing-customer check.
 - scrollUntilVisible:
     element: "Add customer details"
     direction: DOWN
@@ -222,57 +392,36 @@ tags:
 
 - tapOn:
     text: "Search for customers"
-- inputText: "zzzzznomatch"
+- runFlow:
+    file: ../subflows/paste_into_focused_field.yaml
+    env:
+      TEXT_TO_PASTE: ${WOO_EXISTING_CUSTOMER_EMAIL}
 - hideKeyboard
 
-# When no match, tap the "Add details manually" CTA to enter the editor
 - extendedWaitUntil:
-    visible: "Add details manually"
-    timeout: 15000
+    visible: "${WOO_EXISTING_CUSTOMER_EMAIL}"
+    timeout: 20000
+    label: "Wait for configured existing customer"
 
 - tapOn:
-    text: "Add details manually"
-    label: "Add customer details manually"
-
-# Customer edit form is now visible — fill first & last name
-- extendedWaitUntil:
-    visible: ".*First name.*|.*Last name.*|.*Email.*"
-    timeout: 15000
-
-- takeScreenshot: order_create_customer_edit_form
-
-- tapOn:
-    id: "edit_text"
-    childOf:
-      id: "first_name"
-- eraseText
-- inputText: "Maestro"
-- hideKeyboard
-
-- tapOn:
-    id: "edit_text"
-    childOf:
-      id: "last_name"
-- eraseText
-- inputText: "SmokeTest"
-- hideKeyboard
-
-- takeScreenshot: order_create_customer_edited
-
-# Save via toolbar DONE
-- tapOn:
-    id: "menu_done"
-    label: "Save customer details"
+    id: "customer_list_item"
+    index: 0
+    retryTapIfNoChange: true
+    label: "Select existing customer"
 
 - extendedWaitUntil:
     visible: "New order"
     timeout: 15000
 
-- takeScreenshot: order_create_with_customer
+- assertVisible:
+    text: "${WOO_EXISTING_CUSTOMER_EMAIL}"
+    label: "Existing customer is attached to the order"
+
+- takeScreenshot: order_create_with_existing_customer
 
 # ── Edit the added customer ───────────────────────────────────────────
 - scrollUntilVisible:
-    element: ".*SmokeTest.*|.*Maestro.*"
+    element: "${WOO_EXISTING_CUSTOMER_EMAIL}"
     direction: DOWN
     timeout: 10000
     label: "Scroll to customer section"

--- a/.maestro/flows/orders_create.yaml
+++ b/.maestro/flows/orders_create.yaml
@@ -281,10 +281,7 @@ tags:
 
 - tapOn:
     id: "order_shipping_name_input"
-- runFlow:
-    file: ../subflows/paste_into_focused_field.yaml
-    env:
-      TEXT_TO_PASTE: Maestro shipping ${SUITE_RUN_ID}
+- inputText: Maestro shipping ${SUITE_RUN_ID}
 - hideKeyboard
 
 - tapOn:
@@ -548,10 +545,7 @@ tags:
     timeout: 10000
 - tapOn:
     id: "search_src_text"
-- runFlow:
-    file: ../subflows/paste_into_focused_field.yaml
-    env:
-      TEXT_TO_PASTE: SmokeTest-${SUITE_RUN_ID}
+- inputText: SmokeTest-${SUITE_RUN_ID}
 - pressKey: Enter
 - extendedWaitUntil:
     visible: ".*SmokeTest-${SUITE_RUN_ID}.*"
@@ -597,10 +591,7 @@ tags:
     visible: "Search for customers"
     timeout: 15000
 - tapOn: "Search for customers"
-- runFlow:
-    file: ../subflows/paste_into_focused_field.yaml
-    env:
-      TEXT_TO_PASTE: ${output.selectedCustomerEmail}
+- inputText: ${output.selectedCustomerEmail}
 - hideKeyboard
 - extendedWaitUntil:
     visible: "${output.selectedCustomerEmail}"

--- a/.maestro/flows/orders_create.yaml
+++ b/.maestro/flows/orders_create.yaml
@@ -1,5 +1,5 @@
 # Smoke Test: Orders - Create Order
-# p2: orders.create.products, orders.create.variable-products, orders.create.quantity, orders.create.product-discount, orders.create.custom-amount, orders.create.custom-amount-note, orders.create.shipping, orders.create.customer-add, orders.create.customer-edit, orders.create.note
+# p2: orders.create.products, orders.create.quantity, orders.create.product-discount, orders.create.custom-amount, orders.create.custom-amount-note, orders.create.shipping, orders.create.customer-add, orders.create.customer-edit, orders.create.note
 # P2 ref: Orders > Create an order (add products, custom amount, customer, customer note)
 #
 # Verifies:
@@ -62,39 +62,32 @@ tags:
 
 - takeScreenshot: order_create_product_selector
 
-# Product rows report their variation count. Find one dynamically so order
-# coverage does not depend on a product name configured outside the app.
-- scrollUntilVisible:
-    element: ".*[1-9][0-9]* variations?.*"
-    direction: DOWN
-    timeout: 30000
-    label: "Find a Variable product with variations"
-
-- tapOn:
-    text: ".*[1-9][0-9]* variations?.*"
-    retryTapIfNoChange: true
-    label: "Open discovered Variable product"
-
-# Requiring a tagged variation row prevents a simple product, the parent row,
-# or the product selector's Clear Selection label from satisfying this check.
+# Select the first product the existing Add Products UI exposes. Variable
+# product behavior is covered independently by products_variations_and_tags.
 - extendedWaitUntil:
     visible:
-      id: "product_selector_variation_item"
-    timeout: 20000
-    label: "Require purchasable variation rows"
-
-- assertNotVisible:
-    text: ".*Search Products.*"
-    label: "Product search is replaced by variation selector"
+      id: "product_selector_product_item"
+    timeout: 15000
+    label: "Require a selectable product"
 
 - tapOn:
-    id: "product_selector_variation_item"
+    id: "product_selector_product_item"
     index: 0
-    label: "Select first available variation"
+    retryTapIfNoChange: true
+    label: "Select the first available product"
 
-# Variation selection is returned to the parent selector on Back. The parent
-# Done button is tagged separately so this cannot tap a stale text match.
-- back
+# If the selected row is Variable, choose its first purchasable variation and
+# return to the parent selector. Simple products remain on the parent directly.
+- runFlow:
+    when:
+      visible:
+        id: "product_selector_variation_item"
+    commands:
+      - tapOn:
+          id: "product_selector_variation_item"
+          index: 0
+          label: "Select first available variation"
+      - back
 
 - extendedWaitUntil:
     visible:
@@ -113,7 +106,7 @@ tags:
 
 - assertVisible:
     id: "order_product_card"
-    label: "Selected variation is present in the order"
+    label: "Selected product is present in the order"
 
 - takeScreenshot: order_create_with_product
 
@@ -121,7 +114,7 @@ tags:
 - tapOn:
     id: "order_product_card"
     retryTapIfNoChange: true
-    label: "Expand selected variation"
+    label: "Expand selected product"
 
 - extendedWaitUntil:
     visible: "Order count"

--- a/.maestro/flows/orders_create.yaml
+++ b/.maestro/flows/orders_create.yaml
@@ -7,7 +7,9 @@
 #   - Add a product from the product selector
 #   - Add a fixed-amount custom amount with a name
 #   - Add an existing customer by searching their email
-#   - Edit the added customer's last name
+#   - Prove the selected customer's identity is attached to the draft
+#   - Edit only the order-local customer copy and persist its marker
+#   - Prove the underlying store customer remains unchanged
 #   - Add a customer-facing note
 #   - All sections display the added data
 #   - Tap "Create" to submit the order — lands on order detail
@@ -385,11 +387,23 @@ tags:
     visible:
       id: "customer_list_item"
     timeout: 20000
-    label: "Wait for an existing customer"
+    label: "Require at least one existing customer"
+
+# Capture and tap the second visible email. Some stores expose an address-only
+# first customer whose list summary has an email but whose full customer fetch
+# does not; requiring another live row keeps the draft identity assertion real.
+- copyTextFrom:
+    text: ".*@.*"
+    index: 1
+- evalScript: ${output.selectedCustomerEmail = maestro.copiedText.trim()}
+- evalScript: |
+    if (!output.selectedCustomerEmail || output.selectedCustomerEmail.indexOf('@') < 1) {
+        throw new Error('Existing customer prerequisite requires at least two customers with email addresses');
+    }
 
 - tapOn:
-    id: "customer_list_item"
-    index: 0
+    text: ".*@.*"
+    index: 1
     retryTapIfNoChange: true
     label: "Select existing customer"
 
@@ -420,6 +434,10 @@ tags:
     visible: ".*Last name.*"
     timeout: 15000
 
+- assertVisible:
+    text: "${output.selectedCustomerEmail}"
+    label: "Customer editor shows the selected live identity"
+
 # Rewrite the last name with a per-suite-run-unique marker so
 # orders_refund.yaml can find THIS exact order and won't pick up an
 # already-refunded leftover from a previous suite run. SUITE_RUN_ID is
@@ -440,6 +458,29 @@ tags:
     id: "menu_done"
     label: "Save customer edit"
 
+- extendedWaitUntil:
+    visible: "New order"
+    timeout: 15000
+
+# The order summary currently omits the name/email block after this edit even
+# though the draft retains both values. Reopen the editor to verify the actual
+# draft model before submitting it.
+- scrollUntilVisible:
+    element: "Edit customer details"
+    direction: DOWN
+    timeout: 10000
+- tapOn:
+    text: "Edit customer details"
+    retryTapIfNoChange: true
+    label: "Reopen customer editor to verify draft persistence"
+- extendedWaitUntil:
+    visible: ".*SmokeTest-${SUITE_RUN_ID}.*"
+    timeout: 15000
+    label: "Edited customer marker is retained by the draft"
+- assertVisible:
+    text: "${output.selectedCustomerEmail}"
+    label: "Selected customer identity is retained by the draft"
+- back
 - extendedWaitUntil:
     visible: "New order"
     timeout: 15000
@@ -497,3 +538,89 @@ tags:
     timeout: 30000
 
 - takeScreenshot: order_create_completed
+
+# Locate the exact completed order and prove the order-local customer edit was
+# persisted by the backend, rather than only rendered in the draft.
+- tapOn:
+    id: "menu_search"
+    label: "Search for the completed smoke order"
+- extendedWaitUntil:
+    visible:
+      id: "search_src_text"
+    timeout: 10000
+- tapOn:
+    id: "search_src_text"
+- runFlow:
+    file: ../subflows/paste_into_focused_field.yaml
+    env:
+      TEXT_TO_PASTE: SmokeTest-${SUITE_RUN_ID}
+- pressKey: Enter
+- extendedWaitUntil:
+    visible: ".*SmokeTest-${SUITE_RUN_ID}.*"
+    timeout: 30000
+    label: "Require the persisted order customer marker"
+- tapOn:
+    id: "orderNum"
+    index: 0
+    retryTapIfNoChange: true
+    label: "Open the completed smoke order"
+- extendedWaitUntil:
+    visible:
+      id: "orderDetail_container"
+    timeout: 20000
+- scrollUntilVisible:
+    element: ".*SmokeTest-${SUITE_RUN_ID}.*"
+    direction: DOWN
+    timeout: 15000
+    label: "Verify the edited marker on persisted order details"
+
+# Return to a fresh draft, reopen the customer picker, and search by the
+# captured email. The original name/email must still be present, proving the
+# arbitrary live customer account was not modified by the order edit.
+- back
+- extendedWaitUntil:
+    visible:
+      id: "ordersList"
+    timeout: 15000
+- tapOn:
+    id: "createOrderButton"
+    retryTapIfNoChange: true
+    label: "Open a fresh order for customer integrity check"
+- scrollUntilVisible:
+    element: "Add customer details"
+    direction: DOWN
+    timeout: 15000
+    label: "Reach customer picker in fresh order"
+- tapOn:
+    text: "Add customer details"
+    retryTapIfNoChange: true
+- extendedWaitUntil:
+    visible: "Search for customers"
+    timeout: 15000
+- tapOn: "Search for customers"
+- runFlow:
+    file: ../subflows/paste_into_focused_field.yaml
+    env:
+      TEXT_TO_PASTE: ${output.selectedCustomerEmail}
+- hideKeyboard
+- extendedWaitUntil:
+    visible: "${output.selectedCustomerEmail}"
+    timeout: 20000
+    label: "Find the original customer after order creation"
+- copyTextFrom:
+    text: "${output.selectedCustomerEmail}"
+- evalScript: |
+    if (maestro.copiedText.trim() !== output.selectedCustomerEmail) {
+        throw new Error('Store customer email changed after editing the order-local copy');
+    }
+- assertNotVisible:
+    text: ".*SmokeTest-${SUITE_RUN_ID}.*"
+    label: "Order-local marker was not persisted to the store customer"
+- back
+- back
+- extendedWaitUntil:
+    visible:
+      id: "ordersList"
+    timeout: 15000
+
+- takeScreenshot: order_create_customer_integrity_verified

--- a/.maestro/flows/orders_create.yaml
+++ b/.maestro/flows/orders_create.yaml
@@ -1,0 +1,366 @@
+# Smoke Test: Orders - Create Order
+# p2: orders.create.products, orders.create.variable-products, orders.create.quantity, orders.create.product-discount, orders.create.custom-amount, orders.create.custom-amount-note, orders.create.shipping, orders.create.customer-add, orders.create.customer-edit, orders.create.note
+# P2 ref: Orders > Create an order (add products, custom amount, customer, customer note)
+#
+# Verifies:
+#   - Order creation FAB works
+#   - Add a product from the product selector
+#   - Add a fixed-amount custom amount with a name
+#   - Add an existing customer by searching their email
+#   - Edit the added customer's last name
+#   - Add a customer-facing note
+#   - All sections display the added data
+#   - Tap "Create" to submit the order — lands on order detail
+#   - Tap "Collect Payment" → pick Cash → Mark Order as Complete to
+#     fully exercise the post-creation cash checkout path
+#
+# The order IS committed to the staging store and completed via COD.
+# Staging orders use test data (SmokeTest customer, $10 gift wrap) so
+# accumulation across runs is acceptable.
+appId: com.woocommerce.android.dev
+name: "Orders - Create a new order"
+tags:
+  - smoke_extended
+  - flaky_quarantine
+  - orders
+  - destructive
+---
+# Start from an already-authenticated session (see comment in
+# ensure_logged_in.yaml — re-logging in on every run triggers WPCom
+# security screens).
+- runFlow:
+    file: ../subflows/ensure_logged_in.yaml
+
+# Navigate to Orders
+- runFlow:
+    file: ../subflows/navigate_to_orders.yaml
+
+# Tap Create Order FAB
+- tapOn:
+    id: "createOrderButton"
+    retryTapIfNoChange: true
+    label: "Tap Create Order FAB"
+
+# Wait for order creation screen (title and Add products are always visible on empty creation)
+- extendedWaitUntil:
+    visible: "Add products"
+    timeout: 15000
+
+- takeScreenshot: order_create_empty
+
+# ── Add a product ─────────────────────────────────────────────────────
+- tapOn:
+    text: "Add products"
+    label: "Tap Add products"
+
+# Product selector loaded
+- extendedWaitUntil:
+    visible: ".*Search Products.*"
+    timeout: 15000
+
+- takeScreenshot: order_create_product_selector
+
+# Tap the first product row - product items sit below the search field
+- tapOn:
+    point: "50%,30%"
+    label: "Tap first product row"
+
+# Confirm selection (regex matches "Select 1 Product" or "Select N Products")
+- extendedWaitUntil:
+    visible: ".*Select \\d+ Product.*"
+    timeout: 15000
+
+- tapOn:
+    text: ".*Select \\d+ Product.*"
+    label: "Confirm product selection"
+
+# Back on order creation
+- extendedWaitUntil:
+    visible: "New order"
+    timeout: 15000
+
+- takeScreenshot: order_create_with_product
+
+# ── Add a custom amount (fixed, with a name) ──────────────────────────
+- scrollUntilVisible:
+    element: "Add custom amount"
+    direction: DOWN
+    timeout: 10000
+    label: "Scroll to custom amounts section"
+
+- tapOn:
+    text: "Add custom amount"
+    label: "Tap Add custom amount"
+
+# Same flake pattern as the orders_cash_payment Collect Payment tap:
+# occasionally the first tap visibly depresses the row but the "Select
+# custom amount type" bottom sheet never presents. Give the happy path
+# 8s, then re-tap if the sheet still isn't there (the first tap was
+# lost). On the normal path the re-tap is skipped because the sheet is
+# already visible.
+- runFlow:
+    when:
+      notVisible: "A fixed amount"
+    commands:
+      - extendedWaitUntil:
+          visible: "A fixed amount"
+          timeout: 8000
+
+- runFlow:
+    when:
+      notVisible: "A fixed amount"
+    commands:
+      - tapOn:
+          text: "Add custom amount"
+          retryTapIfNoChange: true
+          label: "Retry tap on Add custom amount (first was lost)"
+
+- extendedWaitUntil:
+    visible: "A fixed amount"
+    timeout: 15000
+
+- tapOn:
+    text: "A fixed amount"
+    label: "Choose fixed amount"
+
+# Fill amount and name in the custom amount dialog
+- extendedWaitUntil:
+    visible:
+      id: "editPrice"
+    timeout: 10000
+
+- tapOn:
+    id: "editPrice"
+- eraseText
+# Emulator locale uses comma as decimal separator — entering "1000" yields 10,00
+- inputText: "1000"
+- hideKeyboard
+
+- tapOn:
+    id: "customAmountNameText"
+- inputText: "Gift wrap"
+- hideKeyboard
+
+- takeScreenshot: order_create_custom_amount_dialog
+
+- tapOn:
+    id: "buttonDone"
+    label: "Tap Done on custom amount"
+
+# Back on order creation — verify custom amount was added
+- extendedWaitUntil:
+    visible: "New order"
+    timeout: 15000
+
+- assertVisible:
+    text: "Gift wrap"
+    label: "Custom amount name is visible in creation screen"
+
+- takeScreenshot: order_create_with_custom_amount
+
+# ── Add a customer-facing note ────────────────────────────────────────
+# Added BEFORE the customer on purpose: when both customer and note are
+# empty, the "Add note" button lives in customer_section (via
+# initCustomerAndNotesEmptySection). Once a customer is added, that
+# button migrates to notes_section whose bounds overlap with the Compose
+# totals_section, and the totals overlay intercepts taps on it.
+- scrollUntilVisible:
+    element: "Add note"
+    direction: DOWN
+    timeout: 10000
+    label: "Scroll to notes button in customer section"
+
+- tapOn:
+    text: "Add note"
+    childOf:
+      id: "customer_section"
+    retryTapIfNoChange: true
+    label: "Tap Add note in empty customer section"
+
+- extendedWaitUntil:
+    visible:
+      id: "customerOrderNote_editor"
+    timeout: 15000
+
+- tapOn:
+    id: "customerOrderNote_editor"
+- inputText: "Maestro smoke test note - please gift wrap."
+- hideKeyboard
+
+- takeScreenshot: order_create_customer_note_typed
+
+# Save via toolbar DONE
+- tapOn:
+    id: "menu_done"
+    label: "Save customer note"
+
+- extendedWaitUntil:
+    visible: "New order"
+    timeout: 15000
+
+- assertVisible:
+    text: ".*Maestro smoke test note.*"
+    label: "Customer note visible in creation screen"
+
+# ── Add a customer ────────────────────────────────────────────────────
+# Uses the search flow to verify it works, then falls back to "Add
+# details manually" so the flow doesn't depend on the staging store
+# containing a matching customer.
+- scrollUntilVisible:
+    element: "Add customer details"
+    direction: DOWN
+    timeout: 10000
+    label: "Scroll to customer section"
+
+- tapOn:
+    text: "Add customer details"
+    label: "Tap Add customer details"
+
+- extendedWaitUntil:
+    visible: "Search for customers"
+    timeout: 15000
+
+- tapOn:
+    text: "Search for customers"
+- inputText: "zzzzznomatch"
+- hideKeyboard
+
+# When no match, tap the "Add details manually" CTA to enter the editor
+- extendedWaitUntil:
+    visible: "Add details manually"
+    timeout: 15000
+
+- tapOn:
+    text: "Add details manually"
+    label: "Add customer details manually"
+
+# Customer edit form is now visible — fill first & last name
+- extendedWaitUntil:
+    visible: ".*First name.*|.*Last name.*|.*Email.*"
+    timeout: 15000
+
+- takeScreenshot: order_create_customer_edit_form
+
+- tapOn:
+    id: "edit_text"
+    childOf:
+      id: "first_name"
+- eraseText
+- inputText: "Maestro"
+- hideKeyboard
+
+- tapOn:
+    id: "edit_text"
+    childOf:
+      id: "last_name"
+- eraseText
+- inputText: "SmokeTest"
+- hideKeyboard
+
+- takeScreenshot: order_create_customer_edited
+
+# Save via toolbar DONE
+- tapOn:
+    id: "menu_done"
+    label: "Save customer details"
+
+- extendedWaitUntil:
+    visible: "New order"
+    timeout: 15000
+
+- takeScreenshot: order_create_with_customer
+
+# ── Edit the added customer ───────────────────────────────────────────
+- scrollUntilVisible:
+    element: ".*SmokeTest.*|.*Maestro.*"
+    direction: DOWN
+    timeout: 10000
+    label: "Scroll to customer section"
+
+- tapOn:
+    id: "edit_button"
+    childOf:
+      id: "customer_section"
+    label: "Tap customer edit button"
+
+- extendedWaitUntil:
+    visible: ".*Last name.*"
+    timeout: 15000
+
+# Rewrite the last name with a per-suite-run-unique marker so
+# orders_refund.yaml can find THIS exact order and won't pick up an
+# already-refunded leftover from a previous suite run. SUITE_RUN_ID is
+# exported by .maestro/scripts/run-smoke-tests.sh (set to the run's
+# timestamp, e.g. 20260421-123100), so every run's customer last name
+# is distinct.
+- tapOn:
+    id: "edit_text"
+    childOf:
+      id: "last_name"
+- eraseText
+- inputText: "SmokeTest-${SUITE_RUN_ID}"
+- hideKeyboard
+
+- takeScreenshot: order_create_customer_re_edited
+
+- tapOn:
+    id: "menu_done"
+    label: "Save customer edit"
+
+- extendedWaitUntil:
+    visible: "New order"
+    timeout: 15000
+
+- takeScreenshot: order_create_fully_customized
+
+# ── Submit + auto-launch payment flow ─────────────────────────────────
+# The Compose totals overlay at the bottom of the creation screen
+# hosts a "Collect Payment" primary button (see
+# OrderCreateEditTotalsHelper.toButtonText → Creation branch). Tapping
+# it submits the order AND sets startPaymentFlow=true, so
+# OrderDetailViewModel's init auto-triggers StartPaymentFlow —
+# landing on the Take-payment selector without requiring a second tap
+# on order detail.
+- scrollUntilVisible:
+    element: "Collect Payment"
+    direction: DOWN
+    timeout: 10000
+    label: "Scroll to Collect Payment primary button"
+
+- tapOn:
+    text: "Collect Payment"
+    retryTapIfNoChange: true
+    label: "Tap Collect Payment to submit + start payment flow"
+
+# Take-payment bottom sheet appears (Card/Cash options).
+- extendedWaitUntil:
+    visible: ".*Take payment.*|.*Cash.*"
+    timeout: 30000
+
+- takeScreenshot: order_create_select_payment_method
+
+- tapOn:
+    text: "Cash"
+    retryTapIfNoChange: true
+    label: "Select Cash payment method"
+
+# Change Due Calculator — the order total is pre-filled, so tapping
+# "Mark Order as Complete" records the cash payment and closes out the
+# order.
+- extendedWaitUntil:
+    visible: ".*Mark Order as Complete.*"
+    timeout: 15000
+
+- takeScreenshot: order_create_change_due_calculator
+
+- tapOn:
+    text: ".*Mark Order as Complete.*"
+    retryTapIfNoChange: true
+    label: "Mark order as complete with cash"
+
+- extendedWaitUntil:
+    visible:
+      id: "ordersList"
+    timeout: 30000
+
+- takeScreenshot: order_create_completed

--- a/.maestro/flows/orders_create.yaml
+++ b/.maestro/flows/orders_create.yaml
@@ -365,8 +365,8 @@ tags:
     label: "Customer note visible in creation screen"
 
 # ── Add a customer ────────────────────────────────────────────────────
-# Select an existing customer by its exact configured email. Manual customer
-# entry does not satisfy the P2 existing-customer check.
+# Select an existing customer from the live store. Manual customer entry does
+# not satisfy the P2 existing-customer check.
 - scrollUntilVisible:
     element: "Add customer details"
     direction: DOWN
@@ -381,18 +381,11 @@ tags:
     visible: "Search for customers"
     timeout: 15000
 
-- tapOn:
-    text: "Search for customers"
-- runFlow:
-    file: ../subflows/paste_into_focused_field.yaml
-    env:
-      TEXT_TO_PASTE: ${WOO_EXISTING_CUSTOMER_EMAIL}
-- hideKeyboard
-
 - extendedWaitUntil:
-    visible: "${WOO_EXISTING_CUSTOMER_EMAIL}"
+    visible:
+      id: "customer_list_item"
     timeout: 20000
-    label: "Wait for configured existing customer"
+    label: "Wait for an existing customer"
 
 - tapOn:
     id: "customer_list_item"
@@ -404,23 +397,23 @@ tags:
     visible: "New order"
     timeout: 15000
 
-- assertVisible:
-    text: "${WOO_EXISTING_CUSTOMER_EMAIL}"
-    label: "Existing customer is attached to the order"
+- scrollUntilVisible:
+    element: "Edit customer details"
+    direction: DOWN
+    timeout: 10000
+    label: "Verify the existing customer is attached"
 
 - takeScreenshot: order_create_with_existing_customer
 
 # ── Edit the added customer ───────────────────────────────────────────
 - scrollUntilVisible:
-    element: "${WOO_EXISTING_CUSTOMER_EMAIL}"
+    element: "Edit customer details"
     direction: DOWN
     timeout: 10000
     label: "Scroll to customer section"
 
 - tapOn:
-    id: "edit_button"
-    childOf:
-      id: "customer_section"
+    text: "Edit customer details"
     label: "Tap customer edit button"
 
 - extendedWaitUntil:

--- a/.maestro/flows/orders_create.yaml
+++ b/.maestro/flows/orders_create.yaml
@@ -1,5 +1,5 @@
 # Smoke Test: Orders - Create Order
-# p2: orders.create.products, orders.create.quantity, orders.create.product-discount, orders.create.custom-amount, orders.create.custom-amount-note, orders.create.shipping, orders.create.customer-add, orders.create.customer-edit, orders.create.note
+# p2: orders.create.products, orders.create.variable-products, orders.create.quantity, orders.create.product-discount, orders.create.custom-amount, orders.create.custom-amount-note, orders.create.shipping, orders.create.customer-add, orders.create.customer-edit, orders.create.note
 # P2 ref: Orders > Create an order (add products, custom amount, customer, customer note)
 #
 # Verifies:
@@ -62,32 +62,74 @@ tags:
 
 - takeScreenshot: order_create_product_selector
 
-# Select the first product the existing Add Products UI exposes. Variable
-# product behavior is covered independently by products_variations_and_tags.
+# Filter to Variable products so this order always exercises the variation
+# picker instead of depending on whichever product happens to be listed first.
+- tapOn:
+    text: "Filter"
+    retryTapIfNoChange: true
+    label: "Open product selector filters"
+
 - extendedWaitUntil:
     visible:
-      id: "product_selector_product_item"
+      id: "filterList"
     timeout: 15000
-    label: "Require a selectable product"
+    label: "Wait for product selector filters"
 
 - tapOn:
-    id: "product_selector_product_item"
-    index: 0
+    text: "Product type"
     retryTapIfNoChange: true
-    label: "Select the first available product"
+    label: "Open Product type filter"
 
-# If the selected row is Variable, choose its first purchasable variation and
-# return to the parent selector. Simple products remain on the parent directly.
+- extendedWaitUntil:
+    visible:
+      id: "filterOptionList"
+    timeout: 15000
+    label: "Wait for Product type options"
+
+- tapOn:
+    text: "Variable"
+    retryTapIfNoChange: true
+    label: "Select Variable products"
+
+- tapOn:
+    id: "filterOptionList_btnShowProducts"
+    retryTapIfNoChange: true
+    label: "Confirm Variable product filter"
+
 - runFlow:
     when:
       visible:
-        id: "product_selector_variation_item"
+        id: "filterList_btnShowProducts"
     commands:
       - tapOn:
-          id: "product_selector_variation_item"
-          index: 0
-          label: "Select first available variation"
-      - back
+          id: "filterList_btnShowProducts"
+          retryTapIfNoChange: true
+          label: "Apply Variable product filter"
+
+- extendedWaitUntil:
+    visible:
+      id: "product_selector_variable_product_item"
+    timeout: 20000
+    label: "Require a Variable product with variations"
+
+- tapOn:
+    id: "product_selector_variable_product_item"
+    index: 0
+    retryTapIfNoChange: true
+    label: "Open the first Variable product"
+
+- extendedWaitUntil:
+    visible:
+      id: "product_selector_variation_item"
+    timeout: 15000
+    label: "Require a purchasable variation"
+
+- tapOn:
+    id: "product_selector_variation_item"
+    index: 0
+    label: "Select first available variation"
+
+- back
 
 - extendedWaitUntil:
     visible:

--- a/.maestro/flows/orders_details_and_actions.yaml
+++ b/.maestro/flows/orders_details_and_actions.yaml
@@ -93,6 +93,31 @@ tags:
 
 - takeScreenshot: order_detail_payment
 
+# ── See receipt ───────────────────────────────────────────────────────
+- scrollUntilVisible:
+    element: "See receipt"
+    direction: DOWN
+    timeout: 15000
+    label: "Scroll to See receipt"
+
+- tapOn:
+    text: "See receipt"
+    retryTapIfNoChange: true
+    label: "Open receipt preview"
+
+- extendedWaitUntil:
+    visible: ".*Receipt Preview.*|.*Print.*|.*Send.*"
+    timeout: 30000
+    label: "Wait for receipt preview"
+
+- takeScreenshot: order_receipt_preview
+- back
+
+- extendedWaitUntil:
+    visible:
+      id: "orderDetail_container"
+    timeout: 15000
+
 # ── Add an order note ────────────────────────────────────────────────
 # Use the addNoteContainer ID directly — more robust than matching the
 # "Add a note" text which is not tagged as clickable (the outer

--- a/.maestro/flows/orders_details_and_actions.yaml
+++ b/.maestro/flows/orders_details_and_actions.yaml
@@ -1,0 +1,125 @@
+# Smoke Test: Orders - Detail view and actions
+# p2: orders.receipt, orders.note
+# P2 ref: Orders > Refund, Add order note, Mark complete, See receipt
+#
+# Verifies:
+#   - Opening an order shows the detail container and status tags
+#   - Can scroll through products and payment sections
+#   - Can add an order note via the "Add a note" row (private by default)
+#   - Returns to orders list cleanly
+#
+# Uses the exact resource IDs from order_detail_note_list.xml
+# (noteList_addNoteContainer, notesList_notes) and menu_add.xml
+# (menu_add) to avoid ambiguous text matches that can collide with the
+# "Add note" button in the order creation flow.
+appId: com.woocommerce.android.dev
+name: "Orders - Detail view and actions"
+tags:
+  - smoke_extended
+  - flaky_quarantine
+  - orders
+  - destructive
+---
+# Start from an already-authenticated session (see comment in
+# ensure_logged_in.yaml — re-logging in on every run triggers WPCom
+# security screens).
+- runFlow:
+    file: ../subflows/ensure_logged_in.yaml
+
+# Navigate to Orders
+- runFlow:
+    file: ../subflows/navigate_to_orders.yaml
+
+# Open the first order
+- tapOn:
+    id: "orderNum"
+    index: 0
+    label: "Tap first order in list"
+
+# Wait for order detail
+- extendedWaitUntil:
+    visible:
+      id: "orderDetail_container"
+    timeout: 15000
+
+# Verify order detail elements
+- assertVisible:
+    id: "orderStatus_orderTags"
+    label: "Order status tags are visible"
+
+- takeScreenshot: order_detail_top
+
+# Scroll down to see products
+- scroll
+
+- assertVisible:
+    id: "productInfo_name"
+    label: "Product name is visible in order detail"
+
+- takeScreenshot: order_detail_products
+
+# Scroll to payment info
+- scrollUntilVisible:
+    element:
+      id: "paymentInfo_total"
+    direction: DOWN
+    timeout: 15000
+    label: "Scroll to payment total"
+
+- takeScreenshot: order_detail_payment
+
+# ── Add an order note ────────────────────────────────────────────────
+# Use the addNoteContainer ID directly — more robust than matching the
+# "Add a note" text which is not tagged as clickable (the outer
+# LinearLayout handles the click).
+- scrollUntilVisible:
+    element:
+      id: "noteList_addNoteContainer"
+    direction: DOWN
+    timeout: 15000
+    label: "Scroll to notes section"
+
+- tapOn:
+    id: "noteList_addNoteContainer"
+    retryTapIfNoChange: true
+    label: "Tap Add a note row"
+
+# Add note screen
+- extendedWaitUntil:
+    visible:
+      id: "addNote_editor"
+    timeout: 15000
+
+- tapOn:
+    id: "addNote_editor"
+- inputText: "Maestro smoke test note"
+- hideKeyboard
+
+- takeScreenshot: order_note_typed
+
+# Save the note via the Add menu item
+- tapOn:
+    id: "menu_add"
+    label: "Save order note"
+
+# Back on order detail — verify note appears in the notes list
+- extendedWaitUntil:
+    visible:
+      id: "notesList_notes"
+    timeout: 15000
+
+- scrollUntilVisible:
+    element: ".*Maestro smoke test note.*"
+    direction: DOWN
+    timeout: 15000
+    label: "Scroll to added note"
+
+- takeScreenshot: order_note_added
+
+# Go back to orders list
+- back
+
+- extendedWaitUntil:
+    visible:
+      id: "ordersList"
+    timeout: 10000

--- a/.maestro/flows/orders_details_and_actions.yaml
+++ b/.maestro/flows/orders_details_and_actions.yaml
@@ -72,12 +72,14 @@ tags:
 
 - takeScreenshot: order_detail_top
 
-# Scroll down to see products
-- scroll
-
-- assertVisible:
-    id: "productInfo_name"
-    label: "Product name is visible in order detail"
+# Scroll to the products section. A plain `scroll` can overshoot on
+# taller devices and land in payment totals before this assertion runs.
+- scrollUntilVisible:
+    element:
+      id: "productInfo_name"
+    direction: DOWN
+    timeout: 15000
+    label: "Scroll to product row in order detail"
 
 - takeScreenshot: order_detail_products
 

--- a/.maestro/flows/orders_details_and_actions.yaml
+++ b/.maestro/flows/orders_details_and_actions.yaml
@@ -30,11 +30,34 @@ tags:
 - runFlow:
     file: ../subflows/navigate_to_orders.yaml
 
-# Open the first order
+# Open one of this run's seeded orders — never an arbitrary first row.
+# This flow persists a note on the order it opens, and on the shared
+# store index-0 can be a manual tester's real order. Searching the
+# suite run id scopes the list to automation-owned fixtures only.
+- tapOn:
+    id: "menu_search"
+    label: "Open order search"
+
+- extendedWaitUntil:
+    visible:
+      id: "search_src_text"
+    timeout: 10000
+
+- tapOn:
+    id: "search_src_text"
+- inputText: ${SUITE_RUN_ID}
+- pressKey: Enter
+
+- extendedWaitUntil:
+    visible:
+      id: "orderNum"
+    timeout: 20000
+    label: "Wait for seeded orders in results"
+
 - tapOn:
     id: "orderNum"
     index: 0
-    label: "Tap first order in list"
+    label: "Open first seeded order"
 
 # Wait for order detail
 - extendedWaitUntil:

--- a/.maestro/flows/orders_mark_complete.yaml
+++ b/.maestro/flows/orders_mark_complete.yaml
@@ -1,0 +1,184 @@
+# Smoke Test: Orders - Mark order complete
+# p2: orders.mark-complete
+# P2 ref: Orders > Mark complete
+#
+# Verifies:
+#   - Filter the orders list by "Processing" status
+#   - Open a processing order
+#   - Navigate to the Fulfill screen via "Mark order complete"
+#   - Complete the fulfillment
+#   - "🎉 Order completed!" snackbar appears
+#   - Undo the status change so the staging store stays clean
+#
+# Filtering to "Processing" guarantees the target order has the Mark
+# Complete button visible — it's hidden on already-completed orders.
+appId: com.woocommerce.android.dev
+name: "Orders - Mark order complete"
+tags:
+  - smoke_extended
+  - flaky_quarantine
+  - orders
+  - destructive
+---
+- runFlow:
+    file: ../subflows/ensure_logged_in.yaml
+
+- runFlow:
+    file: ../subflows/navigate_to_orders.yaml
+
+# ── Filter by Processing status ───────────────────────────────────────
+# Clear any previously-applied filter first. Prior flows in the suite
+# (e.g. orders_refund with a Completed filter) can leave a status
+# selected; re-selecting "Processing" on top of that would stack the
+# statuses and surface orders that don't have the Mark Complete
+# button.
+- tapOn:
+    id: "btn_order_filter"
+    label: "Open filters"
+
+- runFlow:
+    when:
+      visible: ".*Clear.*"
+    commands:
+      - tapOn:
+          text: ".*Clear.*"
+          label: "Clear existing filters"
+
+- extendedWaitUntil:
+    visible: "Order Status"
+    timeout: 10000
+
+- tapOn:
+    text: "Order Status"
+    label: "Open status filter"
+
+# Status labels include counts, e.g. "Processing (50)".
+- extendedWaitUntil:
+    visible: ".*Processing.*"
+    timeout: 10000
+
+- tapOn:
+    text: ".*Processing.*"
+    label: "Select Processing status"
+
+- tapOn:
+    id: "showOrdersButton"
+    label: "Apply filter"
+
+- extendedWaitUntil:
+    visible:
+      id: "ordersList"
+    timeout: 15000
+
+# Pull-to-refresh so the status filter reflects the latest server
+# state — stale caches can leave a just-completed order at index 0.
+- swipe:
+    from:
+      id: "ordersList"
+    direction: DOWN
+    duration: 800
+
+- takeScreenshot: orders_filtered_processing
+
+# ── Open the first processing order ──────────────────────────────────
+- tapOn:
+    id: "orderNum"
+    index: 0
+    label: "Open first processing order"
+
+- extendedWaitUntil:
+    visible:
+      id: "orderDetail_container"
+    timeout: 15000
+
+- takeScreenshot: order_detail_processing
+
+# ── Mark complete → Fulfill screen ───────────────────────────────────
+- scrollUntilVisible:
+    element:
+      id: "productList_btnMarkOrderComplete"
+    direction: DOWN
+    timeout: 15000
+    label: "Scroll to Mark order complete button"
+
+- tapOn:
+    id: "productList_btnMarkOrderComplete"
+    retryTapIfNoChange: true
+    label: "Tap Mark order complete"
+
+# Fulfill screen has its own Mark Complete CTA that actually commits
+# the status change.
+- extendedWaitUntil:
+    visible:
+      id: "button_mark_order_compete"
+    timeout: 15000
+
+- takeScreenshot: order_fulfill_screen
+
+- tapOn:
+    id: "button_mark_order_compete"
+    retryTapIfNoChange: true
+    label: "Confirm mark complete"
+
+# ── Verify completion + undo ─────────────────────────────────────────
+# The completion snackbar shows "🎉 Order completed!" with an "Undo"
+# action and auto-dismisses after a few seconds, so tap Undo first.
+# On stores with shipping labels enabled, the Fulfill confirm can also
+# race into an auto-navigation to the Create Shipping Label screen, so
+# the post-Undo state is not deterministically on order detail. Back
+# out until the orders list reappears, which is this flow's final
+# state anyway.
+- runFlow:
+    when:
+      visible: "Undo"
+    commands:
+      - tapOn:
+          text: "Undo"
+          retryTapIfNoChange: true
+          label: "Undo status change"
+
+- runFlow:
+    when:
+      visible: ".*Create shipping label.*"
+    commands:
+      - back
+          # Create Shipping Label is a sibling of Order Detail in the
+          # nav graph — a single back returns directly to the orders
+          # list on this store config.
+
+# If we're still on order detail, back out to the orders list.
+- runFlow:
+    when:
+      visible:
+        id: "orderDetail_container"
+    commands:
+      - back
+
+- extendedWaitUntil:
+    visible:
+      id: "ordersList"
+    timeout: 15000
+
+- takeScreenshot: order_marked_complete_reverted
+
+# ── Clear the filter so future runs start from an unfiltered list ────
+- tapOn:
+    id: "btn_order_filter"
+    label: "Re-open filters to clear"
+
+- runFlow:
+    when:
+      visible: ".*Clear.*"
+    commands:
+      - tapOn:
+          text: ".*Clear.*"
+          label: "Clear filters"
+
+- tapOn:
+    id: "showOrdersButton"
+    label: "Apply cleared filter"
+
+- extendedWaitUntil:
+    visible:
+      id: "ordersList"
+    timeout: 10000

--- a/.maestro/flows/orders_mark_complete.yaml
+++ b/.maestro/flows/orders_mark_complete.yaml
@@ -3,15 +3,15 @@
 # P2 ref: Orders > Mark complete
 #
 # Verifies:
-#   - Search locates this run's seeded processing order
+#   - Create a fresh paid automation order through the app UI
+#   - Move that order back to Processing via the order status editor
 #   - Navigate to the Fulfill screen via "Mark order complete"
 #   - Complete the fulfillment
 #   - "🎉 Order completed!" snackbar appears
-#   - Undo the status change so the staging store stays clean
 #
-# The seeded processing fixture guarantees the target order has the
-# Mark Complete button visible — it's hidden on already-completed
-# orders — and that a missed Undo only ever affects automation data.
+# The Mark Complete button is only exposed for paid orders whose status
+# is not Completed. This flow creates its own paid order, moves that
+# automation-owned order to Processing, then marks it Completed again.
 appId: com.woocommerce.android.dev
 name: "Orders - Mark order complete"
 tags:
@@ -26,42 +26,114 @@ tags:
 - runFlow:
     file: ../subflows/navigate_to_orders.yaml
 
-# ── Find this run's seeded processing order ──────────────────────────
-# Fixtures are located by query, never by list position — on the shared
-# store the first processing order can be a manual tester's real order,
-# and the Undo below is best-effort (the snackbar auto-dismisses).
-# Searching the suite run id only surfaces automation-owned orders
-# (seeded billing name is the run id); the "Processing" row is a seeded
-# paid fixture that exposes the Mark Complete action.
+# ── Create a paid automation order ───────────────────────────────────
 - tapOn:
-    id: "menu_search"
-    label: "Open order search"
+    id: "createOrderButton"
+    retryTapIfNoChange: true
+    label: "Tap Create Order FAB"
+
+- extendedWaitUntil:
+    visible: "Add products"
+    timeout: 15000
+
+- tapOn:
+    text: "Add products"
+    label: "Tap Add products"
+
+- extendedWaitUntil:
+    visible: ".*Search Products.*"
+    timeout: 15000
+
+- tapOn:
+    point: "50%,30%"
+    label: "Tap first product row"
+
+- extendedWaitUntil:
+    visible: ".*Select \\d+ Product.*"
+    timeout: 15000
+
+- tapOn:
+    text: ".*Select \\d+ Product.*"
+    label: "Confirm product selection"
+
+- extendedWaitUntil:
+    visible: "New order"
+    timeout: 15000
+
+- scrollUntilVisible:
+    element: "Collect Payment"
+    direction: DOWN
+    timeout: 10000
+    label: "Scroll to Collect Payment primary button"
+
+- tapOn:
+    text: "Collect Payment"
+    retryTapIfNoChange: true
+    label: "Submit order and start payment flow"
+
+- extendedWaitUntil:
+    visible: ".*Take payment.*|.*Cash.*"
+    timeout: 30000
+
+- tapOn:
+    text: "Cash"
+    retryTapIfNoChange: true
+    label: "Select Cash payment method"
+
+- extendedWaitUntil:
+    visible: ".*Mark Order as Complete.*"
+    timeout: 15000
+
+- tapOn:
+    text: ".*Mark Order as Complete.*"
+    retryTapIfNoChange: true
+    label: "Create paid completed order"
 
 - extendedWaitUntil:
     visible:
-      id: "search_src_text"
-    timeout: 10000
+      id: "ordersList"
+    timeout: 30000
 
+- takeScreenshot: order_mark_complete_paid_order_created
+
+# Reopen the newest order this flow just created. It is automation-owned
+# and appears at the top of the list after the cash completion above.
 - tapOn:
-    id: "search_src_text"
-- inputText: ${SUITE_RUN_ID}
-- pressKey: Enter
-
-- extendedWaitUntil:
-    visible: ".*Processing.*"
-    timeout: 20000
-    label: "Wait for a seeded processing order in results"
-
-- takeScreenshot: orders_search_processing
-
-- tapOn:
-    text: ".*Processing.*"
-    label: "Open this run's processing order"
+    id: "orderNum"
+    index: 0
+    retryTapIfNoChange: true
+    label: "Open newly-created completed order"
 
 - extendedWaitUntil:
     visible:
       id: "orderDetail_container"
     timeout: 15000
+
+- takeScreenshot: order_detail_completed_before_status_edit
+
+# ── Move the paid order back to Processing ───────────────────────────
+- tapOn:
+    id: "orderStatus_container"
+    retryTapIfNoChange: true
+    label: "Open order status selector"
+
+- extendedWaitUntil:
+    visible: "Change order status"
+    timeout: 10000
+
+- tapOn:
+    text: "Processing"
+    label: "Select Processing status"
+
+- tapOn:
+    text: "Apply"
+    retryTapIfNoChange: true
+    label: "Apply Processing status"
+
+- extendedWaitUntil:
+    visible: ".*Processing.*"
+    timeout: 30000
+    label: "Wait for Processing status"
 
 - takeScreenshot: order_detail_processing
 
@@ -92,23 +164,10 @@ tags:
     retryTapIfNoChange: true
     label: "Confirm mark complete"
 
-# ── Verify completion + undo ─────────────────────────────────────────
-# The completion snackbar shows "🎉 Order completed!" with an "Undo"
-# action and auto-dismisses after a few seconds, so tap Undo first.
-# On stores with shipping labels enabled, the Fulfill confirm can also
-# race into an auto-navigation to the Create Shipping Label screen, so
-# the post-Undo state is not deterministically on order detail. Back
-# out until the orders list reappears, which is this flow's final
-# state anyway.
-- runFlow:
-    when:
-      visible: "Undo"
-    commands:
-      - tapOn:
-          text: "Undo"
-          retryTapIfNoChange: true
-          label: "Undo status change"
-
+# ── Verify completion ────────────────────────────────────────────────
+# On stores with shipping labels enabled, the Fulfill confirm can race
+# into an auto-navigation to the Create Shipping Label screen. Back out
+# until the orders list reappears, which is this flow's final state.
 - runFlow:
     when:
       visible: ".*Create shipping label.*"
@@ -124,6 +183,11 @@ tags:
       visible:
         id: "orderDetail_container"
     commands:
+      - extendedWaitUntil:
+          visible: ".*Completed.*|.*Order completed.*|.*Undo.*"
+          timeout: 15000
+          label: "Verify completed status or snackbar"
+      - takeScreenshot: order_marked_complete
       - back
 
 - extendedWaitUntil:
@@ -131,16 +195,7 @@ tags:
       id: "ordersList"
     timeout: 15000
 
-- takeScreenshot: order_marked_complete_reverted
-
-# ── Exit search if still active so downstream flows start clean ──────
-- runFlow:
-    when:
-      visible:
-        id: "search_src_text"
-    commands:
-      - back
-      - back
+- takeScreenshot: order_marked_complete_list
 
 - extendedWaitUntil:
     visible:

--- a/.maestro/flows/orders_mark_complete.yaml
+++ b/.maestro/flows/orders_mark_complete.yaml
@@ -3,15 +3,15 @@
 # P2 ref: Orders > Mark complete
 #
 # Verifies:
-#   - Filter the orders list by "Processing" status
-#   - Open a processing order
+#   - Search locates this run's seeded processing order
 #   - Navigate to the Fulfill screen via "Mark order complete"
 #   - Complete the fulfillment
 #   - "🎉 Order completed!" snackbar appears
 #   - Undo the status change so the staging store stays clean
 #
-# Filtering to "Processing" guarantees the target order has the Mark
-# Complete button visible — it's hidden on already-completed orders.
+# The seeded processing fixture guarantees the target order has the
+# Mark Complete button visible — it's hidden on already-completed
+# orders — and that a missed Undo only ever affects automation data.
 appId: com.woocommerce.android.dev
 name: "Orders - Mark order complete"
 tags:
@@ -26,65 +26,37 @@ tags:
 - runFlow:
     file: ../subflows/navigate_to_orders.yaml
 
-# ── Filter by Processing status ───────────────────────────────────────
-# Clear any previously-applied filter first. Prior flows in the suite
-# (e.g. orders_refund with a Completed filter) can leave a status
-# selected; re-selecting "Processing" on top of that would stack the
-# statuses and surface orders that don't have the Mark Complete
-# button.
+# ── Find this run's seeded processing order ──────────────────────────
+# Fixtures are located by query, never by list position — on the shared
+# store the first processing order can be a manual tester's real order,
+# and the Undo below is best-effort (the snackbar auto-dismisses).
+# Searching the suite run id only surfaces automation-owned orders
+# (seeded billing name is the run id); the "Processing" row is a seeded
+# paid fixture that exposes the Mark Complete action.
 - tapOn:
-    id: "btn_order_filter"
-    label: "Open filters"
-
-- runFlow:
-    when:
-      visible: ".*Clear.*"
-    commands:
-      - tapOn:
-          text: ".*Clear.*"
-          label: "Clear existing filters"
-
-- extendedWaitUntil:
-    visible: "Order Status"
-    timeout: 10000
-
-- tapOn:
-    text: "Order Status"
-    label: "Open status filter"
-
-# Status labels include counts, e.g. "Processing (50)".
-- extendedWaitUntil:
-    visible: ".*Processing.*"
-    timeout: 10000
-
-- tapOn:
-    text: ".*Processing.*"
-    label: "Select Processing status"
-
-- tapOn:
-    id: "showOrdersButton"
-    label: "Apply filter"
+    id: "menu_search"
+    label: "Open order search"
 
 - extendedWaitUntil:
     visible:
-      id: "ordersList"
-    timeout: 15000
+      id: "search_src_text"
+    timeout: 10000
 
-# Pull-to-refresh so the status filter reflects the latest server
-# state — stale caches can leave a just-completed order at index 0.
-- swipe:
-    from:
-      id: "ordersList"
-    direction: DOWN
-    duration: 800
-
-- takeScreenshot: orders_filtered_processing
-
-# ── Open the first processing order ──────────────────────────────────
 - tapOn:
-    id: "orderNum"
-    index: 0
-    label: "Open first processing order"
+    id: "search_src_text"
+- inputText: ${SUITE_RUN_ID}
+- pressKey: Enter
+
+- extendedWaitUntil:
+    visible: ".*Processing.*"
+    timeout: 20000
+    label: "Wait for a seeded processing order in results"
+
+- takeScreenshot: orders_search_processing
+
+- tapOn:
+    text: ".*Processing.*"
+    label: "Open this run's processing order"
 
 - extendedWaitUntil:
     visible:
@@ -161,22 +133,14 @@ tags:
 
 - takeScreenshot: order_marked_complete_reverted
 
-# ── Clear the filter so future runs start from an unfiltered list ────
-- tapOn:
-    id: "btn_order_filter"
-    label: "Re-open filters to clear"
-
+# ── Exit search if still active so downstream flows start clean ──────
 - runFlow:
     when:
-      visible: ".*Clear.*"
+      visible:
+        id: "search_src_text"
     commands:
-      - tapOn:
-          text: ".*Clear.*"
-          label: "Clear filters"
-
-- tapOn:
-    id: "showOrdersButton"
-    label: "Apply cleared filter"
+      - back
+      - back
 
 - extendedWaitUntil:
     visible:

--- a/.maestro/flows/orders_refund.yaml
+++ b/.maestro/flows/orders_refund.yaml
@@ -97,8 +97,12 @@ tags:
 # here instead of a leftover "SmokeTest*" customer from a previous
 # suite run — those prior orders will have already been fully
 # refunded and show 0 refundable items on the Issue Refund screen.
-# Fall back to the first completed order when the suite-tagged
-# customer isn't visible (e.g. this flow is run standalone).
+# Fall back to this run's seeded refundable fixture (its billing name
+# is the run id) when the suite-tagged customer isn't visible (e.g.
+# this flow is run standalone). Never fall back to an arbitrary first
+# row — on the shared store that could issue a refund against a manual
+# tester's real order; if neither automation order is visible, failing
+# here is the correct outcome.
 - runFlow:
     when:
       visible: ".*SmokeTest-${SUITE_RUN_ID}.*"
@@ -113,9 +117,9 @@ tags:
       notVisible: ".*SmokeTest-${SUITE_RUN_ID}.*"
     commands:
       - tapOn:
-          id: "orderNum"
-          index: 0
-          label: "Open first completed order (fallback)"
+          text: ".*${SUITE_RUN_ID}.*"
+          retryTapIfNoChange: true
+          label: "Open this run's seeded refundable order (fallback)"
 
 - extendedWaitUntil:
     visible:

--- a/.maestro/flows/orders_refund.yaml
+++ b/.maestro/flows/orders_refund.yaml
@@ -1,0 +1,249 @@
+# Smoke Test: Orders - Issue refund
+# p2: orders.refund
+# P2 ref: Orders > Refund
+#
+# Verifies:
+#   - Filter the orders list by "Completed" status (the Refund button
+#     in the payment section is only exposed once an order has been
+#     transitioned to Completed — Processing orders do not show it
+#     on this app)
+#   - Open a completed order
+#   - Tap "Refund" in the payment info section
+#   - Select all items on the Issue Refund screen
+#   - Advance to the Refund Summary screen
+#   - Enter a refund reason
+#   - Tap the Refund CTA to reach the confirmation dialog
+#   - Confirm the refund by tapping the positive "Refund" button,
+#     which actually hits the WPCom refund endpoint
+#   - Wait for the success snackbar ("The refund was successfully
+#     submitted.") and verify we land back on order detail with the
+#     refund recorded
+#
+# Unlike the mark-complete flow, the refund is fully committed — the
+# staging store will accumulate refunded orders across runs. Test
+# orders on the store are priced low enough that this is acceptable.
+appId: com.woocommerce.android.dev
+name: "Orders - Issue refund"
+tags:
+  - smoke_extended
+  - flaky_quarantine
+  - orders
+  - destructive
+---
+- runFlow:
+    file: ../subflows/ensure_logged_in.yaml
+
+- runFlow:
+    file: ../subflows/navigate_to_orders.yaml
+
+# ── Filter by Completed status ────────────────────────────────────────
+# The Refund button in the payment info section is only exposed on
+# orders that have been transitioned to Completed. Processing-status
+# orders — even those paid via gateways that support refunds — do not
+# show the button on this app. Clear any previously-applied filters
+# first to avoid cross-test contamination.
+- tapOn:
+    id: "btn_order_filter"
+    label: "Open filters"
+
+- runFlow:
+    when:
+      visible: ".*Clear.*"
+    commands:
+      - tapOn:
+          text: ".*Clear.*"
+          label: "Clear existing filters"
+
+- extendedWaitUntil:
+    visible: "Order Status"
+    timeout: 10000
+
+- tapOn:
+    text: "Order Status"
+    label: "Open status filter"
+
+- extendedWaitUntil:
+    visible: ".*Completed.*"
+    timeout: 10000
+
+- tapOn:
+    text: ".*Completed.*"
+    label: "Select Completed status"
+
+- tapOn:
+    id: "showOrdersButton"
+    label: "Apply filter"
+
+- extendedWaitUntil:
+    visible:
+      id: "ordersList"
+    timeout: 15000
+
+# Pull-to-refresh so the status filter reflects the latest server
+# state. Without this, the cached list can still contain an order
+# that was just refunded in a previous run — the refund button won't
+# exist on it once the refund API has reclassified it as Refunded,
+# and the scrollUntilVisible below would fail.
+- swipe:
+    from:
+      id: "ordersList"
+    direction: DOWN
+    duration: 800
+
+# ── Open the freshly-created order (suite) or first completed order ──
+# In a full-suite run, orders_create.yaml stamps the created order's
+# customer last name with the suite's unique run ID (SUITE_RUN_ID,
+# e.g. "SmokeTest-20260421-123100") so we can target that exact order
+# here instead of a leftover "SmokeTest*" customer from a previous
+# suite run — those prior orders will have already been fully
+# refunded and show 0 refundable items on the Issue Refund screen.
+# Fall back to the first completed order when the suite-tagged
+# customer isn't visible (e.g. this flow is run standalone).
+- runFlow:
+    when:
+      visible: ".*SmokeTest-${SUITE_RUN_ID}.*"
+    commands:
+      - tapOn:
+          text: ".*SmokeTest-${SUITE_RUN_ID}.*"
+          retryTapIfNoChange: true
+          label: "Open this-run's SmokeTest order"
+
+- runFlow:
+    when:
+      notVisible: ".*SmokeTest-${SUITE_RUN_ID}.*"
+    commands:
+      - tapOn:
+          id: "orderNum"
+          index: 0
+          label: "Open first completed order (fallback)"
+
+- extendedWaitUntil:
+    visible:
+      id: "orderDetail_container"
+    timeout: 15000
+
+# ── Refund → Issue Refund screen ─────────────────────────────────────
+- scrollUntilVisible:
+    element:
+      id: "paymentInfo_issueRefundButton"
+    direction: DOWN
+    timeout: 15000
+    label: "Scroll to Refund button"
+
+- tapOn:
+    id: "paymentInfo_issueRefundButton"
+    retryTapIfNoChange: true
+    label: "Tap Refund"
+
+- extendedWaitUntil:
+    visible:
+      id: "issueRefund_btnNextFromItems"
+    timeout: 15000
+
+- takeScreenshot: issue_refund_items
+
+# Select all items
+- tapOn:
+    id: "issueRefund_selectButton"
+    retryTapIfNoChange: true
+    label: "Select all items"
+
+- tapOn:
+    id: "issueRefund_btnNextFromItems"
+    retryTapIfNoChange: true
+    label: "Next to refund summary"
+
+# ── Refund Summary ───────────────────────────────────────────────────
+- extendedWaitUntil:
+    visible:
+      id: "refundSummary_btnRefund"
+    timeout: 15000
+
+- takeScreenshot: refund_summary
+
+# Enter a reason so the "Refund" CTA is verifiably exercised with a
+# filled-in reason field.
+- tapOn:
+    id: "refundSummary_reason"
+- inputText: "Maestro smoke test refund"
+- hideKeyboard
+
+- takeScreenshot: refund_summary_with_reason
+
+- tapOn:
+    id: "refundSummary_btnRefund"
+    retryTapIfNoChange: true
+    label: "Tap Refund (opens confirmation dialog)"
+
+# ── Confirmation dialog — confirm to submit the refund ───────────────
+- extendedWaitUntil:
+    visible: ".*Are you sure you want to issue a refund.*"
+    timeout: 15000
+
+- takeScreenshot: refund_confirmation_dialog
+
+# The MaterialAlertDialog positive button is the standard Android
+# `button1` resource ID, with label "Refund" (from
+# R.string.order_refunds_refund). Tapping it fires onRefundConfirmed
+# → initiateRefund → WPCom POST /wc/v3/orders/{id}/refunds.
+- tapOn:
+    id: "button1"
+    retryTapIfNoChange: true
+    label: "Confirm refund"
+
+# ── Verify the refund succeeded ──────────────────────────────────────
+# On success the ViewModel shows a transient snackbar ("The refund was
+# successfully submitted.") and pops the back stack past the
+# IssueRefund fragment, landing on order detail with a "Refunded"
+# line recorded in the payment totals section. The snackbar
+# auto-dismisses in ~3-5s which is often faster than Maestro can
+# observe reliably, so the durable assertion is the post-refund state:
+# we're back on orderDetail_container AND a Refunded line is present.
+- runFlow:
+    when:
+      visible: ".*The refund was successfully submitted.*"
+    commands:
+      - takeScreenshot: refund_success_snackbar
+
+- extendedWaitUntil:
+    visible:
+      id: "orderDetail_container"
+    timeout: 20000
+
+- scrollUntilVisible:
+    element: ".*Refunded.*"
+    direction: DOWN
+    timeout: 15000
+    label: "Scroll to Refunded line in payment totals"
+
+- takeScreenshot: order_detail_after_refund
+
+# ── Back out to orders list ──────────────────────────────────────────
+- back
+
+- extendedWaitUntil:
+    visible:
+      id: "ordersList"
+    timeout: 10000
+
+# ── Clear the filter so future runs start from an unfiltered list ────
+- tapOn:
+    id: "btn_order_filter"
+    label: "Re-open filters to clear"
+
+- runFlow:
+    when:
+      visible: ".*Clear.*"
+    commands:
+      - tapOn:
+          text: ".*Clear.*"
+          label: "Clear filters"
+
+- tapOn:
+    id: "showOrdersButton"
+    label: "Apply cleared filter"
+
+- extendedWaitUntil:
+    visible:
+      id: "ordersList"
+    timeout: 10000

--- a/.maestro/flows/orders_refund.yaml
+++ b/.maestro/flows/orders_refund.yaml
@@ -111,10 +111,16 @@ tags:
           text: ".*SmokeTest-${SUITE_RUN_ID}.*"
           retryTapIfNoChange: true
           label: "Open this-run's SmokeTest order"
+      - extendedWaitUntil:
+          visible:
+            id: "orderDetail_container"
+          timeout: 15000
+          label: "Wait for SmokeTest order detail"
 
 - runFlow:
     when:
-      notVisible: ".*SmokeTest-${SUITE_RUN_ID}.*"
+      notVisible:
+        id: "orderDetail_container"
     commands:
       - tapOn:
           text: ".*${SUITE_RUN_ID}.*"

--- a/.maestro/flows/products_create.yaml
+++ b/.maestro/flows/products_create.yaml
@@ -99,14 +99,16 @@ tags:
 - takeScreenshot: product_create_empty_form
 
 # ─────────────────────────────────────────────────────────────────────
-# 2. Name — fixed string so search at the end is deterministic even
-#    after previous runs have accumulated duplicates.
+# 2. Name — stamped with the suite run id so (a) the end-of-flow search
+#    matches exactly this run's product, never a leftover duplicate,
+#    and (b) the stale-orphan sweep can find and delete it if the run
+#    crashes before any cleanup.
 # ─────────────────────────────────────────────────────────────────────
 - tapOn:
     id: "editText"
     label: "Tap product name field"
 
-- inputText: "Maestro Smoke Product"
+- inputText: "Maestro Smoke Product ${SUITE_RUN_ID}"
 
 - hideKeyboard
 
@@ -333,19 +335,20 @@ tags:
 - tapOn:
     id: "search_src_text"
 
-- inputText: "Maestro Smoke"
+- inputText: ${SUITE_RUN_ID}
 
 - hideKeyboard
 
 # The search is debounced, and the staging backend can take a couple
 # of seconds to return results for a just-published product. Generous
-# timeout to accommodate that round-trip.
+# timeout to accommodate that round-trip. Matching on the run id makes
+# this assert immune to leftovers from previous runs.
 - extendedWaitUntil:
-    visible: "Maestro Smoke Product"
+    visible: ".*Maestro Smoke Product ${SUITE_RUN_ID}.*"
     timeout: 30000
     label: "Wait for the new product in search results"
 
-- assertVisible: "Maestro Smoke Product"
+- assertVisible: ".*Maestro Smoke Product ${SUITE_RUN_ID}.*"
 
 - takeScreenshot: product_create_found_in_list
 

--- a/.maestro/flows/products_create.yaml
+++ b/.maestro/flows/products_create.yaml
@@ -1,0 +1,358 @@
+# Smoke Test: Products - Create and publish a full product
+# p2: products.create
+# P2 ref: Products > Create product
+#
+# Exercises the full happy-path creation flow for a Simple physical
+# product, filling in the fields most commonly set at creation time
+# and then actually publishing so we can confirm the product lands
+# in the list:
+#
+#   1. FAB → Manual → Simple physical product
+#   2. Enter the product name (fixed string "Maestro Smoke Product" —
+#      re-using the same name each run keeps staging cleanup to a
+#      single bulk-delete by search rather than piling up timestamped
+#      orphans)
+#   3. "Add price" → enter regular price → back (auto-saves)
+#   4. Tap "Add more details" (productDetail_addMoreButton) — on a
+#      freshly-created simple product the Short description and
+#      Categories rows don't appear on the detail screen until the
+#      user opts them in from this bottom sheet
+#   5. From the sheet pick "Short description" → Aztec visual editor
+#      → type → back (auto-saves + adds the row to the detail list)
+#   6. Tap "Add more details" again → pick "Categories" → ProductCategorySelector
+#      → select the first category ("Uncategorized" if present) → Done
+#   7. Tap PUBLISH in the toolbar
+#   8. Return to the Products list and search for "Maestro Smoke" via
+#      menu_search + search_src_text; assert at least one matching row
+#
+# ⚠️  STAGING-STORE MUTATION: this flow publishes a REAL product on
+# the staging store every run. Clean up periodically by searching
+# "Maestro Smoke" in wp-admin → Products and bulk-trashing the matches.
+# A future improvement would be to trash the product automatically at
+# the end of the flow (menu_trash_product exists).
+#
+# Source strings (res/values/strings.xml):
+#   - product_price_empty                → "Add price"
+#   - product_detail_add_more            → "Add more details"
+#   - product_short_description          → "Short description"
+#   - product_categories                 → "Categories"
+#   - product_category_selector_title    → "Select categories"
+#   - product_category_selector_select_button_title_one → "Select 1 category"
+#   - product_add_tool_bar_menu_button_done → "Publish"
+appId: com.woocommerce.android.dev
+name: "Products - Create and publish a full product"
+tags:
+  - smoke_extended
+  - flaky_quarantine
+  - products
+  - destructive
+---
+# Reuse the logged-in session.
+- runFlow:
+    file: ../subflows/ensure_logged_in.yaml
+
+# Navigate to Products
+- runFlow:
+    file: ../subflows/navigate_to_products.yaml
+
+# ─────────────────────────────────────────────────────────────────────
+# 1. Start product creation
+# ─────────────────────────────────────────────────────────────────────
+- tapOn:
+    id: "addProductButton"
+    retryTapIfNoChange: true
+    label: "Tap Add Product FAB"
+
+- extendedWaitUntil:
+    visible: ".*manual.*|.*Manual.*|.*Select a product type.*|.*Simple physical.*"
+    timeout: 15000
+    label: "Wait for creation entry sheet"
+
+- runFlow:
+    when:
+      visible: ".*manual.*|.*Manual.*"
+    commands:
+      - tapOn: ".*manual.*|.*Manual.*"
+
+- runFlow:
+    when:
+      visible: ".*Simple physical product.*"
+    commands:
+      - tapOn: ".*Simple physical product.*"
+
+- extendedWaitUntil:
+    visible: ".*GOT IT.*|.*Write with AI.*|.*Describe your product.*"
+    timeout: 20000
+    label: "Wait for creation form"
+
+- runFlow:
+    when:
+      visible: "GOT IT"
+    commands:
+      - tapOn: "GOT IT"
+
+- extendedWaitUntil:
+    visible:
+      id: "editText"
+    timeout: 10000
+
+- takeScreenshot: product_create_empty_form
+
+# ─────────────────────────────────────────────────────────────────────
+# 2. Name — fixed string so search at the end is deterministic even
+#    after previous runs have accumulated duplicates.
+# ─────────────────────────────────────────────────────────────────────
+- tapOn:
+    id: "editText"
+    label: "Tap product name field"
+
+- inputText: "Maestro Smoke Product"
+
+- hideKeyboard
+
+- takeScreenshot: product_create_named
+
+# ─────────────────────────────────────────────────────────────────────
+# 3. Price — "Add price" ComplexProperty → ProductPricingFragment
+# ─────────────────────────────────────────────────────────────────────
+- scrollUntilVisible:
+    element: ".*Add price.*|.*Price.*"
+    direction: DOWN
+    timeout: 10000
+    label: "Scroll to Add price row"
+
+- tapOn:
+    text: ".*Add price.*|.*Price.*"
+    retryTapIfNoChange: true
+    label: "Tap Add price row"
+
+- extendedWaitUntil:
+    visible:
+      id: "product_regular_price"
+    timeout: 15000
+    label: "Wait for pricing editor"
+
+- tapOn:
+    id: "product_regular_price"
+    label: "Tap regular price field"
+
+- inputText: "19.99"
+
+- hideKeyboard
+
+- takeScreenshot: product_create_price_entered
+
+# Back auto-saves the price via navigateBackWithResult.
+- back
+
+- extendedWaitUntil:
+    visible:
+      id: "editText"
+    timeout: 10000
+    label: "Wait for detail screen after price edit"
+
+# ─────────────────────────────────────────────────────────────────────
+# 4. Open the "Add more details" bottom sheet to unlock the Short
+#    description + Categories rows. The sheet's list items are built
+#    by ProductDetailBottomSheetBuilder; their visible text comes
+#    from the same string resources used on the detail rows.
+# ─────────────────────────────────────────────────────────────────────
+- scrollUntilVisible:
+    element:
+      id: "productDetail_addMoreButton"
+    direction: DOWN
+    timeout: 10000
+    label: "Scroll to Add more details button"
+
+- tapOn:
+    id: "productDetail_addMoreButton"
+    retryTapIfNoChange: true
+    label: "Tap Add more details"
+
+- extendedWaitUntil:
+    visible: "Short description"
+    timeout: 10000
+    label: "Wait for Add more details bottom sheet"
+
+- takeScreenshot: product_create_add_more_sheet_1
+
+# ─────────────────────────────────────────────────────────────────────
+# 5. Short description — Aztec visual editor
+# ─────────────────────────────────────────────────────────────────────
+- tapOn:
+    text: "Short description"
+    retryTapIfNoChange: true
+    label: "Tap Short description in sheet"
+
+- extendedWaitUntil:
+    visible:
+      id: "visualEditor"
+    timeout: 15000
+    label: "Wait for Aztec visual editor"
+
+- tapOn:
+    id: "visualEditor"
+    label: "Focus the Aztec editor"
+
+# Maestro inputText does not support Unicode (see mobile-dev-inc/maestro#146),
+# so we stick to plain ASCII — no em-dashes, smart quotes, etc.
+- inputText: "Automated smoke test product - safe to delete."
+
+- hideKeyboard
+
+- takeScreenshot: product_create_short_description_entered
+
+- back
+
+- extendedWaitUntil:
+    visible:
+      id: "editText"
+    timeout: 10000
+    label: "Wait for detail screen after description edit"
+
+# ─────────────────────────────────────────────────────────────────────
+# 6. Categories — open "Add more details" sheet again, pick Categories
+# ─────────────────────────────────────────────────────────────────────
+- scrollUntilVisible:
+    element:
+      id: "productDetail_addMoreButton"
+    direction: DOWN
+    timeout: 10000
+    label: "Scroll to Add more details button again"
+
+- tapOn:
+    id: "productDetail_addMoreButton"
+    retryTapIfNoChange: true
+    label: "Tap Add more details (Categories)"
+
+- extendedWaitUntil:
+    visible: "Categories"
+    timeout: 10000
+    label: "Wait for Add more details bottom sheet"
+
+- takeScreenshot: product_create_add_more_sheet_2
+
+- tapOn:
+    text: "Categories"
+    retryTapIfNoChange: true
+    label: "Tap Categories in sheet"
+
+# ViewProductCategories navigates to ProductCategoriesFragment —
+# a View-based screen (NOT the Compose ProductCategorySelectorScreen
+# that's also in the codebase). Signal that the screen has loaded by
+# waiting for its RecyclerView instead of a title string, since
+# "Categories" text is ambiguous with the still-visible detail row.
+- extendedWaitUntil:
+    visible:
+      id: "productCategoriesRecycler"
+    timeout: 15000
+    label: "Wait for category list"
+
+- takeScreenshot: product_create_category_screen
+
+# Only the checkbox itself toggles selection —
+# ProductCategoriesAdapter wires the click listener exclusively on
+# `categoryCheckbox`, NOT on the row or the category name TextView
+# (the row's `selectableItemBackground` is purely decorative). We
+# therefore tap the first `categoryCheckbox` directly (index 0 =
+# whichever category renders at the top of the list; which one is
+# irrelevant for this smoke — the point is "product gets a category").
+- tapOn:
+    id: "categoryCheckbox"
+    index: 0
+    retryTapIfNoChange: true
+    label: "Tick first category checkbox"
+
+# Small settle so the checked-state animation completes before the
+# back press tears the fragment down.
+- extendedWaitUntil:
+    visible:
+      id: "categoryCheckbox"
+    timeout: 3000
+
+# ProductCategoriesFragment saves via viewModel.onBackButtonClicked
+# → setResult back to the detail fragment when the user presses back.
+- back
+
+- extendedWaitUntil:
+    visible:
+      id: "editText"
+    timeout: 15000
+    label: "Wait for detail screen after category edit"
+
+- takeScreenshot: product_create_all_fields_set
+
+# ─────────────────────────────────────────────────────────────────────
+# 7. Publish
+# ─────────────────────────────────────────────────────────────────────
+- extendedWaitUntil:
+    visible: ".*PUBLISH.*"
+    timeout: 10000
+    label: "Wait for Publish action"
+
+- tapOn:
+    text: "PUBLISH"
+    retryTapIfNoChange: true
+    label: "Tap Publish"
+
+# After publishing the app may stay on the detail screen (with
+# action label swapping PUBLISH → SAVE) or return to the products
+# list. Either settling signal is good.
+- extendedWaitUntil:
+    visible: ".*productsRecycler.*|.*SAVE.*|.*updated.*|.*published.*"
+    timeout: 45000
+    label: "Wait for publish to complete"
+
+- takeScreenshot: product_create_published
+
+# ─────────────────────────────────────────────────────────────────────
+# 8. Confirm the product is in the list
+# ─────────────────────────────────────────────────────────────────────
+- runFlow:
+    when:
+      notVisible:
+        id: "productsRecycler"
+    commands:
+      - back
+
+- extendedWaitUntil:
+    visible:
+      id: "productsRecycler"
+    timeout: 15000
+    label: "Wait for products list"
+
+- tapOn:
+    id: "menu_search"
+    label: "Open product search"
+
+- extendedWaitUntil:
+    visible:
+      id: "search_src_text"
+    timeout: 10000
+
+- tapOn:
+    id: "search_src_text"
+
+- inputText: "Maestro Smoke"
+
+- hideKeyboard
+
+# The search is debounced, and the staging backend can take a couple
+# of seconds to return results for a just-published product. Generous
+# timeout to accommodate that round-trip.
+- extendedWaitUntil:
+    visible: "Maestro Smoke Product"
+    timeout: 30000
+    label: "Wait for the new product in search results"
+
+- assertVisible: "Maestro Smoke Product"
+
+- takeScreenshot: product_create_found_in_list
+
+# Close search to leave the UI clean for downstream flows.
+- back
+
+- extendedWaitUntil:
+    visible:
+      id: "productsRecycler"
+    timeout: 10000

--- a/.maestro/flows/products_create.yaml
+++ b/.maestro/flows/products_create.yaml
@@ -1,33 +1,29 @@
 # Smoke Test: Products - Create and publish a full product
-# p2: products.create, products.detail.inventory, products.detail.shipping, products.detail.linked, products.detail.downloads
+# p2: products.create, products.detail.description, products.detail.price, products.detail.inventory, products.detail.shipping, products.detail.type, products.detail.tags, products.detail.short-description, products.detail.linked, products.detail.downloads
 # P2 ref: Products > Create product
 #
-# Exercises the full happy-path creation flow for a Simple physical
-# product, filling in the fields most commonly set at creation time
-# and then actually publishing so we can confirm the product lands
-# in the list:
+# Exercises the full happy-path creation flow for a run-owned Simple physical
+# product, publishes it, reopens the exact product, and verifies its values:
 #
 #   1. FAB → Manual → Simple physical product
-#   2. Enter the product name (fixed string "Maestro Smoke Product" —
-#      re-using the same name each run keeps staging cleanup to a
-#      single bulk-delete by search rather than piling up timestamped
-#      orphans)
-#   3. "Add price" → enter regular price → back (auto-saves)
+#   2. Enter a name and main description unique to SUITE_RUN_ID
+#   3. Set the regular price
 #   4. Configure Inventory with a unique SKU and managed stock quantity
-#   5. Add Shipping dimensions from "Add more details"
-#   6. Add an Upsell from Linked products
-#   7. Add a downloadable file by URL
-#   8. Tap "Add more details" (productDetail_addMoreButton) — on a
+#   5. Add Shipping dimensions and prove the draft is a physical Simple product
+#   6. Create and attach a unique tag
+#   7. Add an Upsell from Linked products
+#   8. Add a downloadable file by URL
+#   9. Tap "Add more details" (productDetail_addMoreButton) — on a
 #      freshly-created simple product the Short description and
 #      Categories rows don't appear on the detail screen until the
 #      user opts them in from this bottom sheet
-#   9. From the sheet pick "Short description" → Aztec visual editor
-#      → type → back (auto-saves + adds the row to the detail list)
-#  10. Tap "Add more details" again → pick "Categories" → ProductCategorySelector
+#  10. From the sheet pick "Short description" and enter a unique value
+#  11. Tap "Add more details" again → pick "Categories" → ProductCategorySelector
 #      → select the first category ("Uncategorized" if present) → Done
-#  11. Tap PUBLISH in the toolbar
-#  12. Search by run ID, reopen the exact product, and verify the Inventory,
-#      Shipping, Linked products, and Downloadable files values persisted
+#  12. Tap PUBLISH in the toolbar
+#  13. Search by run ID, reopen the exact product, and verify Description,
+#      Price, Inventory, Shipping, type, tag, Short description, Upsell, and
+#      Downloadable file values persisted in their editors
 #
 # ⚠️  STAGING-STORE MUTATION: this flow publishes a REAL product on
 # the staging store every run. Clean up periodically by searching
@@ -54,6 +50,9 @@ tags:
 # Reuse the logged-in session.
 - runFlow:
     file: ../subflows/ensure_logged_in.yaml
+
+- runFlow:
+    file: ../subflows/ensure_configured_woo_store.yaml
 
 # Navigate to Products
 - runFlow:
@@ -118,6 +117,56 @@ tags:
 
 - takeScreenshot: product_create_named
 
+# Main description — unique to this run so the reopened editor proves the
+# published product, rather than a stale list row, retained the mutation.
+- tapOn:
+    text: "Describe your product"
+    retryTapIfNoChange: true
+    label: "Open main product description"
+
+- extendedWaitUntil:
+    visible:
+      id: "visualEditor"
+    timeout: 15000
+
+- tapOn:
+    id: "visualEditor"
+- inputText: "Maestro description ${SUITE_RUN_ID}"
+- hideKeyboard
+- tapOn:
+    point: "7%,6%"
+    retryTapIfNoChange: true
+    label: "Save main description through the editor toolbar"
+
+- extendedWaitUntil:
+    visible:
+      id: "editText"
+    timeout: 10000
+    label: "Return after main description edit"
+
+- tapOn:
+    text: "Description"
+    retryTapIfNoChange: true
+    label: "Reopen draft main description"
+- extendedWaitUntil:
+    visible:
+      id: "visualEditor"
+    timeout: 15000
+- copyTextFrom:
+    id: "visualEditor"
+- evalScript: |
+    if (!maestro.copiedText || !maestro.copiedText.includes('Maestro description ' + String(SUITE_RUN_ID))) {
+        throw new Error('Draft product did not retain its main description');
+    }
+- tapOn:
+    point: "7%,6%"
+    retryTapIfNoChange: true
+    label: "Return from verified main description"
+- extendedWaitUntil:
+    visible:
+      id: "editText"
+    timeout: 10000
+
 # ─────────────────────────────────────────────────────────────────────
 # 3. Price — "Add price" ComplexProperty → ProductPricingFragment
 # ─────────────────────────────────────────────────────────────────────
@@ -148,8 +197,11 @@ tags:
 
 - takeScreenshot: product_create_price_entered
 
-# Back auto-saves the price via navigateBackWithResult.
-- back
+# Use the toolbar affordance so ProductPricingFragment delivers its result.
+- tapOn:
+    point: "7%,6%"
+    retryTapIfNoChange: true
+    label: "Save price through the editor toolbar"
 
 - extendedWaitUntil:
     visible:
@@ -208,7 +260,10 @@ tags:
 
 - takeScreenshot: product_create_inventory
 
-- back
+- tapOn:
+    point: "7%,6%"
+    retryTapIfNoChange: true
+    label: "Save inventory through the editor toolbar"
 
 - extendedWaitUntil:
     visible:
@@ -263,7 +318,10 @@ tags:
 
 - takeScreenshot: product_create_shipping
 
-- back
+- tapOn:
+    point: "7%,6%"
+    retryTapIfNoChange: true
+    label: "Save shipping through the editor toolbar"
 
 - extendedWaitUntil:
     visible:
@@ -276,6 +334,144 @@ tags:
     direction: DOWN
     timeout: 10000
     label: "Shipping row was added"
+
+# The selected creation type must still be a non-virtual Simple product before
+# adding a downloadable file changes the summary to Downloadable product.
+- scrollUntilVisible:
+    element: "Physical product"
+    direction: DOWN
+    timeout: 10000
+    label: "Require the Simple physical product type"
+
+- assertVisible:
+    text: "Physical product"
+    label: "Draft is a Simple physical product"
+
+# Tags — create a run-unique tag and attach it to this run-owned draft.
+- scrollUntilVisible:
+    element:
+      id: "productDetail_addMoreButton"
+    direction: DOWN
+    timeout: 10000
+    label: "Reach Add more details for Tags"
+
+- tapOn:
+    id: "productDetail_addMoreButton"
+    retryTapIfNoChange: true
+    label: "Open Add more details for Tags"
+
+- scrollUntilVisible:
+    element: "Tags"
+    direction: DOWN
+    timeout: 10000
+    label: "Require Tags option"
+
+- tapOn:
+    text: "Tags"
+    retryTapIfNoChange: true
+    label: "Open product tags"
+
+- extendedWaitUntil:
+    visible:
+      id: "productTagsRecycler"
+    timeout: 15000
+
+- tapOn:
+    id: "addTagsEditText"
+- inputText: "Maestro tag ${SUITE_RUN_ID}"
+- pressKey: Enter
+- hideKeyboard
+
+- extendedWaitUntil:
+    visible:
+      text: "Maestro tag ${SUITE_RUN_ID}"
+      childOf:
+        id: "selectedTagsGroup"
+    timeout: 15000
+    label: "Run-owned tag is selected"
+
+- tapOn:
+    point: "7%,6%"
+    retryTapIfNoChange: true
+    label: "Save tags through the editor toolbar"
+
+- extendedWaitUntil:
+    visible:
+      id: "editText"
+    timeout: 30000
+    label: "Return after creating the run-owned tag"
+
+# Reopen Tags after the asynchronous create request has completed. If the
+# first request returned no tag, repeat the same unique selection once.
+- scrollUntilVisible:
+    element:
+      id: "productDetail_addMoreButton"
+    direction: DOWN
+    timeout: 10000
+
+- runFlow:
+    when:
+      visible: "Tags"
+    commands:
+      - tapOn:
+          text: "Tags"
+          retryTapIfNoChange: true
+          label: "Reopen attached run-owned tag"
+      - extendedWaitUntil:
+          visible:
+            id: "productTagsRecycler"
+          timeout: 15000
+
+- runFlow:
+    when:
+      notVisible:
+        id: "productTagsRecycler"
+    commands:
+      - tapOn:
+          id: "productDetail_addMoreButton"
+          retryTapIfNoChange: true
+          label: "Reopen Add more details for tag recovery"
+      - extendedWaitUntil:
+          visible: "Tags"
+          timeout: 10000
+      - tapOn:
+          text: "Tags"
+          retryTapIfNoChange: true
+          label: "Reopen Tags for tag recovery"
+
+- extendedWaitUntil:
+    visible:
+      id: "productTagsRecycler"
+    timeout: 15000
+
+- runFlow:
+    when:
+      notVisible:
+        text: "Maestro tag ${SUITE_RUN_ID}"
+        childOf:
+          id: "selectedTagsGroup"
+    commands:
+      - tapOn:
+          id: "addTagsEditText"
+      - inputText: "Maestro tag ${SUITE_RUN_ID}"
+      - pressKey: Enter
+      - hideKeyboard
+      - extendedWaitUntil:
+          visible:
+            text: "Maestro tag ${SUITE_RUN_ID}"
+            childOf:
+              id: "selectedTagsGroup"
+          timeout: 15000
+
+- tapOn:
+    point: "7%,6%"
+    retryTapIfNoChange: true
+    label: "Confirm the run-owned tag after asynchronous creation"
+
+- extendedWaitUntil:
+    visible: "Maestro tag ${SUITE_RUN_ID}"
+    timeout: 30000
+    label: "Run-owned tag is attached to the product draft"
 
 # ─────────────────────────────────────────────────────────────────────
 # 6. Linked products — add one existing product as an Upsell
@@ -351,7 +547,10 @@ tags:
     timeout: 15000
     label: "Upsell product appears in the linked list"
 
-- back
+- tapOn:
+    point: "7%,6%"
+    retryTapIfNoChange: true
+    label: "Save selected Upsell through the toolbar"
 
 - extendedWaitUntil:
     visible:
@@ -365,7 +564,10 @@ tags:
 
 - takeScreenshot: product_create_linked_product
 
-- back
+- tapOn:
+    point: "7%,6%"
+    retryTapIfNoChange: true
+    label: "Save Linked products through the toolbar"
 
 - extendedWaitUntil:
     visible:
@@ -431,8 +633,9 @@ tags:
     id: "menu_done"
     label: "Add downloadable file"
 
-- extendedWaitUntil:
-    visible: "Downloadable files"
+- scrollUntilVisible:
+    element: "Downloadable files"
+    direction: DOWN
     timeout: 15000
     label: "Downloadable files row was added"
 
@@ -484,19 +687,25 @@ tags:
 
 # Maestro inputText does not support Unicode (see mobile-dev-inc/maestro#146),
 # so we stick to plain ASCII — no em-dashes, smart quotes, etc.
-- inputText: "Automated smoke test product - safe to delete."
+- inputText: "Maestro short description ${SUITE_RUN_ID}"
 
 - hideKeyboard
 
 - takeScreenshot: product_create_short_description_entered
 
-- back
+- tapOn:
+    point: "7%,6%"
+    retryTapIfNoChange: true
+    label: "Save short description through the editor toolbar"
 
 - extendedWaitUntil:
-    visible:
-      id: "editText"
+    visible: ".*PUBLISH.*|.*SAVE.*"
     timeout: 10000
     label: "Wait for detail screen after description edit"
+
+- assertVisible:
+    text: "Maestro short description ${SUITE_RUN_ID}"
+    label: "Short description is attached to the draft"
 
 # ─────────────────────────────────────────────────────────────────────
 # 6. Categories — open "Add more details" sheet again, pick Categories
@@ -563,8 +772,7 @@ tags:
 - back
 
 - extendedWaitUntil:
-    visible:
-      id: "editText"
+    visible: ".*PUBLISH.*|.*SAVE.*"
     timeout: 15000
     label: "Wait for detail screen after category edit"
 
@@ -651,6 +859,54 @@ tags:
     timeout: 20000
     label: "Wait for published product detail"
 
+# Main-description persistence in its editor.
+- tapOn:
+    text: "Description"
+    retryTapIfNoChange: true
+    label: "Reopen persisted main description"
+- extendedWaitUntil:
+    visible:
+      id: "visualEditor"
+    timeout: 15000
+- copyTextFrom:
+    id: "visualEditor"
+- evalScript: |
+    if (!maestro.copiedText || !maestro.copiedText.includes('Maestro description ' + String(SUITE_RUN_ID))) {
+        throw new Error('Published product did not retain its main description');
+    }
+- tapOn:
+    point: "7%,6%"
+    retryTapIfNoChange: true
+    label: "Return from persisted main description"
+- extendedWaitUntil:
+    visible:
+      id: "editText"
+    timeout: 10000
+
+# Price persistence in its editor.
+- scrollUntilVisible:
+    element: "Price"
+    direction: DOWN
+    timeout: 10000
+- tapOn:
+    text: "Price"
+    retryTapIfNoChange: true
+    label: "Reopen persisted price"
+- extendedWaitUntil:
+    visible:
+      id: "product_regular_price"
+    timeout: 15000
+- copyTextFrom:
+    id: "product_regular_price"
+- evalScript: |
+    if (!maestro.copiedText || maestro.copiedText.trim().replace(',', '.') !== '19.99') {
+        throw new Error('Published product did not retain regular price 19.99');
+    }
+- back
+- extendedWaitUntil:
+    visible: "Price"
+    timeout: 10000
+
 # Inventory persistence.
 - scrollUntilVisible:
     element: "Inventory"
@@ -667,7 +923,7 @@ tags:
 - copyTextFrom:
     id: "product_sku"
 - evalScript: |
-    if (!maestro.copiedText || !maestro.copiedText.includes('SMOKE-${SUITE_RUN_ID}')) {
+    if (!maestro.copiedText || !maestro.copiedText.includes('SMOKE-' + String(SUITE_RUN_ID))) {
         throw new Error('Published product did not retain its run-owned SKU');
     }
 - assertVisible:
@@ -684,8 +940,7 @@ tags:
 - back
 
 - extendedWaitUntil:
-    visible:
-      id: "editText"
+    visible: "Inventory"
     timeout: 10000
 
 # Shipping persistence.
@@ -725,8 +980,7 @@ tags:
 - back
 
 - extendedWaitUntil:
-    visible:
-      id: "editText"
+    visible: "Shipping"
     timeout: 10000
 
 # Linked-products persistence.
@@ -751,8 +1005,7 @@ tags:
 - back
 
 - extendedWaitUntil:
-    visible:
-      id: "editText"
+    visible: "Linked products"
     timeout: 10000
 
 # Downloadable-file persistence.
@@ -777,8 +1030,68 @@ tags:
 - back
 
 - extendedWaitUntil:
+    visible: "Downloadable files"
+    timeout: 10000
+
+# Product-type persistence. A Simple physical product with an attached file is
+# summarized as Downloadable product after publishing; Shipping persistence
+# above proves it was not converted to a virtual product.
+- scrollUntilVisible:
+    element: "Downloadable product"
+    direction: DOWN
+    timeout: 10000
+    label: "Published product retains its Simple downloadable type"
+- assertVisible:
+    text: "Downloadable product"
+
+# Tag persistence in the tags editor.
+- scrollUntilVisible:
+    element: "Tags"
+    direction: UP
+    timeout: 10000
+- tapOn:
+    text: "Tags"
+    retryTapIfNoChange: true
+    label: "Reopen persisted tags"
+- extendedWaitUntil:
     visible:
-      id: "editText"
+      id: "productTagsRecycler"
+    timeout: 15000
+- assertVisible:
+    text: "Maestro tag ${SUITE_RUN_ID}"
+    childOf:
+      id: "selectedTagsGroup"
+    label: "Published product retains the run-owned tag"
+- back
+- extendedWaitUntil:
+    visible: "Tags"
+    timeout: 10000
+
+# Short-description persistence in its editor.
+- scrollUntilVisible:
+    element: "Short description"
+    direction: DOWN
+    timeout: 10000
+- tapOn:
+    text: "Short description"
+    retryTapIfNoChange: true
+    label: "Reopen persisted short description"
+- extendedWaitUntil:
+    visible:
+      id: "visualEditor"
+    timeout: 15000
+- copyTextFrom:
+    id: "visualEditor"
+- evalScript: |
+    if (!maestro.copiedText || !maestro.copiedText.includes('Maestro short description ' + String(SUITE_RUN_ID))) {
+        throw new Error('Published product did not retain its short description');
+    }
+- tapOn:
+    point: "7%,6%"
+    retryTapIfNoChange: true
+    label: "Return from verified short description"
+- extendedWaitUntil:
+    visible: "Linked products"
     timeout: 10000
 
 - back

--- a/.maestro/flows/products_create.yaml
+++ b/.maestro/flows/products_create.yaml
@@ -1,5 +1,5 @@
 # Smoke Test: Products - Create and publish a full product
-# p2: products.create
+# p2: products.create, products.detail.inventory, products.detail.shipping, products.detail.linked, products.detail.downloads
 # P2 ref: Products > Create product
 #
 # Exercises the full happy-path creation flow for a Simple physical
@@ -13,17 +13,21 @@
 #      single bulk-delete by search rather than piling up timestamped
 #      orphans)
 #   3. "Add price" → enter regular price → back (auto-saves)
-#   4. Tap "Add more details" (productDetail_addMoreButton) — on a
+#   4. Configure Inventory with a unique SKU and managed stock quantity
+#   5. Add Shipping dimensions from "Add more details"
+#   6. Add an Upsell from Linked products
+#   7. Add a downloadable file by URL
+#   8. Tap "Add more details" (productDetail_addMoreButton) — on a
 #      freshly-created simple product the Short description and
 #      Categories rows don't appear on the detail screen until the
 #      user opts them in from this bottom sheet
-#   5. From the sheet pick "Short description" → Aztec visual editor
+#   9. From the sheet pick "Short description" → Aztec visual editor
 #      → type → back (auto-saves + adds the row to the detail list)
-#   6. Tap "Add more details" again → pick "Categories" → ProductCategorySelector
+#  10. Tap "Add more details" again → pick "Categories" → ProductCategorySelector
 #      → select the first category ("Uncategorized" if present) → Done
-#   7. Tap PUBLISH in the toolbar
-#   8. Return to the Products list and search for "Maestro Smoke" via
-#      menu_search + search_src_text; assert at least one matching row
+#  11. Tap PUBLISH in the toolbar
+#  12. Search by run ID, reopen the exact product, and verify the Inventory,
+#      Shipping, Linked products, and Downloadable files values persisted
 #
 # ⚠️  STAGING-STORE MUTATION: this flow publishes a REAL product on
 # the staging store every run. Clean up periodically by searching
@@ -154,7 +158,289 @@ tags:
     label: "Wait for detail screen after price edit"
 
 # ─────────────────────────────────────────────────────────────────────
-# 4. Open the "Add more details" bottom sheet to unlock the Short
+# 4. Inventory — set a run-unique SKU and enable managed stock
+# ─────────────────────────────────────────────────────────────────────
+- scrollUntilVisible:
+    element: "Inventory"
+    direction: DOWN
+    timeout: 10000
+    label: "Scroll to Inventory"
+
+- tapOn:
+    text: "Inventory"
+    retryTapIfNoChange: true
+    label: "Open Inventory settings"
+
+- extendedWaitUntil:
+    visible:
+      id: "product_sku"
+    timeout: 15000
+    label: "Wait for Inventory editor"
+
+- tapOn:
+    id: "product_sku"
+    label: "Focus SKU"
+- eraseText
+- inputText: "SMOKE-${SUITE_RUN_ID}"
+- hideKeyboard
+
+- tapOn:
+    id: "manageStock_switch"
+    label: "Enable stock management"
+
+- extendedWaitUntil:
+    visible:
+      id: "product_stock_quantity"
+    timeout: 10000
+    label: "Wait for managed stock fields"
+
+- tapOn:
+    id: "product_stock_quantity"
+    label: "Focus stock quantity"
+- eraseText
+- inputText: "7"
+- hideKeyboard
+
+- assertVisible:
+    id: "manageStock_switch"
+    checked: true
+    label: "Stock management is enabled"
+
+- takeScreenshot: product_create_inventory
+
+- back
+
+- extendedWaitUntil:
+    visible:
+      id: "editText"
+    timeout: 10000
+    label: "Wait for detail screen after Inventory"
+
+# ─────────────────────────────────────────────────────────────────────
+# 5. Shipping — add weight and dimensions to the physical product
+# ─────────────────────────────────────────────────────────────────────
+- scrollUntilVisible:
+    element:
+      id: "productDetail_addMoreButton"
+    direction: DOWN
+    timeout: 10000
+    label: "Scroll to Add more details for Shipping"
+
+- tapOn:
+    id: "productDetail_addMoreButton"
+    retryTapIfNoChange: true
+    label: "Open Add more details for Shipping"
+
+- extendedWaitUntil:
+    visible: "Shipping"
+    timeout: 10000
+    label: "Require Shipping option"
+
+- tapOn:
+    text: "Shipping"
+    retryTapIfNoChange: true
+    label: "Open Shipping settings"
+
+- extendedWaitUntil:
+    visible:
+      id: "product_weight"
+    timeout: 15000
+    label: "Wait for Shipping editor"
+
+- tapOn: { id: "product_weight", label: "Focus weight" }
+- eraseText
+- inputText: "1.25"
+- tapOn: { id: "product_length", label: "Focus length" }
+- eraseText
+- inputText: "2.5"
+- tapOn: { id: "product_width", label: "Focus width" }
+- eraseText
+- inputText: "3.75"
+- tapOn: { id: "product_height", label: "Focus height" }
+- eraseText
+- inputText: "4.5"
+- hideKeyboard
+
+- takeScreenshot: product_create_shipping
+
+- back
+
+- extendedWaitUntil:
+    visible:
+      id: "editText"
+    timeout: 10000
+    label: "Wait for detail screen after Shipping"
+
+- scrollUntilVisible:
+    element: "Shipping"
+    direction: DOWN
+    timeout: 10000
+    label: "Shipping row was added"
+
+# ─────────────────────────────────────────────────────────────────────
+# 6. Linked products — add one existing product as an Upsell
+# ─────────────────────────────────────────────────────────────────────
+- scrollUntilVisible:
+    element:
+      id: "productDetail_addMoreButton"
+    direction: DOWN
+    timeout: 10000
+    label: "Scroll to Add more details for Linked products"
+
+- tapOn:
+    id: "productDetail_addMoreButton"
+    retryTapIfNoChange: true
+    label: "Open Add more details for Linked products"
+
+- scrollUntilVisible:
+    element: "Linked products"
+    direction: DOWN
+    timeout: 10000
+    label: "Require Linked products option"
+
+- tapOn:
+    text: "Linked products"
+    retryTapIfNoChange: true
+    label: "Open Linked products"
+
+- extendedWaitUntil:
+    visible:
+      id: "add_upsell_products"
+    timeout: 15000
+    label: "Wait for Linked products editor"
+
+- tapOn:
+    id: "add_upsell_products"
+    retryTapIfNoChange: true
+    label: "Open Upsell products"
+
+- extendedWaitUntil:
+    visible: "Add product"
+    timeout: 15000
+    label: "Wait for empty Upsell list"
+
+- tapOn:
+    text: "Add product"
+    retryTapIfNoChange: true
+    label: "Choose an Upsell product"
+
+- extendedWaitUntil:
+    visible:
+      id: "productName"
+    timeout: 20000
+    label: "Wait for product selection list"
+
+- tapOn:
+    id: "productName"
+    index: 0
+    label: "Select first existing product as Upsell"
+
+- extendedWaitUntil:
+    visible:
+      id: "menu_done"
+    timeout: 10000
+    label: "Wait for product selection action"
+
+- tapOn:
+    id: "menu_done"
+    label: "Confirm Upsell product"
+
+- extendedWaitUntil:
+    visible:
+      id: "productName"
+    timeout: 15000
+    label: "Upsell product appears in the linked list"
+
+- back
+
+- extendedWaitUntil:
+    visible:
+      id: "upsells_count"
+    timeout: 10000
+    label: "Wait for Upsell count"
+
+- assertVisible:
+    id: "upsells_count"
+    label: "One Upsell is attached to the product draft"
+
+- takeScreenshot: product_create_linked_product
+
+- back
+
+- extendedWaitUntil:
+    visible:
+      id: "editText"
+    timeout: 10000
+    label: "Wait for detail screen after Linked products"
+
+# ─────────────────────────────────────────────────────────────────────
+# 7. Downloadable files — attach a deterministic URL and file name
+# ─────────────────────────────────────────────────────────────────────
+- scrollUntilVisible:
+    element:
+      id: "productDetail_addMoreButton"
+    direction: DOWN
+    timeout: 10000
+    label: "Scroll to Add more details for Downloadable files"
+
+- tapOn:
+    id: "productDetail_addMoreButton"
+    retryTapIfNoChange: true
+    label: "Open Add more details for Downloadable files"
+
+- scrollUntilVisible:
+    element: "Downloadable files"
+    direction: DOWN
+    timeout: 10000
+    label: "Require Downloadable files option"
+
+- tapOn:
+    text: "Downloadable files"
+    retryTapIfNoChange: true
+    label: "Open downloadable file sources"
+
+- extendedWaitUntil:
+    visible:
+      id: "add_downloadable_manually"
+    timeout: 10000
+    label: "Wait for downloadable file source sheet"
+
+- tapOn:
+    id: "add_downloadable_manually"
+    label: "Enter downloadable file URL"
+
+- extendedWaitUntil:
+    visible:
+      id: "product_download_url"
+    timeout: 15000
+    label: "Wait for downloadable file editor"
+
+- tapOn: { id: "product_download_url", label: "Focus file URL" }
+- inputText: "https://example.com/maestro-${SUITE_RUN_ID}.pdf"
+- tapOn: { id: "product_download_name", label: "Focus file name" }
+- inputText: "Maestro download ${SUITE_RUN_ID}"
+- hideKeyboard
+
+- extendedWaitUntil:
+    visible:
+      id: "menu_done"
+    timeout: 10000
+    label: "Wait for Add downloadable file action"
+
+- tapOn:
+    id: "menu_done"
+    label: "Add downloadable file"
+
+- extendedWaitUntil:
+    visible: "Downloadable files"
+    timeout: 15000
+    label: "Downloadable files row was added"
+
+- assertVisible: "1 file"
+- takeScreenshot: product_create_downloadable_file
+
+# ─────────────────────────────────────────────────────────────────────
+# 8. Open the "Add more details" bottom sheet to unlock the Short
 #    description + Categories rows. The sheet's list items are built
 #    by ProductDetailBottomSheetBuilder; their visible text comes
 #    from the same string resources used on the detail rows.
@@ -351,6 +637,157 @@ tags:
 - assertVisible: ".*Maestro Smoke Product ${SUITE_RUN_ID}.*"
 
 - takeScreenshot: product_create_found_in_list
+
+# Reopen the exact run-owned product after publishing and verify the four
+# edited detail surfaces persisted through the product update.
+- tapOn:
+    text: ".*Maestro Smoke Product ${SUITE_RUN_ID}.*"
+    retryTapIfNoChange: true
+    label: "Reopen the published run-owned product"
+
+- extendedWaitUntil:
+    visible:
+      id: "editText"
+    timeout: 20000
+    label: "Wait for published product detail"
+
+# Inventory persistence.
+- scrollUntilVisible:
+    element: "Inventory"
+    direction: DOWN
+    timeout: 10000
+- tapOn:
+    text: "Inventory"
+    retryTapIfNoChange: true
+- extendedWaitUntil:
+    visible:
+      id: "product_sku"
+    timeout: 15000
+
+- copyTextFrom:
+    id: "product_sku"
+- evalScript: |
+    if (!maestro.copiedText || !maestro.copiedText.includes('SMOKE-${SUITE_RUN_ID}')) {
+        throw new Error('Published product did not retain its run-owned SKU');
+    }
+- assertVisible:
+    id: "manageStock_switch"
+    checked: true
+    label: "Published product retains managed stock"
+- copyTextFrom:
+    id: "product_stock_quantity"
+- evalScript: |
+    if (!maestro.copiedText || !maestro.copiedText.includes('7')) {
+        throw new Error('Published product did not retain stock quantity 7');
+    }
+- takeScreenshot: product_persisted_inventory
+- back
+
+- extendedWaitUntil:
+    visible:
+      id: "editText"
+    timeout: 10000
+
+# Shipping persistence.
+- scrollUntilVisible:
+    element: "Shipping"
+    direction: DOWN
+    timeout: 10000
+- tapOn:
+    text: "Shipping"
+    retryTapIfNoChange: true
+- extendedWaitUntil:
+    visible:
+      id: "product_weight"
+    timeout: 15000
+
+- copyTextFrom: { id: "product_weight" }
+- evalScript: |
+    if (!maestro.copiedText || !maestro.copiedText.includes('1.25')) {
+        throw new Error('Published product did not retain weight 1.25');
+    }
+- copyTextFrom: { id: "product_length" }
+- evalScript: |
+    if (!maestro.copiedText || !maestro.copiedText.includes('2.5')) {
+        throw new Error('Published product did not retain length 2.5');
+    }
+- copyTextFrom: { id: "product_width" }
+- evalScript: |
+    if (!maestro.copiedText || !maestro.copiedText.includes('3.75')) {
+        throw new Error('Published product did not retain width 3.75');
+    }
+- copyTextFrom: { id: "product_height" }
+- evalScript: |
+    if (!maestro.copiedText || !maestro.copiedText.includes('4.5')) {
+        throw new Error('Published product did not retain height 4.5');
+    }
+- takeScreenshot: product_persisted_shipping
+- back
+
+- extendedWaitUntil:
+    visible:
+      id: "editText"
+    timeout: 10000
+
+# Linked-products persistence.
+- scrollUntilVisible:
+    element: "Linked products"
+    direction: DOWN
+    timeout: 10000
+- tapOn:
+    text: "Linked products"
+    retryTapIfNoChange: true
+- extendedWaitUntil:
+    visible:
+      id: "upsells_count"
+    timeout: 15000
+- copyTextFrom:
+    id: "upsells_count"
+- evalScript: |
+    if (!maestro.copiedText || !maestro.copiedText.trim().startsWith('1')) {
+        throw new Error('Published product did not retain its Upsell');
+    }
+- takeScreenshot: product_persisted_linked_product
+- back
+
+- extendedWaitUntil:
+    visible:
+      id: "editText"
+    timeout: 10000
+
+# Downloadable-file persistence.
+- scrollUntilVisible:
+    element: "Downloadable files"
+    direction: DOWN
+    timeout: 10000
+- tapOn:
+    text: "Downloadable files"
+    retryTapIfNoChange: true
+- extendedWaitUntil:
+    visible:
+      id: "productDownloadsRecycler"
+    timeout: 15000
+- assertVisible:
+    text: "Maestro download ${SUITE_RUN_ID}"
+    label: "Published product retains downloadable file name"
+- assertVisible:
+    text: "https://example.com/maestro-${SUITE_RUN_ID}.pdf"
+    label: "Published product retains downloadable file URL"
+- takeScreenshot: product_persisted_downloadable_file
+- back
+
+- extendedWaitUntil:
+    visible:
+      id: "editText"
+    timeout: 10000
+
+- back
+
+- extendedWaitUntil:
+    visible:
+      id: "productsRecycler"
+    timeout: 10000
+    label: "Return to filtered product results"
 
 # Close search to leave the UI clean for downstream flows.
 - back

--- a/.maestro/flows/products_detail.yaml
+++ b/.maestro/flows/products_detail.yaml
@@ -1,5 +1,5 @@
 # Smoke Test: Products - Product Detail
-# p2: products.detail.description, products.detail.categories, products.detail.type
+# p2: products.detail.categories
 # P2 ref: Products > Product details (all details)
 #
 # IMPORTANT: this flow opens "the first product" in the staging list.
@@ -25,9 +25,10 @@
 # Verifies:
 #   - Product detail screen loads
 #   - Product name field + "Describe your product" area render
-#   - Universal ComplexProperty rows render (Product type, Reviews,
-#     Categories). Type-specific editors remain manual until this flow targets
-#     a product fixture that guarantees those rows.
+#   - Universal ComplexProperty rows render (Product type, Reviews, Categories)
+#
+# Mutable description and product-type persistence is verified against the
+# run-owned product in products_create.yaml.
 appId: com.woocommerce.android.dev
 name: "Products - Product detail view"
 tags:

--- a/.maestro/flows/products_media_upload.yaml
+++ b/.maestro/flows/products_media_upload.yaml
@@ -23,12 +23,10 @@
 #     └─ back → product detail (dirty — new image in draft)
 #        └─ tap Save / Publish → product detail updated on backend
 #
-# ⚠️  STAGING-STORE MUTATION: unlike most smoke flows, this one DOES
-# persist a change — the image is attached to the product it opens.
-# The flow therefore targets this run's seeded simple product (located
-# via search on ${FIXTURE_SIMPLE_PRODUCT}), which manifest cleanup
-# deletes after the run, so the mutation never touches real store data
-# and never outlives the suite.
+# ⚠️  STORE MUTATION: unlike most smoke flows, this one DOES persist a
+# change — the image is attached to the product it opens. The flow
+# therefore targets the automation-owned product created earlier in the
+# suite by products_create.yaml, located by the unique suite run id.
 #
 # Source strings (res/values/strings.xml):
 #   - image_source_wp_media_library → "WordPress media library"
@@ -56,11 +54,37 @@ tags:
 - runFlow:
     file: ../subflows/navigate_to_products.yaml
 
-# Open this run's seeded simple product — never an arbitrary first
-# row. This flow persists an image on whatever product it opens, and
-# on the shared store index-0 can be a manual tester's real product.
-# The seeded fixture is deleted by manifest cleanup after the run, so
-# the gallery mutation never outlives the suite.
+# products_variations_and_tags.yaml leaves the Product type filter
+# active when it runs earlier in the suite. Clear active filters before
+# searching for this run's simple product.
+- runFlow:
+    when:
+      visible: "Filters.*[0-9]"
+    commands:
+      - tapOn:
+          id: "btn_product_filter"
+          retryTapIfNoChange: true
+          label: "Open active product filters"
+      - extendedWaitUntil:
+          visible:
+            id: "filterList"
+          timeout: 15000
+      - tapOn:
+          id: "menu_clear"
+          retryTapIfNoChange: true
+          label: "Clear active product filters"
+      - tapOn:
+          id: "filterList_btnShowProducts"
+          retryTapIfNoChange: true
+          label: "Show products without filters"
+      - extendedWaitUntil:
+          visible:
+            id: "productsRecycler"
+          timeout: 15000
+
+# Open this run's newly-created product — never an arbitrary first row.
+# This flow persists an image on whatever product it opens, and on the
+# shared store index-0 can be a manual tester's real product.
 - tapOn:
     id: "menu_search"
     label: "Open product search"
@@ -72,19 +96,22 @@ tags:
 
 - tapOn:
     id: "search_src_text"
-- inputText: ${FIXTURE_SIMPLE_PRODUCT}
+- inputText: "Maestro Smoke Product ${SUITE_RUN_ID}"
 - hideKeyboard
 
 - extendedWaitUntil:
     visible:
-      text: "${FIXTURE_SIMPLE_PRODUCT}"
+      text: "Maestro Smoke Product ${SUITE_RUN_ID}"
     timeout: 20000
-    label: "Wait for the seeded product in search results"
+    label: "Wait for this run's product in search results"
+
+- hideKeyboard
 
 - tapOn:
-    text: "${FIXTURE_SIMPLE_PRODUCT}"
+    id: "productName"
+    index: 0
     retryTapIfNoChange: true
-    label: "Open seeded simple product"
+    label: "Open this run's product"
 
 - extendedWaitUntil:
     visible: ".*GOT IT.*|.*Describe your product.*|.*Write with AI.*|.*PUBLISH.*|.*SAVE.*"
@@ -104,14 +131,31 @@ tags:
 
 - takeScreenshot: media_upload_product_detail
 
-# Tap the add-image affordance. We try the gallery per-item icon
-# first (addImageIcon) and fall back to the empty-state container;
-# both call ProductDetailViewModel.onAddImageButtonClicked which
-# navigates to ProductImagesFragment with showChooser = true.
-- tapOn:
-    id: "addImageIcon"
-    retryTapIfNoChange: true
-    label: "Tap add image icon (gallery)"
+# Tap the add-image affordance. Newly-created products show the
+# empty-gallery "Add a product image" row; products that already have
+# media show the gallery add icon/container. All paths call
+# ProductDetailViewModel.onAddImageButtonClicked which navigates to
+# ProductImagesFragment with showChooser = true.
+- runFlow:
+    when:
+      visible: "Add a product image"
+    commands:
+      - tapOn:
+          text: "Add a product image"
+          retryTapIfNoChange: true
+          label: "Tap empty-gallery add image row"
+      - extendedWaitUntil:
+          visible: "Select an upload method"
+          timeout: 10000
+
+- runFlow:
+    when:
+      notVisible: "Select an upload method"
+    commands:
+      - tapOn:
+          id: "addImageIcon"
+          retryTapIfNoChange: true
+          label: "Tap add image icon (gallery)"
 
 - runFlow:
     when:
@@ -203,9 +247,15 @@ tags:
 
 - takeScreenshot: media_upload_image_in_gallery
 
-# Navigate back to the product detail. ProductImagesFragment's back
-# press returns to ProductDetail with the draft's images updated.
-- back
+# Navigate back to the product detail through ProductImagesFragment's
+# toolbar navigation. That path calls onNavigateBackButtonClicked()
+# and returns ExitWithResult(images) to ProductDetailFragment. A raw
+# device back can pop the destination without delivering that result
+# on some app/back-stack states.
+- tapOn:
+    point: "7%,6%"
+    retryTapIfNoChange: true
+    label: "Tap image gallery toolbar back"
 
 - extendedWaitUntil:
     visible:

--- a/.maestro/flows/products_media_upload.yaml
+++ b/.maestro/flows/products_media_upload.yaml
@@ -77,13 +77,13 @@ tags:
 
 - extendedWaitUntil:
     visible:
-      id: "productName"
+      text: "${FIXTURE_SIMPLE_PRODUCT}"
     timeout: 20000
     label: "Wait for the seeded product in search results"
 
 - tapOn:
-    id: "productName"
-    index: 0
+    text: "${FIXTURE_SIMPLE_PRODUCT}"
+    retryTapIfNoChange: true
     label: "Open seeded simple product"
 
 - extendedWaitUntil:

--- a/.maestro/flows/products_media_upload.yaml
+++ b/.maestro/flows/products_media_upload.yaml
@@ -1,0 +1,236 @@
+# Smoke Test: Products - Media upload via WordPress media library
+# p2: products.detail.media
+# P2 ref: Products > Media upload
+#
+# Exercises the full WP-media-library upload path end-to-end:
+#
+#   Product detail
+#     └─ tap "Add image"
+#        (ProductDetailViewModel.onAddImageButtonClicked →
+#         ViewProductImageGallery with showChooser = true)
+#           ▼
+#   ProductImagesFragment ("Photos" screen)
+#     └─ image-source dialog auto-opens
+#        └─ tap "WordPress media library"
+#           (mediaPickerHelper.showMediaPicker(WP_MEDIA_LIBRARY))
+#              ▼
+#   MediaPickerActivity (external org.wordpress:mediapicker lib)
+#     └─ tap first image_thumbnail in the recycler
+#     └─ tap mnu_confirm_selection ("Add N") in the toolbar
+#        └─ result returned to ProductImagesFragment
+#           ▼
+#   ProductImagesFragment — gallery now shows the image
+#     └─ back → product detail (dirty — new image in draft)
+#        └─ tap Save / Publish → product detail updated on backend
+#
+# ⚠️  STAGING-STORE MUTATION: unlike most smoke flows, this one DOES
+# persist a change — the image is attached to the real product
+# returned by the list's first tap. Re-running the flow grows the
+# product's media gallery over time. That's an intentional trade-off
+# to actually exercise the upload path; clean the test product's
+# images manually if the staging store needs a reset.
+#
+# Source strings (res/values/strings.xml):
+#   - image_source_wp_media_library → "WordPress media library"
+#   - product_add_tool_bar_menu_button_done → "Publish"
+#
+# External lib resource IDs (from
+# org.wordpress:mediapicker:0.3.5 AAR):
+#   - recycler                 — media thumbnail list
+#   - image_thumbnail          — per-tile ImageView
+#   - mnu_confirm_selection    — "Add N" action-mode menu item
+#   - soft_ask_view            — storage-permission prompt (guarded)
+appId: com.woocommerce.android.dev
+name: "Products - Media upload via WP media library"
+tags:
+  - smoke_extended
+  - flaky_quarantine
+  - products
+  - destructive
+---
+# Reuse the logged-in session.
+- runFlow:
+    file: ../subflows/ensure_logged_in.yaml
+
+# Navigate to Products
+- runFlow:
+    file: ../subflows/navigate_to_products.yaml
+
+# Open the first product. Its type doesn't matter for this flow —
+# every product type can have images attached.
+- tapOn:
+    id: "productName"
+    index: 0
+    label: "Tap first product"
+
+- extendedWaitUntil:
+    visible: ".*GOT IT.*|.*Describe your product.*|.*Write with AI.*|.*PUBLISH.*|.*SAVE.*"
+    timeout: 25000
+    label: "Wait for product detail to load"
+
+- runFlow:
+    when:
+      visible: "GOT IT"
+    commands:
+      - tapOn: "GOT IT"
+
+- extendedWaitUntil:
+    visible:
+      id: "editText"
+    timeout: 10000
+
+- takeScreenshot: media_upload_product_detail
+
+# Tap the add-image affordance. We try the gallery per-item icon
+# first (addImageIcon) and fall back to the empty-state container;
+# both call ProductDetailViewModel.onAddImageButtonClicked which
+# navigates to ProductImagesFragment with showChooser = true.
+- tapOn:
+    id: "addImageIcon"
+    retryTapIfNoChange: true
+    label: "Tap add image icon (gallery)"
+
+- runFlow:
+    when:
+      notVisible: "Select an upload method"
+    commands:
+      - tapOn:
+          id: "addImageContainer"
+          retryTapIfNoChange: true
+          label: "Tap add image container (fallback)"
+
+- runFlow:
+    when:
+      notVisible: "Select an upload method"
+    commands:
+      - tapOn:
+          text: "Add image"
+          retryTapIfNoChange: true
+          label: "Tap by Add image content description"
+
+# Dialog should be showing now.
+- extendedWaitUntil:
+    visible: "Select an upload method"
+    timeout: 15000
+    label: "Wait for image source dialog"
+
+- takeScreenshot: media_upload_source_dialog
+
+# Pick the WP media library source. The Choose / Camera entries are
+# probed incidentally by the existence-assertions in the original
+# smoke flow; here we specifically exercise the network-backed path.
+- tapOn:
+    text: "WordPress media library"
+    label: "Tap WordPress media library"
+
+# MediaPickerActivity should open with the thumbnails RecyclerView.
+# On a freshly-installed app it occasionally shows the permission
+# soft-ask first — we grant it if it appears. The APK installer uses
+# `adb install -g` which usually pre-grants runtime permissions, but
+# the soft-ask is an in-app affordance unrelated to runtime perms,
+# so we still guard for it.
+- runFlow:
+    when:
+      visible:
+        id: "soft_ask_view"
+    commands:
+      - tapOn:
+          text: ".*Allow access.*|.*Allow.*"
+
+- extendedWaitUntil:
+    visible:
+      id: "recycler"
+    timeout: 30000
+    label: "Wait for WP Media Library to load"
+
+- takeScreenshot: media_upload_wp_library
+
+# Select the first image in the grid.
+- tapOn:
+    id: "image_thumbnail"
+    index: 0
+    retryTapIfNoChange: true
+    label: "Tap first WP Media Library item"
+
+- takeScreenshot: media_upload_item_selected
+
+# Confirm the selection via the action-mode menu item. The
+# mediapicker library labels this button dynamically based on
+# selection count ("Add 1", "Add 2", …) so we target the id
+# directly — it's stable across counts.
+- tapOn:
+    id: "mnu_confirm_selection"
+    retryTapIfNoChange: true
+    label: "Tap Add in toolbar"
+
+# Back on ProductImagesFragment. The gallery now shows the freshly-
+# picked image. The thumbnail's id is `productImage`
+# (image_gallery_item.xml) — asserting it's visible proves the
+# image-add round-trip worked. Allow generous timeout because the
+# image is streamed from Jetpack / wp.com.
+- extendedWaitUntil:
+    visible:
+      id: "productImage"
+    timeout: 45000
+    label: "Wait for image to appear in product gallery"
+
+- assertVisible:
+    id: "productImage"
+    label: "Image is displayed in ProductImagesFragment"
+
+- takeScreenshot: media_upload_image_in_gallery
+
+# Navigate back to the product detail. ProductImagesFragment's back
+# press returns to ProductDetail with the draft's images updated.
+- back
+
+- extendedWaitUntil:
+    visible:
+      id: "editText"
+    timeout: 10000
+    label: "Wait for product detail to reappear"
+
+# Save the product so the image is persisted on the backend. On an
+# existing product the action is labelled "SAVE"; on a brand-new
+# product it would read "PUBLISH". Match either.
+- extendedWaitUntil:
+    visible: ".*SAVE.*|.*PUBLISH.*"
+    timeout: 10000
+    label: "Wait for Save/Publish action"
+
+- tapOn:
+    text: ".*SAVE.*|.*PUBLISH.*"
+    retryTapIfNoChange: true
+    label: "Tap Save/Publish to persist the image"
+
+# A few outcomes are possible depending on app version + network:
+#   1. The button label flips back to the non-dirty state and we
+#      stay on the detail screen.
+#   2. A success snackbar appears.
+#   3. The detail screen closes automatically.
+# We accept any of those signals as "save worked".
+- extendedWaitUntil:
+    visible: ".*updated.*|.*saved.*|.*productsRecycler.*|.*Describe your product.*"
+    timeout: 30000
+    label: "Wait for save confirmation"
+
+- takeScreenshot: media_upload_saved
+
+# Return to the product list for the next flow.
+- runFlow:
+    when:
+      notVisible:
+        id: "productsRecycler"
+    commands:
+      - back
+
+- runFlow:
+    when:
+      visible: "Discard"
+    commands:
+      - tapOn: "Discard"
+
+- extendedWaitUntil:
+    visible:
+      id: "productsRecycler"
+    timeout: 15000

--- a/.maestro/flows/products_media_upload.yaml
+++ b/.maestro/flows/products_media_upload.yaml
@@ -24,11 +24,11 @@
 #        └─ tap Save / Publish → product detail updated on backend
 #
 # ⚠️  STAGING-STORE MUTATION: unlike most smoke flows, this one DOES
-# persist a change — the image is attached to the real product
-# returned by the list's first tap. Re-running the flow grows the
-# product's media gallery over time. That's an intentional trade-off
-# to actually exercise the upload path; clean the test product's
-# images manually if the staging store needs a reset.
+# persist a change — the image is attached to the product it opens.
+# The flow therefore targets this run's seeded simple product (located
+# via search on ${FIXTURE_SIMPLE_PRODUCT}), which manifest cleanup
+# deletes after the run, so the mutation never touches real store data
+# and never outlives the suite.
 #
 # Source strings (res/values/strings.xml):
 #   - image_source_wp_media_library → "WordPress media library"
@@ -56,12 +56,35 @@ tags:
 - runFlow:
     file: ../subflows/navigate_to_products.yaml
 
-# Open the first product. Its type doesn't matter for this flow —
-# every product type can have images attached.
+# Open this run's seeded simple product — never an arbitrary first
+# row. This flow persists an image on whatever product it opens, and
+# on the shared store index-0 can be a manual tester's real product.
+# The seeded fixture is deleted by manifest cleanup after the run, so
+# the gallery mutation never outlives the suite.
+- tapOn:
+    id: "menu_search"
+    label: "Open product search"
+
+- extendedWaitUntil:
+    visible:
+      id: "search_src_text"
+    timeout: 10000
+
+- tapOn:
+    id: "search_src_text"
+- inputText: ${FIXTURE_SIMPLE_PRODUCT}
+- hideKeyboard
+
+- extendedWaitUntil:
+    visible:
+      id: "productName"
+    timeout: 20000
+    label: "Wait for the seeded product in search results"
+
 - tapOn:
     id: "productName"
     index: 0
-    label: "Tap first product"
+    label: "Open seeded simple product"
 
 - extendedWaitUntil:
     visible: ".*GOT IT.*|.*Describe your product.*|.*Write with AI.*|.*PUBLISH.*|.*SAVE.*"

--- a/.maestro/flows/products_variations_and_tags.yaml
+++ b/.maestro/flows/products_variations_and_tags.yaml
@@ -1,5 +1,5 @@
 # Smoke Test: Products - Variations via Product Type filter
-# p2: products.detail.tags, products.detail.variations, products.detail.variation-attributes
+# p2: products.detail.variations, products.detail.variation-attributes
 # P2 ref: Products > Product details — Variations, Variation detail
 #
 # Exercises the real Variable-product path end-to-end:
@@ -24,6 +24,9 @@
 # a positive variation count after the filter is applied will fail — that's
 # intentional. The test doesn't know whether "no variable products" is
 # a regression in the app or missing store data.
+#
+# Mutable tag persistence is verified against the run-owned product in
+# products_create.yaml.
 #
 # Key selectors (from the app's XML layouts):
 #   - btn_product_filter              — WCToggleOutlinedButton on the

--- a/.maestro/subflows/ensure_configured_woo_store.yaml
+++ b/.maestro/subflows/ensure_configured_woo_store.yaml
@@ -1,0 +1,46 @@
+appId: com.woocommerce.android.dev
+---
+- runFlow:
+    file: navigate_to_more_menu.yaml
+
+- copyTextFrom:
+    id: "more_menu_store_url"
+- evalScript: ${output.configuredCurrentStoreUrl = maestro.copiedText.trim()}
+
+- runFlow:
+    when:
+      true: ${String(output.configuredCurrentStoreUrl).toLowerCase().split('://').pop().split('/')[0].split('?')[0].split('#')[0].split(':')[0] != String(WOO_JETPACK_STORE_URL).toLowerCase().split('://').pop().split('/')[0].split('?')[0].split('#')[0].split(':')[0]}
+    commands:
+      - tapOn:
+          id: "more_menu_store_switcher"
+          label: "Open store picker for configured fixture"
+      - extendedWaitUntil:
+          visible:
+            id: "sites_recycler"
+          timeout: 20000
+      - scrollUntilVisible:
+          element:
+            text: ".*${String(WOO_JETPACK_STORE_URL).toLowerCase().split('://').pop().split('/')[0].split('?')[0].split('#')[0].split(':')[0]}.*"
+          direction: DOWN
+          timeout: 20000
+          label: "Find configured Woo fixture store"
+      - tapOn:
+          text: ".*${String(WOO_JETPACK_STORE_URL).toLowerCase().split('://').pop().split('/')[0].split('?')[0].split('#')[0].split(':')[0]}.*"
+          label: "Select configured Woo fixture store"
+      - tapOn:
+          id: "button_primary"
+          retryTapIfNoChange: true
+          label: "Confirm configured Woo fixture store"
+      - extendedWaitUntil:
+          visible:
+            id: "dashboard_container"
+          timeout: 30000
+
+- runFlow:
+    file: navigate_to_more_menu.yaml
+- copyTextFrom:
+    id: "more_menu_store_url"
+- evalScript: ${output.configuredSelectedStoreUrl = maestro.copiedText.trim()}
+- assertTrue:
+    condition: ${String(output.configuredSelectedStoreUrl).toLowerCase().split('://').pop().split('/')[0].split('?')[0].split('#')[0].split(':')[0] == String(WOO_JETPACK_STORE_URL).toLowerCase().split('://').pop().split('/')[0].split('?')[0].split('#')[0].split(':')[0]}
+    label: "Configured Woo fixture store is selected"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
@@ -132,7 +133,8 @@ fun EditCouponScreen(
                 text = stringResource(id = viewState.saveButtonText),
                 modifier = Modifier
                     .padding(horizontal = dimensionResource(id = R.dimen.major_100))
-                    .fillMaxWidth(),
+                    .fillMaxWidth()
+                    .testTag(EditCouponTestTags.SAVE_BUTTON),
                 enabled = viewState.hasChanges
             )
         }
@@ -177,7 +179,9 @@ private fun DetailsSection(
             onValueChange = { onCouponCodeChanged(it.toLowerCase(Locale.current)) },
             helperText = stringResource(id = R.string.coupon_edit_code_helper),
             keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.Characters),
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag(EditCouponTestTags.CODE_INPUT)
         )
         WCTextButton(
             onClick = {
@@ -331,8 +335,16 @@ private fun AmountField(amount: BigDecimal?, amountUnit: String, type: Type?, on
         // TODO use KeyboardType.Decimal after updating to Compose 1.2.0
         //  (https://issuetracker.google.com/issues/209835363)
         keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-        modifier = Modifier.fillMaxWidth()
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag(EditCouponTestTags.AMOUNT_INPUT)
     )
+}
+
+internal object EditCouponTestTags {
+    const val AMOUNT_INPUT = "edit_coupon_amount_input"
+    const val CODE_INPUT = "edit_coupon_code_input"
+    const val SAVE_BUTTON = "edit_coupon_save_button"
 }
 
 @Composable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customer/CustomerListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customer/CustomerListScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
@@ -195,8 +196,13 @@ private fun CustomerListItem(
         name = customer.name.render(),
         username = customer.username.render(),
         email = customer.email.render(),
+        modifier = Modifier.testTag(CustomerListTestTags.CUSTOMER_ITEM),
         onClick = { onCustomerSelected(customer.payload) },
     )
+}
+
+internal object CustomerListTestTags {
+    const val CUSTOMER_ITEM = "customer_list_item"
 }
 
 @Composable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/AmountBigDecimalTextField.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/AmountBigDecimalTextField.kt
@@ -33,6 +33,7 @@ fun AmountBigDecimalTextField(
                 boxBackgroundMode = TextInputLayout.BOX_BACKGROUND_NONE
                 val textSize = 28f
                 editText.apply {
+                    id = R.id.order_shipping_amount_input
                     background = null
                     setTextAppearance(R.style.TextAppearance_Woo_EditText)
                     setTextSize(TypedValue.COMPLEX_UNIT_SP, textSize)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -138,7 +139,9 @@ fun UpdateShippingScreen(
             FieldEditValue(
                 name.orEmpty(),
                 { name -> onNameChanged(name) },
-                Modifier.fillMaxWidth()
+                Modifier
+                    .fillMaxWidth()
+                    .testTag(OrderShippingTestTags.NAME_INPUT)
             )
         }
         Column(
@@ -163,7 +166,9 @@ fun UpdateShippingScreen(
             WCColoredButton(
                 enabled = isSaveChangesEnabled,
                 onClick = { onSaveChanges() },
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag(OrderShippingTestTags.SAVE_BUTTON)
             ) {
                 val buttonResId = if (isEditFlow) {
                     R.string.order_creation_shipping_edit
@@ -174,6 +179,11 @@ fun UpdateShippingScreen(
             }
         }
     }
+}
+
+internal object OrderShippingTestTags {
+    const val NAME_INPUT = "order_shipping_name_input"
+    const val SAVE_BUTTON = "order_shipping_save_button"
 }
 
 @Composable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/ExpandableProductCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/ExpandableProductCard.kt
@@ -53,6 +53,7 @@ import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
@@ -83,6 +84,11 @@ import com.woocommerce.android.util.getVariationAttributesAndStockText
 import java.math.BigDecimal
 
 const val ANIM_DURATION_MILLIS = 128
+
+internal object ExpandableProductCardTestTags {
+    const val DISCOUNT_AMOUNT = "order_product_discount_amount"
+}
+
 const val MULTIPLICATION_CHAR = "×"
 
 @SuppressLint("UnusedTransitionTargetStateParameter")
@@ -168,6 +174,7 @@ fun ExpandableProductCard(
         if (!isExpanded && product.productInfo.hasDiscount) {
             Text(
                 modifier = Modifier
+                    .testTag(ExpandableProductCardTestTags.DISCOUNT_AMOUNT)
                     .constrainAs(discount) {
                         end.linkTo(chevron.start)
                         top.linkTo(stock.top)
@@ -414,6 +421,7 @@ fun ExtendedProductCardContent(
             }
             Text(
                 modifier = Modifier
+                    .testTag(ExpandableProductCardTestTags.DISCOUNT_AMOUNT)
                     .padding(horizontal = dimensionResource(id = R.dimen.minor_100))
                     .constrainAs(discountAmount) {
                         end.linkTo(parent.end)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/ExpandableProductCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/ExpandableProductCard.kt
@@ -86,6 +86,7 @@ import java.math.BigDecimal
 const val ANIM_DURATION_MILLIS = 128
 
 internal object ExpandableProductCardTestTags {
+    const val PRODUCT_CARD = "order_product_card"
     const val DISCOUNT_AMOUNT = "order_product_discount_amount"
 }
 
@@ -116,6 +117,7 @@ fun ExpandableProductCard(
     }
     ConstraintLayout(
         modifier = Modifier
+            .testTag(ExpandableProductCardTestTags.PRODUCT_CARD)
             .fillMaxWidth()
             .clickable(
                 interactionSource = remember { MutableInteractionSource() },

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
@@ -68,6 +69,7 @@ import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.Sel
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.ViewState
 import com.woocommerce.android.ui.products.selector.SelectionState.PARTIALLY_SELECTED
 import com.woocommerce.android.ui.products.selector.SelectionState.SELECTED
+import com.woocommerce.android.ui.products.selector.components.ProductSelectorTestTags
 import com.woocommerce.android.ui.products.selector.components.SelectorListItem
 import com.woocommerce.android.util.StringUtils
 
@@ -324,6 +326,7 @@ private fun displayProductsSection(
                 imageContentDescription = stringResource(string.product_image_content_description),
                 isCogwheelVisible = product is ListItem.ConfigurableListItem,
                 enabled = state.selectionEnabled && product.enabled,
+                testTag = ProductSelectorTestTags.PRODUCT_ITEM,
                 onEditConfiguration = {
                     (product as? ListItem.ConfigurableListItem)?.let(onEditConfiguration)
                 }
@@ -446,6 +449,7 @@ private fun ProductList(
                     imageContentDescription = stringResource(string.product_image_content_description),
                     isCogwheelVisible = product is ListItem.ConfigurableListItem,
                     enabled = state.selectionEnabled && product.enabled,
+                    testTag = ProductSelectorTestTags.PRODUCT_ITEM,
                     onEditConfiguration = {
                         (product as? ListItem.ConfigurableListItem)?.let(onEditConfiguration)
                     }
@@ -505,6 +509,7 @@ private fun SelectionConfirmButton(
         },
         enabled = state.isDoneButtonEnabled,
         modifier = Modifier
+            .testTag(ProductSelectorTestTags.DONE_BUTTON)
             .fillMaxWidth()
             .padding(dimensionResource(id = dimen.major_100))
     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
@@ -326,11 +326,7 @@ private fun displayProductsSection(
                 imageContentDescription = stringResource(string.product_image_content_description),
                 isCogwheelVisible = product is ListItem.ConfigurableListItem,
                 enabled = state.selectionEnabled && product.enabled,
-                testTag = if (product.hasVariations()) {
-                    ProductSelectorTestTags.VARIABLE_PRODUCT_ITEM
-                } else {
-                    ProductSelectorTestTags.PRODUCT_ITEM
-                },
+                testTag = product.selectorTestTag,
                 onEditConfiguration = {
                     (product as? ListItem.ConfigurableListItem)?.let(onEditConfiguration)
                 }
@@ -352,6 +348,13 @@ enum class ProductType {
     POPULAR,
     RECENT
 }
+
+private val ListItem.selectorTestTag: String
+    get() = if (hasVariations()) {
+        ProductSelectorTestTags.VARIABLE_PRODUCT_ITEM
+    } else {
+        ProductSelectorTestTags.PRODUCT_ITEM
+    }
 
 @Composable
 private fun ProductList(
@@ -453,11 +456,7 @@ private fun ProductList(
                     imageContentDescription = stringResource(string.product_image_content_description),
                     isCogwheelVisible = product is ListItem.ConfigurableListItem,
                     enabled = state.selectionEnabled && product.enabled,
-                    testTag = if (product.hasVariations()) {
-                        ProductSelectorTestTags.VARIABLE_PRODUCT_ITEM
-                    } else {
-                        ProductSelectorTestTags.PRODUCT_ITEM
-                    },
+                    testTag = product.selectorTestTag,
                     onEditConfiguration = {
                         (product as? ListItem.ConfigurableListItem)?.let(onEditConfiguration)
                     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
@@ -326,7 +326,11 @@ private fun displayProductsSection(
                 imageContentDescription = stringResource(string.product_image_content_description),
                 isCogwheelVisible = product is ListItem.ConfigurableListItem,
                 enabled = state.selectionEnabled && product.enabled,
-                testTag = ProductSelectorTestTags.PRODUCT_ITEM,
+                testTag = if (product.hasVariations()) {
+                    ProductSelectorTestTags.VARIABLE_PRODUCT_ITEM
+                } else {
+                    ProductSelectorTestTags.PRODUCT_ITEM
+                },
                 onEditConfiguration = {
                     (product as? ListItem.ConfigurableListItem)?.let(onEditConfiguration)
                 }
@@ -449,7 +453,11 @@ private fun ProductList(
                     imageContentDescription = stringResource(string.product_image_content_description),
                     isCogwheelVisible = product is ListItem.ConfigurableListItem,
                     enabled = state.selectionEnabled && product.enabled,
-                    testTag = ProductSelectorTestTags.PRODUCT_ITEM,
+                    testTag = if (product.hasVariations()) {
+                        ProductSelectorTestTags.VARIABLE_PRODUCT_ITEM
+                    } else {
+                        ProductSelectorTestTags.PRODUCT_ITEM
+                    },
                     onEditConfiguration = {
                         (product as? ListItem.ConfigurableListItem)?.let(onEditConfiguration)
                     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/components/SelectorListItem.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/components/SelectorListItem.kt
@@ -60,7 +60,7 @@ fun SelectorListItem(
 ) {
     Row(
         modifier = Modifier
-            .then(testTag?.let { Modifier.testTag(it) } ?: Modifier)
+            .optionalTestTag(testTag)
             .clickable(
                 enabled = enabled,
                 role = Role.Button,
@@ -176,6 +176,9 @@ object ProductSelectorTestTags {
     const val VARIATION_ITEM = "product_selector_variation_item"
     const val DONE_BUTTON = "product_selector_done_button"
 }
+
+private fun Modifier.optionalTestTag(tag: String?): Modifier =
+    if (tag == null) this else testTag(tag)
 
 @Composable
 private fun SelectorListItemInfo(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/components/SelectorListItem.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/components/SelectorListItem.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
@@ -54,10 +55,12 @@ fun SelectorListItem(
     isCogwheelVisible: Boolean,
     enabled: Boolean,
     onEditConfiguration: () -> Unit,
+    testTag: String? = null,
     onItemClick: () -> Unit,
 ) {
     Row(
         modifier = Modifier
+            .then(testTag?.let { Modifier.testTag(it) } ?: Modifier)
             .clickable(
                 enabled = enabled,
                 role = Role.Button,
@@ -165,6 +168,12 @@ fun SelectorListItem(
             )
         }
     }
+}
+
+object ProductSelectorTestTags {
+    const val PRODUCT_ITEM = "product_selector_product_item"
+    const val VARIATION_ITEM = "product_selector_variation_item"
+    const val DONE_BUTTON = "product_selector_done_button"
 }
 
 @Composable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/components/SelectorListItem.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/components/SelectorListItem.kt
@@ -172,6 +172,7 @@ fun SelectorListItem(
 
 object ProductSelectorTestTags {
     const val PRODUCT_ITEM = "product_selector_product_item"
+    const val VARIABLE_PRODUCT_ITEM = "product_selector_variable_product_item"
     const val VARIATION_ITEM = "product_selector_variation_item"
     const val DONE_BUTTON = "product_selector_done_button"
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/selector/VariationSelectorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/selector/VariationSelectorScreen.kt
@@ -51,6 +51,7 @@ import com.woocommerce.android.ui.compose.component.InfiniteListHandler
 import com.woocommerce.android.ui.compose.component.TopAppBarEdgeToEdge
 import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.products.selector.SelectionState.SELECTED
+import com.woocommerce.android.ui.products.selector.components.ProductSelectorTestTags
 import com.woocommerce.android.ui.products.selector.components.SelectorListItem
 import com.woocommerce.android.ui.products.variations.selector.VariationSelectorViewModel.LoadingState.APPENDING
 import com.woocommerce.android.ui.products.variations.selector.VariationSelectorViewModel.LoadingState.LOADING
@@ -186,6 +187,7 @@ private fun VariationList(
                     imageContentDescription = stringResource(string.product_image_content_description),
                     isCogwheelVisible = false,
                     enabled = true,
+                    testTag = ProductSelectorTestTags.VARIATION_ITEM,
                     onEditConfiguration = {}
                 ) {
                     onVariationClick(variation)

--- a/WooCommerce/src/main/res/values/ids.xml
+++ b/WooCommerce/src/main/res/values/ids.xml
@@ -5,4 +5,5 @@
     <item type="id" name="product_selector_compose_view" />
     <item type="id" name="product_configuration_view" />
     <item type="id" name="analytics_hub_settings_view" />
+    <item type="id" name="order_shipping_amount_input" />
 </resources>


### PR DESCRIPTION
### Description

Adds Maestro flows that intentionally mutate test-store data. This is stack layer **4 of 8**.

Included coverage:

- order creation with products/variation, quantity, discount, custom amount, shipping, customer changes, and note;
- order detail/receipt/note paths;
- cash payment, mark-complete, and committed refund paths;
- creation and publication of a run-owned physical product;
- persisted inventory, shipping, linked-product, download, tag, description, category, and price fields;
- media-library selection attached to the run-owned product;
- committed run-scoped coupon creation.

The app changes add stable semantic selectors for coupon editing, customer/product/variation selection, order product cards, shipping fields, and selector confirmation. They do not change the underlying production behavior.

### Destructive safety boundary

- Every flow in this layer is tagged `destructive`, `smoke_extended`, and `flaky_quarantine`; this PR does not expand the release-gating core signal.
- These flows are for an automation-owned disposable lab store only at this point. Do not run them against a shared store.
- Orders, refunds, coupons, and UI-created products can persist. Run-scoped names make them identifiable, but this layer does not guarantee rollback of every in-app mutation.
- The audited shared-store preflight, exact-host checks, fixture journal, locking, and cleanup-failure semantics are added by #16372. Promotion remains blocked until that layer and runtime verification are complete.
- Blind retry remains unsafe for stateful mutations until the follow-up hardening/promotion work is verified.
- No live Maestro flow, payment, refund, product creation, or store mutation was performed during this PR review.

### Stack

- Integration target: `feature/maestro-smoke-testing-automation`
- Position: **4 of 8**
- Previous: #16198
- Next: #16200
- The complete stack is being assembled and validated on the integration branch before any proposal to merge it into `trunk`.

### Test Steps

1. Parse the added YAML flows/subflows with a YAML parser.
2. Run `python3 .maestro/scripts/generate-strings-env.py --check-flow-references`.
3. Run `git diff --check` and compile the Wasabi debug Kotlin sources.
4. For an explicit runtime check, verify `.maestro/.env.local` points to an automation-owned disposable lab store and include quarantine deliberately.
5. Run only the selected destructive flow(s), inspect all created entities, and clean them from the lab store afterward. Do not use `shared`.

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
