### PR TITLE
[WOOMOB-987] Load order asynchronously in order editing start

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/BaseOrderEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/BaseOrderEditingFragment.kt
@@ -95,11 +95,20 @@ abstract class BaseOrderEditingFragment : BaseFragment, BackPressListener {
                 is MultiLiveEvent.Event.ShowSnackbar -> {
                     uiMessageResolver.showSnack(event.message)
                 }
+                is OrderEditingViewModel.OrderLoaded -> {
+                    onOrderLoaded()
+                }
             }
         }
 
         sharedViewModel.start()
     }
+
+    /**
+     * Called once the shared view model has loaded the order. Descendants that read
+     * [OrderEditingViewModel.order] should do so from here instead of [onViewCreated].
+     */
+    protected open fun onOrderLoaded() {}
 
     @CallSuper
     fun onMenuItemSelected(item: MenuItem): Boolean {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/CustomerOrderNoteEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/CustomerOrderNoteEditingFragment.kt
@@ -36,11 +36,6 @@ class CustomerOrderNoteEditingFragment :
         setupToolbar()
         onPrepareMenu()
 
-        if (savedInstanceState == null) {
-            binding.customerOrderNoteEditor.requestFocus()
-            ActivityUtils.showKeyboard(binding.customerOrderNoteEditor)
-        }
-
         binding.customerOrderNoteEditor.addTextChangedListener(textWatcher)
     }
 
@@ -48,6 +43,8 @@ class CustomerOrderNoteEditingFragment :
         if (pendingInitialNoteFill) {
             pendingInitialNoteFill = false
             binding.customerOrderNoteEditor.setText(sharedViewModel.order.customerNote)
+            binding.customerOrderNoteEditor.requestFocus()
+            ActivityUtils.showKeyboard(binding.customerOrderNoteEditor)
         } else {
             updateDoneMenuItem()
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/CustomerOrderNoteEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/CustomerOrderNoteEditingFragment.kt
@@ -43,6 +43,7 @@ class CustomerOrderNoteEditingFragment :
         if (pendingInitialNoteFill) {
             pendingInitialNoteFill = false
             binding.customerOrderNoteEditor.setText(sharedViewModel.order.customerNote)
+            binding.customerOrderNoteEditor.setSelection(binding.customerOrderNoteEditor.length())
             binding.customerOrderNoteEditor.requestFocus()
             ActivityUtils.showKeyboard(binding.customerOrderNoteEditor)
         } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/CustomerOrderNoteEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/CustomerOrderNoteEditingFragment.kt
@@ -20,26 +20,37 @@ class CustomerOrderNoteEditingFragment :
     private var _binding: FragmentOrderCreateEditCustomerNoteBinding? = null
     private val binding get() = _binding!!
 
+    private var pendingInitialNoteFill = false
+
     override val analyticsValue: String = AnalyticsTracker.ORDER_EDIT_CUSTOMER_NOTE
 
     override val activityAppBarStatus: AppBarStatus
         get() = AppBarStatus.Hidden
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-
         _binding = FragmentOrderCreateEditCustomerNoteBinding.bind(view)
+        pendingInitialNoteFill = savedInstanceState == null
+
+        super.onViewCreated(view, savedInstanceState)
 
         setupToolbar()
         onPrepareMenu()
 
         if (savedInstanceState == null) {
-            binding.customerOrderNoteEditor.setText(sharedViewModel.order.customerNote)
             binding.customerOrderNoteEditor.requestFocus()
             ActivityUtils.showKeyboard(binding.customerOrderNoteEditor)
         }
 
         binding.customerOrderNoteEditor.addTextChangedListener(textWatcher)
+    }
+
+    override fun onOrderLoaded() {
+        if (pendingInitialNoteFill) {
+            pendingInitialNoteFill = false
+            binding.customerOrderNoteEditor.setText(sharedViewModel.order.customerNote)
+        } else {
+            updateDoneMenuItem()
+        }
     }
 
     private fun setupToolbar() {
@@ -83,7 +94,8 @@ class CustomerOrderNoteEditingFragment :
         }
     }
 
