### PR TITLE
Add POS Maestro smoke flows

### DIFF
--- a/.maestro/flows/pos_cash_payment.yaml
+++ b/.maestro/flows/pos_cash_payment.yaml
@@ -1,0 +1,151 @@
+# Smoke Test: POS - Cash Payment flow (Tablet)
+# p2: pos.add-products, pos.pay-cash, pos.email-receipts
+# P2 ref: POS > Search products, Add to cart, Pay with Cash
+#
+# POS exposes Compose test tags as resource IDs (WooPosTheme enables
+# testTagsAsResourceId at the root of the Compose tree).
+#
+# NOTE: This flow requires a tablet device/emulator with POS enabled.
+# On phones the POS tab is hidden by the app, so the core POS assertions
+# are wrapped in a visibility guard. The flow will still pass on phones
+# (smoke purpose: "does login → reach main nav" succeeded) but the POS
+# body is skipped. Run on a tablet emulator to exercise the full flow.
+#
+# Verifies (on tablet):
+#   - POS screen loads from bottom navigation
+#   - Products load and can be added to cart
+#   - Checkout flow works
+#   - Cash payment can be completed
+#   - Payment success screen displays
+#   - "Email receipt" button opens the Email receipt screen with a
+#     "Send" action (we do NOT actually send — that would email a
+#     customer on the staging store; we back out to the success
+#     screen and then start a new order)
+appId: com.woocommerce.android.dev
+name: "POS - Cash payment flow"
+tags:
+  - pos_tablet
+  - flaky_quarantine
+  - destructive
+---
+# Reuse the logged-in session — login flows run first and leave the
+# app authenticated. See subflows/ensure_logged_in.yaml.
+- runFlow:
+    file: ../subflows/ensure_logged_in.yaml
+
+# Navigate to POS tab (only available on tablets with POS enabled).
+# Guarded because the tab is hidden on phones by design.
+- runFlow:
+    when:
+      visible:
+        id: "point_of_sale"
+    commands:
+      - tapOn:
+          id: "point_of_sale"
+          label: "Tap POS tab"
+
+      # Wait for POS products to load
+      - extendedWaitUntil:
+          visible:
+            id: "woo_pos_product_item"
+          timeout: 20000
+
+      - takeScreenshot: pos_products
+
+      # Add first product to cart
+      - tapOn:
+          id: "woo_pos_product_item"
+          index: 0
+          label: "Add first product to cart"
+
+      # Add another product to cart
+      - tapOn:
+          id: "woo_pos_product_item"
+          index: 2
+          label: "Add third product to cart"
+
+      # Validate cart has items via JavaScript
+      - copyTextFrom:
+          id: "woo_pos_cart_items_count"
+      - evalScript: |
+          if (maestro.copiedText) {
+              var count = parseInt(maestro.copiedText, 10);
+              if (isNaN(count) || count < 1) {
+                  throw new Error('Cart should have at least 1 item, found: ' + maestro.copiedText);
+              }
+          }
+
+      - takeScreenshot: pos_cart
+
+      # Proceed to checkout
+      - extendedWaitUntil:
+          visible:
+            id: "woo_pos_checkout_button"
+          timeout: 10000
+      - tapOn:
+          id: "woo_pos_checkout_button"
+          label: "Tap Checkout"
+
+      # Wait for totals/payment screen
+      - extendedWaitUntil:
+          visible:
+            id: "woo_pos_cash_payment_button"
+          timeout: 15000
+
+      - takeScreenshot: pos_totals
+
+      # Select cash payment
+      - tapOn:
+          id: "woo_pos_cash_payment_button"
+          label: "Select Cash payment"
+
+      # Complete cash payment
+      - extendedWaitUntil:
+          visible:
+            id: "woo_pos_complete_payment_button"
+          timeout: 10000
+      - tapOn:
+          id: "woo_pos_complete_payment_button"
+          label: "Complete payment"
+
+      # Verify payment success
+      - extendedWaitUntil:
+          visible:
+            id: "woo_pos_new_order_button"
+          timeout: 15000
+
+      - assertVisible:
+          id: "woo_pos_success_checkmark_icon"
+          label: "Payment success checkmark visible"
+
+      - takeScreenshot: pos_payment_success
+
+      # Open the Email receipt screen from the success screen. The
+      # button is a WooPosOutlinedButton whose label is
+      # R.string.woopos_receipt_button → "Email receipt" (it has no
+      # test tag, so we match by text).
+      - tapOn:
+          text: "Email receipt"
+          label: "Tap Email receipt"
+
+      # Verify the Email receipt screen loaded. The toolbar title is
+      # R.string.woopos_email_receipt_title and the send button text
+      # is R.string.woopos_email_receipt_send_button → "Send".
+      - runFlow:
+          when:
+            visible: "Send"
+          commands:
+            - assertVisible: "Email receipt"
+            - takeScreenshot: pos_email_receipt_screen
+            # Back out without sending — we don't want the staging
+            # store to actually dispatch a receipt email on every run.
+            - back
+
+      # Start new order from the (now restored) success screen.
+      - extendedWaitUntil:
+          visible:
+            id: "woo_pos_new_order_button"
+          timeout: 10000
+      - tapOn:
+          id: "woo_pos_new_order_button"
+          label: "Start new order"

--- a/.maestro/flows/pos_cash_payment.yaml
+++ b/.maestro/flows/pos_cash_payment.yaml
@@ -54,40 +54,8 @@ tags:
           text: "Clear cart"
           label: "Own an empty POS cart"
 
-- tapOn:
-    id: "woo_pos_search_input"
-    label: "Open product search"
-- extendedWaitUntil:
-    visible: ".*Search products and variations.*"
-    timeout: 10000
-- tapOn:
-    id: "woo_pos_search_input"
-    label: "Focus product search"
 - runFlow:
-    file: ../subflows/paste_into_focused_field.yaml
-    env:
-      TEXT_TO_PASTE: ${WOO_VARIABLE_PRODUCT_NAME}
-- hideKeyboard
-
-- extendedWaitUntil:
-    visible: "${WOO_VARIABLE_PRODUCT_NAME}"
-    timeout: 20000
-
-- tapOn:
-    id: "woo_pos_product_item"
-    index: 0
-    label: "Open variable product variations"
-- extendedWaitUntil:
-    notVisible: ".*Search products and variations.*"
-    timeout: 10000
-- extendedWaitUntil:
-    visible:
-      id: "woo_pos_product_item"
-    timeout: 20000
-- tapOn:
-    id: "woo_pos_product_item"
-    index: 0
-    label: "Add first variation to owned cart"
+    file: ../subflows/pos_add_discovered_variable_product.yaml
 
 - copyTextFrom:
     id: "woo_pos_cart_items_count"

--- a/.maestro/flows/pos_cash_payment.yaml
+++ b/.maestro/flows/pos_cash_payment.yaml
@@ -1,15 +1,12 @@
 # Smoke Test: POS - Cash Payment flow (Tablet)
-# p2: pos.add-products, pos.pay-cash, pos.email-receipts
+# p2: pos.add-products, pos.pay-cash
 # P2 ref: POS > Search products, Add to cart, Pay with Cash
 #
 # POS exposes Compose test tags as resource IDs (WooPosTheme enables
 # testTagsAsResourceId at the root of the Compose tree).
 #
-# NOTE: This flow requires a tablet device/emulator with POS enabled.
-# On phones the POS tab is hidden by the app, so the core POS assertions
-# are wrapped in a visibility guard. The flow will still pass on phones
-# (smoke purpose: "does login → reach main nav" succeeded) but the POS
-# body is skipped. Run on a tablet emulator to exercise the full flow.
+# NOTE: This flow requires a tablet device/emulator and a genuinely POS-
+# eligible store. Missing POS navigation must fail the release signal.
 #
 # Verifies (on tablet):
 #   - POS screen loads from bottom navigation
@@ -17,10 +14,7 @@
 #   - Checkout flow works
 #   - Cash payment can be completed
 #   - Payment success screen displays
