### PR TITLE
Fix time-dependent assertion in RefundStoreTest

### DIFF
--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/wc/refunds/RefundStoreTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/wc/refunds/RefundStoreTest.kt
@@ -146,7 +146,7 @@ class RefundStoreTest {
         val lineItems = listOf(RefundV4LineItem.quantityBased(lineItemId = 1L, quantity = 2))
         val response = SimplifiedRefundResponse(
             refundId = 55L,
-            dateCreated = null,
+            dateCreated = "2026-06-26T08:20:53",
             amount = "110.00",
             reason = "reason",
             refundedPayment = true,


### PR DESCRIPTION
### Description

`RefundStoreTest > when createSimplifiedItemsRefund succeeds, then response is mapped to model` us flaky on CI while passing locally. The failure is a timing bug in the test, not in production code.

`RefundMapper.toModel(SimplifiedRefundResponse)` maps a missing date to the current time:

```kotlin
dateCreated = response.dateCreated?.let { fromFormattedDate(it) } ?: Date(),
```

The test passes `dateCreated = null`, so both the store's mapping and the test's own `mapper.toModel(response)` call fall into the `?: Date()` branch — capturing the wall clock at two different moments, with a coroutine context switch (`coroutineEngine.withDefaultContext`) in between. `WCRefundModel` is a `data class`, so its `equals` compares `dateCreated`; the assertion fails whenever those two reads land in different seconds.

The fix pins the fixture's `dateCreated` to a fixed value, matching the convention already used in `RefundMapperTest`, so both mappings are deterministic. 

### Test Steps

CI is green

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
