### PR TITLE
[WOOMOB-2980] Make saved package rows clickable on package selection screen

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,7 +5,7 @@
 25.2
 -----
 - [*] Added a shortcut to view guest orders when searching for the Guest label returns no results [https://github.com/woocommerce/woocommerce-android/pull/16189]
-- [*] Fixed saved package rows not responding to taps on the shipping label package selection screen [PR URL]
+- [*] Fixed saved package rows not responding to taps on the shipping label package selection screen [https://github.com/woocommerce/woocommerce-android/pull/16210]
 - [*] Refunding an order paid with a gift card is now blocked in the app with a prompt to refund from your store admin, so the gift-card balance is restored correctly [https://github.com/woocommerce/woocommerce-android/pull/16169]
 - [*] Fixed duplicated products reusing the original product slug [https://github.com/woocommerce/woocommerce-android/pull/16142]
 - [*] Fixed account-mismatch login retry requiring merchants to re-enter their store URL [https://github.com/woocommerce/woocommerce-android/pull/16162]

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 25.2
 -----
 - [*] Added a shortcut to view guest orders when searching for the Guest label returns no results [https://github.com/woocommerce/woocommerce-android/pull/16189]
+- [*] Fixed saved package rows not responding to taps on the shipping label package selection screen [PR URL]
 - [*] Refunding an order paid with a gift card is now blocked in the app with a prompt to refund from your store admin, so the gift-card balance is restored correctly [https://github.com/woocommerce/woocommerce-android/pull/16169]
 - [*] Fixed duplicated products reusing the original product slug [https://github.com/woocommerce/woocommerce-android/pull/16142]
 - [*] Fixed account-mismatch login retry requiring merchants to re-enter their store URL [https://github.com/woocommerce/woocommerce-android/pull/16162]

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/components/PackageItemComponents.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/components/PackageItemComponents.kt
@@ -36,11 +36,11 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.PackageDa
 
 @Composable
 fun WooShippingPackageListItem(
-    modifier: Modifier = Modifier,
     packageData: PackageData,
     onPackageSelected: (PackageData, Boolean) -> Unit,
-    divider: Boolean = true,
     packageItemSupportsStarring: Boolean,
+    modifier: Modifier = Modifier,
+    divider: Boolean = true,
     onPackageStarred: (PackageData, Boolean) -> Unit = { _, _ -> },
     onPackageRemoved: ((PackageData) -> Unit)? = null,
 ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/components/PackageItemComponents.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/components/PackageItemComponents.kt
@@ -36,7 +36,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.PackageDa
 
 @Composable
 fun WooShippingPackageListItem(
-    modifier: Modifier,
+    modifier: Modifier = Modifier,
     packageData: PackageData,
     onPackageSelected: (PackageData, Boolean) -> Unit,
     divider: Boolean = true,
@@ -100,7 +100,9 @@ fun WooShippingPackageListItemContent(
 ) {
     Surface {
         Row(
-            modifier = modifier.padding(16.dp),
+            modifier = modifier
+                .clickable { onPackageSelected(packageData, !packageData.isSelected) }
+                .padding(16.dp),
             horizontalArrangement = Arrangement.spacedBy(8.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/WooShippingCarrierPackageScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/WooShippingCarrierPackageScreen.kt
@@ -3,7 +3,6 @@ package com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui
 import android.content.res.Configuration
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -269,7 +268,6 @@ private fun PackageListSection(
         Divider()
         packages.forEachIndexed { index, packageData ->
             WooShippingPackageListItem(
-                modifier = Modifier.clickable { onPackageSelected(packageData, packageData.isSelected.not()) },
                 packageData = packageData,
                 onPackageSelected = onPackageSelected,
                 divider = index < packages.size - 1,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/WooShippingSavedPackageScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/WooShippingSavedPackageScreen.kt
@@ -129,9 +129,9 @@ fun WooShippingSavedPackageContent(
             key = { index, packageData -> packageData.id }
         ) { index, packageData ->
             WooShippingPackageListItem(
-                modifier.animateItem(),
-                packageData,
-                onSavedPackageSelected,
+                modifier = modifier.animateItem(),
+                packageData = packageData,
+                onPackageSelected = onSavedPackageSelected,
                 divider = index < savedPackages.size - 1,
                 packageItemSupportsStarring = false,
                 onPackageRemoved = onSavedPackageRemoved


### PR DESCRIPTION
Fixes WOOMOB-2980

### Description

On the shipping label package selection screen, rows on the **Saved** tab only reacted to taps on the checkbox. The row click listener now lives in the shared list item component, so tapping anywhere on a row toggles the selection on both the Saved and Carrier tabs; the Carrier tab's own `clickable` is removed in favor of it.

### Test Steps

On a store with Woo Shipping and at least one saved package:

1. Open an order and start creating a shipping label.
2. In the package selection step, open the **Saved** tab.
3. Tap anywhere on a saved package row and confirm it toggles the selection.
4. Swipe a saved package row left and confirm delete still works.
5. On the **Carrier** tab, confirm tapping a row still selects it.

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt`.