### PR TITLE
Restore ui-tooling-preview on the release compile classpath

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -451,6 +451,7 @@ dependencies {
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.compose.material.main)
     implementation(libs.androidx.compose.animation.main)
+    implementation(libs.androidx.compose.ui.tooling.preview)
     debugImplementation(libs.androidx.compose.ui.tooling.main)
     implementation(libs.androidx.compose.runtime.livedata)
     implementation(libs.androidx.compose.ui.text.google.fonts)


### PR DESCRIPTION
### Description

Release builds don't compile on `trunk`. ddcbab0f18f moved `ui-tooling` to `debugImplementation`, which also dropped `ui-tooling-preview` (where `@Preview` lives) from the release classpath. This adds it back explicitly, keeping `ui-tooling` debug-only.

### Test Steps

1. `./gradlew :WooCommerce:compileVanillaReleaseKotlin` — fails on `trunk`, passes on this branch.

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.