-#   - "Email receipt" button opens the Email receipt screen with a
-#     "Send" action (we do NOT actually send — that would email a
-#     customer on the staging store; we back out to the success
-#     screen and then start a new order)
+#   - A new order can be started after successful payment
 appId: com.woocommerce.android.dev
 name: "POS - Cash payment flow"
 tags:
@@ -33,119 +27,110 @@ tags:
 - runFlow:
     file: ../subflows/ensure_logged_in.yaml
 
-# Navigate to POS tab (only available on tablets with POS enabled).
-# Guarded because the tab is hidden on phones by design.
+- extendedWaitUntil:
+    visible:
+      id: "point_of_sale"
+    timeout: 10000
+    label: "Require real POS eligibility"
+
+- tapOn:
+    id: "point_of_sale"
+    label: "Tap POS tab"
+
+- extendedWaitUntil:
+    visible:
+      id: "woo_pos_product_item"
+    timeout: 20000
+
 - runFlow:
     when:
       visible:
-        id: "point_of_sale"
+        id: "woo_pos_clear_cart_button"
     commands:
       - tapOn:
-          id: "point_of_sale"
-          label: "Tap POS tab"
-
-      # Wait for POS products to load
-      - extendedWaitUntil:
-          visible:
-            id: "woo_pos_product_item"
-          timeout: 20000
-
-      - takeScreenshot: pos_products
-
-      # Add first product to cart
+          id: "woo_pos_clear_cart_button"
+          label: "Open clear-cart menu"
       - tapOn:
-          id: "woo_pos_product_item"
-          index: 0
-          label: "Add first product to cart"
+          text: "Clear cart"
+          label: "Own an empty POS cart"
 
-      # Add another product to cart
-      - tapOn:
-          id: "woo_pos_product_item"
-          index: 2
-          label: "Add third product to cart"
+- tapOn:
+    id: "woo_pos_search_input"
+    label: "Open product search"
+- extendedWaitUntil:
+    visible: ".*Search products and variations.*"
+    timeout: 10000
+- tapOn:
+    id: "woo_pos_search_input"
+    label: "Focus product search"
+- runFlow:
+    file: ../subflows/paste_into_focused_field.yaml
+    env:
+      TEXT_TO_PASTE: ${WOO_VARIABLE_PRODUCT_NAME}
+- hideKeyboard
 
-      # Validate cart has items via JavaScript
-      - copyTextFrom:
-          id: "woo_pos_cart_items_count"
-      - evalScript: |
-          if (maestro.copiedText) {
-              var count = parseInt(maestro.copiedText, 10);
-              if (isNaN(count) || count < 1) {
-                  throw new Error('Cart should have at least 1 item, found: ' + maestro.copiedText);
-              }
-          }
+- extendedWaitUntil:
+    visible: "${WOO_VARIABLE_PRODUCT_NAME}"
+    timeout: 20000
 
-      - takeScreenshot: pos_cart
+- tapOn:
+    id: "woo_pos_product_item"
+    index: 0
+    label: "Open variable product variations"
+- extendedWaitUntil:
+    notVisible: ".*Search products and variations.*"
+    timeout: 10000
+- extendedWaitUntil:
+    visible:
+      id: "woo_pos_product_item"
+    timeout: 20000
+- tapOn:
+    id: "woo_pos_product_item"
+    index: 0
+    label: "Add first variation to owned cart"
 
-      # Proceed to checkout
-      - extendedWaitUntil:
-          visible:
-            id: "woo_pos_checkout_button"
-          timeout: 10000
-      - tapOn:
-          id: "woo_pos_checkout_button"
-          label: "Tap Checkout"
+- copyTextFrom:
+    id: "woo_pos_cart_items_count"
+- evalScript: |
+    var count = parseInt(maestro.copiedText, 10);
+    if (isNaN(count) || count < 1) {
+        throw new Error('Owned POS cart should contain a product');
+    }
 
-      # Wait for totals/payment screen
-      - extendedWaitUntil:
-          visible:
-            id: "woo_pos_cash_payment_button"
-          timeout: 15000
+- extendedWaitUntil:
+    visible:
+      id: "woo_pos_checkout_button"
+    timeout: 10000
+- tapOn:
+    id: "woo_pos_checkout_button"
+    label: "Tap Checkout"
 
-      - takeScreenshot: pos_totals
+- extendedWaitUntil:
+    visible:
+      id: "woo_pos_cash_payment_button"
+    timeout: 15000
+- tapOn:
+    id: "woo_pos_cash_payment_button"
+    label: "Select Cash payment"
 
-      # Select cash payment
-      - tapOn:
-          id: "woo_pos_cash_payment_button"
-          label: "Select Cash payment"
+- extendedWaitUntil:
+    visible:
+      id: "woo_pos_complete_payment_button"
+    timeout: 10000
+- tapOn:
+    id: "woo_pos_complete_payment_button"
+    label: "Complete payment"
 
-      # Complete cash payment
-      - extendedWaitUntil:
-          visible:
-            id: "woo_pos_complete_payment_button"
-          timeout: 10000
-      - tapOn:
-          id: "woo_pos_complete_payment_button"
-          label: "Complete payment"
+- extendedWaitUntil:
+    visible:
+      id: "woo_pos_new_order_button"
+    timeout: 15000
+- assertVisible:
+    id: "woo_pos_success_checkmark_icon"
+    label: "Payment success checkmark visible"
 
-      # Verify payment success
-      - extendedWaitUntil:
-          visible:
-            id: "woo_pos_new_order_button"
-          timeout: 15000
+- takeScreenshot: pos_payment_success
 
-      - assertVisible:
-          id: "woo_pos_success_checkmark_icon"
-          label: "Payment success checkmark visible"
-
-      - takeScreenshot: pos_payment_success
-
-      # Open the Email receipt screen from the success screen. The
-      # button is a WooPosOutlinedButton whose label is
-      # R.string.woopos_receipt_button → "Email receipt" (it has no
-      # test tag, so we match by text).
-      - tapOn:
-          text: "Email receipt"
-          label: "Tap Email receipt"
-
-      # Verify the Email receipt screen loaded. The toolbar title is
-      # R.string.woopos_email_receipt_title and the send button text
-      # is R.string.woopos_email_receipt_send_button → "Send".
-      - runFlow:
-          when:
-            visible: "Send"
-          commands:
-            - assertVisible: "Email receipt"
-            - takeScreenshot: pos_email_receipt_screen
-            # Back out without sending — we don't want the staging
-            # store to actually dispatch a receipt email on every run.
-            - back
-
-      # Start new order from the (now restored) success screen.
-      - extendedWaitUntil:
-          visible:
-            id: "woo_pos_new_order_button"
-          timeout: 10000
-      - tapOn:
-          id: "woo_pos_new_order_button"
-          label: "Start new order"
+- tapOn:
+    id: "woo_pos_new_order_button"
+    label: "Start new order"

--- a/.maestro/flows/pos_search_and_coupons.yaml
+++ b/.maestro/flows/pos_search_and_coupons.yaml
@@ -10,15 +10,13 @@
 #   - Coupons tab:  hint is R.string.woopos_search_coupons
 #     → "Search coupons"
 #
-# NOTE: POS is tablet-only. On phones the point_of_sale bottom-nav
-# item is hidden; this flow guards on that id and skips the body on
-# phones — the login+dashboard checks above already exercise the
-# main-app paths.
+# NOTE: POS is tablet-only and requires a genuinely eligible store. Missing
+# POS navigation is a setup failure, not a reason to skip this release signal.
 #
 # Verifies (on tablet):
 #   - POS screen loads with Products + Coupons tabs visible
-#   - Switching to the Coupons tab loads the coupons list
-#   - The search hint reflects the active tab (products vs coupons)
+#   - Search resolves the configured variable product and a variation
+#   - A real coupon is added to the cart
 #   - Switching back to Products reloads the product grid
 appId: com.woocommerce.android.dev
 name: "POS - Search and Coupons tab"
