### PR TITLE
[Design System] Update component documentation

### DIFF
--- a/docs/design-system/android-adapter.md
+++ b/docs/design-system/android-adapter.md
@@ -31,7 +31,7 @@ New Compose APIs live under:
 com.woocommerce.android.ui.compose.designsystem
 ```
 
-Suggested subpackages:
+Subpackages:
 
 - `foundation`: theme, color, typography, spacing, shape, elevation, and token helpers.
 - `component`: production-ready Woo Mobile Design System components.
@@ -56,6 +56,9 @@ rollout wiring should stay outside the module.
 - The new `WooTheme` accessor lives under `com.woocommerce.android.ui.compose.designsystem`.
   The existing `com.woocommerce.android.ui.compose.theme.WooTheme` composable remains the legacy Store
   wrapper until deliberately removed; new design-system code should not import it.
+- Follow-up `WOOMOB-3515` tracks a detekt guardrail for files that import both the legacy
+  `com.woocommerce.android.ui.compose.theme.*` APIs and the design-system
+  `com.woocommerce.android.ui.compose.designsystem.*` APIs during migration.
 - Do not expose raw Figma variable names as public Android API.
 - Public APIs should expose only production-ready tokens and components.
 - In-progress i1 areas may be documented, tracked, or preview-only until signed off.

--- a/docs/design-system/android-adapter.md
+++ b/docs/design-system/android-adapter.md
@@ -18,6 +18,8 @@ doc defines the technical boundaries that support that rollout.
 - Figma is the design-intent source of truth. Android owns the runtime API contract.
 - Source references use public-repo shorthands: P2 `pe5sF9-5ox-p2`, Figma
   `50XIH5MmOf4xUYEkM6fAm6-fi`. Do not expand them into raw URLs in public repo docs.
+- Agents should use [figma-navigation.md](figma-navigation.md) when inspecting Figma components or
+  collecting live Figma screenshots.
 - Foundation source values come from `docs/design-system/figma-export.json`. This docs branch is
   allowed to lack runtime foundation code; future implementation consumes these docs as the contract.
 
@@ -29,7 +31,7 @@ New Compose APIs live under:
 com.woocommerce.android.ui.compose.designsystem
 ```
 
-Subpackages:
+Suggested subpackages:
 
 - `foundation`: theme, color, typography, spacing, shape, elevation, and token helpers.
 - `component`: production-ready Woo Mobile Design System components.
@@ -54,25 +56,22 @@ rollout wiring should stay outside the module.
 - The new `WooTheme` accessor lives under `com.woocommerce.android.ui.compose.designsystem`.
   The existing `com.woocommerce.android.ui.compose.theme.WooTheme` composable remains the legacy Store
   wrapper until deliberately removed; new design-system code should not import it.
-- The foundation implementation should add a detekt guardrail that reports files importing both legacy
-  `com.woocommerce.android.ui.compose.theme.*` and design-system
-  `com.woocommerce.android.ui.compose.designsystem.*` APIs.
 - Do not expose raw Figma variable names as public Android API.
 - Public APIs should expose only production-ready tokens and components.
 - In-progress i1 areas may be documented, tracked, or preview-only until signed off.
 - Preview-only components should not be exposed as reusable product-screen APIs.
 - Keep preview-only implementations private/internal to catalog or preview files under `designsystem.preview`.
 - The planned public foundation surface is:
-  - `WooTheme.colors` grouped as `core`, `container`, `surface`, `outline`, `status`, `alert`,
-    `background`, `overlay`, and `palette`.
+  - `WooTheme.colors` with direct core roles plus `container`, `surface`, `status`, `background`,
+    `overlay`, `alert`, and `palette` groups.
   - `WooTheme.text` with `regular`, `emphasized`, and `strong` variants.
   - `WooTheme.spacing` and `WooTheme.padding` as separate APIs with identical value scales.
   - `WooTheme.radius` including Woo-only `none` and `full` plus Material projection roles.
   - `WooTheme.iconSize` scoped to glyph sizes only.
   - `WooTheme.stroke` for source-backed border and divider widths used by production components.
 - Expose primitive palette ramps intentionally through public `WooTheme.colors.palette.*` fields.
-- Treat `surfaceBright`, `surfaceDim`, and `surfaceContainerHighest` as source-backed Store roles,
-  not generated Material aliases.
+- Treat `surfaceDim` and `surfaceContainerHighest` as source-backed public Store roles, not
+  generated Material aliases.
 - Expose `WooTheme.stroke` because production design-system components use the source-backed stroke
   scale. Fractional stroke widths still need visual verification in components that use them.
 - Keep state layers internal-first until semantic names and mode behavior are approved. Do not create
@@ -124,7 +123,13 @@ Top app bar/chrome migration is not just a token change. Moving from the Activit
 The direction is a unified design-system visual look, not one mandatory implementation:
 
 - Compose-owned screens use `WooTopAppBar`.
+- The module `WooTopAppBar` is design-system-only and lives in `:libs:store-design-system`.
 - Heavy XML screens may keep XML toolbar ownership if the toolbar matches the design-system look.
+- XML-heavy screens that need visual parity can use `WooDesignSystemToolbar` from
+  `:libs:store-design-system` for automatic design-system chrome. The library also owns
+  `Widget.Woo.DesignSystem.Toolbar` and `ThemeOverlay.Woo.DesignSystem.Toolbar` for XML opt-ins.
+  Visible inflated icon actions are decorated in place; text actions stay borderless, and
+  expanded/custom action views remain screen-owned.
 - Migrated Compose-owned screens render `WooTopAppBar` under the design-system root.
 - Legacy-heavy screens can preserve existing toolbar ownership unless a scoped migration chooses a
   DS-looking XML toolbar or an explicit Compose chrome migration.
@@ -166,10 +171,10 @@ i1 uses manual Kotlin/Compose runtime token definitions first.
   fixed roles or surface-container aliases unless those names are real source-backed tokens.
 - The runtime may intentionally leave unsupported Material 3 roles on builder defaults when a Store
   token would be a guess. Project source-backed container and promoted surface roles from Store
-  fields, including `surfaceBright`.
+  fields.
 - `outline` and `outlineVariant` are source-backed tokens and public under `WooTheme.colors`.
-- Preserve source intent with shallow groups such as core, container, surface, outline, status,
-  alert, background, overlay, and palette.
+- Preserve source intent with direct core roles plus shallow groups such as container, surface,
+  status, alert, background, overlay, and palette.
 - Keep unresolved non-color Figma variables tracked in docs or internal mapping first, but
   source-backed color tokens still belong in the public foundation surface.
 - `WooTheme.radius`, `WooTheme.iconSize`, and `WooTheme.stroke` are public because they are

--- a/docs/design-system/component-catalog.md
+++ b/docs/design-system/component-catalog.md
@@ -2,105 +2,159 @@
 
 This catalog tracks Woo Mobile Design System i1 components for Android.
 
-The goal is to implement the i1 foundation and component catalog with previews, while only allowing
-production-ready APIs into migrated Store screens.
+Production design-system foundations and components live in the Store-only `:libs:store-design-system`
+module under `com.woocommerce.android.ui.compose.designsystem.*`.
 
-Production design-system components live in the Store-only `:libs:store-design-system` module under
-`com.woocommerce.android.ui.compose.designsystem.*`.
+When comparing catalog components to Figma, use [figma-navigation.md](figma-navigation.md) to
+discover source pages and nodes from live Figma metadata instead of relying on local work notes.
 
