### PR TITLE
[WOOMOB-3444] Fix crash when age signals service binder dies during age check

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 
 25.1
 -----
+- [*] Fixed a crash when the Play Store age signals service disconnected during the age eligibility check [https://github.com/woocommerce/woocommerce-android/pull/16206]
 - [Internal] Added analytics for Woo Core push token deletion results [https://github.com/woocommerce/woocommerce-android/pull/16184]
 - [*] POS: the Issue Refund flow now opens full screen from the start instead of inside the order details pane [https://github.com/woocommerce/woocommerce-android/pull/16116]
 - [*] Fixed a startup crash when WordPress.com returns malformed site details [https://github.com/woocommerce/woocommerce-android/pull/16102]

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/ageeligibility/AgeEligibilityChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/ageeligibility/AgeEligibilityChecker.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.ageeligibility
 
+import android.os.RemoteException
 import androidx.annotation.StringRes
 import com.google.android.gms.common.api.ApiException
 import com.google.android.play.agesignals.model.AgeSignalsVerificationStatus
@@ -58,12 +59,12 @@ class AgeEligibilityChecker @Inject constructor(
                 trackingProperties["retrieved_age"] = result.ageUpper ?: -1
                 trackingProperties["user_status"] = getUserStatusAsString(result.userStatus)
             } catch (exception: ApiException) {
-                WooLog.i(
-                    WooLog.T.UTILS,
-                    "AgeEligibilityChecker ${exception.javaClass.simpleName} while checking user " +
-                        "age: ${exception.message}, reverting user eligibility to default true"
-                )
-                _ageEligibilityState.update { _ageEligibilityState.value.copy(isUserAgeRangeEligible = true) }
+                revertEligibilityToDefault(exception)
+            } catch (exception: RemoteException) {
+                // The age signals service is backed by a Play Store binder that can die at any
+                // time (e.g. Play Store killed or updated); the pending check then fails with a
+                // plain RemoteException instead of an ApiException
+                revertEligibilityToDefault(exception)
             }
 
             val isAccessRestricted = _ageEligibilityState.value.isUserAgeRangeEligible.not()
@@ -76,6 +77,15 @@ class AgeEligibilityChecker @Inject constructor(
         } else {
             _ageEligibilityState.update { _ageEligibilityState.value.copy(isUserAgeRangeEligible = true) }
         }
+    }
+
+    private fun revertEligibilityToDefault(exception: Exception) {
+        WooLog.i(
+            WooLog.T.UTILS,
+            "AgeEligibilityChecker ${exception.javaClass.simpleName} while checking user " +
+                "age: ${exception.message}, reverting user eligibility to default true"
+        )
+        _ageEligibilityState.update { _ageEligibilityState.value.copy(isUserAgeRangeEligible = true) }
     }
 
     private fun isAgeBelowWooCommerceTOSMinimum(ageUpper: Int?): Boolean =

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/ageeligibility/AgeEligibilityCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/ageeligibility/AgeEligibilityCheckerTest.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.ageeligibility
 
+import android.os.RemoteException
 import com.google.android.play.agesignals.AgeSignalsException
 import com.google.android.play.agesignals.model.AgeSignalsVerificationStatus
 import com.woocommerce.android.AppPrefsWrapper
@@ -181,7 +182,23 @@ class AgeEligibilityCheckerTest : BaseUnitTest() {
 
     @Test
     fun `given checkAge throws exception, when checkAge called, then user is eligible`() = testBlocking {
-        client.setThrowException(true)
+        client.setThrowException(AgeSignalsException(-5))
+
+        ageEligibilityChecker.checkAge()
+
+        assertEquals(true, ageEligibilityChecker.ageEligibilityState.value.isUserAgeRangeEligible)
+
+        verify(trackerWrapper).track(
+            AnalyticsEvent.ACCOUNT_AGE_RESTRICTION_CHECKED,
+            mapOf(
+                "access_restricted" to false
+            )
+        )
+    }
+
+    @Test
+    fun `given age signals service binder dies, when checkAge called, then user is eligible`() = testBlocking {
+        client.setThrowException(mock<RemoteException>())
 
         ageEligibilityChecker.checkAge()
 
@@ -235,7 +252,7 @@ class AgeEligibilityCheckerTest : BaseUnitTest() {
         }
 
     class FakeAgeSignalsClient : AgeSignalsClient {
-        private var shouldThrow = false
+        private var exceptionToThrow: Exception? = null
         private var userStatus: Int = DEFAULT_USER_AGE_STATUS
         private var ageUpper: Int? = DEFAULT_USER_AGE_UPPER
 
@@ -244,14 +261,12 @@ class AgeEligibilityCheckerTest : BaseUnitTest() {
             this.ageUpper = ageUpper
         }
 
-        fun setThrowException(shouldThrow: Boolean) {
-            this.shouldThrow = shouldThrow
+        fun setThrowException(exception: Exception) {
+            this.exceptionToThrow = exception
         }
 
         override suspend fun checkAge(): AgeCheckResult {
-            if (shouldThrow) {
-                throw AgeSignalsException(-5)
-            }
+            exceptionToThrow?.let { throw it }
             return AgeCheckResult(userStatus, ageUpper)
         }
     }


### PR DESCRIPTION
### Description

Fixes WOOMOB-3444

> [!NOTE]
> Targets `release/25.1` as a beta fix given the crash severity (93 users / 103 events in ~3 weeks, top new crash in 25.0).

Fixes the top new crash in 25.0 ([Sentry WOOCOMMERCE-ANDROID-VSQ](https://a8c.sentry.io/issues/WOOCOMMERCE-ANDROID-VSQ)): `RemoteException: AgeSignalsService : Binder has died.`

**Why it happens:** the age eligibility check (`GoogleAgeSignalsClient`) awaits a Task from the Play `age-signals` library. That Task is backed by a binder connection to the Play Store's `AgeSignalsService`. When the Play Store process dies while a check is in flight (killed by the system on low-memory devices, updated, or the app is backgrounded — most affected devices are `device.class: low`), the library's `DeathRecipient` fails all pending tasks with a plain `android.os.RemoteException` rather than an `ApiException`. `AgeEligibilityChecker.checkAge()` only caught `ApiException`, so the `RemoteException` was rethrown by `.await()` into `appCoroutineScope` (which has no `CoroutineExceptionHandler`) and crashed the app.

**Fix:** catch `RemoteException` alongside `ApiException` and apply the existing failure policy — log and revert eligibility to the safe default (`true`). We are already on the latest version of the `age-signals` library (0.0.3), so there is no library-side fix available.

### Test Steps

I tried multiple approaches but couldn't reproduce the binder death manually. I tried debugging the app, pausing the execution at `val result = client.checkAge()` then resumed execution at the same time that I ran `adb shell am force-stop com.android.vending` to simulate the race condition killing the Google Service, but it was imposible to reproduce the crash. Let me know if you have any better idea on how to trigger the exception.

In any case, catching the `RemoteException` as we previously did for `ApiException` should be a safe enough solution to get rid of the crash. 

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.