### PR TITLE
[WOOMOB-2554] Restore dashboard scroll tracking for used_analytics event

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -19,6 +19,7 @@
 - [*] The customer note editor now shows a back arrow like the other order editing screens instead of an X [https://github.com/woocommerce/woocommerce-android/pull/16218]
 - [*] Tapping the current bottom tab again now scrolls the screen back to the top as intended [https://github.com/woocommerce/woocommerce-android/pull/16221]
 - [*] Fixed the main toolbar showing the wrong menu after opening a feedback survey [https://github.com/woocommerce/woocommerce-android/pull/16220]
+- [Internal] Restored dashboard scroll tracking for the used_analytics event lost in the Compose migration [https://github.com/woocommerce/woocommerce-android/pull/16229]
 
 25.1
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
@@ -27,6 +27,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.key
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -63,7 +64,12 @@ import com.woocommerce.android.ui.dashboard.stats.DashboardStatsCard
 import com.woocommerce.android.ui.dashboard.stock.DashboardProductStockCard
 import com.woocommerce.android.ui.dashboard.topperformers.DashboardTopPerformersWidgetCard
 import com.woocommerce.android.ui.main.MainActivityViewModel
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.drop
+
+private const val SCROLL_INTERACTION_DEBOUNCE_MS = 1000L
 
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
@@ -103,6 +109,7 @@ fun DashboardContainer(
     }
 }
 
+@OptIn(FlowPreview::class)
 @Composable
 private fun DashboardWidgets(
     widgetUiModels: List<DashboardWidgetUiModel>,
@@ -120,6 +127,13 @@ private fun DashboardWidgets(
         scrollToTopTrigger.collect {
             scrollState.animateScrollTo(0)
         }
+    }
+
+    LaunchedEffect(scrollState) {
+        snapshotFlow { scrollState.value }
+            .drop(1) // Ignore the initial value emitted on composition
+            .debounce(SCROLL_INTERACTION_DEBOUNCE_MS)
+            .collect { dashboardViewModel.onDashboardInteracted() }
     }
 
     if (numberOfColumns == 1) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
@@ -214,6 +214,10 @@ class DashboardViewModel @Inject constructor(
         maybeShowScheduledImportNotice()
     }
 
+    fun onDashboardInteracted() {
+        usageTracksEventEmitter.interacted()
+    }
+
     private fun maybeShowScheduledImportNotice() {
         val shouldShow = _isScheduledImportEnabled.value &&
             hasVisibleDelayedStatsCard() &&

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModelTest.kt
@@ -871,6 +871,19 @@ class DashboardViewModelTest : BaseUnitTest() {
             assertThat(events).doesNotContain(DashboardViewModel.DashboardEvent.ShowScheduledImportNotice)
         }
 
+    @Test
+    fun `when the dashboard is interacted with, then the usage tracks event emitter is notified`() =
+        testBlocking {
+            // GIVEN
+            setup {}
+
+            // WHEN
+            viewModel.onDashboardInteracted()
+
+            // THEN
+            verify(usageTracksEventEmitter).interacted(any())
+        }
+
     private companion object {
         fun dashboardWidget(
             type: DashboardWidget.Type,


### PR DESCRIPTION
### Description

Fixes WOOMOB-2554

The `woocommerceandroid_used_analytics` Tracks event dropped ~24% (≈495k → ≈413k/month) starting January 2025 and has stayed on a lower plateau since. The regression was traced to the Dashboard's XML→Compose migration (commit `2b7fbfc0bec`, Dec 2024), which dropped the scroll listener that reported user interactions:

```kotlin
// removed from the old XML DashboardFragment:
binding.statsScrollView.scrollStartEvents()
    .onEach { usageTracksEventEmitter.interacted() }
    .launchIn(viewLifecycleOwner.lifecycleScope)
```

`USED_ANALYTICS` only fires once the `DashboardStatsUsageTracksEventEmitter` threshold is met (5+ interactions spanning 10+ seconds, resetting after 20s idle). Scrolling was by far the most frequent interaction source, so once it stopped being reported most sessions never reached the threshold from the remaining sources (pull-to-refresh, range changes, chart/top-performer taps, tab navigation). A February 2025 mitigation added chart-tap tracking, but taps are far rarer than scrolls, so the metric stayed depressed.

This PR re-adds scroll interaction tracking in the Compose layer:

- **`DashboardViewModel`** — new `onDashboardInteracted()` that forwards to the already-injected `usageTracksEventEmitter.interacted()`, mirroring the existing `onPullToRefresh()` convention (the emitter stays private to the ViewModel).
- **`DashboardContainer`** — in `DashboardWidgets` the previously inline-and-unhoisted `rememberScrollState()` is now hoisted and observed via `snapshotFlow`, debounced by 1s, then reported through the ViewModel. The debounce collapses a scroll gesture into ~one interaction (matching the original `scrollStartEvents()` intent and the existing 1s debounce used for chart interactions in `DashboardStatsView`). `drop(1)` skips the initial snapshot emitted on composition so a passive screen load isn't miscounted as an interaction. The same hoisted state is shared by both the single-column and multi-column (tablet) layouts.

No behavioral change to the emitter's threshold algorithm or to chart-tap tracking.

### Test Steps

1. Build and run a debug build, open the **My Store** (dashboard) tab.
2. Scroll the dashboard up and down several times, pausing briefly (~1s) between gestures, over ~15 seconds (5+ interactions spanning 10+ seconds).
3. Observe logcat for the Tracks log line and confirm `woocommerceandroid_used_analytics` fires once the threshold is met:
   ```
   adb logcat | grep -i "used_analytics"
   ```
4. Negative check: open the dashboard and let it sit without scrolling or tapping — the event should NOT fire (confirms the initial composition snapshot isn't counted).

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.