-The component PR should provide visual coverage for the full i1 catalog, but it does not need to mark
-every component as production-ready. Components needed by the first-wave tab and top-detail surfaces
-plus low-risk primitives can become production APIs first; unsettled components should remain
-private/internal preview catalog implementations. Rollout scope is defined in
-[rollout-direction.md](rollout-direction.md).
+The component catalog has three boundaries:
 
-## Initial Production Subset
+- Figma-backed public production APIs that Store screens may import from `designsystem.component`.
+- Public adapter utilities that wrap Material 3 or platform primitives with Store Design System
+  tokens, but are not one-to-one Figma components.
+- Preview-only samples under `designsystem.preview` for catalog coverage while design, app-shell,
+  navigation, or data semantics remain unsettled.
 
-Before first-wave screen migration begins, production-ready APIs should exist for:
+The module must not import app `R`, legacy app theme classes, app modifiers, Hilt, feature packages,
+POS APIs, or `WooThemeWithBackground`.
 
-- Top/navigation bar.
-- Page title/body/link text styles or wrappers.
-- Primary button.
-- Settings cell/row.
-- Switch.
-- Icon button.
-- Divider.
-- Progress indicator.
-- Spacing, radius, color, and typography tokens used by those components.
+## Figma-Backed Production API Scope
 
-Production components should read approved foundation values through `WooTheme.*`. `MaterialTheme` remains available
-inside wrappers when Material 3 components or defaults require interop projection values.
+The current module exposes Figma-backed production Compose APIs for:
 
-Production components must render correctly under the design-system root and must not rely on static
-hardcoded light fallback defaults. Non-migrated screens stay on the legacy root and should not
-consume production design-system components until explicitly migrated.
+- Badges.
+- Fill, Tonal, and Outlined buttons in medium and small sizes.
+- Generic cells and settings rows; Figma `Cell Content` maps to internal row content styling.
+- Checkbox, radio button, and filter chip controls.
+- Horizontal and vertical dividers.
+- Icon containers.
+- Static notice banners.
+- Page headers.
+- Controlled search fields.
+- Top text tabs.
+- Design-system top app bars with descriptor actions.
 
-Do not add additional thin wrappers beyond this subset unless a later design-system decision
-explicitly expands the catalog. This prevents the adapter from becoming an unlimited Material 3
-wrapper library.
+Figma-backed production components must render correctly under the design-system root and must not
+rely on static light fallback defaults. Non-migrated screens stay on the legacy root and should not
+consume production design-system components until explicitly migrated. Production components read
+foundation values through `WooTheme.*`. Prefer `WooTheme.radius` and `WooTheme.iconSize` for
+design-system-owned shapes and icon sizes; use Material 3 defaults only where the Material component
+API owns the internal behavior.
+
+## Public Adapter Utility Scope
+
+The module also exposes public utility wrappers that are useful for composing Figma-backed
+components, but should not be cited as Figma-backed component implementations:
+
+- Plain and outlined icon buttons. Figma has a `navigation-button` treatment; `WooIconButton` and
+  `WooOutlinedIconButton` are Material 3 / token adapters used by page headers, top app bars, and
+  screen-specific actions.
+- Controlled switches. `WooSwitch` is a Material 3 / token adapter used by settings rows.
+- Switch settings rows compose the Figma-backed cell layout with the `WooSwitch` Material 3 /
+  token adapter.
+- Linear and circular progress indicators. These are thin Material 3 wrappers scoped to Store Design
+  System colors and sizing.
+- `WooDesignSystemToolbar`, `Widget.Woo.DesignSystem.Toolbar`, and
+  `ThemeOverlay.Woo.DesignSystem.Toolbar` are XML-facing toolbar bridge APIs for legacy-heavy
+  screens that opt into design-system chrome.
+
+## Module-Safe Port Decisions
+
+The broad component branch predated the standalone module and included app-local conveniences. The
+split module keeps the component API clean:
+
+- Preview icons and component-owned search/close icons are module-local vector drawables.
+- Component previews use `WooDesignSystemTheme` or `WooDesignSystemThemeWithBackground` from the
+  library module.
+- The Developer Options entry hosts the same module catalog screen through app-level navigation.
+- The old `WooThemeWithBackground` legacy-compatible top-app-bar path is not ported into the module.
+- `WooTopAppBar` is a design-system-only top app bar.
+- XML toolbar convergence is library-owned component infrastructure. The toolbar decorates rendered
+  icon actions in place so inflated menus, collapsed `SearchView` triggers, title, navigation,
+  overflow, and custom action-view ownership remain AppCompat-owned.
+- Product-screen XML toolbar adoption remains migration work; the component split provides the bridge
+  and catalog coverage only.
+- App screenshot catalog wiring from the broad branch is not moved in this port. The module currently
+  provides Compose preview coverage and an interactive Developer Options catalog; screenshot wiring
+  can be added separately when the module has an approved screenshot-test setup.
 
 ## Preview Standard
 
 Use `androidx.compose.ui.tooling.preview.PreviewLightDark` for design-system component previews.
 
-Older Store Compose screens may use the project `LightDarkThemePreviews` annotation. New
-design-system foundations, components, preview catalog entries, and first-wave screen updates should
-use `@PreviewLightDark`.
+Design-system component previews should wrap content in `WooDesignSystemTheme`. Full catalog and
+foundation previews may use `WooDesignSystemThemeWithBackground` when a background surface is useful.
+Migrate app screen previews separately; do not make the library depend on app preview annotations or
+legacy app themes.
 
-Design-system component previews should wrap content in `WooDesignSystemTheme`, not the legacy Store
-theme root. Migrated screen previews should cover the design-system root in light and dark mode.
+Design-system component previews should wrap content in `WooDesignSystemTheme`, not
+`WooThemeWithBackground`. Migrated screen previews should cover the design-system root in light and
+dark mode.
 
-Preview coverage is required for every component. Screenshot verification is required for first-wave
-screens and high-risk components, but not for every small primitive component.
+Preview coverage exists for the production components and for preview-only catalog samples. Screenshot
+verification remains required for first-wave screens and high-risk component adoptions, but the
+component split does not add module screenshot infrastructure.
 
 ## Status Values
 
 - `production`: Stable API, visual states, accessibility behavior, and previews.
-- `preview_only`: Implemented for catalog or design review, but not exposed as a reusable production-screen API.
-- `needs_design`: Design intent or required states are not signed off.
-- `needs_android_mapping`: Android API or Material 3 mapping is not resolved.
+- `material_adapter`: Public Material 3 / token adapter; useful in DS composition but not a
+  one-to-one Figma component.
+- `not_public`: Search/discovery can find a source, but agents should not treat it as public
+  production component inventory.
+- `preview_only`: Implemented for catalog/design review only; not a reusable production-screen API.
+- `needs_design`: Design source or promotion decision is not signed off.
+- `needs_android_mapping`: Android API or Material 3 mapping is not resolved for production adoption.
 
 ## Catalog
 