@@ -31,68 +29,121 @@ tags:
 - runFlow:
     file: ../subflows/ensure_logged_in.yaml
 
-# Guard on the POS bottom-nav item — it's only present on tablet
-# builds with POS enabled.
+- extendedWaitUntil:
+    visible:
+      id: "point_of_sale"
+    timeout: 10000
+    label: "Require real POS eligibility"
+
+- tapOn:
+    id: "point_of_sale"
+    label: "Tap POS tab"
+
+- extendedWaitUntil:
+    visible:
+      id: "woo_pos_product_item"
+    timeout: 20000
+
 - runFlow:
     when:
       visible:
-        id: "point_of_sale"
+        id: "woo_pos_clear_cart_button"
     commands:
       - tapOn:
-          id: "point_of_sale"
-          label: "Tap POS tab"
-
-      # Wait for product grid.
-      - extendedWaitUntil:
-          visible:
-            id: "woo_pos_product_item"
-          timeout: 20000
-
-      # Both tabs should be visible at the top of the items screen.
-      - assertVisible: "Products"
-      - assertVisible: "Coupons"
-
-      - takeScreenshot: pos_products_tab
-
-      # Products-tab search hint.
-      - assertVisible:
-          id: "woo_pos_search_input"
-      - assertVisible:
-          text: ".*Search products and variations.*"
-
-      # Switch to the Coupons tab.
+          id: "woo_pos_clear_cart_button"
+          label: "Open clear-cart menu"
       - tapOn:
-          text: "Coupons"
-          retryTapIfNoChange: true
-          label: "Tap Coupons tab"
+          text: "Clear cart"
+          label: "Clear leftover POS cart"
 
-      # Either the coupons list loads OR the empty state appears —
-      # accept either so the assertion isn't tied to seed data on the
-      # staging store. The search hint changes as soon as the tab
-      # switches, which is our signal that the tab switch worked.
-      - extendedWaitUntil:
-          visible: ".*Search coupons.*|.*No coupons found.*|.*Unable to load coupons.*"
-          timeout: 20000
-          label: "Wait for Coupons tab content"
+- assertVisible: "Products"
+- assertVisible: "Coupons"
+- assertVisible:
+    id: "woo_pos_search_input"
 
-      - takeScreenshot: pos_coupons_tab
+- tapOn:
+    id: "woo_pos_search_input"
+    label: "Open product search"
 
-      # Coupon add-to-cart action. Optional until the flow owns seeded
-      # cart prerequisites for coupon application.
-      - assertVisible:
-          id: "woo_pos_coupon_add_to_cart_button"
+- extendedWaitUntil:
+    visible: ".*Search products and variations.*"
+    timeout: 10000
 
-      # Switch back to the Products tab to leave POS in the default
-      # state for any downstream flow that reuses it.
-      - tapOn:
-          text: "Products"
-          retryTapIfNoChange: true
-          label: "Tap Products tab"
+- tapOn:
+    id: "woo_pos_search_input"
+    label: "Focus product search"
+- runFlow:
+    file: ../subflows/paste_into_focused_field.yaml
+    env:
+      TEXT_TO_PASTE: ${WOO_VARIABLE_PRODUCT_NAME}
+- hideKeyboard
 
-      - extendedWaitUntil:
-          visible:
-            id: "woo_pos_product_item"
-          timeout: 15000
-          label: "Wait for products grid to reload"
+- extendedWaitUntil:
+    visible: "${WOO_VARIABLE_PRODUCT_NAME}"
+    timeout: 20000
+    label: "Wait for configured variable product"
 
-      - takeScreenshot: pos_products_tab_restored
+- tapOn:
+    id: "woo_pos_product_item"
+    index: 0
+    label: "Open variable product variations"
+
+- extendedWaitUntil:
+    notVisible: ".*Search products and variations.*"
+    timeout: 10000
+    label: "Require variation selection screen"
+
+- extendedWaitUntil:
+    visible:
+      id: "woo_pos_product_item"
+    timeout: 20000
+    label: "Wait for POS variations"
+
+- tapOn:
+    id: "woo_pos_product_item"
+    index: 0
+    label: "Add first variation to cart"
+
+- runFlow:
+    when:
+      notVisible: "Coupons"
+    commands:
+      - back
+
+- extendedWaitUntil:
+    visible: "Coupons"
+    timeout: 10000
+
+- tapOn:
+    text: "Coupons"
+    retryTapIfNoChange: true
+    label: "Tap Coupons tab"
+
+- extendedWaitUntil:
+    visible:
+      id: "woo_pos_coupon_add_to_cart_button"
+    timeout: 20000
+    label: "Require a usable coupon"
+
+- tapOn:
+    id: "woo_pos_coupon_add_to_cart_button"
+    index: 0
+    label: "Add coupon to cart"
+
+- extendedWaitUntil:
+    visible:
+      id: "woo_pos_cart_coupon_item"
+    timeout: 10000
+    label: "Verify coupon in POS cart"
+
+- takeScreenshot: pos_coupon_in_cart
+
+- tapOn:
+    text: "Products"
+    retryTapIfNoChange: true
+    label: "Restore Products tab"
+
+- extendedWaitUntil:
+    visible:
+      id: "woo_pos_product_item"
+    timeout: 15000

--- a/.maestro/flows/pos_search_and_coupons.yaml
+++ b/.maestro/flows/pos_search_and_coupons.yaml
@@ -1,0 +1,98 @@
+# Smoke Test: POS - Search + Coupons tab (Tablet)
+# p2: pos.search-products, pos.coupons
+# P2 ref: POS > Search products, Use coupons
+#
+# POS exposes the Products/Coupons tabs as plain Compose text. The shared
+# WooPosSearchInput exposes a stable resource ID and the hint strings tell
+# which mode it is in:
+#   - Products tab: hint is R.string.woopos_search_products_and_variations
+#     → "Search products and variations"
+#   - Coupons tab:  hint is R.string.woopos_search_coupons
+#     → "Search coupons"
+#
+# NOTE: POS is tablet-only. On phones the point_of_sale bottom-nav
+# item is hidden; this flow guards on that id and skips the body on
+# phones — the login+dashboard checks above already exercise the
+# main-app paths.
+#
+# Verifies (on tablet):
+#   - POS screen loads with Products + Coupons tabs visible
+#   - Switching to the Coupons tab loads the coupons list
+#   - The search hint reflects the active tab (products vs coupons)
+#   - Switching back to Products reloads the product grid
+appId: com.woocommerce.android.dev
+name: "POS - Search and Coupons tab"
+tags:
+  - pos_tablet
+  - flaky_quarantine
+---
+# Reuse the logged-in session — login flows run first and leave the
+# app authenticated. See subflows/ensure_logged_in.yaml.
+- runFlow:
+    file: ../subflows/ensure_logged_in.yaml
+
+# Guard on the POS bottom-nav item — it's only present on tablet
+# builds with POS enabled.
+- runFlow:
+    when:
+      visible:
+        id: "point_of_sale"
+    commands:
+      - tapOn:
+          id: "point_of_sale"
+          label: "Tap POS tab"
+
+      # Wait for product grid.
+      - extendedWaitUntil:
+          visible:
+            id: "woo_pos_product_item"
+          timeout: 20000
+
+      # Both tabs should be visible at the top of the items screen.
+      - assertVisible: "Products"
+      - assertVisible: "Coupons"
+
+      - takeScreenshot: pos_products_tab
+
+      # Products-tab search hint.
+      - assertVisible:
+          id: "woo_pos_search_input"
+      - assertVisible:
+          text: ".*Search products and variations.*"
+
+      # Switch to the Coupons tab.
+      - tapOn:
+          text: "Coupons"
+          retryTapIfNoChange: true
+          label: "Tap Coupons tab"
+
+      # Either the coupons list loads OR the empty state appears —
+      # accept either so the assertion isn't tied to seed data on the
+      # staging store. The search hint changes as soon as the tab
+      # switches, which is our signal that the tab switch worked.
+      - extendedWaitUntil:
+          visible: ".*Search coupons.*|.*No coupons found.*|.*Unable to load coupons.*"
+          timeout: 20000
+          label: "Wait for Coupons tab content"
+
+      - takeScreenshot: pos_coupons_tab
+
+      # Coupon add-to-cart action. Optional until the flow owns seeded
+      # cart prerequisites for coupon application.
+      - assertVisible:
+          id: "woo_pos_coupon_add_to_cart_button"
+
+      # Switch back to the Products tab to leave POS in the default
+      # state for any downstream flow that reuses it.
+      - tapOn:
+          text: "Products"
+          retryTapIfNoChange: true
+          label: "Tap Products tab"
+
+      - extendedWaitUntil:
+          visible:
+            id: "woo_pos_product_item"
+          timeout: 15000
+          label: "Wait for products grid to reload"
+
+      - takeScreenshot: pos_products_tab_restored

