### PR TITLE
Prepare build config for AGP 9 and validate in-app update type

### DIFF
--- a/WooCommerce-Wear/build.gradle
+++ b/WooCommerce-Wear/build.gradle
@@ -64,6 +64,7 @@ android {
     buildFeatures {
         buildConfig = true
         compose = true
+        resValues = true
     }
     packaging {
         resources {

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -132,6 +132,7 @@ android {
         buildConfig = true
         compose = true
         viewBinding = true
+        resValues = true
     }
 
     compileOptions {
@@ -173,7 +174,7 @@ android {
             // Proguard is used to shrink our apk, and reduce the number of methods in our final apk,
             // but we don't obfuscate the bytecode.
             minifyEnabled = true
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
 
         debug {

--- a/WooCommerce/proguard-rules.pro
+++ b/WooCommerce/proguard-rules.pro
@@ -1,4 +1,5 @@
 -dontobfuscate
+-dontoptimize
 
 ###### OkHttp - begin
 -dontwarn okio.**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/AppUpgradeActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/AppUpgradeActivity.kt
@@ -31,7 +31,10 @@ abstract class AppUpgradeActivity :
      * The type of in app update to display:
      * [AppUpdateType.FLEXIBLE] OR [AppUpdateType.IMMEDIATE]
      */
-    private val inAppUpdateType = BuildConfig.IN_APP_UPDATE_TYPE.toInt()
+    private val inAppUpdateType = when (BuildConfig.IN_APP_UPDATE_TYPE.toInt()) {
+        AppUpdateType.IMMEDIATE -> AppUpdateType.IMMEDIATE
+        else -> AppUpdateType.FLEXIBLE
+    }
 
     /**
      * The latest app version code that is available for download

--- a/libs/commons/build.gradle
+++ b/libs/commons/build.gradle
@@ -68,6 +68,7 @@ dependencies {
     testImplementation(libs.androidx.arch.core.testing)
     testImplementation(libs.androidx.lifecycle.runtime.testing)
 
+    testFixturesImplementation(platform(libs.androidx.compose.bom))
     testFixturesImplementation(libs.androidx.compose.ui.main)
     testFixturesCompileOnly(libs.kotlinx.coroutines.test)
     testFixturesCompileOnly(libs.junit)


### PR DESCRIPTION
This is part of a chain of PRs that take us to AGP 9. They are stacked, so each targets the one above it and should merge top-down:

1. #16234 — RefundStoreTest fix (targets `trunk`; a pre-existing timing-dependent failure the chain is stacked on)
2. **#16226 — build config prep (this PR)**
3. #16227 — androidx navigation bump
4. #16228 — the AGP 9 update itself

Each one keeps its base green on its own.

### Description

AGP 9 changes a few defaults we currently rely on implicitly. This PR makes them explicit while we're still on AGP 8, so the actual bump in #16228 is a no-op for them and the diff there stays focused.

- **ProGuard.** AGP 9 removes `proguard-android.txt`. That file's only meaningful difference from `proguard-android-optimize.txt` was that it supplied `-dontoptimize`, so we switch to the optimize variant and declare `-dontoptimize` ourselves. Optimizations stay off. Worth knowing: the optimize file also carries `-allowaccessmodification`, which has no inverse flag, so it now applies. It shrinks the release APK by ~32KB (same dex count) — R8 widens access modifiers and drops some synthetic accessors. No optimization passes run.
- **`resValues`.** This build feature currently defaults to on and flips to off in AGP 9. Both the app and the Wear module use `resValue`, so we set it explicitly.
- **Compose BOM on `commons` testFixtures.** `testFixturesImplementation(compose.ui)` is versionless and was picking up the BOM by accident. AGP 9 no longer propagates it there, so we declare it.

Separately, `AppUpgradeActivity` read `BuildConfig.IN_APP_UPDATE_TYPE` and handed the raw int straight to Play Core, which expects the `AppUpdateType` IntDef. Nothing validated it. AGP 9's newer lint flags this, and it's a genuine latent bug, so the value now maps through the IntDef with `FLEXIBLE` as the fallback. Our configured value is `0` (`FLEXIBLE`), so nothing changes in practice.

### Test Steps

No behaviour change is expected from this PR on its own. Smoke testing the app is covered once at the end of the chain, on #16228.

1. Confirm CI is green.

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