-| Component | Android API | Strategy | Status | Required previews | Notes |
-| --- | --- | --- | --- | --- | --- |
-| Badges | TBD | Material 3 wrapper or custom after review | needs_android_mapping | Light/dark, states | i1 component. |
-| Buttons | TBD | Material 3 wrapper first | needs_android_mapping | Light/dark, enabled/disabled/loading if supported | First-wave screens need primary actions. |
-| Cell | TBD | Material 3 wrapper or custom after review | needs_android_mapping | Light/dark, leading/trailing content | Common migration component. |
-| Cell Content | TBD | Custom composition if needed | needs_android_mapping | Light/dark, text density variants | Pair with Cell. |
-| Check Box | TBD | Material 3 wrapper first | needs_android_mapping | Light/dark, checked/unchecked/disabled | Form candidate. |
-| Chip | TBD | Material 3 wrapper first | needs_android_mapping | Light/dark, selected/unselected/disabled | Filter/search candidate. |
-| Divider | TBD | Material 3 wrapper first | needs_android_mapping | Light/dark | Low-risk early component. |
-| Icons | TBD | Existing icon assets plus token mapping | needs_android_mapping | Light/dark, sizing | Avoid new naming until icon policy is clear. |
-| Navigation Bar | TBD | Material 3 wrapper or app-specific custom | needs_android_mapping | Light/dark, navigation/action/search/collapse states | Unified visual spec across Compose `WooTopAppBar` and DS-looking XML toolbar. |
-| Page Header | TBD | Custom composition if needed | needs_android_mapping | Light/dark, title/subtitle variants | Useful for screen migrations. |
-| Radio Button | TBD | Material 3 wrapper first | needs_android_mapping | Light/dark, selected/unselected/disabled | Form candidate. |
-| Search | TBD | Material 3 wrapper or custom after review | needs_android_mapping | Light/dark, focused/unfocused/query states | Existing search components may inform behavior only. |
-| Segment Control | TBD | Preview-only until design signed off | preview_only | Light/dark, selected states | i1 marks this in progress. |
-| Sheets | TBD | Material 3 wrapper first | needs_android_mapping | Light/dark, content variants | Migration should preserve navigation/event ownership. |
-| Tab Bar | TBD | Material 3 wrapper first | needs_android_mapping | Light/dark, selected/unselected | Existing `WCPrimaryTabRow` remains legacy. |
-| Table | TBD | Custom after review | needs_android_mapping | Light/dark, row density variants | Likely high migration cost on real screens. |
-| Progress Indicator | TBD | Thin Material 3 wrapper | needs_android_mapping | Light/dark, indeterminate/determinate if supported | Not listed as an i1 Figma component. Candidate wrapper for the component PR. |
+| Component | Android API | Status | Notes |
+| --- | --- | --- | --- |
+| Badges | `WooBadge`, `WooBadgeTone` | production | Compact label badge with optional decorative leading icon and status tones including `NeutralOutlined`. |
+| Buttons | `WooFilledButton`, `WooFilledTonalButton`, `WooOutlinedButton`, `WooButtonSize` | production | Figma-backed Fill/Tonal/Outline treatments exposed with Material 3-aligned Filled, Filled Tonal, and Outlined API names. Supports optional leading icon, enabled/disabled state, medium/small sizes, and 48dp touch target preservation. Use one Filled button per screen, Filled Tonal for alternatives, and Outlined for low-emphasis actions. |
+| Cell | `WooCell`, `WooSettingsRow` | production | Slot-based row primitive plus settings convenience. Keep one row-level action; avoid duplicate child semantics. Figma `Cell Content` maps to internal row content styling, not a standalone public API. |
+| Checkbox | `WooCheckbox` | production | Controlled Material 3 checkbox wrapper. Caller owns label and group semantics. |
+| Chip | `WooFilterChip` | production | Controlled Material 3 filter chip wrapper with optional leading icon. |
+| Divider | `WooDivider`, `WooVerticalDivider` | production | Thin divider wrappers using design-system outline tokens. |
+| Icon Button | `WooIconButton`, `WooOutlinedIconButton`, `WooIconButtonEmphasis` | material_adapter | Public Material 3 / token adapters. Requires non-blank content descriptions. Figma has a `navigation-button` treatment for outlined navigation actions; the generic plain/outlined icon-button APIs are Android composition utilities. |
+| Icon Container | `WooIconContainer`, `WooIconContainerTone` | production | Restricted palette-tone icon box, decorative by default unless a content description is supplied. |
+| Notice Banner | `WooNoticeBanner`, `WooNoticeBannerTone` | production | Static title/description banner. Dismissible/actionable/live-region behavior remains future work. |
+| Page Header | `WooPageHeader` | production | 64dp header surface with optional right actions and bottom divider. |
+| Progress Indicator | `WooLinearProgressIndicator`, `WooCircularProgressIndicator` | material_adapter | Thin Material 3 wrappers, including determinate progress coercion. |
+| Radio Button | `WooRadioButton` | production | Controlled Material 3 radio wrapper. Caller owns label and group semantics. |
+| Search | `WooSearchField` | production | Controlled search text field with optional clear action, optional external text action, module-owned icons, and `WooTheme.colors.surface.surfaceDim` as the field container fallback. Search orchestration remains screen-owned. |
+| Section Header | No public API | not_public | Figma search may surface `section-header`, but its master lives in `Components Playground`, not on a promoted component page. Agents should ignore it for production inventory and API work for now. |
+| Switch | `WooSwitch` | material_adapter | Controlled Material 3 / token adapter with minimum touch target. Figma does not currently expose a canonical `Switch` component in the Mobile Design System library. |
+| Switch Settings Row | `WooSwitchSettingsRow` | material_adapter | Composes the Figma-backed cell layout with the `WooSwitch` Material 3 / token adapter. Keep one row-level toggle action and avoid duplicate child semantics. |
+| Tabs | `WooTabRow`, `WooTab` | production | Top text tabs only; bottom tab bar parity remains preview-only and app-shell-owned. |
+| Top App Bar | `WooTopAppBar`, `WooTopAppBarAction`, `WooDesignSystemToolbar` | production | Android API for Figma's `Top Navigation Bar`. `WooDesignSystemToolbar` applies chrome automatically and decorates visible inflated icon actions without replacing `MenuItem.actionView`, preserving `SearchView`, custom action views, ActionMode, collapsing behavior, overflow, and menu ownership. |
+| Segment Control | Private catalog sample | preview_only | i1 source is still in progress; no public API yet. |
+| Sheets | Private catalog sample | preview_only | Requires real screen decisions for state, dismissal, navigation, and semantics. |
+| Bottom Tab Bar | Private catalog sample | preview_only | App-shell navigation ownership remains out of component split scope. |
+| Table | Private catalog sample | preview_only | Requires data model, scrolling, sorting/selection, and accessibility semantics before a public API. |
 
 ## Production Checklist
 
 Before a component is marked `production`:
 
 - It uses `Woo` naming inside `com.woocommerce.android.ui.compose.designsystem`.
-- It is wrapped by `WooDesignSystemTheme` in design-system previews.
-- It reads production foundation values through `WooTheme.*`, except where a Material 3 API requires `MaterialTheme`
-  interop values.
+- It is in `:libs:store-design-system` and does not depend on the app module.
+- It reads production foundation values through `WooTheme.*`, except where a Material 3 API owns
+  internal interop behavior.
 - It has light and dark previews through `@PreviewLightDark`.
-- Required states are covered in previews.
-- Screenshot verification is completed if the component is high-risk.
-- Accessibility is reviewed: semantic role where applicable, label/contentDescription rules, disabled
-  state behavior, minimum touch target, and font-scale resilience.
-- Its tokens are mapped in `docs/design-system/token-map.md`.
+- Required enabled, disabled, long text, large font, and RTL states are covered where applicable.
+- Accessibility is reviewed: semantic role, label/contentDescription rules, disabled behavior,
+  minimum touch target, and font-scale resilience.
+- Its token usage is represented in `docs/design-system/token-map.md` when a source-backed token is
+  involved.
 - It does not depend on POS APIs or POS design-system concepts.
 
 ## Preview-Only Boundary
 
