### PR TITLE
Wire Maestro smoke tests into Buildkite

### DIFF
--- a/.buildkite/commands/run-maestro-tests.sh
+++ b/.buildkite/commands/run-maestro-tests.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+set -euo pipefail
+
+# Run the Maestro smoke suite through the repository runner.
+#
+# Expected CI secrets:
+#   MAESTRO_WOO_SHARED_STORE_URL
+#   MAESTRO_WOO_SHARED_EMAIL
+#   MAESTRO_WOO_SHARED_PASSWORD
+#   MAESTRO_WOO_SHARED_CONSUMER_KEY
+#   MAESTRO_WOO_SHARED_CONSUMER_SECRET
+#
+# Optional controls:
+#   MAESTRO_STORE=shared|lab
+#   MAESTRO_INCLUDE_TAGS=smoke_core,smoke_extended,destructive
+#   MAESTRO_REPEAT=3
+#   MAESTRO_APK_PATH=/path/to/beta.apk
+
+if .buildkite/commands/should-skip-job.sh --job-type validation; then
+  echo "Skipping Maestro tests - no relevant changes"
+  exit 0
+fi
+
+STORE="${MAESTRO_STORE:-shared}"
+INCLUDE_TAGS="${MAESTRO_INCLUDE_TAGS:-smoke_core}"
+REPEAT="${MAESTRO_REPEAT:-1}"
+OUTPUT_DIR="${MAESTRO_OUTPUT_DIR:-WooCommerce/build/outputs/maestro-smoke}"
+
+if [[ -n "${MAESTRO_APK_PATH:-}" ]]; then
+  APK_PATH="$MAESTRO_APK_PATH"
+else
+  echo "--- Building and installing wasabi debug APK"
+  "$(dirname "${BASH_SOURCE[0]}")/restore-cache.sh"
+  ./gradlew :WooCommerce:installWasabiDebug
+  APK_PATH=""
+fi
+
+echo "--- Running Maestro smoke tests"
+set +e
+if [[ -n "$APK_PATH" ]]; then
+  .maestro/scripts/run-smoke-tests.sh \
+    --store "$STORE" \
+    --include-tags "$INCLUDE_TAGS" \
+    --repeat "$REPEAT" \
+    --output-dir "$OUTPUT_DIR" \
+    --no-open \
+    --apk "$APK_PATH"
+else
+  .maestro/scripts/run-smoke-tests.sh \
+    --store "$STORE" \
+    --include-tags "$INCLUDE_TAGS" \
+    --repeat "$REPEAT" \
+    --output-dir "$OUTPUT_DIR" \
+    --no-open
+fi
+MAESTRO_EXIT_STATUS=$?
+set -e
+
+echo "--- Collecting Maestro results"
+mkdir -p WooCommerce/build/buildkite-test-analytics
+LATEST_REPORT_DIR="$(find "$OUTPUT_DIR" -mindepth 1 -maxdepth 1 -type d | sort | tail -n 1)"
+if [[ -n "$LATEST_REPORT_DIR" && -f "$LATEST_REPORT_DIR/report.xml" ]]; then
+  cp "$LATEST_REPORT_DIR/report.xml" WooCommerce/build/buildkite-test-analytics/maestro-report.xml
+fi
+
+if [[ "$MAESTRO_EXIT_STATUS" -ne 0 ]]; then
+  echo "^^^ +++"
+  echo "Maestro smoke tests were not clean. Check flaky/failure details in artifacts."
+fi
+
+exit "$MAESTRO_EXIT_STATUS"

--- a/.buildkite/commands/run-maestro-tests.sh
+++ b/.buildkite/commands/run-maestro-tests.sh
@@ -4,17 +4,16 @@ set -euo pipefail
 # Run the Maestro smoke suite through the repository runner.
 #
 # Expected CI secrets:
-#   MAESTRO_WOO_SHARED_STORE_URL
-#   MAESTRO_WOO_SHARED_EMAIL
-#   MAESTRO_WOO_SHARED_PASSWORD
-#   MAESTRO_WOO_SHARED_CONSUMER_KEY
-#   MAESTRO_WOO_SHARED_CONSUMER_SECRET
+#   MAESTRO_WOO_SHARED_JETPACK_STORE_URL
+#   MAESTRO_WOO_SHARED_WPCOM_EMAIL
+#   MAESTRO_WOO_SHARED_WPCOM_PASSWORD
 #
 # Optional controls:
 #   MAESTRO_STORE=shared|lab
 #   MAESTRO_INCLUDE_TAGS=smoke_core,smoke_extended,destructive
 #   MAESTRO_REPEAT=3
 #   MAESTRO_APK_PATH=/path/to/beta.apk
+#   MAESTRO_SEED=true
 
 if .buildkite/commands/should-skip-job.sh --job-type validation; then
   echo "Skipping Maestro tests - no relevant changes"
@@ -25,6 +24,10 @@ STORE="${MAESTRO_STORE:-shared}"
 INCLUDE_TAGS="${MAESTRO_INCLUDE_TAGS:-smoke_core}"
 REPEAT="${MAESTRO_REPEAT:-1}"
 OUTPUT_DIR="${MAESTRO_OUTPUT_DIR:-WooCommerce/build/outputs/maestro-smoke}"