--- a/.maestro/flows/pos_search_and_coupons.yaml
+++ b/.maestro/flows/pos_search_and_coupons.yaml
@@ -15,7 +15,7 @@
 #
 # Verifies (on tablet):
 #   - POS screen loads with Products + Coupons tabs visible
-#   - Search resolves the configured variable product and a variation
+#   - Search resolves a variable product discovered from the live catalog
 #   - A real coupon is added to the cart
 #   - Switching back to Products reloads the product grid
 appId: com.woocommerce.android.dev
@@ -61,48 +61,8 @@ tags:
 - assertVisible:
     id: "woo_pos_search_input"
 
-- tapOn:
-    id: "woo_pos_search_input"
-    label: "Open product search"
-
-- extendedWaitUntil:
-    visible: ".*Search products and variations.*"
-    timeout: 10000
-
-- tapOn:
-    id: "woo_pos_search_input"
-    label: "Focus product search"
 - runFlow:
-    file: ../subflows/paste_into_focused_field.yaml
-    env:
-      TEXT_TO_PASTE: ${WOO_VARIABLE_PRODUCT_NAME}
-- hideKeyboard
-
-- extendedWaitUntil:
-    visible: "${WOO_VARIABLE_PRODUCT_NAME}"
-    timeout: 20000
-    label: "Wait for configured variable product"
-
-- tapOn:
-    id: "woo_pos_product_item"
-    index: 0
-    label: "Open variable product variations"
-
-- extendedWaitUntil:
-    notVisible: ".*Search products and variations.*"
-    timeout: 10000
-    label: "Require variation selection screen"
-
-- extendedWaitUntil:
-    visible:
-      id: "woo_pos_product_item"
-    timeout: 20000
-    label: "Wait for POS variations"
-
-- tapOn:
-    id: "woo_pos_product_item"
-    index: 0
-    label: "Add first variation to cart"
+    file: ../subflows/pos_add_discovered_variable_product.yaml
 
 - runFlow:
     when:

--- a/.maestro/scripts/check-smoke-coverage.py
+++ b/.maestro/scripts/check-smoke-coverage.py
@@ -12,16 +12,25 @@ from pathlib import Path
 ID_RE = re.compile(r"^\s*-\s+id:\s*([A-Za-z0-9_.-]+)\s*$")
 FLOW_RE = re.compile(r"^\s+flow:\s*(.+?)\s*$")
 MANUAL_RE = re.compile(r"^\s+manual:\s*(.+?)\s*$")
-P2_RE = re.compile(r"^#\s*p2:\s*(.+?)\s*$")
+P2_RE = re.compile(r"^#\s*p2:\s*(.+?)\s*$", re.IGNORECASE)
+P2_PROBE_RE = re.compile(r"^#\s*p2\s+probe:\s*(.+?)\s*$", re.IGNORECASE)
 
 
-def parse_snapshot(path: Path) -> dict[str, dict[str, str]]:
+def parse_header_ids(value: str) -> set[str]:
+    ids = re.split(r"\s+\(", value, maxsplit=1)[0]
+    return {item.strip() for item in ids.split(",") if item.strip()}
+
+
+def parse_snapshot(path: Path) -> tuple[dict[str, dict[str, str]], set[str]]:
     items: dict[str, dict[str, str]] = {}
+    duplicates: set[str] = set()
     current: str | None = None
     for line in path.read_text(encoding="utf-8").splitlines():
         id_match = ID_RE.match(line)
         if id_match:
             current = id_match.group(1)
+            if current in items:
+                duplicates.add(current)
             items[current] = {}
             continue
         if current is None:
@@ -34,19 +43,26 @@ def parse_snapshot(path: Path) -> dict[str, dict[str, str]]:
         if manual_match:
             items[current]["manual"] = manual_match.group(1).strip().strip('"')
             continue
-    return items
+    return items, duplicates
 
 
-def parse_flow_headers(flows_dir: Path) -> dict[str, set[str]]:
-    result: dict[str, set[str]] = {}
+def parse_flow_headers(flows_dir: Path) -> tuple[dict[str, set[str]], dict[str, set[str]]]:
+    claims: dict[str, set[str]] = {}
+    probes: dict[str, set[str]] = {}
     for flow in sorted(flows_dir.glob("*.yaml")):
-        ids: set[str] = set()
+        flow_claims: set[str] = set()
+        flow_probes: set[str] = set()
         for line in flow.read_text(encoding="utf-8").splitlines()[:40]:
-            match = P2_RE.match(line)
-            if match:
-                ids.update(item.strip() for item in match.group(1).split(",") if item.strip())
-        result[str(flow)] = ids
-    return result
+            probe_match = P2_PROBE_RE.match(line)
+            if probe_match:
+                flow_probes.update(parse_header_ids(probe_match.group(1)))
+                continue
+            claim_match = P2_RE.match(line)
+            if claim_match:
+                flow_claims.update(parse_header_ids(claim_match.group(1)))
+        claims[str(flow)] = flow_claims
+        probes[str(flow)] = flow_probes
+    return claims, probes
 
 
 def main() -> int:
@@ -55,31 +71,44 @@ def main() -> int:
     parser.add_argument("--flows-dir", default=".maestro/flows", type=Path)
     args = parser.parse_args()
 
-    items = parse_snapshot(args.coverage)
-    flow_headers = parse_flow_headers(args.flows_dir)
+    items, duplicates = parse_snapshot(args.coverage)
+    flow_claims, flow_probes = parse_flow_headers(args.flows_dir)
     errors: list[str] = []
+
+    for item_id in sorted(duplicates):
+        errors.append(f"{args.coverage}: duplicate item id {item_id}")
 
     for item_id, data in sorted(items.items()):
         if not data.get("flow") and not data.get("manual"):
             errors.append(f"{args.coverage}: item {item_id} has neither flow nor manual reason")
 
     known_ids = set(items)
-    header_ids = set().union(*flow_headers.values()) if flow_headers else set()
-    for flow, ids in flow_headers.items():
-        if not ids:
-            errors.append(f"{flow}: missing '# p2:' header")
-        for item_id in sorted(ids - known_ids):
+    for flow in flow_claims:
+        claims = flow_claims[flow]
+        probes = flow_probes[flow]
+        if not claims and not probes:
+            errors.append(f"{flow}: missing '# p2:' or '# P2 probe:' header")
+        for item_id in sorted((claims | probes) - known_ids):
             errors.append(f"{flow}: unknown p2 id {item_id}")
+
+        for item_id in sorted(claims & known_ids):
+            mapped_flow = items[item_id].get("flow", "")
+            if mapped_flow != flow:
+                errors.append(f"{flow}: p2 id {item_id} maps to {mapped_flow or 'manual coverage'}")
+
+        for item_id in sorted(probes & known_ids):
+            if items[item_id].get("flow"):
+                errors.append(f"{flow}: probe id {item_id} is counted as automated coverage")
 
     for item_id, data in sorted(items.items()):
         flow = data.get("flow", "")