-Preview-only components may exist only as private/internal catalog or preview implementations, preferably under `designsystem.preview`.
+Preview-only components may exist only as private/internal catalog or preview implementations under
+`designsystem.preview`.
 
 Do not expose preview-only components as reusable public APIs. This keeps product-screen migrations
-and AI agents from importing components that are not signed off.
+and AI agents from importing components whose API would encode unstable design, navigation, or data
+semantics.

--- a/docs/design-system/figma-navigation.md
+++ b/docs/design-system/figma-navigation.md
@@ -1,0 +1,187 @@
+# Figma Navigation For Agents
+
+This guide defines how agents should inspect the Woo Mobile Design System Figma file for Store
+Design System work.
+
+Figma remains the design-intent source of truth. Android owns the runtime API contract. Use Figma
+inspection to verify source geometry, typography, color bindings, variants, and screenshots; do not
+replace Figma values with Android-side guesses because a value looks wrong.
+
+## Source Shorthands
+
+Use the approved repo shorthand when writing docs:
+
+- Figma file: `Woo Mobile Design System` (`50XIH5MmOf4xUYEkM6fAm6-fi`).
+- Figma tool `fileKey`: `50XIH5MmOf4xUYEkM6fAm6`.
+
+Do not expand the shorthand into raw Figma URLs in public repo docs. When using Figma tools, strip
+the `-fi` suffix and pass only the file key.
+
+## Discovery Flow
+
+Use live Figma discovery as the source of page and node IDs. Do not depend on local work notes as the
+authority for Figma nodes.
+
+1. Start from the approved file key:
+
+   ```text
+   fileKey = 50XIH5MmOf4xUYEkM6fAm6
+   ```
+
+2. Resolve the current `Mobile Design System` library from the file:
+
+   ```text
+   get_libraries(fileKey)
+   ```
+
+   Use the returned `Mobile Design System` library key to scope component searches. This avoids
+   matching similarly named components from WPDS, WordPress, Automattic, or deprecated libraries.
+
+3. Search by component family name before choosing a node:
+
+   ```text
+   search_design_system(
+     fileKey = 50XIH5MmOf4xUYEkM6fAm6,
+     query = "Button",
+     includeLibraryKeys = [Mobile Design System library key],
+     includeComponents = true,
+     includeVariables = false,
+     includeStyles = false
+   )
+   ```
+
+   Search results identify canonical component names, `componentKey`, `filePath`, and update time.
+   A `componentKey` is useful evidence, but it is not directly screenshotable.
+
+4. Use Figma metadata when it is available:
+
+   ```text
+   get_metadata(fileKey = 50XIH5MmOf4xUYEkM6fAm6, nodeId = "0:0")
+   ```
+
+   The `0:0` node is intentionally not a real design node. In MCP sessions where `get_metadata` is
+   available, the tool may report it as invalid while also returning the top-level pages of the
+   document. Use that page list to find pages such as `Badges`, `Buttons`, `Cell`, `Navigation`,
+   `Notice Banner`, `Search`, and `Tabs`.
+
+   Treat metadata as a useful navigation shortcut, not a blocker. Do not stop if `get_metadata` is
+   unavailable, fails, or returns only `COVER` / top-level noise.
+
+5. If metadata is unavailable or incomplete, use the whole-file Code Connect component graph:
+
+   ```text
+   list_file_components_for_code_connect(fileKey = 50XIH5MmOf4xUYEkM6fAm6)
+   ```
+
+   Use the returned component graph to find canonical component node IDs, page names, component-set
+   names, and variant property definitions. This is the fallback path when metadata traversal cannot
+   reliably locate the promoted source component.
+
+6. Inspect the relevant page or canonical component node:
+
+   ```text
+   get_metadata(fileKey = 50XIH5MmOf4xUYEkM6fAm6, nodeId = "<page id from live page list>")
+   get_context_for_code_connect(fileKey = 50XIH5MmOf4xUYEkM6fAm6, nodeId = "<canonical node id>")
+   get_design_context(fileKey = 50XIH5MmOf4xUYEkM6fAm6, nodeId = "<canonical node id>")
+   get_variable_defs(fileKey = 50XIH5MmOf4xUYEkM6fAm6, nodeId = "<canonical node id>")
+   ```
+
+   Prefer top-level component frames, component sets, or representative page frames for screenshots.
+   Avoid sublayers inside instances because those IDs may not persist. Use node-level context,
+   variable definitions, screenshots, and assets to confirm source geometry, variables, and variants.
+
+7. Capture Figma evidence from existing nodes only:
+
+   ```text
+   get_screenshot(
+     fileKey = 50XIH5MmOf4xUYEkM6fAm6,
+     nodeId = "<frame or component-set id discovered from live Figma evidence>"
+   )
+   ```
+
+   Increase `maxDimension` when fine detail matters. If implementation work is needed, call
+   `get_design_context` on the canonical node after discovery; metadata and component graph results
+   are navigation evidence only.
+
+   For visual primitives where generated context returns image assets, download and inspect the asset
+   SVG when context and search evidence do not expose the needed fill, stroke, or opacity details.
+
+## Component Search Terms
+
+Use Android API names to choose likely Figma search terms, then verify against live Figma evidence.
+
+| Android family | Figma search terms / likely page names |
+| --- | --- |
+| `WooBadge`, `WooBadgeTone` | `Badge`, `Badges` |
+| `WooFilledButton`, `WooFilledTonalButton`, `WooOutlinedButton`, `WooButtonSize` | `Button`, `Buttons`; source treatments are labeled `Fill`, `Tonal`, and `Outline` |
+| `WooCell`, `WooSettingsRow` | `Cell`, `cell`; `Cell Content` is an internal text/content subcomponent mapping |
+| `WooCheckbox` | `Check Box`, `checkbox`, `check-box-cell-content` |
+| `WooFilterChip` | `Chip`, `Chips`, `Chip - Filter` |
+| `WooDivider`, `WooVerticalDivider` | `Divider` |
+| `WooIconButton`, `WooOutlinedIconButton` | Material 3 / token adapters; inspect `navigation-button` only for the Figma outlined navigation treatment |
+| `WooIconContainer`, `WooIconContainerTone` | `Icon Container`, `icon-box` |
+| `WooNoticeBanner`, `WooNoticeBannerTone` | `Notice Banner`, `notice-banner` |
+| `WooPageHeader` | `Page Header`, `page-header` |
+| `WooRadioButton` | `Radio Button`, `radio-button`; canonical node `1208:7478` in current Figma evidence |
+| `WooSearchField` | `Search` |
+| `WooSwitch` | Material 3 / token adapter; no canonical `Switch` component is currently found in Mobile Design System library search |
+| `WooSwitchSettingsRow` | Adapter composition over `Cell` / `Cell Content` plus `WooSwitch` |
+| `WooTabRow`, `WooTab` | `Tabs`, `tab-item` |
+| `WooTopAppBar`, `WooTopAppBarAction`, `WooDesignSystemToolbar` | `Navigation`, `Top Navigation Bar`, `navigation-button` |
+| Section header | `section-header` may appear in search, but its master lives in `Components Playground`, not on a promoted component page. Treat it as not public and ignore it for Android production API work for now |
+| Preview-only families | `Segment Control`, `Sheets`, `Tab Bar`, `Table` |
+
+`WooLinearProgressIndicator` and `WooCircularProgressIndicator` are thin Material 3 adapters. They
+are not currently treated as i1 Figma component pages.
+
+## Evidence Rules
+
+- For reviews, record the exact Figma tool calls or search terms used.
+- Record `libraryName`, `libraryKey`, `componentKey`, `filePath`, and `updatedAt` from
+  `search_design_system` when available.
+- Record page and node IDs discovered from live metadata or the Code Connect component graph in
+  review artifacts. Treat those IDs as navigation aids that may need refresh if Figma components are
+  recreated.
+- Do not create scratch Figma files, temporary pages, or imported instances for read-only fidelity
+  review unless the user explicitly approves that heavier workflow.
+- Do not use local work notes as proof of Figma structure. They can be historical hints only when the
+  task explicitly allows them.
+- Do not report dark-theme contrast problems as component bugs when the component is faithfully using
+  Figma-provided variables. Those fixes belong in foundations/design source.
+- Do not promote top-level `Semantic` variables to runtime/public mappings unless a concrete
+  component audit updates the token contract with approved evidence.
+- Do not invent component tokens from source gaps. For example, `WooSearchField` currently uses
+  `WooTheme.colors.surface.surfaceDim` for the field container; do not document an unconfirmed
+  `search.fieldContainer` token.
+- For visual primitives, search results are not enough. Confirm fills, strokes, state layers, and
+  variant matrices with node-level context, variable definitions, screenshots, or asset SVGs.
+
+## Radio Button Evidence Example
+
+The radio button audit used the Code Connect fallback path because search-level evidence did not
+expose all visual state details:
+
+- `search_design_system` scoped to `Mobile Design System` confirmed the `radio-button` component
+  identity.
+- `list_file_components_for_code_connect(fileKey = 50XIH5MmOf4xUYEkM6fAm6)` identified canonical
+  node `1208:7478` on page `Radio Button`.
+- The variant matrix is `Type = Selected | Unselected` and `State = Enabled | Disabled`. There are
+  no radio error or indeterminate variants.
+- Node-level variable and SVG asset evidence showed selected uses a primary fill with an on-primary
+  dot, unselected uses transparent fill with `Stroke/Weight/Medium = 1.5`, and disabled uses
+  `State Layers/On Surface/Opacity-16`.
+
+## Troubleshooting
+
+- If metadata without a `nodeId` only returns `COVER`, use `nodeId = "0:0"` to get the top-level page
+  list when `get_metadata` is available.
+- If `get_metadata` is not available, fails, or still returns only `COVER` / top-level noise, use
+  `list_file_components_for_code_connect(fileKey = 50XIH5MmOf4xUYEkM6fAm6)` and drill into the
+  canonical node with `get_context_for_code_connect`, `get_design_context`, and `get_variable_defs`.
+- If a node ID is rejected, refresh discovery through metadata or the Code Connect component graph.
+  The component may have been recreated, or the ID may point to a non-persistent sublayer of an
+  instance.
+- If search returns decoy libraries, scope the search to the current `Mobile Design System` library
+  key returned by `get_libraries`.
+- If a family has no dedicated component page, document the search terms tried and compare against
+  the nearest source-backed Figma instance, token map, or intentional Android-only wrapper.

