### PR TITLE
[WOOMOB-3215] Restore support form subject and site fields on rotation

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 
 25.2
 -----
+- [*] Fixed the Contact Support form losing the subject and site address fields after rotating the device [PR URL]
 - [*] The Report Crashes privacy setting is now saved on your WordPress.com account, so it's kept across logins and devices
 - [*] Fixed a crash when a notifications sync deletes a very large number of cached notifications at once [https://github.com/woocommerce/woocommerce-android/pull/16214]
 - [*] Added a shortcut to view guest orders when searching for the Guest label returns no results [https://github.com/woocommerce/woocommerce-android/pull/16189]

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,7 +4,7 @@
 
 25.2
 -----
-- [*] Fixed the Contact Support form losing the subject and site address fields after rotating the device [PR URL]
+- [*] Fixed the Contact Support form losing the subject and site address fields after rotating the device [https://github.com/woocommerce/woocommerce-android/pull/16236]
 - [*] The Report Crashes privacy setting is now saved on your WordPress.com account, so it's kept across logins and devices
 - [*] Fixed a crash when a notifications sync deletes a very large number of cached notifications at once [https://github.com/woocommerce/woocommerce-android/pull/16214]
 - [*] Added a shortcut to view guest orders when searching for the Guest label returns no results [https://github.com/woocommerce/woocommerce-android/pull/16189]

--- a/WooCommerce/src/main/res/layout/activity_support_request_form.xml
+++ b/WooCommerce/src/main/res/layout/activity_support_request_form.xml
@@ -151,7 +151,6 @@
                         android:imeOptions="flagNoFullscreen"
                         android:inputType="textAutoComplete"
                         android:nextFocusForward="@id/request_site_address"
-                        android:saveEnabled="false"
                         app:errorEnabled="true" />
 
                     <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
@@ -162,7 +161,6 @@
                         android:hint="@string/support_request_site_address"
                         android:imeOptions="flagNoFullscreen"
                         android:inputType="textAutoComplete"
-                        android:saveEnabled="false"
                         app:errorEnabled="true" />
 
                     <com.google.android.material.card.MaterialCardView


### PR DESCRIPTION
Fixes WOOMOB-3215

### Description

On the Contact Support form, the subject and site address fields had `android:saveEnabled="false"`, which disabled the state restore that `WCMaterialOutlinedEditTextView` already implements. Rotating the device left both fields visually empty even though the view model still held the old values, so a user could submit a request containing text they could no longer see.

Removed the attribute from both fields so they restore their text like the message field already does. The AI-chat prefill path is unaffected since prefill only runs on a fresh launch (`savedInstanceState == null`).

### Test Steps

1. Open **Help & Support**.
2. Tap the **Contact support** icon in the top-right toolbar to open the support request form.
3. Enter text in the **Subject** and **Site address** fields.
4. Rotate the device.
5. Confirm both fields keep the text you entered.

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt`.