-    override fun hasChanges() = getCustomerNote() != sharedViewModel.order.customerNote
+    override fun hasChanges() =
+        sharedViewModel.isOrderLoaded && getCustomerNote() != sharedViewModel.order.customerNote
 
     override fun saveChanges() = sharedViewModel.updateCustomerOrderNote(getCustomerNote())
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/CustomerOrderNoteEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/CustomerOrderNoteEditingFragment.kt
@@ -42,10 +42,12 @@ class CustomerOrderNoteEditingFragment :
     override fun onOrderLoaded() {
         if (pendingInitialNoteFill) {
             pendingInitialNoteFill = false
-            binding.customerOrderNoteEditor.setText(sharedViewModel.order.customerNote)
-            binding.customerOrderNoteEditor.setSelection(binding.customerOrderNoteEditor.length())
-            binding.customerOrderNoteEditor.requestFocus()
-            ActivityUtils.showKeyboard(binding.customerOrderNoteEditor)
+            with(binding.customerOrderNoteEditor) {
+                setText(sharedViewModel.order.customerNote)
+                setSelection(length())
+                requestFocus()
+                ActivityUtils.showKeyboard(this)
+            }
         } else {
             updateDoneMenuItem()
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/OrderEditingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/OrderEditingViewModel.kt
@@ -20,7 +20,6 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.store.WCOrderStore
@@ -51,8 +50,11 @@ class OrderEditingViewModel @Inject constructor(
     lateinit var order: Order
     private var orderId: Long = -1L
 
+    val isOrderLoaded
+        get() = ::order.isInitialized
+
     fun start() {
-        runBlocking {
+        launch {
             val orderId = if (orderId == -1L) {
                 navArgs.orderId
             } else {
@@ -61,6 +63,7 @@ class OrderEditingViewModel @Inject constructor(
             order = requireNotNull(orderDetailRepository.getOrderById(orderId)) {
                 "Order $orderId not found in the database."
             }
+            triggerEvent(OrderLoaded)
         }
     }
 
@@ -166,6 +169,7 @@ class OrderEditingViewModel @Inject constructor(
         val replicateBothAddressesToggleActivated: Boolean? = null
     ) : Parcelable
 
+    object OrderLoaded : MultiLiveEvent.Event()
     object OrderEdited : MultiLiveEvent.Event()
     data class OrderEditFailed(@StringRes val message: Int) : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/OrderEditingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/OrderEditingViewModel.kt
@@ -160,7 +160,7 @@ class OrderEditingViewModel @Inject constructor(
 
     private inline fun runWhenUpdateIsPossible(
         crossinline action: suspend () -> Unit
-    ) = checkConnectionAndResetState().also {
+    ) = (isOrderLoaded && checkConnectionAndResetState()).also {
         if (it) launch(dispatchers.io) { action() }
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/details/editing/OrderEditingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/details/editing/OrderEditingViewModelTest.kt
@@ -18,6 +18,7 @@ import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.stub
 import org.mockito.kotlin.verify
 import org.wordpress.android.fluxc.store.WCOrderStore
@@ -59,6 +60,15 @@ class OrderEditingViewModelTest : BaseUnitTest() {
             assertThat(sut.isOrderLoaded).isTrue
             assertThat(sut.order).isEqualTo(testOrder)
             assertThat(orderLoadedEmitted).isTrue
+        }
+
+    @Test
+    fun `given order not loaded, when an update is requested, then nothing is dispatched`() =
+        testBlocking {
+            val dispatched = sut.updateShippingAddress(addressToUpdate)
+
+            assertThat(dispatched).isFalse
+            verify(orderEditingRepository, never()).updateOrderAddress(any(), any())
         }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/details/editing/OrderEditingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/details/editing/OrderEditingViewModelTest.kt
@@ -46,6 +46,22 @@ class OrderEditingViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `when started, then order is loaded and OrderLoaded event is emitted`() =
+        testBlocking {
+            var orderLoadedEmitted = false
+
+            sut.start()
+
+            observeEvents { event ->
+                if (event is OrderEditingViewModel.OrderLoaded) orderLoadedEmitted = true
+            }
+
+            assertThat(sut.isOrderLoaded).isTrue
+            assertThat(sut.order).isEqualTo(testOrder)
+            assertThat(orderLoadedEmitted).isTrue
+        }
+
+    @Test
     fun `should replicate billing to shipping when toggle is activated`() =
         testBlocking {
             orderEditingRepository.stub {


### PR DESCRIPTION
Fixes WOOMOB-987

### Description

`OrderEditingViewModel.start()` loaded the order with `runBlocking`, blocking the main thread on a DB read every time one of the order editing screens (customer note, shipping/billing address) opened.

`start()` now loads the order in a coroutine and emits an `OrderLoaded` event when done. The customer note editor is the only screen that reads the order while setting up, so its initial note fill moved from `onViewCreated` to the new `onOrderLoaded` hook (first launch only; on restore the field keeps its own state). Part of WOOMOB-983.

Note: the discard dialog never triggering on these screens is pre-existing; filed as WOOMOB-3460.

### Test Steps

1. Open an order and edit the customer-provided note; the existing note appears in the field and the keyboard opens.
2. Change the note and rotate the device; your edited text is kept.
3. Save with **Done** and confirm the updated note shows on the order detail.
4. Edit the shipping or billing address and save; confirm it still works (these screens share the same view model).

### Images/gif

N/A

- [x] I have considered if this change warrants release notes. This is an internal threading fix with no user-visible change, so none were added.