-        if flow and item_id not in header_ids:
-            errors.append(f"{args.coverage}: item {item_id} maps to {flow}, but no flow header declares it")
+        if flow and item_id not in flow_claims.get(flow, set()):
+            errors.append(f"{args.coverage}: item {item_id} maps to {flow}, but that flow does not declare it")
 
     if errors:
         print("\n".join(errors), file=sys.stderr)
         return 1
-    print(f"Coverage snapshot OK: {len(items)} items, {len(flow_headers)} flows")
+    print(f"Coverage snapshot OK: {len(items)} items, {len(flow_claims)} flows")
     return 0
 
 

--- a/.maestro/smoke-coverage.yaml
+++ b/.maestro/smoke-coverage.yaml
@@ -61,7 +61,7 @@ items:
     flow: .maestro/flows/dashboard_view_all_analytics.yaml
   - id: dashboard.customization
     title: Dashboard card customization
-    flow: .maestro/flows/dashboard_customize.yaml
+    manual: "Current flow opens the editor but does not toggle or reorder cards."
 
   - id: orders.push.arrives
     title: New order push notification arrives
@@ -74,7 +74,7 @@ items:
     flow: .maestro/flows/orders_list_and_search.yaml
   - id: orders.pagination
     title: Orders pagination
-    flow: .maestro/flows/orders_list_and_search.yaml
+    manual: "Current flow scrolls the list but does not prove another API page loaded."
   - id: orders.search
     title: Search for an order
     flow: .maestro/flows/orders_list_and_search.yaml
@@ -147,7 +147,7 @@ items:
     flow: .maestro/flows/products_list_and_sort.yaml
   - id: products.pagination
     title: Product pagination
-    flow: .maestro/flows/products_list_and_sort.yaml
+    manual: "Current flow scrolls the list but does not prove another API page loaded."
   - id: products.sort
     title: Sort product list
     flow: .maestro/flows/products_list_and_sort.yaml
@@ -162,10 +162,10 @@ items:
     flow: .maestro/flows/products_media_upload.yaml
   - id: products.detail.price
     title: Product price settings
-    flow: .maestro/flows/products_detail.yaml
+    manual: "Current flow does not open and verify this product-type-specific setting."
   - id: products.detail.inventory
     title: Product inventory settings
-    flow: .maestro/flows/products_detail.yaml
+    manual: "Current flow does not open and verify this product-type-specific setting."
   - id: products.detail.categories
     title: Product categories settings
     flow: .maestro/flows/products_detail.yaml
@@ -177,16 +177,16 @@ items:
     flow: .maestro/flows/products_variations_and_tags.yaml
   - id: products.detail.shipping
     title: Product shipping settings
-    flow: .maestro/flows/products_detail.yaml
+    manual: "Current flow does not open and verify this product-type-specific setting."
   - id: products.detail.short-description
     title: Product short description settings
-    flow: .maestro/flows/products_detail.yaml
+    manual: "Current flow does not open and verify this product-type-specific setting."
   - id: products.detail.linked
     title: Linked products
-    flow: .maestro/flows/products_detail.yaml
+    manual: "Current flow does not open and verify this product-type-specific setting."
   - id: products.detail.downloads
     title: Downloadable files
-    flow: .maestro/flows/products_detail.yaml
+    manual: "Current flow does not open and verify this product-type-specific setting."
   - id: products.detail.variations
     title: Variations and variation detail
     flow: .maestro/flows/products_variations_and_tags.yaml
@@ -223,10 +223,10 @@ items:
     flow: .maestro/flows/hub_menu_admin_and_store.yaml
   - id: hub.blaze.create
     title: Blaze campaign creation entry point
-    flow: .maestro/flows/blaze_campaign.yaml
+    manual: "Feature-gated probe only; an ineligible store must not count as coverage."
   - id: hub.google-for-woo
     title: Google for Woo campaign webview
-    flow: .maestro/flows/google_for_woo.yaml
+    manual: "Feature-gated probe only; an ineligible store must not count as coverage."
 
   - id: payments.card-reader
     title: Collect payment using card reader
@@ -255,7 +255,7 @@ items:
     flow: .maestro/flows/pos_cash_payment.yaml
   - id: pos.email-receipts
     title: POS send and check email receipts
-    flow: .maestro/flows/pos_cash_payment.yaml
+    manual: "Requires sending and checking a real receipt email."
 
   - id: other.localization
     title: Switch device to non-English language

--- a/.maestro/smoke-coverage.yaml
+++ b/.maestro/smoke-coverage.yaml
@@ -61,7 +61,7 @@ items:
     flow: .maestro/flows/dashboard_view_all_analytics.yaml
   - id: dashboard.customization
     title: Dashboard card customization
-    manual: "Current flow opens the editor but does not toggle or reorder cards."
+    flow: .maestro/flows/dashboard_customize.yaml
 
   - id: orders.push.arrives
     title: New order push notification arrives

--- a/.maestro/smoke-coverage.yaml
+++ b/.maestro/smoke-coverage.yaml
@@ -74,7 +74,7 @@ items:
     flow: .maestro/flows/orders_list_and_search.yaml
   - id: orders.pagination
     title: Orders pagination
-    manual: "Current flow scrolls the list but does not prove another API page loaded."
+    manual: "Not automated."
   - id: orders.search
     title: Search for an order
     flow: .maestro/flows/orders_list_and_search.yaml
@@ -83,7 +83,7 @@ items:
     flow: .maestro/flows/orders_create.yaml
   - id: orders.create.variable-products
     title: Create order with variable products
-    flow: .maestro/flows/orders_create.yaml
+    manual: "The order flow selects an available product; Variable-order selection is not automated."
   - id: orders.create.quantity
     title: Increase and decrease quantity
     flow: .maestro/flows/orders_create.yaml
@@ -147,7 +147,7 @@ items:
     flow: .maestro/flows/products_list_and_sort.yaml
   - id: products.pagination
     title: Product pagination
-    manual: "Current flow scrolls the list but does not prove another API page loaded."
+    manual: "Not automated."
   - id: products.sort
     title: Sort product list
     flow: .maestro/flows/products_list_and_sort.yaml

