### PR TITLE
Enable QR code login for all users

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/login/WelcomeScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/login/WelcomeScreen.kt
@@ -1,12 +1,18 @@
 package com.woocommerce.android.e2e.screens.login
 
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.By
+import androidx.test.uiautomator.UiDevice
+import androidx.test.uiautomator.Until
 import com.woocommerce.android.R
 import com.woocommerce.android.e2e.helpers.util.Screen
 import com.woocommerce.android.e2e.screens.TabNavComponent
 
 class WelcomeScreen : Screen {
     companion object {
+        private const val QR_PROLOGUE_TIMEOUT = 5000L
+
         fun logoutIfNeeded(composeTestRule: ComposeContentTestRule): WelcomeScreen {
             if (isElementDisplayed(R.id.dashboard)) {
                 TabNavComponent()
@@ -33,7 +39,20 @@ class WelcomeScreen : Screen {
 
     fun selectLogin(): SiteAddressScreen {
         clickOn(R.id.button_login_store)
+        proceedThroughQrLoginPrologueIfNeeded()
         return SiteAddressScreen()
+    }
+
+    // With QR login enabled, the primary button opens the QR login prologue; continue to the
+    // site-address screen through its fallback link. UiAutomator is used because the QR prologue
+    // is Compose and there is no ComposeTestRule available here.
+    private fun proceedThroughQrLoginPrologueIfNeeded() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val fallbackLinkText = instrumentation.targetContext
+            .getString(R.string.login_qr_prologue_fallback_link)
+        UiDevice.getInstance(instrumentation)
+            .wait(Until.findObject(By.text(fallbackLinkText)), QR_PROLOGUE_TIMEOUT)
+            ?.click()
     }
 
     fun selectWPCOMLogin(): EmailAddressScreen {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -307,7 +307,7 @@ class LoginActivity :
 
     override fun onQrLoginFallbackClicked() {
         disableDynamicEdgeToEdge()
-        loginViaSiteAddress()
+        loginViaSiteAddress(prefilledSiteUrl = null, flow = Flow.LOGIN_QR)
     }
 
     override fun onQrLoginCompleted(localSiteId: Int) {
@@ -541,8 +541,8 @@ class LoginActivity :
 
     override fun loginViaSiteAddress() = loginViaSiteAddress(prefilledSiteUrl = null)
 
-    private fun loginViaSiteAddress(prefilledSiteUrl: String?) {
-        unifiedLoginTracker.setFlowAndStep(LOGIN_SITE_ADDRESS, ENTER_SITE_ADDRESS)
+    private fun loginViaSiteAddress(prefilledSiteUrl: String?, flow: Flow = LOGIN_SITE_ADDRESS) {
+        unifiedLoginTracker.setFlowAndStep(flow, ENTER_SITE_ADDRESS)
         val loginSiteAddressFragment = getLoginViaSiteAddressFragment()
             ?: WooLoginSiteAddressFragment.newInstance(prefilledSiteUrl)
         changeFragment(loginSiteAddressFragment, true, LoginSiteAddressFragment.TAG)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginAnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginAnalyticsTracker.kt
@@ -193,7 +193,8 @@ class LoginAnalyticsTracker(
 
     override fun trackUrlFormViewed() {
         AnalyticsTracker.track(AnalyticsEvent.LOGIN_URL_FORM_VIEWED)
-        unifiedLoginTracker.track(Flow.LOGIN_SITE_ADDRESS, Step.START)
+        val flow = if (unifiedLoginTracker.getFlow() == Flow.LOGIN_QR) Flow.LOGIN_QR else Flow.LOGIN_SITE_ADDRESS
+        unifiedLoginTracker.track(flow, Step.START)
     }
 
     override fun trackUrlHelpScreenViewed() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginAvailability.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginAvailability.kt
@@ -9,9 +9,9 @@ import javax.inject.Inject
 /**
  * Decides whether the QR login flow should be offered.
  *
- * The remote feature flag gates both entry points: we require an explicit `remoteValue == true`
- * (a `null`/not-yet-loaded remote value is treated as off) since this runs in the login flow before
- * remote flags are guaranteed to have loaded. Only a debug override bypasses this.
+ * [FeatureFlag.QR_LOGIN] gates both entry points via its effective value (override → remote →
+ * local). No remote flag is configured for it, so the local value (enabled) applies; creating
+ * the `woo_qr_code_login` remote key would act as a kill-switch.
  *
  * For the in-app entry point ([isAvailable]):
  *  - The device must have a camera — we don't gate on Google Play Services: we ship the bundled
@@ -27,15 +27,8 @@ class QrLoginAvailability @Inject constructor(
     private val featureFlagRepository: FeatureFlagRepository,
     private val deviceFeatures: DeviceFeatures,
 ) {
-    @Suppress("ReturnCount")
     fun isAvailable(): Boolean {
-        val flagState = featureFlagRepository.getFlagState(FeatureFlag.QR_LOGIN)
-        val override = flagState.overrideValue
-        if (override != null) {
-            if (!override) return false
-        } else {
-            if (flagState.remoteValue != true) return false
-        }
+        if (!featureFlagRepository.isEnabled(FeatureFlag.QR_LOGIN)) return false
 
         if (!deviceFeatures.hasCamera()) {
             WooLog.d(WooLog.T.LOGIN, "QR login unavailable: device has no camera")
@@ -45,8 +38,5 @@ class QrLoginAvailability @Inject constructor(
         return true
     }
 
-    fun isAvailableForDeepLink(): Boolean {
-        val flagState = featureFlagRepository.getFlagState(FeatureFlag.QR_LOGIN)
-        return flagState.overrideValue ?: (flagState.remoteValue == true)
-    }
+    fun isAvailableForDeepLink(): Boolean = featureFlagRepository.isEnabled(FeatureFlag.QR_LOGIN)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginAvailability.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginAvailability.kt
@@ -1,15 +1,10 @@
 package com.woocommerce.android.ui.login.qrlogin
 
-import com.woocommerce.android.AppPrefsWrapper
-import com.woocommerce.android.ui.login.qrlogin.QrLoginAvailability.Companion.ROLLOUT_BUCKETS_ENABLED
-import com.woocommerce.android.ui.login.qrlogin.QrLoginAvailability.Companion.ROLLOUT_BUCKET_MAX
-import com.woocommerce.android.ui.login.qrlogin.QrLoginAvailability.Companion.ROLLOUT_BUCKET_MIN
 import com.woocommerce.android.util.DeviceFeatures
 import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.FeatureFlagRepository
 import com.woocommerce.android.util.WooLog
 import javax.inject.Inject
-import kotlin.random.Random
 
 /**
  * Decides whether the QR login flow should be offered.
@@ -23,18 +18,14 @@ import kotlin.random.Random
  *    ML Kit barcode scanning variant, which works on GMS-less devices. If `bindToLifecycle` still
  *    fails at runtime, [com.woocommerce.android.ui.login.qrlogin.QrLoginScannerFragment] opens the
  *    OS camera app so the merchant can scan the QR there and tap the resulting deep link.
- *  - Each install is assigned a number in [ROLLOUT_BUCKET_MIN]..[ROLLOUT_BUCKET_MAX] on first read
- *    and persisted, so the decision is stable across restarts. Only installs in
- *    [ROLLOUT_BUCKETS_ENABLED] get the entry point. A debug override bypasses the bucket check.
  *
  * For deep-link entry ([isAvailableForDeepLink]), e.g. scanning a QR from wp-admin with a
- * 3rd-party camera: the bucket is bypassed (the user already chose this flow), and the camera
- * check is skipped (they already have the token; no scanning needed in-app).
+ * 3rd-party camera: the camera check is skipped (they already have the token; no scanning needed
+ * in-app).
  */
 class QrLoginAvailability @Inject constructor(
     private val featureFlagRepository: FeatureFlagRepository,
     private val deviceFeatures: DeviceFeatures,
-    private val appPrefsWrapper: AppPrefsWrapper,
 ) {
     @Suppress("ReturnCount")
     fun isAvailable(): Boolean {
@@ -44,10 +35,6 @@ class QrLoginAvailability @Inject constructor(
             if (!override) return false
         } else {
             if (flagState.remoteValue != true) return false
-            if (getOrAssignRolloutBucket() !in ROLLOUT_BUCKETS_ENABLED) {
-                WooLog.d(WooLog.T.LOGIN, "QR login unavailable: outside rollout bucket")
-                return false
-            }
         }
 
         if (!deviceFeatures.hasCamera()) {
@@ -61,15 +48,5 @@ class QrLoginAvailability @Inject constructor(
     fun isAvailableForDeepLink(): Boolean {
         val flagState = featureFlagRepository.getFlagState(FeatureFlag.QR_LOGIN)
         return flagState.overrideValue ?: (flagState.remoteValue == true)
-    }
-
-    private fun getOrAssignRolloutBucket(): Int =
-        appPrefsWrapper.qrLoginRolloutBucket ?: Random.nextInt(ROLLOUT_BUCKET_MIN, ROLLOUT_BUCKET_MAX + 1)
-            .also { appPrefsWrapper.qrLoginRolloutBucket = it }
-
-    companion object {
-        const val ROLLOUT_BUCKET_MIN = 1
-        const val ROLLOUT_BUCKET_MAX = 10
-        val ROLLOUT_BUCKETS_ENABLED = 1..1
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -45,5 +45,5 @@ enum class FeatureFlag(
     IPP_COUNTRY_EXPANSION("woo_ipp_country_expansion"),
     IPP_COUNTRY_EXPANSION_EU_EXTENDED("woo_ipp_country_expansion_eu_extended"),
     IPP_AUSTRALIA_WOOPAYMENTS("woo_ipp_australia_woopayments"),
-    QR_LOGIN("woo_qr_code_login", localValue = PackageUtils.isDebugBuild()),
+    QR_LOGIN("woo_qr_code_login"),
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginAvailabilityTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginAvailabilityTest.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.login.qrlogin
 
-import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.util.DeviceFeatures
 import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.FeatureFlagRepository
@@ -10,7 +9,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
-import org.mockito.kotlin.argThat
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
@@ -21,19 +19,17 @@ class QrLoginAvailabilityTest : BaseUnitTest() {
 
     private val featureFlagRepository: FeatureFlagRepository = mock()
     private val deviceFeatures: DeviceFeatures = mock()
-    private val appPrefsWrapper: AppPrefsWrapper = mock()
 
-    private val availability = QrLoginAvailability(featureFlagRepository, deviceFeatures, appPrefsWrapper)
+    private val availability = QrLoginAvailability(featureFlagRepository, deviceFeatures)
 
     @Before
     fun setUp() {
         whenever(featureFlagRepository.getFlagState(FeatureFlag.QR_LOGIN)).thenReturn(flagState(remote = true))
         whenever(deviceFeatures.hasCamera()).thenReturn(true)
-        whenever(appPrefsWrapper.qrLoginRolloutBucket).thenReturn(1)
     }
 
     @Test
-    fun `given flag enabled, bucket in rollout, camera present, when isAvailable, then true`() {
+    fun `given flag enabled and camera present, when isAvailable, then true`() {
         assertThat(availability.isAvailable()).isTrue()
     }
 
@@ -59,13 +55,6 @@ class QrLoginAvailabilityTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given bucket outside rollout, when isAvailable, then false`() {
-        whenever(appPrefsWrapper.qrLoginRolloutBucket).thenReturn(2)
-
-        assertThat(availability.isAvailable()).isFalse()
-    }
-
-    @Test
     fun `given override enabled and remote disabled, when isAvailable, then true`() {
         whenever(featureFlagRepository.getFlagState(FeatureFlag.QR_LOGIN))
             .thenReturn(flagState(remote = false, override = true))
@@ -74,7 +63,7 @@ class QrLoginAvailabilityTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given override disabled, when isAvailable, then false even if bucket in rollout`() {
+    fun `given override disabled, when isAvailable, then false`() {
         whenever(featureFlagRepository.getFlagState(FeatureFlag.QR_LOGIN))
             .thenReturn(flagState(remote = true, override = false))
 
@@ -82,19 +71,8 @@ class QrLoginAvailabilityTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given no bucket assigned, when isAvailable, then bucket is generated and persisted`() {
-        whenever(appPrefsWrapper.qrLoginRolloutBucket).thenReturn(null)
-
-        availability.isAvailable()
-
-        verify(appPrefsWrapper).qrLoginRolloutBucket = argThat<Int> { this in 1..10 }
-    }
-
-    @Test
-    fun `given remote true, when isAvailableForDeepLink, then true regardless of bucket`() {
+    fun `given remote true, when isAvailableForDeepLink, then true`() {
         assertThat(availability.isAvailableForDeepLink()).isTrue()
-
-        verify(appPrefsWrapper, never()).qrLoginRolloutBucket
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginAvailabilityTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginAvailabilityTest.kt
@@ -3,7 +3,6 @@ package com.woocommerce.android.ui.login.qrlogin
 import com.woocommerce.android.util.DeviceFeatures
 import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.FeatureFlagRepository
-import com.woocommerce.android.util.FeatureFlagRepository.FeatureFlagState
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
@@ -24,7 +23,7 @@ class QrLoginAvailabilityTest : BaseUnitTest() {
 
     @Before
     fun setUp() {
-        whenever(featureFlagRepository.getFlagState(FeatureFlag.QR_LOGIN)).thenReturn(flagState(remote = true))
+        whenever(featureFlagRepository.isEnabled(FeatureFlag.QR_LOGIN)).thenReturn(true)
         whenever(deviceFeatures.hasCamera()).thenReturn(true)
     }
 
@@ -34,15 +33,8 @@ class QrLoginAvailabilityTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given remote flag false, when isAvailable, then false`() {
-        whenever(featureFlagRepository.getFlagState(FeatureFlag.QR_LOGIN)).thenReturn(flagState(remote = false))
-
-        assertThat(availability.isAvailable()).isFalse()
-    }
-
-    @Test
-    fun `given remote flag not loaded, when isAvailable, then false`() {
-        whenever(featureFlagRepository.getFlagState(FeatureFlag.QR_LOGIN)).thenReturn(flagState(remote = null))
+    fun `given flag disabled, when isAvailable, then false`() {
+        whenever(featureFlagRepository.isEnabled(FeatureFlag.QR_LOGIN)).thenReturn(false)
 
         assertThat(availability.isAvailable()).isFalse()
     }
@@ -55,44 +47,13 @@ class QrLoginAvailabilityTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given override enabled and remote disabled, when isAvailable, then true`() {
-        whenever(featureFlagRepository.getFlagState(FeatureFlag.QR_LOGIN))
-            .thenReturn(flagState(remote = false, override = true))
-
-        assertThat(availability.isAvailable()).isTrue()
-    }
-
-    @Test
-    fun `given override disabled, when isAvailable, then false`() {
-        whenever(featureFlagRepository.getFlagState(FeatureFlag.QR_LOGIN))
-            .thenReturn(flagState(remote = true, override = false))
-
-        assertThat(availability.isAvailable()).isFalse()
-    }
-
-    @Test
-    fun `given remote true, when isAvailableForDeepLink, then true`() {
+    fun `given flag enabled, when isAvailableForDeepLink, then true`() {
         assertThat(availability.isAvailableForDeepLink()).isTrue()
     }
 
     @Test
-    fun `given remote false, when isAvailableForDeepLink, then false`() {
-        whenever(featureFlagRepository.getFlagState(FeatureFlag.QR_LOGIN)).thenReturn(flagState(remote = false))
-
-        assertThat(availability.isAvailableForDeepLink()).isFalse()
-    }
-
-    @Test
-    fun `given remote not loaded, when isAvailableForDeepLink, then false`() {
-        whenever(featureFlagRepository.getFlagState(FeatureFlag.QR_LOGIN)).thenReturn(flagState(remote = null))
-
-        assertThat(availability.isAvailableForDeepLink()).isFalse()
-    }
-
-    @Test
-    fun `given override disabled, when isAvailableForDeepLink, then false`() {
-        whenever(featureFlagRepository.getFlagState(FeatureFlag.QR_LOGIN))
-            .thenReturn(flagState(remote = true, override = false))
+    fun `given flag disabled, when isAvailableForDeepLink, then false`() {
+        whenever(featureFlagRepository.isEnabled(FeatureFlag.QR_LOGIN)).thenReturn(false)
 
         assertThat(availability.isAvailableForDeepLink()).isFalse()
     }
@@ -103,11 +64,4 @@ class QrLoginAvailabilityTest : BaseUnitTest() {
 
         verify(deviceFeatures, never()).hasCamera()
     }
-
-    private fun flagState(remote: Boolean?, override: Boolean? = null) = FeatureFlagState(
-        flag = FeatureFlag.QR_LOGIN,
-        localValue = FeatureFlag.QR_LOGIN.localValue,
-        remoteValue = remote,
-        overrideValue = override
-    )
 }


### PR DESCRIPTION
### Description

QR code login is currently rolled out to only 10% of installs: `QrLoginAvailability` assigned each install a persisted random bucket (1–10) and only showed the in-app entry point for bucket 1. This PR removes the rollout bucket check so the feature is enabled for 100% of users — the entry point is now gated only by the `QR_LOGIN` feature flag and the device having a camera. Targeted at `release/25.1` as a beta fix.

**Flag gating fix:** `QrLoginAvailability` required an explicit `remoteValue == true` for `QR_LOGIN`, but no `woo_qr_code_login` remote flag exists (and none is planned), so after removing the bucket the feature still resolved to unavailable (`remoteValue = null`). It now gates on the flag's standard effective value (`override → remote → local`) via `FeatureFlagRepository.isEnabled`, and `QR_LOGIN`'s `localValue` changes from debug-only to the default (`true`). 

**Tracking change:** when the site-address login screen is opened from the QR login prologue's "No computer? Log in with site address" link (or the scanner's equivalent fallback), the `unified_login_step` event for that screen now reports `flow: login_qr` instead of `flow: login_site_address`, so QR-originated fallbacks can be distinguished in Tracks. All other entry points to the site-address screen keep reporting `flow: login_site_address`.

### Test Steps

1. Fresh install (or clear app data) so no previous rollout bucket is persisted.
2. Log out if needed and open the login screen.
3. Verify the QR code login entry point appears and works.
4. Repeat steps 1–3 a few times (clear data between attempts): the entry point must appear on every launch, not probabilistically (previously it only appeared for ~1 in 10 installs).
5. Sanity-check the remaining gates: with the `QR_LOGIN` flag disabled via the debug feature-flag override, the entry point is hidden; scanning a wp-admin QR login code with a 3rd-party camera app still deep-links into the flow.

Tracking:

6. From the QR login prologue, tap "No computer? Log in with site address" and check logcat/Tracks debug output: 
```
🔵 Tracked: woocommerceandroid_unified_login_step, Properties {"source":"default","flow":"login_qr","step":"start","is_debug":true}
```

### Images/gif

https://github.com/user-attachments/assets/513c8dd0-8873-46a7-b5a0-5ea2d08e0311

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