--- a/docs/design-system/implementation-plan.md
+++ b/docs/design-system/implementation-plan.md
@@ -65,8 +65,8 @@ Expected output:
 - Manual i1 runtime tokens, with colors as the XML-safe resource-backed exception and non-color
   foundations remaining Kotlin/Compose-owned.
 - Foundation groups for color, typography, spacing, padding, radius, icon size, and stroke.
-- Source-backed color tokens exposed through `WooTheme.colors`, grouped shallowly by Store authoring
-  intent: core, container, surface, outline, status, alert, background, overlay, and palette.
+- Source-backed color tokens exposed through `WooTheme.colors`, with direct core roles plus shallow
+  Store authoring groups: container, surface, status, background, overlay, alert, and palette.
 - Internal Material 3 projections for Material 3 component interop, with Material 3 treated as a
   projection rather than the source of Store foundations.
 - Full text roles through `WooTheme.text`.
@@ -74,7 +74,7 @@ Expected output:
   `WooTheme.radius`, `WooTheme.iconSize`, and `WooTheme.stroke`.
 - Supported status, alert, overlay, and palette colors as grouped fields under `WooTheme.colors`;
   no separate `WooTheme.semanticColors`.
-- `surfaceDim`, `surfaceBright`, and `surfaceContainerHighest` as source-backed Store roles.
+- `surfaceDim` and `surfaceContainerHighest` as source-backed Store roles.
 - State layers remain internal-first until semantic names and mode behavior are approved.
 - `WooTheme.iconSize` scoped to glyph sizes only.
 - Source-backed stroke from `Shape/Stroke/Weight/*` through `WooTheme.stroke`, promoted for
@@ -83,9 +83,6 @@ Expected output:
 - Token map entries for implemented foundations.
 - Design-system module code does not import app resources, legacy app theme classes, Hilt, POS, or
   Store feature packages.
-- A detekt guardrail that reports files importing both legacy
-  `com.woocommerce.android.ui.compose.theme.*` and design-system
-  `com.woocommerce.android.ui.compose.designsystem.*` APIs.
 
 Implementation risks to verify when code work begins:
 
@@ -122,9 +119,9 @@ Expected output:
 
 Production screens should consume only production-ready components. In-progress components can remain preview-only.
 
-The initial production subset should cover top/navigation bar, page title/body/link text styles or
-wrappers, primary button, list/cell rows, switch, icon button, divider, progress
-indicator, and the spacing/radius/color/typography tokens they depend on.
+The initial production subset should cover top/navigation bar, page title/body/link text-token usage,
+primary button, list/cell rows, switch, icon button, divider, progress indicator, and the
+spacing/radius/color/typography tokens they depend on.
 
 Chrome components should follow [rollout-direction.md](rollout-direction.md): unified visual look,
 not one forced implementation. Compose-owned screens use `WooTopAppBar`; heavy XML screens may keep a

--- a/docs/design-system/integration-checkpoint.md
+++ b/docs/design-system/integration-checkpoint.md
@@ -79,7 +79,7 @@ Do not expand these shorthands into raw P2 or Figma URLs in public repo docs.
 - Use Material 3 wrappers as the default implementation strategy; build custom components only when Material 3 is too different.
 - Component PR scope is full i1 catalog with previews, but production APIs only for first-wave needs and low-risk primitives.
 - Unsettled components stay private/internal preview catalog implementations.
-- Initial production subset covers top/navigation bar, page title/body/link text styles or wrappers,
+- Initial production subset covers top/navigation bar, page title/body/link text-token usage,
   primary button, list/cell rows, switch, icon button, divider, progress indicator,
   and the tokens they depend on.
 - Progress indicator is not listed as an i1 Figma component, but should still be wrapped as a thin
@@ -92,7 +92,12 @@ Do not expand these shorthands into raw P2 or Figma URLs in public repo docs.
 - The module must not import app `R`, legacy app theme classes, Hilt, POS, or Store feature
   packages. App-layer rollout wiring stays outside the module.
 - Package root: `com.woocommerce.android.ui.compose.designsystem`.