--- a/.maestro/smoke-coverage.yaml
+++ b/.maestro/smoke-coverage.yaml
@@ -1,0 +1,283 @@
+# Maestro smoke coverage snapshot.
+#
+# Source P2: https://woomobilep2.wordpress.com/flows-for-app-features-smoke-testing/
+# Fetched through context-a8c wpcom/posts-text on 2026-07-04.
+# P2 modified timestamp observed: 2026-05-18T02:37:47+00:00.
+#
+# Every item needs either `flow:` or `manual:`. Flow YAMLs declare covered
+# items with `# p2:` headers, and .maestro/scripts/check-smoke-coverage.py
+# validates this file offline.
+
+items:
+  - id: install.upgrade
+    title: Upgrade from existing store version
+    manual: "Requires APK version swap and logged-in state migration outside Maestro."
+  - id: install.fresh
+    title: Fresh install smoke
+    flow: .maestro/flows/login_successful.yaml
+
+  - id: login.help
+    title: Login help section
+    flow: .maestro/flows/login_help.yaml
+  - id: login.not-wp-site
+    title: Login with a non-WordPress site
+    flow: .maestro/flows/login_not_wp_site.yaml
+  - id: login.not-woo-store
+    title: Login to a WordPress site without WooCommerce
+    flow: .maestro/flows/login_not_woo_store.yaml
+  - id: login.no-jetpack
+    title: Login to WooCommerce site without Jetpack
+    flow: .maestro/flows/login_no_jetpack.yaml
+  - id: login.jetpack-not-connected
+    title: Login with Jetpack installed but not connected
+    manual: "Requires manually disconnecting Jetpack on a disposable Jurassic Ninja site."
+  - id: login.jetpack
+    title: Login to Jetpack-connected WooCommerce store
+    flow: .maestro/flows/login_successful.yaml
+  - id: login.wrong-account
+    title: Wrong account for the store
+    flow: .maestro/flows/login_wrong_account.yaml
+  - id: login.wrong-credentials
+    title: Wrong credentials
+    flow: .maestro/flows/login_wrong_credentials.yaml
+  - id: login.passwordless
+    title: Passwordless login
+    manual: "Later automation needs Mailosaur API and secret management."
+  - id: login.social-google
+    title: Social login with Google
+    flow: .maestro/flows/login_google.yaml
+  - id: login.social-apple
+    title: Social login with Apple
+    manual: "iOS-only per P2."
+  - id: login.2fa
+    title: Login with 2FA
+    manual: "Needs dedicated test account plus TOTP secret handling."
+
+  - id: dashboard.stats
+    title: Dashboard charts and stats respond
+    flow: .maestro/flows/dashboard_stats.yaml
+  - id: dashboard.analytics
+    title: View all store analytics
+    flow: .maestro/flows/dashboard_view_all_analytics.yaml
+  - id: dashboard.customization
+    title: Dashboard card customization
+    flow: .maestro/flows/dashboard_customize.yaml
+
+  - id: orders.push.arrives
+    title: New order push notification arrives
+    manual: "Later automation should trigger an order via API and assert push delivery."
+  - id: orders.push.deep-link
+    title: Push opens the correct order
+    manual: "Blocked with push delivery automation."
+  - id: orders.list
+    title: Orders list loads
+    flow: .maestro/flows/orders_list_and_search.yaml
+  - id: orders.pagination
+    title: Orders pagination
+    flow: .maestro/flows/orders_list_and_search.yaml
+  - id: orders.search
+    title: Search for an order
+    flow: .maestro/flows/orders_list_and_search.yaml
+  - id: orders.create.products
+    title: Create order with products
+    flow: .maestro/flows/orders_create.yaml
+  - id: orders.create.variable-products
+    title: Create order with variable products
+    flow: .maestro/flows/orders_create.yaml
+  - id: orders.create.quantity
+    title: Increase and decrease quantity
+    flow: .maestro/flows/orders_create.yaml
+  - id: orders.create.product-discount
+    title: Apply product discount
+    flow: .maestro/flows/orders_create.yaml
+  - id: orders.create.custom-amount
+    title: Add custom amount
+    flow: .maestro/flows/orders_create.yaml
+  - id: orders.create.custom-amount-note
+    title: Add custom amount with note
+    flow: .maestro/flows/orders_create.yaml
+  - id: orders.create.shipping
+    title: Add shipping
+    flow: .maestro/flows/orders_create.yaml
+  - id: orders.create.customer-add
+    title: Add existing customer
+    flow: .maestro/flows/orders_create.yaml
+  - id: orders.create.customer-edit
+    title: Edit existing customer
+    flow: .maestro/flows/orders_create.yaml
+  - id: orders.create.note
+    title: Add customer note during order creation
+    flow: .maestro/flows/orders_create.yaml
+  - id: orders.barcode.open-scanner
+    title: Barcode button opens scanner
+    manual: "Requires camera or guided manual mode."
+  - id: orders.barcode.add-product
+    title: Add product using barcode scanner
+    manual: "Requires camera or guided manual mode."
+  - id: orders.collect-payment.qr
+    title: Scan to Pay displays QR code
+    manual: "Not in PR baseline; add after core phone suite is stable."
+  - id: orders.collect-payment.share-link
+    title: Share payment link
+    manual: "Not in PR baseline; add after core phone suite is stable."
+  - id: orders.collect-payment.cash
+    title: Cash payment method
+    flow: .maestro/flows/orders_cash_payment.yaml
+  - id: orders.receipt
+    title: See receipt from order detail
+    flow: .maestro/flows/orders_details_and_actions.yaml
+  - id: orders.refund
+    title: Refund an order
+    flow: .maestro/flows/orders_refund.yaml
+  - id: orders.note
+    title: Add order note
+    flow: .maestro/flows/orders_details_and_actions.yaml
+  - id: orders.shipping-label
+    title: Create a shipping label
+    manual: "External shipping-label flow is outside current smoke scope."
+  - id: orders.mark-complete
+    title: Mark order complete
+    flow: .maestro/flows/orders_mark_complete.yaml
+  - id: orders.barcode.start-order
+    title: Start order creation by scanning barcode
+    manual: "Requires camera or guided manual mode."
+
+  - id: products.list
+    title: Product list loads
+    flow: .maestro/flows/products_list_and_sort.yaml
+  - id: products.pagination
+    title: Product pagination
+    flow: .maestro/flows/products_list_and_sort.yaml
+  - id: products.sort
+    title: Sort product list
+    flow: .maestro/flows/products_list_and_sort.yaml
+  - id: products.search
+    title: Search product list
+    flow: .maestro/flows/products_list_and_sort.yaml
+  - id: products.detail.description
+    title: Product description details
+    flow: .maestro/flows/products_detail.yaml
+  - id: products.detail.media
+    title: Product media upload entry point
+    flow: .maestro/flows/products_media_upload.yaml
+  - id: products.detail.price
+    title: Product price settings
+    flow: .maestro/flows/products_detail.yaml
+  - id: products.detail.inventory
+    title: Product inventory settings
+    flow: .maestro/flows/products_detail.yaml
+  - id: products.detail.categories
+    title: Product categories settings
+    flow: .maestro/flows/products_detail.yaml
+  - id: products.detail.type
+    title: Product type settings
+    flow: .maestro/flows/products_detail.yaml
+  - id: products.detail.tags
+    title: Product tags settings
+    flow: .maestro/flows/products_variations_and_tags.yaml
+  - id: products.detail.shipping
+    title: Product shipping settings
+    flow: .maestro/flows/products_detail.yaml
+  - id: products.detail.short-description
+    title: Product short description settings
+    flow: .maestro/flows/products_detail.yaml
+  - id: products.detail.linked
+    title: Linked products
+    flow: .maestro/flows/products_detail.yaml
+  - id: products.detail.downloads
+    title: Downloadable files
+    flow: .maestro/flows/products_detail.yaml
+  - id: products.detail.variations
+    title: Variations and variation detail
+    flow: .maestro/flows/products_variations_and_tags.yaml
+  - id: products.detail.variation-attributes
+    title: Variation attributes
+    flow: .maestro/flows/products_variations_and_tags.yaml
+  - id: products.create
+    title: Create product
+    flow: .maestro/flows/products_create.yaml
+
+  - id: hub.change-store
+    title: Change store
+    flow: .maestro/flows/hub_menu_admin_and_store.yaml
+  - id: hub.settings
+    title: Hub settings
+    flow: .maestro/flows/hub_menu_settings.yaml
+  - id: hub.payments
+    title: Payments hub
+    flow: .maestro/flows/hub_menu_payments.yaml
+  - id: hub.coupons.create
+    title: Create a coupon
+    flow: .maestro/flows/hub_menu_coupons.yaml
+  - id: hub.customers
+    title: Customers
+    flow: .maestro/flows/hub_menu_customers_inbox.yaml
+  - id: hub.inbox
+    title: Inbox
+    flow: .maestro/flows/hub_menu_customers_inbox.yaml
+  - id: hub.wc-admin
+    title: WC Admin
+    flow: .maestro/flows/hub_menu_admin_and_store.yaml
+  - id: hub.view-store
+    title: View Store
+    flow: .maestro/flows/hub_menu_admin_and_store.yaml
+  - id: hub.blaze.create
+    title: Blaze campaign creation entry point
+    flow: .maestro/flows/blaze_campaign.yaml
+  - id: hub.google-for-woo
+    title: Google for Woo campaign webview
+    flow: .maestro/flows/google_for_woo.yaml
+
+  - id: payments.card-reader
+    title: Collect payment using card reader
+    manual: "Hardware-dependent; later guided-manual mode."
+  - id: payments.ttp
+    title: Collect payment using Tap to Pay
+    manual: "Hardware/account-dependent; later guided-manual mode."
+  - id: payments.ipp-refund
+    title: Refund an IPP order
+    manual: "Hardware/payment-account dependent."
+
+  - id: pos.search-products
+    title: POS search products
+    flow: .maestro/flows/pos_search_and_coupons.yaml
+  - id: pos.add-products
+    title: POS add products to cart
+    flow: .maestro/flows/pos_cash_payment.yaml
+  - id: pos.coupons
+    title: POS use coupons
+    flow: .maestro/flows/pos_search_and_coupons.yaml
+  - id: pos.pay-card
+    title: POS pay with card
+    manual: "Card reader hardware-dependent; later guided-manual mode."
+  - id: pos.pay-cash
+    title: POS pay with cash
+    flow: .maestro/flows/pos_cash_payment.yaml
+  - id: pos.email-receipts
+    title: POS send and check email receipts
+    flow: .maestro/flows/pos_cash_payment.yaml
+
+  - id: other.localization
+    title: Switch device to non-English language
+    manual: "Requires locale matrix run; selectors are prepared to avoid text-driven navigation."
+  - id: other.home-widget
+    title: Home screen widgets
+    manual: "Outside Maestro app surface."
+  - id: other.quick-actions
+    title: Quick Actions
+    manual: "Launcher long-press flow outside current Maestro suite."
+  - id: other.ios-push-long-press
+    title: Long press iPhone push notification
+    manual: "iOS-only per P2."
+  - id: other.watch.my-store
+    title: Watch app My Store
+    manual: "Watch app stays manual per plan."
+  - id: other.watch.orders-list
+    title: Watch app order list
+    manual: "Watch app stays manual per plan."
+  - id: other.watch.order-detail
+    title: Watch app order detail
+    manual: "Watch app stays manual per plan."
+  - id: other.watch.push
+    title: Watch push notification opens order details
+    manual: "Watch app stays manual per plan."

