### PR TITLE
[WOOMOB-3441] Stop feedback survey screens from replacing the activity action bar

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 
 25.2
 -----
+- [*] Fixed the main toolbar showing the wrong menu after opening a feedback survey [PR URL]
 - [*] Fixed a crash when a notifications sync deletes a very large number of cached notifications at once [https://github.com/woocommerce/woocommerce-android/pull/16214]
 - [*] Added a shortcut to view guest orders when searching for the Guest label returns no results [https://github.com/woocommerce/woocommerce-android/pull/16189]
 - [*] Fixed saved package rows not responding to taps on the shipping label package selection screen [https://github.com/woocommerce/woocommerce-android/pull/16210]

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,7 +4,7 @@
 
 25.2
 -----
-- [*] Fixed the main toolbar showing the wrong menu after opening a feedback survey [PR URL]
+- [*] Fixed the main toolbar showing the wrong menu after opening a feedback survey [https://github.com/woocommerce/woocommerce-android/pull/16220]
 - [*] Fixed a crash when a notifications sync deletes a very large number of cached notifications at once [https://github.com/woocommerce/woocommerce-android/pull/16214]
 - [*] Added a shortcut to view guest orders when searching for the Guest label returns no results [https://github.com/woocommerce/woocommerce-android/pull/16189]
 - [*] Fixed saved package rows not responding to taps on the shipping label package selection screen [https://github.com/woocommerce/woocommerce-android/pull/16210]

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackCompletedFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackCompletedFragment.kt
@@ -2,7 +2,6 @@ package com.woocommerce.android.ui.feedback
 
 import android.os.Bundle
 import android.view.View
-import androidx.appcompat.app.AppCompatActivity
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.google.android.material.appbar.MaterialToolbar
@@ -49,24 +48,17 @@ class FeedbackCompletedFragment : BaseFragment(R.layout.fragment_feedback_comple
     }
 
     private fun setupToolbar(toolbar: MaterialToolbar) {
-        (requireActivity() as AppCompatActivity).setSupportActionBar(toolbar)
-        (requireActivity() as AppCompatActivity).supportActionBar?.title = getString(R.string.feedback_completed_title)
+        toolbar.title = getString(R.string.feedback_completed_title)
         toolbar.setNavigationIcon(R.drawable.ic_gridicons_cross_24dp)
         toolbar.setNavigationOnClickListener {
             findNavController().navigateUp()
         }
-        activity?.invalidateOptionsMenu()
     }
 
     override fun onResume() {
         super.onResume()
 
         trackSurveyCompletedScreenAnalytics()
-    }
-
-    override fun onStop() {
-        super.onStop()
-        activity?.invalidateOptionsMenu()
     }
 
     private fun trackSurveyCompletedScreenAnalytics() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackSurveyFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackSurveyFragment.kt
@@ -8,7 +8,6 @@ import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.activity.OnBackPressedCallback
-import androidx.appcompat.app.AppCompatActivity
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.google.android.material.appbar.MaterialToolbar
@@ -71,14 +70,11 @@ class FeedbackSurveyFragment : BaseFragment(R.layout.fragment_feedback_survey) {
     }
 
     private fun setupToolbar(toolbar: MaterialToolbar) {
-        (requireActivity() as AppCompatActivity).setSupportActionBar(toolbar)
-        (requireActivity() as AppCompatActivity).supportActionBar?.title =
-            getString(R.string.feedback_survey_request_title)
+        toolbar.title = getString(R.string.feedback_survey_request_title)
         toolbar.setNavigationIcon(R.drawable.ic_gridicons_cross_24dp)
         toolbar.setNavigationOnClickListener {
             findNavController().navigateUp()
         }
-        activity?.invalidateOptionsMenu()
     }
 
     private fun setupBackPressHandling() {
@@ -128,11 +124,6 @@ class FeedbackSurveyFragment : BaseFragment(R.layout.fragment_feedback_survey) {
                 KEY_FEEDBACK_ACTION to VALUE_FEEDBACK_OPENED
             )
         )
-    }
-
-    override fun onStop() {
-        super.onStop()
-        activity?.invalidateOptionsMenu()
     }
 
     override fun onViewStateRestored(savedInstanceState: Bundle?) {


### PR DESCRIPTION
Fixes WOOMOB-3441

### Description

The feedback survey and survey-completed screens called `setSupportActionBar` with their own temporary toolbars, hijacking the activity's action bar. `MainActivity` manages menus and toolbar visibility for the top-level screens through its own toolbar, so once a survey screen was closed the activity was left pointing at a dead toolbar and the next screen's menu got mixed up (e.g. the Analytics Hub's pencil action lingering over other screens, or Reviews losing its mark-all-read action).

Both screens now set the title directly on their own toolbar instead, like the app's other `AppBarStatus.Hidden` screens, and the `invalidateOptionsMenu()` calls that papered over the problem are removed.

### Test Steps

1. Open the **Analytics Hub** and tap **Send feedback** on the feedback banner. Note: the banner only shows while the survey is unanswered, so on a used install you may need to clear app data or do a clean install to bring it back.
2. Close the survey with the X (or complete it).
3. Switch to another tab (e.g. **Reviews**) and confirm its toolbar shows its own actions instead of the leftover Analytics pencil icon.

### Images/gif
|Before|After|
|-|-|
|<img width="300" alt="before" src="https://github.com/user-attachments/assets/decdd842-280f-454d-8490-c712aeef42a2" />|<img width="300" alt="after" src="https://github.com/user-attachments/assets/393516a6-0323-4d38-ae70-a99778397261" />|

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt`.