-- Subpackages: `foundation`, `component`, and `preview`.
+- Suggested subpackages: `foundation`, `component`, and `preview`.
+- The component split ports production components into `:libs:store-design-system`; old app-local
+  `WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem` component paths are
+  historical only and should not be resurrected.
+- Module component previews may use module-local vector drawables for catalog coverage. App drawables,
+  app preview annotations, and app screenshot harnesses stay outside the library boundary.
 - Use a separate opt-in `WooDesignSystemTheme`, Material 3-only.
 - `WooDesignSystemTheme` is the migration-era wrapper name while the legacy
   `com.woocommerce.android.ui.compose.theme.WooTheme` wrapper exists. Do not introduce `WooNewTheme`.
@@ -104,6 +109,13 @@ Do not expand these shorthands into raw P2 or Figma URLs in public repo docs.
 - The legacy Store theme root remains app-owned until the controlled rename boundary in
   [rollout-direction.md](rollout-direction.md).
 - The design-system module does not read app resources directly.
+- `WooTopAppBar` in the module is design-system-only. The old root-provided legacy-compatible
+  appearance from the broad branch is intentionally not part of the library.
+- XML toolbar convergence lives in `:libs:store-design-system` through `WooDesignSystemToolbar` and
+  the library-owned `Widget.Woo.DesignSystem.Toolbar` / `ThemeOverlay.Woo.DesignSystem.Toolbar`
+  styles. Prefer the subclass when inflated toolbar icon actions need design-system outlines; it
+  decorates visible rendered actions in place while preserving `SearchView`, custom action views, and
+  overflow ownership. Product-screen toolbar adoption belongs to migration work.
 - Migrated first-wave screens should cover the design-system root in light and dark mode.
 - New design-system foundations, components, preview catalog entries, and first-wave screen updates
   should use `androidx.compose.ui.tooling.preview.PreviewLightDark` for light/dark previews.
@@ -134,9 +146,29 @@ These remain rejected for i1:
 ## Screen Migration Candidate Criteria
 
 For first-wave screens, use [rollout-direction.md](rollout-direction.md) as the assignment source.
