### PR TITLE
[WOOMOB-1034] Fix the store login error showing a placeholder instead of the status code

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,7 +4,7 @@
 
 25.3
 -----
-- [*] Fixed the store login error message showing a placeholder instead of the status code [PR URL]
+- [*] Fixed the store login error message showing a placeholder instead of the status code [https://github.com/woocommerce/woocommerce-android/pull/16246]
 
 25.2
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,7 +4,7 @@
 
 25.3
 -----
-
+- [*] Fixed the store login error message showing a placeholder instead of the status code [PR URL]
 
 25.2
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
@@ -413,8 +413,12 @@ class LoginSiteCredentialsViewModel @Inject constructor(
 
     private fun String.removeSchemeAndSuffix() = UrlUtils.removeScheme(UrlUtils.removeXmlrpcSuffix(this))
 
-    private fun UiString.toPresentableString() = when (this) {
-        is UiStringRes -> resourceProvider.getString(stringRes)
+    @Suppress("SpreadOperator")
+    private fun UiString.toPresentableString(): String = when (this) {
+        is UiStringRes -> resourceProvider.getString(
+            stringRes,
+            *params.map { it.toPresentableString() }.toTypedArray()
+        )
         is UiStringText -> text
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModelTest.kt
@@ -8,6 +8,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.applicationpasswords.ApplicationPasswordGenerationException
 import com.woocommerce.android.applicationpasswords.ApplicationPasswordsNotifier
+import com.woocommerce.android.model.UiString.UiStringRes
 import com.woocommerce.android.model.UiString.UiStringText
 import com.woocommerce.android.notifications.push.RegisterDevice
 import com.woocommerce.android.tools.SelectedSite
@@ -378,6 +379,40 @@ class LoginSiteCredentialsViewModelTest : BaseUnitTest() {
             assertThat(event).isInstanceOf(LoginSiteCredentialsViewModel.ShowApplicationPasswordTutorialScreen::class.java)
             assertThat((event as LoginSiteCredentialsViewModel.ShowApplicationPasswordTutorialScreen).url)
                 .isEqualTo(urlAuthFull)
+        }
+
+    @Test
+    fun `given login fails with a status code error, when the tutorial screen is shown, then the error message resolves its params`() =
+        testBlocking {
+            val statusCode = "403"
+            val formattedError = "Login failed with status code $statusCode"
+            val httpError = CookieNonceAuthenticationException(
+                errorMessage = UiStringRes(
+                    stringRes = R.string.login_site_credentials_http_error,
+                    params = listOf(UiStringText(statusCode))
+                ),
+                errorType = Nonce.CookieNonceErrorType.GENERIC_ERROR,
+                networkStatusCode = statusCode.toInt()
+            )
+
+            setup {
+                whenever(resourceProvider.getString(R.string.login_site_credentials_http_error, statusCode))
+                    .thenReturn(formattedError)
+                whenever(wpApiSiteRepository.login(siteAddress, testUsername, testPassword))
+                    .thenReturn(Result.failure(httpError))
+                whenever(wpApiSiteRepository.fetchSite(siteAddress))
+                    .thenReturn(Result.success(testSite.apply { applicationPasswordsAuthorizeUrl = urlAuthBase }))
+            }
+
+            val event = viewModel.event.runAndCaptureValues {
+                viewModel.onUsernameChanged(testUsername)
+                viewModel.onPasswordChanged(testPassword)
+                viewModel.viewState.getOrAwaitValue()
+                viewModel.onContinueClick()
+            }.last()
+
+            assertThat((event as LoginSiteCredentialsViewModel.ShowApplicationPasswordTutorialScreen).errorMessage)
+                .isEqualTo(formattedError)
         }
 
     @Test


### PR DESCRIPTION
Fixes WOOMOB-1034

### Description

When a store is connected with site credentials and the login fails with an HTTP status code, the failure is shown as the subtitle of the Application Password Tutorial screen. That message, `login_site_credentials_http_error` ("Login failed with status code %1$s"), is built as a `UiStringRes` carrying the status code as a param.

The subtitle is produced by a view-model-local `toPresentableString()` helper. It resolved a `UiStringRes` to its string resource but ignored the `params`, so the format placeholder was never filled and the screen showed a raw `%1$s` instead of the code. The fix makes `toPresentableString()` resolve the params recursively, the same way the shared `UiHelpers.getTextOfUiString` already does.

### Test Steps

This message only appears when the login endpoint returns an HTTP error status. To force one, add this snippet to the store (Code Snippets or the theme's `functions.php`):

```php
add_action('login_init', function () {
    if (!empty($_POST['log'])) {
        status_header(403);
        exit;
    }
});
```

Then:

1. Tap **Log In** on the welcome screen.
2. Tap **Log in with site address**.
3. Enter the store address.
4. Tap **Continue**.
5. Enter the site username and password.
6. Tap **Continue**.
7. On the "We couldn't log in into your store" screen, confirm the subtitle shows the actual status code, e.g. "Login failed with status code 403", and not "Login failed with status code %1$s".

### Images/gif

| Before | After |
| --- | --- |
|<img width="300" alt="Screenshot_20260711_132724" src="https://github.com/user-attachments/assets/04e27586-8320-466a-ba7c-7311a5ff7f6a" />|<img width="300" alt="Screenshot_20260711_172707" src="https://github.com/user-attachments/assets/1d4cc1d2-0fe5-4f8a-9719-39cfc33b856f" />|

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary.