+SEED_ARGS=()
+if [[ "${MAESTRO_SEED:-false}" == "true" ]]; then
+  SEED_ARGS+=(--seed)
+fi
 
 if [[ -n "${MAESTRO_APK_PATH:-}" ]]; then
   APK_PATH="$MAESTRO_APK_PATH"
@@ -43,6 +46,7 @@ if [[ -n "$APK_PATH" ]]; then
     --include-tags "$INCLUDE_TAGS" \
     --repeat "$REPEAT" \
     --output-dir "$OUTPUT_DIR" \
+    "${SEED_ARGS[@]}" \
     --no-open \
     --apk "$APK_PATH"
 else
@@ -51,6 +55,7 @@ else
     --include-tags "$INCLUDE_TAGS" \
     --repeat "$REPEAT" \
     --output-dir "$OUTPUT_DIR" \
+    "${SEED_ARGS[@]}" \
     --no-open
 fi
 MAESTRO_EXIT_STATUS=$?

--- a/.buildkite/commands/run-maestro-tests.sh
+++ b/.buildkite/commands/run-maestro-tests.sh
@@ -11,6 +11,7 @@ set -euo pipefail
 # Optional controls:
 #   MAESTRO_STORE=shared|lab
 #   MAESTRO_INCLUDE_TAGS=smoke_core,smoke_extended,destructive
+#   MAESTRO_EXCLUDE_TAGS=flaky_quarantine,pos_tablet
 #   MAESTRO_REPEAT=3
 #   MAESTRO_APK_PATH=/path/to/beta.apk
 #   MAESTRO_SEED=true
@@ -25,8 +26,12 @@ INCLUDE_TAGS="${MAESTRO_INCLUDE_TAGS:-smoke_core}"
 REPEAT="${MAESTRO_REPEAT:-1}"
 OUTPUT_DIR="${MAESTRO_OUTPUT_DIR:-WooCommerce/build/outputs/maestro-smoke}"
 SEED_ARGS=()
+EXCLUDE_TAGS_ARGS=()
 if [[ "${MAESTRO_SEED:-false}" == "true" ]]; then
   SEED_ARGS+=(--seed)
+fi
+if [[ -n "${MAESTRO_EXCLUDE_TAGS:-}" ]]; then
+  EXCLUDE_TAGS_ARGS+=(--exclude-tags "$MAESTRO_EXCLUDE_TAGS")
 fi
 
 if [[ -n "${MAESTRO_APK_PATH:-}" ]]; then
@@ -47,6 +52,7 @@ if [[ -n "$APK_PATH" ]]; then
     --repeat "$REPEAT" \
     --output-dir "$OUTPUT_DIR" \
     "${SEED_ARGS[@]}" \
+    "${EXCLUDE_TAGS_ARGS[@]}" \
     --no-open \
     --apk "$APK_PATH"
 else
@@ -56,6 +62,7 @@ else
     --repeat "$REPEAT" \
     --output-dir "$OUTPUT_DIR" \
     "${SEED_ARGS[@]}" \
+    "${EXCLUDE_TAGS_ARGS[@]}" \
     --no-open
 fi
 MAESTRO_EXIT_STATUS=$?

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -117,6 +117,22 @@ steps:
         artifact_paths:
           - "**/build/instrumented-tests/**/*"
 
+      - input: Run Maestro smoke tests?
+        prompt: "Run on-demand Maestro smoke tests. Requires MAESTRO_WOO_* secrets and an Android device/emulator."
+        key: maestro_smoke_tests_triggered
+
+      - label: ":maestro: Maestro smoke tests"
+        depends_on: maestro_smoke_tests_triggered
+        command: .buildkite/commands/run-maestro-tests.sh
+        plugins:
+          - $CI_TOOLKIT
+          - $TEST_COLLECTOR :
+              <<: *test_collector_common_params
+              api-token-env-name: "BUILDKITE_ANALYTICS_TOKEN_MAESTRO_TESTS"
+        artifact_paths:
+          - "WooCommerce/build/outputs/maestro-smoke/**/*"
+          - "WooCommerce/build/buildkite-test-analytics/maestro-report.xml"
+
 
   - label: "🐘 Populate Gradle build cache"
     command: .buildkite/commands/gradle-cache-build.sh

--- a/.buildkite/release-pipelines/maestro-smoke.yml
+++ b/.buildkite/release-pipelines/maestro-smoke.yml
@@ -7,6 +7,7 @@ agents:
 env:
   MAESTRO_STORE: "shared"
   MAESTRO_INCLUDE_TAGS: "smoke_core,smoke_extended,destructive"
+  MAESTRO_EXCLUDE_TAGS: "flaky_quarantine,pos_tablet"
   MAESTRO_REPEAT: "1"
 
 steps:

--- a/.buildkite/release-pipelines/maestro-smoke.yml
+++ b/.buildkite/release-pipelines/maestro-smoke.yml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+---
+
+agents:
+  queue: "android"
+
+env:
+  MAESTRO_STORE: "shared"
+  MAESTRO_INCLUDE_TAGS: "smoke_core,smoke_extended,destructive"
+  MAESTRO_REPEAT: "1"
+
+steps:
+  - label: ":maestro: Release Maestro smoke tests"
+    command: .buildkite/commands/run-maestro-tests.sh
+    plugins:
+      - $CI_TOOLKIT
+      - $TEST_COLLECTOR :
+          files: "WooCommerce/build/buildkite-test-analytics/*.xml"
+          format: "junit"
+          api-token-env-name: "BUILDKITE_ANALYTICS_TOKEN_MAESTRO_TESTS"
+    artifact_paths:
+      - "WooCommerce/build/outputs/maestro-smoke/**/*"
+      - "WooCommerce/build/buildkite-test-analytics/maestro-report.xml"

--- a/.buildkite/schedules/maestro-smoke-burst.yml
+++ b/.buildkite/schedules/maestro-smoke-burst.yml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+---
+
+# Intended Buildkite schedule:
+#   Bi-weekly Thursday night before the Monday production rollout.
+#   Branch: active release branch.
+#
+# This is deliberately not a nightly pipeline.
+
+agents:
+  queue: "android"
+
+env:
+  MAESTRO_STORE: "shared"
+  MAESTRO_INCLUDE_TAGS: "smoke_core,smoke_extended,destructive"
+  MAESTRO_REPEAT: "3"
+
+steps:
+  - label: ":maestro: Thursday Maestro smoke burst"
+    command: .buildkite/commands/run-maestro-tests.sh
+    plugins:
+      - $CI_TOOLKIT
+      - $TEST_COLLECTOR :
+          files: "WooCommerce/build/buildkite-test-analytics/*.xml"
+          format: "junit"
+          api-token-env-name: "BUILDKITE_ANALYTICS_TOKEN_MAESTRO_TESTS"
+    artifact_paths:
+      - "WooCommerce/build/outputs/maestro-smoke/**/*"
+      - "WooCommerce/build/buildkite-test-analytics/maestro-report.xml"
+
+notify:
+  - slack:
+      channels:
+        - "#woo-android-notifs"
+    if: "build.state != 'passed'"

--- a/.buildkite/schedules/maestro-smoke-burst.yml
+++ b/.buildkite/schedules/maestro-smoke-burst.yml
@@ -13,6 +13,7 @@ agents:
 env:
   MAESTRO_STORE: "shared"
   MAESTRO_INCLUDE_TAGS: "smoke_core,smoke_extended,destructive"
+  MAESTRO_EXCLUDE_TAGS: "flaky_quarantine,pos_tablet"
   MAESTRO_REPEAT: "3"
 
 steps:


### PR DESCRIPTION
### Description

Adds Buildkite entry points around the repo-owned Maestro runner. This is stack layer **7 of 8**.

Included here:

- a shared Buildkite command that resolves store/tags/repeat/app inputs and returns the runner status;
- an on-demand pipeline input;
- a release-pipeline definition;
- a scheduled three-repeat burst definition;
- HTML/JUnit/log/media artifact upload wiring and Test Analytics collection.

Because the previous layers quarantine every extended/destructive flow, the effective release selection at this point remains the same four `smoke_core` flows even though the release profile names broader tags.

### CI rollout boundary

- These definitions are integration scaffolding, not an activated release gate or proof of a successful device run.
- This layer can fall back to building/installing a Wasabi debug APK. It does not yet prove the immutable release candidate.
- The manual input is unconditional in the general pipeline and can leave an otherwise successful build waiting/blocked.
- The checked-in scheduled burst reflects the stack’s original proposal. Current P2 cadence is release/beta-triggered plus a final release run; operational schedule/trigger activation must be aligned before promotion.
- At this layer, the release/scheduled destructive definitions do not yet enable owned fixture seeding or shared-store concurrency, and the wrapper applies the PR changed-file skip to every invocation. #16372 adds scoped shared-store safety, mandatory seeding, concurrency, and a PR-only skip gate, alongside toolchain pinning and stricter result publication.
- No Buildkite Maestro device job or live store flow was triggered during this PR review.

### Stack

- Integration target: `feature/maestro-smoke-testing-automation`
- Position: **7 of 8**
- Previous: #16256
- Next/final hardening: #16372
- The complete stack is being assembled and validated on the integration branch before any proposal to merge it into `trunk`.

### Test Steps

1. Run `bash -n .buildkite/commands/run-maestro-tests.sh`.
2. Parse `.buildkite/pipeline.yml`, `.buildkite/release-pipelines/maestro-smoke.yml`, and `.buildkite/schedules/maestro-smoke-burst.yml` with a YAML parser.
3. Run the repository’s Buildkite pipeline-upload validation.
4. Confirm the command preserves the runner exit status and copies the latest JUnit report into `WooCommerce/build/buildkite-test-analytics`.
5. Confirm artifacts are collected from `WooCommerce/build/outputs/maestro-smoke` and the Test Analytics directory.

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