-For future unassigned screens, use the
-[Candidate Assessment](screen-migration-playbook.md#candidate-assessment) section in the migration
-playbook.
+The criteria below apply to future unassigned screens.
+
+A good unassigned candidate:
+
+- Is a low-risk product surface.
+- Has visible design-system value such as toolbar, text hierarchy, cells, buttons, banners,
+  empty/loading states, or forms.
+- Has bounded state and navigation.
+- Can be verified with previews and screenshots in light and dark mode.
+- Avoids RecyclerView behavior, selection tracking, `ActionMode`, complex custom Views, or major
+  accessibility redesign.
+- Has a clear before/after baseline for AI agents.
+
+High-risk unassigned screens require explicit confirmation before editing. High-risk signals include:
+
+- RecyclerView, ListAdapter, PagingDataAdapter, or adapter-heavy migration.
+- Selection tracking or `ActionMode`.
+- Complex custom Views or compound widgets.
+- Shared element transitions or complicated animation behavior.
+- Embedded WebView, camera, barcode scanner, media picker, or payment/card-reader UI.
+- Product, order, payment editing, or fulfillment flows.
+- Many navigation branches or multiple child fragments.
+- No reliable preview or screenshot baseline.
 
 ## AI-Agent Documentation
 
@@ -146,6 +178,7 @@ Design-system docs:
 - `docs/design-system/android-adapter.md`
 - `docs/design-system/token-map.md`
 - `docs/design-system/component-catalog.md`
+- `docs/design-system/figma-navigation.md`
 - `docs/design-system/material3-reference.md`
 - `docs/design-system/screen-migration-playbook.md`
 - `docs/design-system/implementation-plan.md`

--- a/docs/design-system/integration-checkpoint.md
+++ b/docs/design-system/integration-checkpoint.md
@@ -92,7 +92,7 @@ Do not expand these shorthands into raw P2 or Figma URLs in public repo docs.
 - The module must not import app `R`, legacy app theme classes, Hilt, POS, or Store feature
   packages. App-layer rollout wiring stays outside the module.
 - Package root: `com.woocommerce.android.ui.compose.designsystem`.
-- Suggested subpackages: `foundation`, `component`, and `preview`.
+- Subpackages: `foundation`, `component`, and `preview`.
 - The component split ports production components into `:libs:store-design-system`; old app-local
   `WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem` component paths are
   historical only and should not be resurrected.
@@ -146,29 +146,9 @@ These remain rejected for i1:
 ## Screen Migration Candidate Criteria
 
 For first-wave screens, use [rollout-direction.md](rollout-direction.md) as the assignment source.
-The criteria below apply to future unassigned screens.
-
-A good unassigned candidate:
-
-- Is a low-risk product surface.
-- Has visible design-system value such as toolbar, text hierarchy, cells, buttons, banners,
-  empty/loading states, or forms.
-- Has bounded state and navigation.
-- Can be verified with previews and screenshots in light and dark mode.
-- Avoids RecyclerView behavior, selection tracking, `ActionMode`, complex custom Views, or major
-  accessibility redesign.
-- Has a clear before/after baseline for AI agents.
-
-High-risk unassigned screens require explicit confirmation before editing. High-risk signals include:
-
-- RecyclerView, ListAdapter, PagingDataAdapter, or adapter-heavy migration.
-- Selection tracking or `ActionMode`.
-- Complex custom Views or compound widgets.
-- Shared element transitions or complicated animation behavior.
-- Embedded WebView, camera, barcode scanner, media picker, or payment/card-reader UI.
-- Product, order, payment editing, or fulfillment flows.
-- Many navigation branches or multiple child fragments.
-- No reliable preview or screenshot baseline.
+For future unassigned screens, use the
+[Candidate Assessment](screen-migration-playbook.md#candidate-assessment) section in the migration
+playbook.
 
 ## AI-Agent Documentation
 

--- a/docs/design-system/material3-reference.md
+++ b/docs/design-system/material3-reference.md
@@ -38,10 +38,10 @@ intentionally use `lightColorScheme(...)` / `darkColorScheme(...)` builder defau
 
 Do not use top-level `Semantic` or high-contrast modes for normal Material color projections.
 Container roles are first-class Store roles and can project to Material container roles. The fuller
-surface role set is first-class Store data, including `surfaceDim`, `surfaceBright`,
-`surfaceContainerHighest`, `onVariantLowest`, `inverted`, and `onInverted`. These roles should
-project from their Store source-backed roles, not older internal aliases. Background, overlay, and
-palette roles remain export-backed even when they are not validated by the Color roles frame.
+surface role set includes `surfaceDim`, `surfaceContainerHighest`, `onVariantLowest`, `inverted`,
+and `onInverted`. These roles should project from their Store source-backed roles, not older
+internal aliases. Background, overlay, and palette roles remain export-backed even when they are not
+validated by the Color roles frame.
 
 Do not generate public `WooTheme.colors` entries for Material fixed roles or source-missing aliases.
 `outline` and `outlineVariant` are source-backed and public under `WooTheme.colors`.
@@ -57,7 +57,7 @@ Do not generate public `WooTheme.colors` entries for Material fixed roles or sou
 | `surface`, `onSurface` | Default app surfaces and primary text/icons on neutral surfaces. |
 | `surfaceVariant`, `onSurfaceVariant` | Lower-emphasis neutral containers, secondary text/icons, and content adjacent to dividers. |
 | `surfaceContainerLowest` through `surfaceContainerHighest` | Nested neutral containers for projection. `surfaceContainerHighest` is a promoted Store role; the rest stay internal unless source-backed names are promoted. |
-| `surfaceDim`, `surfaceBright` | Source-backed Store surface roles. |
+| `surfaceDim` | Source-backed Store surface role. |
 | `background`, `onBackground` | Root/background areas when distinct from `surface`. In M3, prefer `surface` for most containers. |
 | `outline`, `outlineVariant` | Borders, dividers, and low-emphasis strokes. |
 | `inverseSurface`, `inverseOnSurface`, `inversePrimary` | Inverse surfaces such as snackbar-like UI. |
@@ -249,7 +249,7 @@ The current adapter decision is:
 - Do not expose top-level `Semantic` groups in PR 2 unless a concrete Figma component audit approves
   that token group.
 - Keep Material 3-only projection aliases internal unless the alias is itself a source-backed token.
-- Treat `surfaceDim`, `surfaceBright`, and `surfaceContainerHighest` as source-backed Store roles.
+- Treat `surfaceDim` and `surfaceContainerHighest` as source-backed Store roles.
 - Keep high-contrast modes out of normal `Light` / `Dark` runtime mapping until accessibility-mode
   scope is decided.
 - Do not create a public `WooTheme.stateAlpha` float API from mode-aware state-layer color tokens.

--- a/docs/design-system/pilot-feedback-completed.md
+++ b/docs/design-system/pilot-feedback-completed.md
@@ -67,7 +67,7 @@ Before reusing this as a migration pattern:
 - Verify the inline help link.
 - Verify analytics are unchanged.
 - Verify the same screen implementation renders under the selected design-system root.
-- Verify DS components do not fall back to hardcoded light defaults.
+- Verify DS components do not fall back to static light defaults.
 - Review light and dark previews/screenshots.
 - Confirm no POS APIs or patterns were introduced.
 

--- a/docs/design-system/pilot-privacy-settings.md
+++ b/docs/design-system/pilot-privacy-settings.md
@@ -71,7 +71,7 @@ Before reusing this as an existing-Compose adoption pattern:
 - Verify policies navigation.
 - Verify snackbar behavior if touched.
 - Verify the same screen implementation renders under the selected design-system root.
-- Verify DS components do not fall back to hardcoded light defaults.
+- Verify DS components do not fall back to static light defaults.
 - Review light and dark previews/screenshots.
 - Confirm no POS APIs or patterns were introduced.
 

--- a/docs/design-system/rollout-direction.md
+++ b/docs/design-system/rollout-direction.md
@@ -120,10 +120,22 @@ Compose reading that same resource. Do not keep parallel Kotlin/Compose and XML 
 The toolbar goal is a unified design-system visual look, not one mandatory implementation.
 
 - Compose-owned screens use `WooTopAppBar`.
+- The module `WooTopAppBar` is design-system-only and lives in `:libs:store-design-system`.
 - Heavy XML screens may keep XML toolbar ownership if the toolbar matches the design-system look.
+- `Widget.Woo.DesignSystem.Toolbar` is a style scaffold for colors, centered title, and insets; it is
+  not enough on its own for parity with the Compose top app bar.
+- XML-heavy screens that need visual parity can use `WooDesignSystemToolbar` from
+  `:libs:store-design-system` for automatic design-system chrome. The library also owns
+  `Widget.Woo.DesignSystem.Toolbar` and `ThemeOverlay.Woo.DesignSystem.Toolbar` for XML opt-ins.
+  Visible inflated icon actions are decorated in place; text actions stay borderless, and
+  expanded/custom action views remain screen-owned.
 - Existing behavior must be preserved for `SearchView`, `ActionMode`, collapsing app bars,
   menu/action ownership, navigation ownership, and insets.
-- A DS-looking XML toolbar is an acceptable migration tool for legacy-heavy screens.
+- A DS-looking XML toolbar is an acceptable migration tool for legacy-heavy screens. The component
+  split adds component/XML toolbar infrastructure and catalog coverage; product-screen adoption
+  remains migration work.
+- If a legacy-themed Compose root still needs toolbar compatibility, implement that compatibility in
+  app code rather than adding app theme/resource coupling to `:libs:store-design-system`.
 
 This keeps the migration focused on UI consistency without forcing a full app rewrite.
 

--- a/docs/design-system/screen-migration-playbook.md
+++ b/docs/design-system/screen-migration-playbook.md
@@ -160,7 +160,7 @@ The current toolbar direction is a unified design-system visual look, not one fo
     RTL and large-font coverage for row-heavy screens.
 11. Verify first-wave screens with screenshot review, targeted tests when behavior changes, and an
     accessibility regression check against the original screen.
-12. Verify design-system components do not fall back to hardcoded light defaults under the
+12. Verify design-system components do not fall back to static light defaults under the
     design-system root.
 13. Before final merge, verify the controlled root-API rename boundary with the strict `rg` audits
     defined in [rollout-direction.md](rollout-direction.md).

--- a/docs/design-system/token-map.md
+++ b/docs/design-system/token-map.md
@@ -255,6 +255,7 @@ the Material builder from another supplied source role.
 | `outline` | `WooTheme.colors.outline` | production | Direct source-backed projection. |
 | `outlineVariant` | `WooTheme.colors.outlineVariant` | production | Direct source-backed projection. |
 | `scrim` | `WooTheme.colors.overlay.overlay50` | production | Source-backed projection; dark alpha is 75%. |
+| `surfaceBright` | `WooTheme.colors.surface.default` | production | Material role projection from the source-backed default surface. |
 | `surfaceDim` | `WooTheme.colors.surface.surfaceDim` | production | Promoted source-backed Store surface role. |
 | `surfaceContainer` | `WooTheme.colors.background.section` | production | Internal surface alias for navigation bars, menus, cards, and sheets. |
 | `surfaceContainerHigh` | `WooTheme.colors.surface.default` | production | Internal surface alias for Material container hierarchy. |

--- a/docs/design-system/token-map.md
+++ b/docs/design-system/token-map.md
@@ -12,10 +12,12 @@ Source references use public-repo shorthands:
 - Figma file: `Woo Mobile Design System` (`50XIH5MmOf4xUYEkM6fAm6-fi`).
 - Full Figma variable export: `figma-export.json`.
 
-Use source shorthands in source-reference columns.
+Use source shorthands in source-reference columns. Do not use raw P2 or Figma URLs in public repo
+docs.
 
 Agent note: Figma references use the public GitHub shorthand `{fileKey}-fi`. When using Figma tools,
-strip the `-fi` suffix and pass only `{fileKey}` as the Figma `fileKey`.
+strip the `-fi` suffix and pass only `{fileKey}` as the Figma `fileKey`. For live Figma component
+inspection, use [figma-navigation.md](figma-navigation.md).
 
 ## Figma Export Parsing Rules
 
@@ -71,7 +73,7 @@ Group the public API shallowly by source intent; do not collapse the source into
 | --- | --- |
 | Core | Primary, on-primary, secondary, and on-secondary roles from the Color roles frame's "Primary and Secondary" section. |
 | Container | Primary container, on-primary container, secondary container, and on-secondary container. These are accent containers; status containers stay under `status`. |
-| Surface | Surface, surface dim, surface bright, surface container highest, on-default, on-variant, on-variant-lowest, inverted, and on-inverted roles. |
+| Surface | Surface, surface dim, surface container highest, on-default, on-variant, on-variant-lowest, inverted, and on-inverted roles. |
 | Outline | `outline` and `outlineVariant`. |
 | Status | Error, warning, caution, success, info, and neutral containers plus their on-container colors. |
 | Alert | Red, orange, green, and blue alert ramp colors plus their on-colors. |
@@ -90,7 +92,6 @@ Group the public API shallowly by source intent; do not collapse the source into
   source-missing aliases as public Store roles.
 - `surfaceDim` and `surfaceContainerHighest` are promoted source-backed Store roles. Do not filter
   them out as generated Material aliases.
-- `surfaceBright` is export-backed and public under `WooTheme.colors.surface`.
 - `outline` and `outlineVariant` are source-backed and public under `WooTheme.colors`.
 - Keep state layers internal-first until semantic names and mode behavior are approved. Do not create
   public `WooTheme.stateAlpha` floats from mode-aware state-layer color tokens.
@@ -162,7 +163,6 @@ Every production `WooTheme.colors` field below is backed by normal `Light` / `Da
 | `WooTheme.colors.surface.onVariantLowest` | `Woo theme/Surface/On-Surface-Variant-Lowest` | `figma-export.json` | `#50575E` / 100% | `#626068` / 100% | No direct M3 role | production | Lowest variant foreground. |
 | `WooTheme.colors.surface.inverted` | `Woo theme/Surface/Inverse-Surface` | `figma-export.json` | `#000000` / 100% | `#FFFFFF` / 100% | `inverseSurface` | production | Inverse surface. |
 | `WooTheme.colors.surface.onInverted` | `Woo theme/Surface/On-Inverse-Surface` | `figma-export.json` | `#FFFFFF` / 100% | `#000000` / 100% | `inverseOnSurface` | production | Foreground for inverse surface. |
-| `WooTheme.colors.surface.surfaceBright` | `Woo theme/Surface/Surface-Bright` | `figma-export.json` | `#FFFFFF` / 100% | `#232529` / 100% | `surfaceBright` | production | Source-backed surface role. |
 | `WooTheme.colors.status.errorContainer` | `Woo theme/Alerts/Error-Container` | `figma-export.json` | `#F6E6E3` / 100% | `#F6E6E3` / 100% | `errorContainer` | production | Error container. |
 | `WooTheme.colors.status.onErrorContainer` | `Woo theme/Alerts/On-Error-Container` | `figma-export.json` | `#470000` / 100% | `#470000` / 100% | `onErrorContainer` | production | Foreground for `errorContainer`. |
 | `WooTheme.colors.status.warningContainer` | `Woo theme/Alerts/Warning-Container` | `figma-export.json` | `#FDE6BE` / 100% | `#FDE6BE` / 100% | No direct M3 role | production | Warning container. |
@@ -214,7 +214,7 @@ Every production `WooTheme.colors` field below is backed by normal `Light` / `Da
 | `WooTheme.colors.palette.wooPurple.shade80` | `Woo theme/Add-On-Colors/Woo-Purple/80` | `figma-export.json` | `#3C087E` / 100% | `#3C087E` / 100% | No direct M3 role | production | Public palette ramp token. |
 | `WooTheme.colors.palette.wooPurple.shade90` | `Woo theme/Add-On-Colors/Woo-Purple/90` | `figma-export.json` | `#2C045D` / 100% | `#2C045D` / 100% | No direct M3 role | production | Public palette ramp token. |
 | `WooTheme.colors.palette.wooPurple.shade100` | `Woo theme/Add-On-Colors/Woo-Purple/100` | `figma-export.json` | `#1F0342` / 100% | `#1F0342` / 100% | No direct M3 role | production | Public palette ramp token. |
-| `WooTheme.colors.palette.gray.0..100` | `Woo theme/Add-On-Colors/Gray/0..100` | `figma-export.json` | Gray ramp / 100% | Gray ramp / 100% | No direct M3 role | production | Public gray palette ramp token. |
+| `WooTheme.colors.palette.gray.shade0..shade100` | `Woo theme/Add-On-Colors/Gray/0..100` | `figma-export.json` | Gray ramp / 100% | Gray ramp / 100% | No direct M3 role | production | Public gray palette ramp token. |
 
 ## Material 3 Color Projection
 
@@ -255,7 +255,6 @@ the Material builder from another supplied source role.
 | `outline` | `WooTheme.colors.outline` | production | Direct source-backed projection. |
 | `outlineVariant` | `WooTheme.colors.outlineVariant` | production | Direct source-backed projection. |
 | `scrim` | `WooTheme.colors.overlay.overlay50` | production | Source-backed projection; dark alpha is 75%. |
-| `surfaceBright` | `WooTheme.colors.surface.surfaceBright` | production | Direct source-backed projection. |
 | `surfaceDim` | `WooTheme.colors.surface.surfaceDim` | production | Promoted source-backed Store surface role. |
 | `surfaceContainer` | `WooTheme.colors.background.section` | production | Internal surface alias for navigation bars, menus, cards, and sheets. |
 | `surfaceContainerHigh` | `WooTheme.colors.surface.default` | production | Internal surface alias for Material container hierarchy. |
@@ -276,8 +275,8 @@ names are camelCase.
 
 `Typescale/<Role>/Font` resolves through `Font theme/Font/Plain`, whose Android value is `Roboto`.
 Android default font is the approved runtime equivalent. Most regular weights use `Weight`, but
-`Display-Large` and `Body-Small` use
-`Weight-Regular`. Most strong weights use `Weight-Strong`, but `Display-Large` uses
+`Display-Large` and `Body-Small` use `Weight-Regular`. Most strong weights use `Weight-Strong`, but
+`Display-Large` uses
 `Weight-Extra-Emphasized`. Displayed tracking values may be rounded in docs; implementation should
 preserve source-backed values.
 


### PR DESCRIPTION
> [!NOTE]
> This is the fifth split PR for Store Design System components. It builds on `store-design-system/components4`, so review the diff against that base rather than `trunk`.

### Description

This docs-only PR recovers the Store Design System documentation updates from the broad component branch and refreshes them against the live `components4` stack.

#### What this adds

- Restores the Figma navigation guide for agents:
  - source shorthand rules
  - live Figma discovery flow
  - component search terms
  - evidence and troubleshooting rules
- Updates the component catalog to match the live `:libs:store-design-system` APIs:
  - production component inventory
  - Material/token adapter boundaries
  - preview-only catalog boundaries
  - not-public `section-header` guidance for agents
- Refreshes rollout, adapter, checkpoint, and token docs for the split stack:
  - XML toolbar bridge boundaries without claiming product-screen adoption
  - Developer Options catalog access as app-level debug wiring
  - `Semantic` as traceability-only for runtime/public mappings
  - public palette ramps and alert `orange` / `onOrange` API names

#### What this does not do

- Does not change Kotlin, XML, resources, Gradle files, or app behavior.
- Does not migrate or adopt components in any product screen.
- Does not document Section Header as a public production API.
- Does not add contrast fixes or override Figma token values.
- Does not add screenshots.
- Does not touch POS.

#### Helpful review focus

- Do the docs describe only the live public APIs and intentional adapter utilities from the split stack?
- Is the Figma navigation guidance clear enough for future source-fidelity checks?
- Are the boundaries clear for section header, `Semantic`, state layers, and search field token naming?
- Does the docs-only PR stay scoped enough to review independently from components4?

No release notes: this is internal design-system documentation.

### Test Steps

1. Review the docs diff against `store-design-system/components4`.
2. Confirm the component catalog entries match the public APIs in `:libs:store-design-system`.
3. Confirm the token docs do not promote top-level `Semantic` or `search.fieldContainer` as public runtime APIs.

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.