--- a/.maestro/smoke-coverage.yaml
+++ b/.maestro/smoke-coverage.yaml
@@ -156,37 +156,37 @@ items:
     flow: .maestro/flows/products_list_and_sort.yaml
   - id: products.detail.description
     title: Product description details
-    flow: .maestro/flows/products_detail.yaml
+    flow: .maestro/flows/products_create.yaml
   - id: products.detail.media
     title: Product media upload entry point
     flow: .maestro/flows/products_media_upload.yaml
   - id: products.detail.price
     title: Product price settings
-    manual: "Current flow does not open and verify this product-type-specific setting."
+    flow: .maestro/flows/products_create.yaml
   - id: products.detail.inventory
     title: Product inventory settings
-    manual: "Current flow does not open and verify this product-type-specific setting."
+    flow: .maestro/flows/products_create.yaml
   - id: products.detail.categories
     title: Product categories settings
     flow: .maestro/flows/products_detail.yaml
   - id: products.detail.type
     title: Product type settings
-    flow: .maestro/flows/products_detail.yaml
+    flow: .maestro/flows/products_create.yaml
   - id: products.detail.tags
     title: Product tags settings
-    flow: .maestro/flows/products_variations_and_tags.yaml
+    flow: .maestro/flows/products_create.yaml
   - id: products.detail.shipping
     title: Product shipping settings
-    manual: "Current flow does not open and verify this product-type-specific setting."
+    flow: .maestro/flows/products_create.yaml
   - id: products.detail.short-description
     title: Product short description settings
-    manual: "Current flow does not open and verify this product-type-specific setting."
+    flow: .maestro/flows/products_create.yaml
   - id: products.detail.linked
     title: Linked products
-    manual: "Current flow does not open and verify this product-type-specific setting."
+    flow: .maestro/flows/products_create.yaml
   - id: products.detail.downloads
     title: Downloadable files
-    manual: "Current flow does not open and verify this product-type-specific setting."
+    flow: .maestro/flows/products_create.yaml
   - id: products.detail.variations
     title: Variations and variation detail
     flow: .maestro/flows/products_variations_and_tags.yaml

--- a/.maestro/subflows/pos_add_discovered_variable_product.yaml
+++ b/.maestro/subflows/pos_add_discovered_variable_product.yaml
@@ -1,0 +1,60 @@
+# Discovers a variable product from the loaded POS catalog, searches for its
+# app-provided name, opens its variations, and adds the first variation.
+appId: com.woocommerce.android.dev
+---
+- scrollUntilVisible:
+    element: "Variable Product .*"
+    direction: DOWN
+    timeout: 30000
+    label: "Find a Variable product in the POS catalog"
+
+- copyTextFrom:
+    text: "Variable Product .*"
+
+- evalScript: ${output.posVariableProductName = maestro.copiedText.replace('Variable Product ', '')}
+- assertTrue:
+    condition: ${output.posVariableProductName.length > 0}
+    label: "Capture the discovered Variable product name"
+
+- tapOn:
+    id: "woo_pos_search_input"
+    label: "Open product search"
+
+- extendedWaitUntil:
+    visible: ".*Search products and variations.*"
+    timeout: 10000
+
+- tapOn:
+    id: "woo_pos_search_input"
+    label: "Focus product search"
+- runFlow:
+    file: paste_into_focused_field.yaml
+    env:
+      TEXT_TO_PASTE: ${output.posVariableProductName}
+- hideKeyboard
+
+- extendedWaitUntil:
+    visible: "Variable Product .*"
+    timeout: 20000
+    label: "Search resolves a Variable product"
+
+- tapOn:
+    id: "woo_pos_product_item"
+    index: 0
+    label: "Open discovered Variable product variations"
+
+- extendedWaitUntil:
+    notVisible: ".*Search products and variations.*"
+    timeout: 10000
+    label: "Require variation selection screen"
+
+- extendedWaitUntil:
+    visible:
+      id: "woo_pos_product_item"
+    timeout: 20000
+    label: "Wait for POS variations"
+
+- tapOn:
+    id: "woo_pos_product_item"
+    index: 0
+    label: "Add first variation to cart"

--- a/.maestro/subflows/pos_add_discovered_variable_product.yaml
+++ b/.maestro/subflows/pos_add_discovered_variable_product.yaml
@@ -27,10 +27,7 @@ appId: com.woocommerce.android.dev
 - tapOn:
     id: "woo_pos_search_input"
     label: "Focus product search"
