### PR TITLE
Update 25.2 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 <!--
 Contains editorialized release notes. Raw release notes should go into `RELEASE-NOTES.txt`.
 -->
+## 25.2
+Managing your store just got smoother: guest orders are easier to find in orders list, shipping packages respond reliably, gift card refunds are handled safely, and weekly stats follow your store settings. We’ve also improved sign-in, navigation, product editing, and overall stability.
+
 ## 25.1
 Refunds in Woo POS now open full screen for a cleaner flow. This release also makes the app more dependable when your store can't be reached, with clearer alerts and a quick path to support. Sign-in errors are easier to understand, and we fixed missing recent orders, a startup crash, and other small glitches. Happy selling!
 

--- a/fastlane/metadata/android/en-US/changelogs/default.txt
+++ b/fastlane/metadata/android/en-US/changelogs/default.txt
@@ -1,17 +1,1 @@
-- [*] Fixed the Contact Support form losing the subject and site address fields after rotating the device [https://github.com/woocommerce/woocommerce-android/pull/16236]
-- [*] The Report Crashes privacy setting is now saved on your WordPress.com account, so it's kept across logins and devices
-- [*] Fixed a crash when a notifications sync deletes a very large number of cached notifications at once [https://github.com/woocommerce/woocommerce-android/pull/16214]
-- [*] Added a shortcut to view guest orders when searching for the Guest label returns no results [https://github.com/woocommerce/woocommerce-android/pull/16189]
-- [*] Fixed saved package rows not responding to taps on the shipping label package selection screen [https://github.com/woocommerce/woocommerce-android/pull/16210]
-- [*] Refunding an order paid with a gift card is now blocked in the app with a prompt to refund from your store admin, so the gift-card balance is restored correctly [https://github.com/woocommerce/woocommerce-android/pull/16169]
-- [*] Fixed duplicated products reusing the original product slug [https://github.com/woocommerce/woocommerce-android/pull/16142]
-- [*] Fixed account-mismatch login retry requiring merchants to re-enter their store URL [https://github.com/woocommerce/woocommerce-android/pull/16162]
-- [*] Fixed This Week stats ranges using the app/device week start instead of the store's configured week start [https://github.com/woocommerce/woocommerce-android/pull/16160]
-- [*] Minor UI fixes on the POS refund flow [https://github.com/woocommerce/woocommerce-android/pull/16171]
-- [*] Blaze now shows a clear error when you pick an unsupported ad image type such as AVIF [https://github.com/woocommerce/woocommerce-android/pull/16151]
-- [Internal] Updated the app's compile SDK to Android 17 (API 37) [https://github.com/woocommerce/woocommerce-android/pull/16158]
-- [*] Variation list rows now show a chevron to indicate they open the variation editor [https://github.com/woocommerce/woocommerce-android/pull/16219]
-- [*] The customer note editor now shows a back arrow like the other order editing screens instead of an X [https://github.com/woocommerce/woocommerce-android/pull/16218]
-- [*] Tapping the current bottom tab again now scrolls the screen back to the top as intended [https://github.com/woocommerce/woocommerce-android/pull/16221]
-- [*] Fixed the main toolbar showing the wrong menu after opening a feedback survey [https://github.com/woocommerce/woocommerce-android/pull/16220]
-- [Internal] Restored dashboard scroll tracking for the used_analytics event lost in the Compose migration [https://github.com/woocommerce/woocommerce-android/pull/16229]
+Managing your store just got smoother: guest orders are easier to find in orders list, shipping packages respond reliably, gift card refunds are handled safely, and weekly stats follow your store settings. We’ve also improved sign-in, navigation, product editing, and overall stability.


### PR DESCRIPTION
### Description
Updates the WooCommerce Android 25.2 release notes with a concise, merchant-friendly summary based on the approved release items. The same copy is added to `CHANGELOG.md` under a new 25.2 section.

The WooCommerce Wear changelog is intentionally unchanged because there is no Wear release for this version.