-- runFlow:
-    file: paste_into_focused_field.yaml
-    env:
-      TEXT_TO_PASTE: ${output.posVariableProductName}
+- inputText: ${output.posVariableProductName}
 - hideKeyboard
 
 - extendedWaitUntil:

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreenTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreenTest.kt
@@ -1,0 +1,63 @@
+package com.woocommerce.android.ui.woopos.home.cart
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
+import com.woocommerce.android.ui.woopos.util.WooPosTestTags
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class WooPosCartScreenTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun productRowDoesNotExposeCouponTestTag() {
+        setCartItem(
+            WooPosCartItemViewState.Product.Simple(
+                itemNumber = 1,
+                id = 1,
+                name = "Product",
+                price = "$10.00",
+                description = null,
+                imageUrl = null,
+            )
+        )
+
+        composeTestRule.onNodeWithTag(WooPosTestTags.CART_COUPON_ITEM).assertDoesNotExist()
+    }
+
+    @Test
+    fun couponRowExposesCouponTestTag() {
+        setCartItem(
+            WooPosCartItemViewState.Coupon(
+                itemNumber = 1,
+                id = 1,
+                name = "Coupon",
+                summary = "10% off",
+            )
+        )
+
+        composeTestRule.onNodeWithTag(WooPosTestTags.CART_COUPON_ITEM).assertIsDisplayed()
+    }
+
+    private fun setCartItem(item: WooPosCartItemViewState) {
+        composeTestRule.setContent {
+            WooPosTheme {
+                WooPosCartScreen(
+                    state = WooPosCartState(
+                        body = WooPosCartState.Body.WithItems(listOf(item)),
+                        checkoutButtonState = WooPosCartState.CheckoutButtonState.Invisible,
+                    ),
+                    onUIEvent = {},
+                    checkoutSlot = WooPosCartCheckoutButtonSlot.External,
+                )
+            }
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosSearchInput.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosSearchInput.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.TextRange
@@ -54,6 +55,7 @@ import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosThe
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
 import com.woocommerce.android.ui.woopos.home.items.WOO_POS_ITEMS_TOOLBAR_HEIGHT
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsUIEvent
+import com.woocommerce.android.ui.woopos.util.WooPosTestTags
 import kotlinx.coroutines.delay
 import kotlinx.parcelize.Parcelize
 
@@ -70,7 +72,7 @@ fun WooPosSearchInput(
     )
 
     Box(
-        modifier = modifier,
+        modifier = modifier.testTag(WooPosTestTags.SEARCH_INPUT),
         contentAlignment = Alignment.CenterEnd
     ) {
         when (state) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/designsystem/WooPosTheme.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/designsystem/WooPosTheme.kt
@@ -3,6 +3,7 @@
 package com.woocommerce.android.ui.woopos.common.composeui.designsystem
 
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Box
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.darkColorScheme
@@ -10,7 +11,10 @@ import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTagsAsResourceId
 
 data class CustomColors(
     val success: Color,
@@ -218,7 +222,9 @@ fun WooPosTheme(content: @Composable () -> Unit) {
 @Composable
 private fun SurfacedContent(content: @Composable () -> Unit) {
     Surface(color = MaterialTheme.colorScheme.surface) {
-        content()
+        Box(Modifier.semantics { testTagsAsResourceId = true }) {
+            content()
+        }
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
@@ -485,6 +485,7 @@ private fun ClearCartButton(
 
     Box(modifier = modifier) {
         WooPosIconButton(
+            modifier = Modifier.testTag(WooPosTestTags.CLEAR_CART_BUTTON),
             icon = ImageVector.vectorResource(R.drawable.ic_delete_24dp),
             enabled = !dropdownExpanded,
             onClick = { dropdownExpanded = true },
@@ -542,6 +543,7 @@ private fun ProductItem(
     WooPosCard(
         modifier = modifier
             .wrapContentHeight()
+            .testTag(WooPosTestTags.CART_COUPON_ITEM)
             .semantics { contentDescription = itemContentDescription },
         backgroundColor = MaterialTheme.colorScheme.surfaceContainerLowest,
         elevation = WooPosElevation.Medium,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
@@ -543,7 +543,6 @@ private fun ProductItem(
     WooPosCard(
         modifier = modifier
             .wrapContentHeight()
-            .testTag(WooPosTestTags.CART_COUPON_ITEM)
             .semantics { contentDescription = itemContentDescription },
         backgroundColor = MaterialTheme.colorScheme.surfaceContainerLowest,
         elevation = WooPosElevation.Medium,
@@ -640,6 +639,7 @@ private fun CouponItem(
     WooPosCard(
         modifier = modifier
             .wrapContentHeight()
+            .testTag(WooPosTestTags.CART_COUPON_ITEM)
             .semantics { contentDescription = itemContentDescription },
         backgroundColor = MaterialTheme.colorScheme.surfaceContainerLowest,
         elevation = WooPosElevation.Medium,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsList.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsList.kt
@@ -368,6 +368,7 @@ fun WooPosCouponCard(
                     onClickLabel = stringResource(R.string.woopos_add_coupon_to_cart_accessibility_label)
                 ) { onItemClicked(item) }
                 .clearAndSetSemantics { contentDescription = itemContentDescription }
+                .testTag(WooPosTestTags.COUPON_ADD_TO_CART_BUTTON)
                 .height(IntrinsicSize.Min)
                 .fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsList.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsList.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -367,8 +368,10 @@ fun WooPosCouponCard(
                     enabled = item.expiredState is Coupon.ExpiredState.NotExpired,
                     onClickLabel = stringResource(R.string.woopos_add_coupon_to_cart_accessibility_label)
                 ) { onItemClicked(item) }
-                .clearAndSetSemantics { contentDescription = itemContentDescription }
-                .testTag(WooPosTestTags.COUPON_ADD_TO_CART_BUTTON)
+                .clearAndSetSemantics {
+                    contentDescription = itemContentDescription
+                    testTag = WooPosTestTags.COUPON_ADD_TO_CART_BUTTON
+                }
                 .height(IntrinsicSize.Min)
                 .fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically

--- a/libs/pos/src/main/java/com/woocommerce/android/ui/woopos/util/WooPosTestTags.kt
+++ b/libs/pos/src/main/java/com/woocommerce/android/ui/woopos/util/WooPosTestTags.kt
@@ -21,4 +21,6 @@ object WooPosTestTags {
     const val NEW_ORDER_BUTTON = "woo_pos_new_order_button"
     const val SUCCESS_CHECKMARK_ICON = "woo_pos_success_checkmark_icon"
     const val CART_ITEMS_COUNT = "woo_pos_cart_items_count"
+    const val CLEAR_CART_BUTTON = "woo_pos_clear_cart_button"
+    const val CART_COUPON_ITEM = "woo_pos_cart_coupon_item"
 }

--- a/libs/pos/src/main/java/com/woocommerce/android/ui/woopos/util/WooPosTestTags.kt
+++ b/libs/pos/src/main/java/com/woocommerce/android/ui/woopos/util/WooPosTestTags.kt
@@ -2,6 +2,8 @@ package com.woocommerce.android.ui.woopos.util
 
 object WooPosTestTags {
     const val PRODUCT_ITEM = "woo_pos_product_item"
+    const val SEARCH_INPUT = "woo_pos_search_input"
+    const val COUPON_ADD_TO_CART_BUTTON = "woo_pos_coupon_add_to_cart_button"
     const val CHECKOUT_BUTTON = "woo_pos_checkout_button"
     const val CASH_PAYMENT_BUTTON = "woo_pos_cash_payment_button"
     const val CARD_READER_PAYMENT_BUTTON = "woo_pos_card_reader_payment_button"


### PR DESCRIPTION
### Description

Adds tablet POS Maestro support, POS flows, and the initial committed coverage snapshot. This is stack layer **5 of 8**.

Included here:

- Compose test tags exported as Android resource IDs at the POS theme root;
- stable selectors for product/coupon rows, search, cart, checkout, cash payment, success, and cart reset;
- a POS product-search and coupon-add-to-cart flow using live eligible-store data;
- a destructive POS cash-payment flow that creates a completed order;
- the first offline P2 checklist-to-flow/manual coverage snapshot and mapping checker.

### Device, state, and coverage boundary

- Both flows require a tablet-sized device and a genuinely POS-eligible store. Missing POS navigation is a setup failure.
- Both POS flows are tagged `flaky_quarantine`; the cash-payment flow is also `destructive`. Neither expands the release-gating phone core.
- The flows clear leftover cart state before owning their assertions, but cash checkout persists a real test order.
- The coverage snapshot in this layer records the implementation state at the time the stack was created. It is not a current release-coverage claim; #16372 refreshes it against the current P2 revision and adds stricter ownership/fidelity validation.
- Card-reader payment and emailed-receipt verification remain manual because they require hardware or external email evidence.
- No live POS Maestro flow, coupon use, or cash transaction was performed during this PR review.

### Stack

- Integration target: `feature/maestro-smoke-testing-automation`
- Position: **5 of 8**
- Previous: #16199
- Next: #16256
- The complete stack is being assembled and validated on the integration branch before any proposal to merge it into `trunk`.

### Test Steps

1. Run `python3 .maestro/scripts/check-smoke-coverage.py`.
2. Parse the POS YAML flows/subflows and coverage snapshot with a YAML parser.
3. Run `git diff --check` and compile the Wasabi debug Kotlin sources.
4. Run the focused Compose semantics test proving `woo_pos_cart_coupon_item` exists only for a coupon row, not a product row.
5. For an explicit runtime check, use a tablet emulator and eligible disposable lab store, deliberately include quarantine, and inspect/reset the POS cart and created order afterward.

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
