### PR TITLE
[WOOMOB-3477] Migrate dashboard content to Store Design System

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/compose/OrderSummaryRowTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/compose/OrderSummaryRowTest.kt
@@ -12,7 +12,7 @@ import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.woocommerce.android.R
-import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.compose.designsystem.foundation.WooDesignSystemThemeWithBackground
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -30,7 +30,7 @@ class OrderSummaryRowTest {
             .getString(R.string.pos_badge)
 
         composeTestRule.setContent {
-            WooThemeWithBackground {
+            WooDesignSystemThemeWithBackground {
                 Box(modifier = Modifier.width(380.dp)) {
                     OrderSummaryRow(
                         order = orderSummaryRowModel(isPosOrder = true),
@@ -66,7 +66,7 @@ class OrderSummaryRowTest {
     @Test
     fun givenNarrowContainer_whenOrderSummaryRowIsRendered_thenMetadataUsesCompactLine() {
         composeTestRule.setContent {
-            WooThemeWithBackground {
+            WooDesignSystemThemeWithBackground {
                 Box(modifier = Modifier.width(332.dp)) {
                     OrderSummaryRow(
                         order = orderSummaryRowModel(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aiassistant/AiAssistantOrderCardRenderer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aiassistant/AiAssistantOrderCardRenderer.kt
@@ -9,7 +9,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.aiassistant.ui.cards.AssistantCard
 import com.woocommerce.android.aiassistant.ui.cards.AssistantCardAction
 import com.woocommerce.android.model.Order
-import com.woocommerce.android.ui.orders.compose.OrderSummaryRow
+import com.woocommerce.android.ui.orders.compose.LegacyOrderSummaryRow
 import com.woocommerce.android.ui.orders.compose.OrderSummaryRowModel
 import com.woocommerce.android.util.DateUtils
 import org.wordpress.android.util.DateTimeUtils
@@ -25,7 +25,7 @@ internal class AiAssistantOrderCardRenderer(
         modifier: Modifier,
     ) {
         val context = LocalContext.current
-        OrderSummaryRow(
+        LegacyOrderSummaryRow(
             order = card.toOrderSummaryRowModel(context, currencyFormatter, dateUtils),
             onClick = { onAction(AssistantCardAction.OpenOrder(card.remoteOrderId)) },
             modifier = modifier,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aiassistant/AiAssistantProductCardRenderer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aiassistant/AiAssistantProductCardRenderer.kt
@@ -9,8 +9,8 @@ import com.woocommerce.android.aiassistant.ui.cards.AssistantCard
 import com.woocommerce.android.aiassistant.ui.cards.AssistantCardAction
 import com.woocommerce.android.ui.products.ProductStatus
 import com.woocommerce.android.ui.products.ProductStockStatus
-import com.woocommerce.android.ui.products.compose.ProductSummaryRow
-import com.woocommerce.android.ui.products.compose.ProductSummaryRowInfo
+import com.woocommerce.android.ui.products.compose.LegacyProductSummaryRow
+import com.woocommerce.android.ui.products.compose.LegacyProductSummaryRowInfo
 import java.math.BigDecimal
 
 internal class AiAssistantProductCardRenderer(
@@ -24,14 +24,14 @@ internal class AiAssistantProductCardRenderer(
     ) {
         val context = LocalContext.current
         val rowModel = card.toProductSummaryRowModel(context, currencyFormatter)
-        ProductSummaryRow(
+        LegacyProductSummaryRow(
             title = rowModel.title,
             imageUrl = rowModel.imageUrl,
             onClick = { onAction(AssistantCardAction.OpenProduct(card.remoteProductId)) },
             modifier = modifier,
         ) {
-            ProductSummaryRowInfo(rowModel.stockStatusPriceText)
-            rowModel.skuText?.let { sku -> ProductSummaryRowInfo(sku) }
+            LegacyProductSummaryRowInfo(rowModel.stockStatusPriceText)
+            rowModel.skuText?.let { sku -> LegacyProductSummaryRowInfo(sku) }
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aiassistant/AiAssistantVariationCardRenderer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aiassistant/AiAssistantVariationCardRenderer.kt
@@ -9,8 +9,8 @@ import com.woocommerce.android.aiassistant.ui.cards.AssistantCard
 import com.woocommerce.android.aiassistant.ui.cards.AssistantCardAction
 import com.woocommerce.android.ui.products.ProductStatus
 import com.woocommerce.android.ui.products.ProductStockStatus
-import com.woocommerce.android.ui.products.compose.ProductSummaryRow
-import com.woocommerce.android.ui.products.compose.ProductSummaryRowInfo
+import com.woocommerce.android.ui.products.compose.LegacyProductSummaryRow
+import com.woocommerce.android.ui.products.compose.LegacyProductSummaryRowInfo
 import java.math.BigDecimal
 
 internal class AiAssistantVariationCardRenderer(
@@ -24,14 +24,14 @@ internal class AiAssistantVariationCardRenderer(
     ) {
         val context = LocalContext.current
         val rowModel = card.toVariationSummaryRowModel(context, currencyFormatter)
-        ProductSummaryRow(
+        LegacyProductSummaryRow(
             title = rowModel.title,
             imageUrl = rowModel.imageUrl,
             onClick = { onAction(card.toOpenProductVariationAction()) },
             modifier = modifier,
         ) {
             rowModel.supportingTexts.forEach { text ->
-                ProductSummaryRowInfo(text)
+                LegacyProductSummaryRowInfo(text)
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignItem.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignItem.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.blaze.campaigs
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -11,22 +12,25 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.colorResource
-import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.sp
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.blaze.BlazeCampaignUi
 import com.woocommerce.android.ui.compose.component.ProductThumbnail
-import com.woocommerce.android.ui.compose.component.WCTag
+import com.woocommerce.android.ui.compose.designsystem.WooTheme
 
+/**
+ * Blaze campaign item for migrated screens rooted in WooDesignSystemTheme.
+ * Legacy-rooted screens should use [LegacyBlazeCampaignItem] until they migrate.
+ */
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun BlazeCampaignItem(
@@ -37,44 +41,44 @@ fun BlazeCampaignItem(
     Box(
         modifier = modifier
             .border(
-                width = dimensionResource(id = R.dimen.minor_10),
-                color = colorResource(R.color.divider_color),
-                shape = RoundedCornerShape(dimensionResource(id = R.dimen.minor_100))
+                width = WooTheme.stroke.regular,
+                color = WooTheme.colors.outlineVariant,
+                shape = RoundedCornerShape(WooTheme.radius.medium),
             )
-            .clip(shape = RoundedCornerShape(dimensionResource(id = R.dimen.minor_100)))
-            .clickable { onCampaignClicked() }
-            .padding(dimensionResource(id = R.dimen.major_100))
+            .clip(RoundedCornerShape(WooTheme.radius.medium))
+            .clickable(onClick = onCampaignClicked)
+            .padding(WooTheme.padding.padding5),
     ) {
         Row(verticalAlignment = Alignment.Top) {
-            ProductThumbnail(imageUrl = campaign.product.imgUrl)
+            ProductThumbnail(
+                imageUrl = campaign.product.imgUrl,
+                contentDescription = stringResource(id = R.string.product_image_content_description),
+            )
             Column(
                 modifier = Modifier
-                    .padding(start = dimensionResource(id = R.dimen.major_100))
+                    .padding(start = WooTheme.padding.padding5)
                     .weight(1f),
             ) {
-                campaign.status?.let {
-                    WCTag(
-                        text = stringResource(id = campaign.status.statusDisplayText).uppercase(),
-                        textColor = colorResource(id = campaign.status.textColor),
-                        backgroundColor = colorResource(id = campaign.status.backgroundColor),
-                        textStyle = MaterialTheme.typography.caption.copy(
-                            letterSpacing = 1.5.sp
-                        )
+                campaign.status?.let { status ->
+                    BlazeStatusTag(
+                        text = stringResource(id = status.statusDisplayText).uppercase(),
+                        textColor = colorResource(id = status.textColor),
+                        backgroundColor = colorResource(id = status.backgroundColor),
                     )
                 }
-
                 Text(
-                    modifier = Modifier
-                        .padding(top = dimensionResource(id = R.dimen.minor_50)),
+                    modifier = Modifier.padding(top = WooTheme.padding.padding2),
                     text = campaign.product.name,
-                    style = MaterialTheme.typography.subtitle1,
-                    fontWeight = FontWeight.Bold,
+                    style = WooTheme.text.titleMedium.strong,
+                    color = WooTheme.colors.surface.onDefault,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
                 )
                 FlowRow(
                     modifier = Modifier
-                        .padding(top = dimensionResource(id = R.dimen.major_100))
+                        .padding(top = WooTheme.padding.padding5)
                         .wrapContentWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween
+                    horizontalArrangement = Arrangement.SpaceBetween,
                 ) {
                     CampaignStat(
                         statName = stringResource(R.string.blaze_campaign_status_ctr_label),
@@ -83,12 +87,11 @@ fun BlazeCampaignItem(
                             campaign.impressions,
                             campaign.clicks,
                         ),
-                        modifier = Modifier.padding(bottom = dimensionResource(id = R.dimen.minor_100))
+                        modifier = Modifier.padding(bottom = WooTheme.padding.padding5),
                     )
-
                     CampaignStat(
                         statName = stringResource(campaign.budgetLabel),
-                        statValue = campaign.formattedBudget
+                        statValue = campaign.formattedBudget,
                     )
                 }
             }
@@ -97,24 +100,42 @@ fun BlazeCampaignItem(
 }
 
 @Composable
+private fun BlazeStatusTag(
+    text: String,
+    textColor: Color,
+    backgroundColor: Color,
+) {
+    Text(
+        text = text,
+        style = WooTheme.text.labelSmall.regular.copy(letterSpacing = 1.5.sp),
+        color = textColor,
+        modifier = Modifier
+            .clip(RoundedCornerShape(WooTheme.radius.small))
+            .background(backgroundColor)
+            .padding(
+                horizontal = WooTheme.padding.padding3 + WooTheme.padding.padding1,
+                vertical = WooTheme.padding.padding2,
+            ),
+    )
+}
+
+@Composable
 private fun CampaignStat(
     statName: String,
     statValue: String,
     modifier: Modifier = Modifier,
 ) {
-    Column(
-        modifier = modifier.padding(end = dimensionResource(id = R.dimen.major_100))
-    ) {
+    Column(modifier = modifier.padding(end = WooTheme.padding.padding5)) {
         Text(
             text = statName,
-            style = MaterialTheme.typography.body2,
-            color = colorResource(id = R.color.color_on_surface_medium_selector),
+            style = WooTheme.text.bodyMedium.regular,
+            color = WooTheme.colors.surface.onDefault,
         )
         Text(
-            modifier = Modifier
-                .padding(top = dimensionResource(id = R.dimen.minor_50)),
+            modifier = Modifier.padding(top = WooTheme.padding.padding2),
             text = statValue,
-            style = MaterialTheme.typography.h6,
+            style = WooTheme.text.titleLarge.strong,
+            color = WooTheme.colors.surface.onDefault,
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignListScreen.kt
@@ -121,7 +121,7 @@ private fun CampaignList(
         val listState = rememberLazyListState()
         LazyColumn(state = listState) {
             items(state.campaigns) { campaign ->
-                BlazeCampaignItem(
+                LegacyBlazeCampaignItem(
                     campaign = campaign.campaignUi,
                     onCampaignClicked = campaign.onCampaignClicked,
                 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/LegacyBlazeCampaignItem.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/LegacyBlazeCampaignItem.kt
@@ -1,0 +1,120 @@
+package com.woocommerce.android.ui.blaze.campaigs
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.blaze.BlazeCampaignUi
+import com.woocommerce.android.ui.compose.component.ProductThumbnail
+import com.woocommerce.android.ui.compose.component.WCTag
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun LegacyBlazeCampaignItem(
+    campaign: BlazeCampaignUi,
+    onCampaignClicked: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .border(
+                width = dimensionResource(id = R.dimen.minor_10),
+                color = colorResource(R.color.divider_color),
+                shape = RoundedCornerShape(dimensionResource(id = R.dimen.minor_100))
+            )
+            .clip(shape = RoundedCornerShape(dimensionResource(id = R.dimen.minor_100)))
+            .clickable { onCampaignClicked() }
+            .padding(dimensionResource(id = R.dimen.major_100))
+    ) {
+        Row(verticalAlignment = Alignment.Top) {
+            ProductThumbnail(imageUrl = campaign.product.imgUrl)
+            Column(
+                modifier = Modifier
+                    .padding(start = dimensionResource(id = R.dimen.major_100))
+                    .weight(1f),
+            ) {
+                campaign.status?.let {
+                    WCTag(
+                        text = stringResource(id = campaign.status.statusDisplayText).uppercase(),
+                        textColor = colorResource(id = campaign.status.textColor),
+                        backgroundColor = colorResource(id = campaign.status.backgroundColor),
+                        textStyle = MaterialTheme.typography.caption.copy(
+                            letterSpacing = 1.5.sp
+                        )
+                    )
+                }
+
+                Text(
+                    modifier = Modifier
+                        .padding(top = dimensionResource(id = R.dimen.minor_50)),
+                    text = campaign.product.name,
+                    style = MaterialTheme.typography.subtitle1,
+                    fontWeight = FontWeight.Bold,
+                )
+                FlowRow(
+                    modifier = Modifier
+                        .padding(top = dimensionResource(id = R.dimen.major_100))
+                        .wrapContentWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    CampaignStat(
+                        statName = stringResource(R.string.blaze_campaign_status_ctr_label),
+                        statValue = stringResource(
+                            id = R.string.blaze_campaign_status_ctr_value_shortened,
+                            campaign.impressions,
+                            campaign.clicks,
+                        ),
+                        modifier = Modifier.padding(bottom = dimensionResource(id = R.dimen.minor_100))
+                    )
+
+                    CampaignStat(
+                        statName = stringResource(campaign.budgetLabel),
+                        statValue = campaign.formattedBudget
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CampaignStat(
+    statName: String,
+    statValue: String,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.padding(end = dimensionResource(id = R.dimen.major_100))
+    ) {
+        Text(
+            text = statName,
+            style = MaterialTheme.typography.body2,
+            color = colorResource(id = R.color.color_on_surface_medium_selector),
+        )
+        Text(
+            modifier = Modifier
+                .padding(top = dimensionResource(id = R.dimen.minor_50)),
+            text = statValue,
+            style = MaterialTheme.typography.h6,
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
@@ -2,9 +2,7 @@ package com.woocommerce.android.ui.dashboard
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -92,7 +90,7 @@ fun DashboardContainer(
             onDashboardInteracted = dashboardViewModel::onDashboardInteracted,
         ) { widget, modifier ->
             DashboardWidgetCard(
-                it = widget,
+                widget = widget,
                 mainActivityViewModel = mainActivityViewModel,
                 dashboardViewModel = dashboardViewModel,
                 blazeCampaignCreationDispatcher = blazeCampaignCreationDispatcher,
@@ -115,7 +113,10 @@ private fun DashboardLayout(
     BoxWithConstraints(
         modifier = Modifier.fillMaxSize(),
     ) {
-        val boxWithConstraintsScope = this
+        val numberOfColumns = calculateColumnNumber(
+            availableWidthInDp = maxWidth - WooTheme.padding.padding7 * 2,
+            visibleWidgetsCount = widgets.count { widget -> widget.isVisible },
+        )
         PullToRefreshBox(
             isRefreshing = isRefreshing,
             onRefresh = onPullToRefresh,
@@ -131,18 +132,13 @@ private fun DashboardLayout(
                 )
             },
         ) {
-            DashboardWidgets(
+            DashboardWidgetLayout(
                 widgetUiModels = widgets,
                 scrollToTopTrigger = scrollToTopTrigger,
                 onDashboardInteracted = onDashboardInteracted,
                 widgetContent = widgetContent,
-                modifier = Modifier
-                    .fillMaxSize()
-                    .background(WooTheme.colors.background.section),
-                numberOfColumns = calculateColumnNumber(
-                    availableWidthInDp = boxWithConstraintsScope.maxWidth - WooTheme.padding.padding7 * 2,
-                    visibleWidgetsCount = widgets.count { widget -> widget.isVisible },
-                ),
+                modifier = Modifier.fillMaxSize(),
+                numberOfColumns = numberOfColumns,
             )
         }
     }
@@ -150,7 +146,7 @@ private fun DashboardLayout(
 
 @OptIn(FlowPreview::class)
 @Composable
-private fun DashboardWidgets(
+private fun DashboardWidgetLayout(
     widgetUiModels: List<DashboardWidgetUiModel>,
     scrollToTopTrigger: Flow<Unit>,
     onDashboardInteracted: () -> Unit,
@@ -160,6 +156,10 @@ private fun DashboardWidgets(
 ) {
     val nestedScrollInterop = rememberNestedScrollInteropConnection()
     val scrollState = rememberScrollState()
+    val scrollModifier = modifier
+        .nestedScroll(nestedScrollInterop)
+        .verticalScroll(scrollState)
+        .padding(WooTheme.padding.padding7)
 
     LaunchedEffect(Unit) {
         scrollToTopTrigger.collect {
@@ -176,10 +176,7 @@ private fun DashboardWidgets(
 
     if (numberOfColumns == 1) {
         Column(
-            modifier = modifier
-                .nestedScroll(nestedScrollInterop)
-                .verticalScroll(scrollState)
-                .padding(WooTheme.padding.padding7),
+            modifier = scrollModifier,
             verticalArrangement = Arrangement.spacedBy(WooTheme.spacing.space7),
         ) {
             widgetUiModels.forEach { widget ->
@@ -195,23 +192,17 @@ private fun DashboardWidgets(
             numberOfColumns = numberOfColumns,
             visibleUiWidgets = widgetUiModels.filter { widget -> widget.isVisible },
         )
-        Box(
-            modifier = modifier
-                .nestedScroll(nestedScrollInterop)
-                .verticalScroll(scrollState)
-                .padding(WooTheme.padding.padding7),
+        Row(
+            modifier = scrollModifier,
+            horizontalArrangement = Arrangement.spacedBy(WooTheme.spacing.space5),
         ) {
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(WooTheme.spacing.space5)
-            ) {
-                widgetColumns.forEach { columnWidgets ->
-                    Column(
-                        modifier = Modifier.weight(1f),
-                        verticalArrangement = Arrangement.spacedBy(WooTheme.spacing.space7),
-                    ) {
-                        columnWidgets.forEach { widget ->
-                            widgetContent(widget, Modifier.fillMaxWidth())
-                        }
+            widgetColumns.forEach { columnWidgets ->
+                Column(
+                    modifier = Modifier.weight(1f),
+                    verticalArrangement = Arrangement.spacedBy(WooTheme.spacing.space7),
+                ) {
+                    columnWidgets.forEach { widget ->
+                        widgetContent(widget, Modifier.fillMaxWidth())
                     }
                 }
             }
@@ -236,7 +227,7 @@ private fun calculateColumnNumber(
 private fun splitWidgetsIntoColumns(
     numberOfColumns: Int,
     visibleUiWidgets: List<DashboardWidgetUiModel>
-): MutableList<MutableList<DashboardWidgetUiModel>> {
+): List<List<DashboardWidgetUiModel>> {
     val widgetColumns = MutableList<MutableList<DashboardWidgetUiModel>>(numberOfColumns) { mutableListOf() }
     for ((index, widget) in visibleUiWidgets.withIndex()) {
         widgetColumns[index % numberOfColumns].add(widget)
@@ -253,16 +244,16 @@ private fun DashboardWidgetUiModel.stableKey(): Any = when (this) {
 
 @Composable
 private fun DashboardWidgetCard(
-    it: DashboardWidgetUiModel,
+    widget: DashboardWidgetUiModel,
     mainActivityViewModel: MainActivityViewModel,
     dashboardViewModel: DashboardViewModel,
     blazeCampaignCreationDispatcher: BlazeCampaignCreationDispatcher,
     modifier: Modifier
 ) {
-    when (it) {
+    when (widget) {
         is ConfigurableWidget -> {
             ConfigurableWidgetCard(
-                widgetUiModel = it,
+                widgetUiModel = widget,
                 mainActivityViewModel = mainActivityViewModel,
                 dashboardViewModel = dashboardViewModel,
                 blazeCampaignCreationDispatcher = blazeCampaignCreationDispatcher,
@@ -272,21 +263,21 @@ private fun DashboardWidgetCard(
 
         is ShareStoreWidget -> {
             ShareStoreCard(
-                onShareClicked = it.onShareClicked,
+                onShareClicked = widget.onShareClicked,
                 modifier = modifier
             )
         }
 
         is FeedbackWidget -> {
             FeedbackCard(
-                widget = it,
+                widget = widget,
                 modifier = modifier
             )
         }
 
         is NewWidgetsCard -> {
             NewWidgetsCard(
-                state = it,
+                state = widget,
                 modifier = modifier
             )
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
@@ -3,7 +3,6 @@ package com.woocommerce.android.ui.dashboard
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -15,14 +14,11 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
-import androidx.compose.material.pullrefresh.PullRefreshIndicator
-import androidx.compose.material.pullrefresh.pullRefresh
-import androidx.compose.material.pullrefresh.rememberPullRefreshState
+import androidx.compose.material3.Text
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.key
@@ -32,20 +28,23 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
-import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.model.DashboardWidget
 import com.woocommerce.android.ui.blaze.creation.BlazeCampaignCreationDispatcher
-import com.woocommerce.android.ui.compose.component.WCColoredButton
-import com.woocommerce.android.ui.compose.component.WCOutlinedButton
-import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardCardsState
+import com.woocommerce.android.ui.compose.designsystem.WooTheme
+import com.woocommerce.android.ui.compose.designsystem.component.WooDivider
+import com.woocommerce.android.ui.compose.designsystem.component.WooFilledButton
+import com.woocommerce.android.ui.compose.designsystem.component.WooOutlinedButton
+import com.woocommerce.android.ui.compose.designsystem.foundation.WooDesignSystemThemeWithBackground
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.OpenRangePicker
+import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetMenu
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetUiModel
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetUiModel.ConfigurableWidget
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetUiModel.FeedbackWidget
@@ -58,20 +57,25 @@ import com.woocommerce.android.ui.dashboard.google.DashboardGoogleAdsCard
 import com.woocommerce.android.ui.dashboard.inbox.DashboardInboxCard
 import com.woocommerce.android.ui.dashboard.onboarding.DashboardOnboardingCard
 import com.woocommerce.android.ui.dashboard.orders.DashboardOrdersCard
+import com.woocommerce.android.ui.dashboard.orders.DashboardOrdersViewModel.ViewState.OrderItem
+import com.woocommerce.android.ui.dashboard.orders.TopOrders
 import com.woocommerce.android.ui.dashboard.pushnotifications.DashboardPushNotificationsCard
 import com.woocommerce.android.ui.dashboard.reviews.DashboardReviewsCard
 import com.woocommerce.android.ui.dashboard.stats.DashboardStatsCard
 import com.woocommerce.android.ui.dashboard.stock.DashboardProductStockCard
+import com.woocommerce.android.ui.dashboard.stock.StockEmptyView
 import com.woocommerce.android.ui.dashboard.topperformers.DashboardTopPerformersWidgetCard
+import com.woocommerce.android.ui.dashboard.topperformers.TopPerformerSkeletonItem
 import com.woocommerce.android.ui.main.MainActivityViewModel
+import com.woocommerce.android.ui.orders.filters.data.OrderStatusOption
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.emptyFlow
 
 private const val SCROLL_INTERACTION_DEBOUNCE_MS = 1000L
 
-@OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun DashboardContainer(
     mainActivityViewModel: MainActivityViewModel,
@@ -80,30 +84,65 @@ fun DashboardContainer(
     scrollToTopTrigger: Flow<Unit>,
 ) {
     dashboardViewModel.dashboardCardsState.observeAsState().value?.let { state ->
-        val pullRefreshState = rememberPullRefreshState(state.isRefreshing, dashboardViewModel::onPullToRefresh)
-        BoxWithConstraints(
-            modifier = Modifier
-                .pullRefresh(pullRefreshState)
-                .fillMaxSize()
-        ) {
-            val boxWithConstraintsScope = this
-            DashboardWidgets(
-                widgetUiModels = state.widgets,
+        DashboardLayout(
+            widgets = state.widgets,
+            isRefreshing = state.isRefreshing,
+            onPullToRefresh = dashboardViewModel::onPullToRefresh,
+            scrollToTopTrigger = scrollToTopTrigger,
+            onDashboardInteracted = dashboardViewModel::onDashboardInteracted,
+        ) { widget, modifier ->
+            DashboardWidgetCard(
+                it = widget,
                 mainActivityViewModel = mainActivityViewModel,
                 dashboardViewModel = dashboardViewModel,
                 blazeCampaignCreationDispatcher = blazeCampaignCreationDispatcher,
+                modifier = modifier,
+            )
+        }
+    }
+}
+
+@Composable
+private fun DashboardLayout(
+    widgets: List<DashboardWidgetUiModel>,
+    isRefreshing: Boolean,
+    onPullToRefresh: () -> Unit,
+    scrollToTopTrigger: Flow<Unit>,
+    onDashboardInteracted: () -> Unit,
+    widgetContent: @Composable (DashboardWidgetUiModel, Modifier) -> Unit,
+) {
+    val pullRefreshState = rememberPullToRefreshState()
+    BoxWithConstraints(
+        modifier = Modifier.fillMaxSize(),
+    ) {
+        val boxWithConstraintsScope = this
+        PullToRefreshBox(
+            isRefreshing = isRefreshing,
+            onRefresh = onPullToRefresh,
+            state = pullRefreshState,
+            modifier = Modifier.fillMaxSize(),
+            indicator = {
+                PullToRefreshDefaults.Indicator(
+                    state = pullRefreshState,
+                    isRefreshing = isRefreshing,
+                    modifier = Modifier.align(Alignment.TopCenter),
+                    containerColor = WooTheme.colors.surface.default,
+                    color = WooTheme.colors.primary,
+                )
+            },
+        ) {
+            DashboardWidgets(
+                widgetUiModels = widgets,
                 scrollToTopTrigger = scrollToTopTrigger,
+                onDashboardInteracted = onDashboardInteracted,
+                widgetContent = widgetContent,
                 modifier = Modifier
                     .fillMaxSize()
-                    .background(MaterialTheme.colors.surface)
-                    .padding(horizontal = 16.dp),
-                numberOfColumns = calculateColumnNumber(boxWithConstraintsScope.maxWidth, state)
-            )
-            PullRefreshIndicator(
-                refreshing = state.isRefreshing,
-                state = pullRefreshState,
-                modifier = Modifier.align(Alignment.TopCenter),
-                contentColor = MaterialTheme.colors.primary,
+                    .background(WooTheme.colors.background.section),
+                numberOfColumns = calculateColumnNumber(
+                    availableWidthInDp = boxWithConstraintsScope.maxWidth - WooTheme.padding.padding7 * 2,
+                    visibleWidgetsCount = widgets.count { widget -> widget.isVisible },
+                ),
             )
         }
     }
@@ -113,12 +152,11 @@ fun DashboardContainer(
 @Composable
 private fun DashboardWidgets(
     widgetUiModels: List<DashboardWidgetUiModel>,
-    mainActivityViewModel: MainActivityViewModel,
-    dashboardViewModel: DashboardViewModel,
-    blazeCampaignCreationDispatcher: BlazeCampaignCreationDispatcher,
     scrollToTopTrigger: Flow<Unit>,
+    onDashboardInteracted: () -> Unit,
+    widgetContent: @Composable (DashboardWidgetUiModel, Modifier) -> Unit,
     modifier: Modifier = Modifier,
-    numberOfColumns: Int = 1
+    numberOfColumns: Int = 1,
 ) {
     val nestedScrollInterop = rememberNestedScrollInteropConnection()
     val scrollState = rememberScrollState()
@@ -133,59 +171,46 @@ private fun DashboardWidgets(
         snapshotFlow { scrollState.value }
             .drop(1) // Ignore the initial value emitted on composition
             .debounce(SCROLL_INTERACTION_DEBOUNCE_MS)
-            .collect { dashboardViewModel.onDashboardInteracted() }
+            .collect { onDashboardInteracted() }
     }
 
     if (numberOfColumns == 1) {
         Column(
             modifier = modifier
                 .nestedScroll(nestedScrollInterop)
-                .verticalScroll(scrollState),
-            verticalArrangement = Arrangement.spacedBy(16.dp),
+                .verticalScroll(scrollState)
+                .padding(WooTheme.padding.padding7),
+            verticalArrangement = Arrangement.spacedBy(WooTheme.spacing.space7),
         ) {
-            Spacer(modifier = Modifier)
             widgetUiModels.forEach { widget ->
                 key(widget.stableKey()) {
                     AnimatedVisibility(widget.isVisible) {
-                        DashboardWidgetCard(
-                            it = widget,
-                            mainActivityViewModel = mainActivityViewModel,
-                            dashboardViewModel = dashboardViewModel,
-                            blazeCampaignCreationDispatcher = blazeCampaignCreationDispatcher,
-                            modifier = Modifier.fillMaxWidth()
-                        )
+                        widgetContent(widget, Modifier.fillMaxWidth())
                     }
                 }
             }
-            Spacer(modifier = Modifier)
         }
     } else {
         val widgetColumns = splitWidgetsIntoColumns(
             numberOfColumns = numberOfColumns,
-            visibleUiWidgets = widgetUiModels.filter { it.isVisible }
+            visibleUiWidgets = widgetUiModels.filter { widget -> widget.isVisible },
         )
         Box(
             modifier = modifier
                 .nestedScroll(nestedScrollInterop)
                 .verticalScroll(scrollState)
-                .padding(bottom = 16.dp)
+                .padding(WooTheme.padding.padding7),
         ) {
             Row(
-                horizontalArrangement = Arrangement.spacedBy(16.dp)
+                horizontalArrangement = Arrangement.spacedBy(WooTheme.spacing.space5)
             ) {
-                widgetColumns.forEachIndexed { columnIndex, columnWidgets ->
+                widgetColumns.forEach { columnWidgets ->
                     Column(
                         modifier = Modifier.weight(1f),
-                        verticalArrangement = Arrangement.spacedBy(16.dp)
+                        verticalArrangement = Arrangement.spacedBy(WooTheme.spacing.space7),
                     ) {
                         columnWidgets.forEach { widget ->
-                            DashboardWidgetCard(
-                                it = widget,
-                                mainActivityViewModel = mainActivityViewModel,
-                                dashboardViewModel = dashboardViewModel,
-                                blazeCampaignCreationDispatcher = blazeCampaignCreationDispatcher,
-                                modifier = Modifier.fillMaxWidth()
-                            )
+                            widgetContent(widget, Modifier.fillMaxWidth())
                         }
                     }
                 }
@@ -197,7 +222,7 @@ private fun DashboardWidgets(
 @Suppress("MagicNumber")
 private fun calculateColumnNumber(
     availableWidthInDp: Dp,
-    state: DashboardCardsState
+    visibleWidgetsCount: Int,
 ): Int {
     val columns = when {
         availableWidthInDp < 600.dp -> 1 // 600dp covers 99.96% of phones in portrait
@@ -205,7 +230,6 @@ private fun calculateColumnNumber(
         else -> 3 // 3 columns should only display on tablets in landscape
     }
 
-    val visibleWidgetsCount = state.widgets.count { it.isVisible }
     return columns.coerceAtMost(maximumValue = maxOf(visibleWidgetsCount, 1))
 }
 
@@ -214,8 +238,8 @@ private fun splitWidgetsIntoColumns(
     visibleUiWidgets: List<DashboardWidgetUiModel>
 ): MutableList<MutableList<DashboardWidgetUiModel>> {
     val widgetColumns = MutableList<MutableList<DashboardWidgetUiModel>>(numberOfColumns) { mutableListOf() }
-    for ((index, item) in visibleUiWidgets.withIndex()) {
-        widgetColumns[index % numberOfColumns].add(item)
+    for ((index, widget) in visibleUiWidgets.withIndex()) {
+        widgetColumns[index % numberOfColumns].add(widget)
     }
     return widgetColumns
 }
@@ -361,36 +385,35 @@ private fun ShareStoreCard(
     onShareClicked: () -> Unit,
     modifier: Modifier
 ) {
-    Column(
-        horizontalAlignment = Alignment.CenterHorizontally,
-        modifier = modifier
-            .border(
-                width = 1.dp,
-                color = colorResource(id = R.color.woo_gray_5),
-                shape = RoundedCornerShape(8.dp)
+    DashboardCardSurface(modifier = modifier) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier.padding(WooTheme.padding.padding5),
+        ) {
+            Image(
+                painter = painterResource(id = R.drawable.blaze_campaign_created_success),
+                contentDescription = null,
             )
-            .padding(16.dp)
-    ) {
-        Image(
-            painter = painterResource(id = R.drawable.blaze_campaign_created_success),
-            contentDescription = null
-        )
-        Spacer(modifier = Modifier.height(24.dp))
-        Text(
-            text = stringResource(id = R.string.get_the_word_out),
-            style = MaterialTheme.typography.h6,
-            textAlign = TextAlign.Center
-        )
-        Spacer(modifier = Modifier.height(8.dp))
-        Text(
-            text = stringResource(id = R.string.share_your_store_message),
-            textAlign = TextAlign.Center
-        )
-        Spacer(modifier = Modifier.height(16.dp))
-        WCColoredButton(
-            onClick = onShareClicked,
-            text = stringResource(id = R.string.share_store_button)
-        )
+            Spacer(modifier = Modifier.height(WooTheme.spacing.space7))
+            Text(
+                text = stringResource(id = R.string.get_the_word_out),
+                style = WooTheme.text.titleLarge.strong,
+                color = WooTheme.colors.surface.onDefault,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(modifier = Modifier.height(WooTheme.spacing.space3))
+            Text(
+                text = stringResource(id = R.string.share_your_store_message),
+                style = WooTheme.text.bodyLarge.regular,
+                color = WooTheme.colors.surface.onDefault,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(modifier = Modifier.height(WooTheme.spacing.space5))
+            WooFilledButton(
+                onClick = onShareClicked,
+                text = stringResource(id = R.string.share_store_button),
+            )
+        }
     }
 }
 
@@ -403,37 +426,33 @@ private fun FeedbackCard(
         widget.onShown()
     }
 
-    Column(
-        horizontalAlignment = Alignment.CenterHorizontally,
-        modifier = modifier
-            .border(
-                width = 1.dp,
-                color = colorResource(id = R.color.woo_gray_5),
-                shape = RoundedCornerShape(8.dp)
-            )
-            .padding(16.dp)
-    ) {
-        Text(
-            text = stringResource(id = R.string.feedback_request_title),
-            style = MaterialTheme.typography.body1,
-            fontWeight = FontWeight.SemiBold,
-            modifier = Modifier.padding(top = 8.dp)
-        )
-        Spacer(modifier = Modifier.height(16.dp))
-        Row(
-            horizontalArrangement = Arrangement.spacedBy(16.dp),
-            modifier = Modifier.fillMaxWidth()
+    DashboardCardSurface(modifier = modifier) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier.padding(WooTheme.padding.padding5),
         ) {
-            WCOutlinedButton(
-                onClick = widget.onNegativeClick,
-                text = stringResource(id = R.string.feedback_request_make_better),
-                modifier = Modifier.weight(1f)
+            Text(
+                text = stringResource(id = R.string.feedback_request_title),
+                style = WooTheme.text.bodyLarge.emphasized,
+                color = WooTheme.colors.surface.onDefault,
+                modifier = Modifier.padding(top = WooTheme.padding.padding3),
             )
-            WCColoredButton(
-                onClick = widget.onPositiveClick,
-                text = stringResource(id = R.string.feedback_request_like_it),
-                modifier = Modifier.weight(1f)
-            )
+            Spacer(modifier = Modifier.height(WooTheme.spacing.space5))
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(WooTheme.spacing.space5),
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                WooOutlinedButton(
+                    onClick = widget.onNegativeClick,
+                    text = stringResource(id = R.string.feedback_request_make_better),
+                    modifier = Modifier.weight(1f),
+                )
+                WooFilledButton(
+                    onClick = widget.onPositiveClick,
+                    text = stringResource(id = R.string.feedback_request_like_it),
+                    modifier = Modifier.weight(1f),
+                )
+            }
         }
     }
 }
@@ -443,30 +462,137 @@ private fun NewWidgetsCard(
     state: NewWidgetsCard,
     modifier: Modifier
 ) {
-    Column(
-        horizontalAlignment = Alignment.CenterHorizontally,
-        modifier = modifier
-            .border(
-                width = 1.dp,
-                color = colorResource(id = R.color.woo_gray_5),
-                shape = RoundedCornerShape(8.dp)
+    DashboardCardSurface(modifier = modifier) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier.padding(WooTheme.padding.padding5),
+        ) {
+            Text(
+                text = stringResource(R.string.dashboard_new_widgets_card_title),
+                style = WooTheme.text.titleLarge.strong,
+                color = WooTheme.colors.surface.onDefault,
+                textAlign = TextAlign.Center,
             )
-            .padding(16.dp)
-    ) {
-        Text(
-            text = stringResource(R.string.dashboard_new_widgets_card_title),
-            style = MaterialTheme.typography.h6,
-            textAlign = TextAlign.Center
-        )
-        Spacer(modifier = Modifier.height(8.dp))
-        Text(
-            text = stringResource(R.string.dashboard_new_widgets_card_description),
-            textAlign = TextAlign.Center
-        )
-        Spacer(modifier = Modifier.height(16.dp))
-        WCColoredButton(
-            onClick = state.onShowCardsClick,
-            text = stringResource(id = R.string.dashboard_new_widgets_card_button)
-        )
+            Spacer(modifier = Modifier.height(WooTheme.spacing.space3))
+            Text(
+                text = stringResource(R.string.dashboard_new_widgets_card_description),
+                style = WooTheme.text.bodyLarge.regular,
+                color = WooTheme.colors.surface.onDefault,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(modifier = Modifier.height(WooTheme.spacing.space5))
+            WooFilledButton(
+                onClick = state.onShowCardsClick,
+                text = stringResource(id = R.string.dashboard_new_widgets_card_button),
+            )
+        }
     }
 }
+
+@PreviewLightDark
+@Preview(name = "Dashboard large font", fontScale = 2f)
+@Preview(name = "Dashboard RTL", locale = "ar")
+@Composable
+private fun DashboardLayoutPreview() {
+    WooDesignSystemThemeWithBackground {
+        DashboardLayout(
+            widgets = previewWidgets,
+            isRefreshing = false,
+            onPullToRefresh = {},
+            scrollToTopTrigger = emptyFlow(),
+            onDashboardInteracted = {},
+        ) { widget, modifier ->
+            DashboardPreviewCardContent(widget = widget, modifier = modifier)
+        }
+    }
+}
+
+@Composable
+private fun DashboardPreviewCardContent(
+    widget: DashboardWidgetUiModel,
+    modifier: Modifier,
+) {
+    val menu = DashboardWidgetMenu(emptyList())
+    val widgetType = (widget as ConfigurableWidget).widget.type
+    when (widgetType) {
+        DashboardWidget.Type.ORDERS -> WidgetCard(
+            titleResource = DashboardWidget.Type.ORDERS.titleResource,
+            menu = menu,
+            isError = false,
+            modifier = modifier,
+        ) {
+            TopOrders(
+                selectedFilter = previewOrderFilter,
+                filterOptions = listOf(previewOrderFilter),
+                onFilterSelected = {},
+                orders = previewOrders,
+                onOrderClicked = {},
+            )
+        }
+
+        DashboardWidget.Type.POPULAR_PRODUCTS -> WidgetCard(
+            titleResource = DashboardWidget.Type.POPULAR_PRODUCTS.titleResource,
+            menu = menu,
+            isError = false,
+            modifier = modifier,
+        ) {
+            Column(modifier = Modifier.padding(horizontal = WooTheme.padding.padding5)) {
+                repeat(3) {
+                    TopPerformerSkeletonItem()
+                    if (it < 2) {
+                        WooDivider()
+                    }
+                }
+            }
+        }
+
+        DashboardWidget.Type.STOCK -> WidgetCard(
+            titleResource = DashboardWidget.Type.STOCK.titleResource,
+            menu = menu,
+            isError = false,
+            modifier = modifier,
+        ) {
+            StockEmptyView()
+        }
+
+        DashboardWidget.Type.REVIEWS -> WidgetCard(
+            titleResource = DashboardWidget.Type.REVIEWS.titleResource,
+            menu = menu,
+            isError = true,
+            modifier = modifier,
+        ) {
+            WidgetError(onContactSupportClicked = {}, onRetryClicked = {})
+        }
+
+        else -> error("Unsupported preview widget type: $widgetType")
+    }
+}
+
+private val previewWidgets = listOf(
+    DashboardWidget.Type.ORDERS,
+    DashboardWidget.Type.POPULAR_PRODUCTS,
+    DashboardWidget.Type.STOCK,
+    DashboardWidget.Type.REVIEWS,
+).map { type ->
+    ConfigurableWidget(DashboardWidget(type, true, DashboardWidget.Status.Available))
+}
+
+private val previewOrderFilter = OrderStatusOption(
+    key = "processing",
+    label = "Processing",
+    statusCount = 1,
+    isSelected = true,
+)
+
+private val previewOrders = listOf(
+    OrderItem(
+        id = 2L,
+        number = "#1041",
+        date = "Yesterday",
+        customerName = "A deliberately long customer name for font scaling",
+        status = "Completed",
+        statusColor = R.color.tag_bg_completed,
+        totalPrice = "$86.00",
+        isPosOrder = true,
+    ),
+)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardDateRangeHeader.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardDateRangeHeader.kt
@@ -9,13 +9,10 @@ import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.material.ContentAlpha
-import androidx.compose.material.DropdownMenu
-import androidx.compose.material.DropdownMenuItem
-import androidx.compose.material.Icon
-import androidx.compose.material.IconButton
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -25,17 +22,17 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
-import com.woocommerce.android.R.dimen
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType
-import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.compose.designsystem.WooTheme
+import com.woocommerce.android.ui.compose.designsystem.component.WooIconButton
+import com.woocommerce.android.ui.compose.designsystem.foundation.WooDesignSystemThemeWithBackground
 import com.woocommerce.android.ui.dashboard.stats.DashboardStatsTestTags
 import java.util.Calendar
 import java.util.Date
@@ -50,35 +47,35 @@ fun DashboardDateRangeHeader(
     modifier: Modifier = Modifier
 ) {
     Row(
-        horizontalArrangement = Arrangement.spacedBy(dimensionResource(id = dimen.minor_100)),
+        horizontalArrangement = Arrangement.spacedBy(WooTheme.spacing.space3),
         verticalAlignment = Alignment.CenterVertically,
         modifier = modifier.padding(
-            start = dimensionResource(id = dimen.major_100)
+            start = WooTheme.padding.padding5,
         )
     ) {
         Text(
             text = rangeSelection.selectionType.title,
-            style = MaterialTheme.typography.body2,
-            color = MaterialTheme.colors.onSurface
+            style = WooTheme.text.bodyMedium.regular,
+            color = WooTheme.colors.surface.onDefault,
         )
 
         val isCustomRange = rangeSelection.selectionType == SelectionType.CUSTOM
         Row(
-            horizontalArrangement = Arrangement.spacedBy(dimensionResource(id = dimen.minor_100)),
+            horizontalArrangement = Arrangement.spacedBy(WooTheme.spacing.space3),
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier
                 .weight(1f)
                 .wrapContentSize(align = Alignment.CenterStart)
                 .then(if (isCustomRange) Modifier.clickable(onClick = onCustomRangeClick) else Modifier)
-                .padding(dimensionResource(id = dimen.minor_100))
+                .padding(WooTheme.padding.padding3)
         ) {
             Text(
                 text = dateFormatted,
-                style = MaterialTheme.typography.body2,
+                style = WooTheme.text.bodyMedium.regular,
                 color = if (isCustomRange) {
-                    MaterialTheme.colors.primary
+                    WooTheme.colors.container.onSecondaryContainer
                 } else {
-                    MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.medium)
+                    WooTheme.colors.surface.onDefault
                 },
                 modifier = Modifier.weight(1f, fill = false)
             )
@@ -86,67 +83,75 @@ fun DashboardDateRangeHeader(
                 Icon(
                     painter = painterResource(id = R.drawable.ic_edit_pencil),
                     contentDescription = null,
-                    tint = MaterialTheme.colors.primary,
-                    modifier = Modifier.size(dimensionResource(id = dimen.image_minor_40))
+                    tint = WooTheme.colors.container.onSecondaryContainer,
+                    modifier = Modifier.size(WooTheme.iconSize.size20),
                 )
             }
         }
 
         Box {
             var isMenuExpanded by remember { mutableStateOf(false) }
-            IconButton(
+            WooIconButton(
                 onClick = { isMenuExpanded = true },
-                modifier = Modifier.testTag(DashboardStatsTestTags.STATS_RANGE_DROPDOWN_BUTTON)
+                contentDescription = stringResource(
+                    id = R.string.dashboard_stats_edit_granularity_content_description
+                ),
+                modifier = Modifier.testTag(DashboardStatsTestTags.STATS_RANGE_DROPDOWN_BUTTON),
             ) {
                 Icon(
                     imageVector = ImageVector.vectorResource(R.drawable.ic_date_range_24dp),
-                    contentDescription = stringResource(
-                        id = R.string.dashboard_stats_edit_granularity_content_description
-                    ),
-                    tint = MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.medium)
+                    contentDescription = null,
                 )
             }
 
             DropdownMenu(
                 expanded = isMenuExpanded,
                 onDismissRequest = { isMenuExpanded = false },
+                containerColor = WooTheme.colors.surface.default,
                 modifier = Modifier
                     .defaultMinSize(minWidth = 250.dp)
                     .testTag(DashboardStatsTestTags.STATS_RANGE_DROPDOWN_MENU)
             ) {
                 DashboardViewModel.SUPPORTED_RANGES_ON_MY_STORE_TAB.forEach {
                     DropdownMenuItem(
+                        text = {
+                            Row(
+                                horizontalArrangement = Arrangement.spacedBy(WooTheme.spacing.space3),
+                            ) {
+                                Text(
+                                    text = it.title,
+                                    style = WooTheme.text.bodyLarge.regular,
+                                    color = WooTheme.colors.surface.onDefault,
+                                )
+                                Spacer(modifier = Modifier.weight(1f))
+                                if (rangeSelection.selectionType == it) {
+                                    Icon(
+                                        imageVector = ImageVector.vectorResource(R.drawable.ic_menu_check),
+                                        contentDescription = stringResource(
+                                            id = androidx.compose.ui.R.string.selected
+                                        ),
+                                        tint = WooTheme.colors.primary,
+                                    )
+                                } else {
+                                    Spacer(modifier = Modifier.size(WooTheme.iconSize.size24))
+                                }
+                            }
+                        },
                         onClick = {
                             onTabSelected(it)
                             isMenuExpanded = false
-                        }
-                    ) {
-                        Row(
-                            horizontalArrangement = Arrangement.spacedBy(dimensionResource(dimen.minor_100))
-                        ) {
-                            Text(text = it.title)
-                            Spacer(modifier = Modifier.weight(1f))
-                            if (rangeSelection.selectionType == it) {
-                                Icon(
-                                    imageVector = ImageVector.vectorResource(R.drawable.ic_menu_check),
-                                    contentDescription = stringResource(id = androidx.compose.ui.R.string.selected),
-                                    tint = MaterialTheme.colors.primary
-                                )
-                            } else {
-                                Spacer(modifier = Modifier.size(dimensionResource(dimen.image_minor_50)))
-                            }
-                        }
-                    }
+                        },
+                    )
                 }
             }
         }
     }
 }
 
-@Preview
+@PreviewLightDark
 @Composable
 fun DashboardDateRangeHeaderPreview() {
-    WooThemeWithBackground {
+    WooDesignSystemThemeWithBackground {
         DashboardDateRangeHeader(
             rangeSelection = SelectionType.TODAY.generateSelectionData(
                 Date(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardDesignSystem.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardDesignSystem.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -40,7 +41,7 @@ internal fun DashboardCardSurface(
     onClick: (() -> Unit)? = null,
     content: @Composable ColumnScope.() -> Unit,
 ) {
-    val shape = RoundedCornerShape(WooTheme.radius.extraLarge)
+    val shape = MaterialTheme.shapes.extraLarge
 
     if (onClick == null) {
         Surface(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardDesignSystem.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardDesignSystem.kt
@@ -1,0 +1,155 @@
+package com.woocommerce.android.ui.dashboard
+
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.Dp
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.designsystem.WooTheme
+import com.woocommerce.android.ui.compose.designsystem.component.WooIconButton
+import com.woocommerce.android.ui.compose.designsystem.icons.Ellipsis
+import com.woocommerce.android.ui.compose.designsystem.icons.WooIcons
+
+@Composable
+internal fun DashboardCardSurface(
+    modifier: Modifier = Modifier,
+    onClick: (() -> Unit)? = null,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    val shape = RoundedCornerShape(WooTheme.radius.extraLarge)
+
+    if (onClick == null) {
+        Surface(
+            modifier = modifier,
+            shape = shape,
+            color = WooTheme.colors.surface.default,
+            contentColor = WooTheme.colors.surface.onDefault,
+            shadowElevation = WooTheme.spacing.space0,
+            tonalElevation = WooTheme.spacing.space0,
+            content = { Column(content = content) },
+        )
+    } else {
+        Surface(
+            onClick = onClick,
+            modifier = modifier,
+            shape = shape,
+            color = WooTheme.colors.surface.default,
+            contentColor = WooTheme.colors.surface.onDefault,
+            shadowElevation = WooTheme.spacing.space0,
+            tonalElevation = WooTheme.spacing.space0,
+            content = { Column(content = content) },
+        )
+    }
+}
+
+@Composable
+internal fun <T> DashboardOverflowMenu(
+    items: List<T>,
+    onSelected: (T) -> Unit,
+    mapper: @Composable (T) -> String,
+    modifier: Modifier = Modifier,
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    Box(modifier = modifier) {
+        WooIconButton(
+            imageVector = WooIcons.Regular.Ellipsis,
+            contentDescription = stringResource(R.string.more_options),
+            onClick = { expanded = true },
+        )
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+            containerColor = WooTheme.colors.surface.default,
+        ) {
+            items.forEach { item ->
+                DropdownMenuItem(
+                    text = {
+                        Text(
+                            text = mapper(item),
+                            style = WooTheme.text.bodyLarge.regular,
+                            color = WooTheme.colors.surface.onDefault,
+                        )
+                    },
+                    onClick = {
+                        expanded = false
+                        onSelected(item)
+                    },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+internal fun DashboardSkeleton(
+    width: Dp,
+    height: Dp,
+    modifier: Modifier = Modifier,
+) {
+    Spacer(
+        modifier = modifier
+            .width(width)
+            .height(height)
+            .background(
+                brush = dashboardSkeletonBrush(),
+                shape = RoundedCornerShape(WooTheme.radius.small),
+            ),
+    )
+}
+
+@Composable
+internal fun DashboardSkeleton(modifier: Modifier) {
+    Spacer(
+        modifier = modifier.background(
+            brush = dashboardSkeletonBrush(),
+            shape = RoundedCornerShape(WooTheme.radius.small),
+        ),
+    )
+}
+
+@Composable
+private fun dashboardSkeletonBrush(): Brush {
+    val baseColor = WooTheme.colors.stateLayers.onSurface.opacity16
+    val highlightColor = WooTheme.colors.stateLayers.onSurface.opacity24
+    val transition = rememberInfiniteTransition(label = "dashboard-skeleton-transition")
+    val translation by transition.animateFloat(
+        initialValue = 0f,
+        targetValue = 4000f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 1700, easing = FastOutSlowInEasing),
+            repeatMode = RepeatMode.Restart,
+        ),
+        label = "dashboard-skeleton-shimmer",
+    )
+
+    return Brush.linearGradient(
+        colors = listOf(baseColor, highlightColor, baseColor),
+        start = Offset(10f, 10f),
+        end = Offset(translation, translation),
+    )
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFilterableCardHeader.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFilterableCardHeader.kt
@@ -7,13 +7,10 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.material.ContentAlpha
-import androidx.compose.material.DropdownMenu
-import androidx.compose.material.DropdownMenuItem
-import androidx.compose.material.Icon
-import androidx.compose.material.IconButton
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -22,13 +19,14 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
-import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.compose.designsystem.WooTheme
+import com.woocommerce.android.ui.compose.designsystem.component.WooIconButton
+import com.woocommerce.android.ui.compose.designsystem.foundation.WooDesignSystemThemeWithBackground
 
 @Composable
 fun <T> DashboardFilterableCardHeader(
@@ -40,69 +38,75 @@ fun <T> DashboardFilterableCardHeader(
     mapper: @Composable (T) -> String = { it.toString() }
 ) {
     Row(
-        horizontalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.minor_100)),
+        horizontalArrangement = Arrangement.spacedBy(WooTheme.spacing.space3),
         verticalAlignment = Alignment.CenterVertically,
         modifier = modifier.padding(
-            start = dimensionResource(id = R.dimen.major_100)
+            start = WooTheme.padding.padding5,
         )
     ) {
         Text(
             text = title,
-            style = MaterialTheme.typography.body2,
-            color = MaterialTheme.colors.onSurface
+            style = WooTheme.text.bodyMedium.regular,
+            color = WooTheme.colors.surface.onDefault,
         )
 
         Text(
             text = mapper(currentFilter),
-            style = MaterialTheme.typography.body2,
-            color = MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.medium)
+            style = WooTheme.text.bodyMedium.regular,
+            color = WooTheme.colors.surface.onDefault,
         )
 
         Spacer(modifier = Modifier.weight(1f))
 
         Box {
             var isMenuExpanded by remember { mutableStateOf(false) }
-            IconButton(
-                onClick = { isMenuExpanded = true }
+            WooIconButton(
+                onClick = { isMenuExpanded = true },
+                contentDescription = stringResource(id = R.string.dashboard_filter_menu_content_description),
             ) {
                 Icon(
                     imageVector = ImageVector.vectorResource(R.drawable.ic_filter),
-                    contentDescription = stringResource(
-                        id = R.string.dashboard_filter_menu_content_description
-                    ),
-                    tint = MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.medium)
+                    contentDescription = null,
                 )
             }
 
             DropdownMenu(
                 expanded = isMenuExpanded,
                 onDismissRequest = { isMenuExpanded = false },
+                containerColor = WooTheme.colors.surface.default,
                 modifier = Modifier
                     .defaultMinSize(minWidth = 250.dp)
             ) {
                 filterList.forEach {
                     DropdownMenuItem(
+                        text = {
+                            Row(
+                                horizontalArrangement = Arrangement.spacedBy(WooTheme.spacing.space3),
+                            ) {
+                                Text(
+                                    text = mapper(it),
+                                    style = WooTheme.text.bodyLarge.regular,
+                                    color = WooTheme.colors.surface.onDefault,
+                                )
+                                Spacer(modifier = Modifier.weight(1f))
+                                if (currentFilter == it) {
+                                    Icon(
+                                        imageVector = ImageVector.vectorResource(R.drawable.ic_menu_check),
+                                        contentDescription = stringResource(
+                                            id = androidx.compose.ui.R.string.selected
+                                        ),
+                                        tint = WooTheme.colors.primary,
+                                    )
+                                } else {
+                                    Spacer(modifier = Modifier.size(WooTheme.iconSize.size24))
+                                }
+                            }
+                        },
                         onClick = {
                             onFilterSelected(it)
                             isMenuExpanded = false
-                        }
-                    ) {
-                        Row(
-                            horizontalArrangement = Arrangement.spacedBy(dimensionResource(R.dimen.minor_100))
-                        ) {
-                            Text(text = mapper(it))
-                            Spacer(modifier = Modifier.weight(1f))
-                            if (currentFilter == it) {
-                                Icon(
-                                    imageVector = ImageVector.vectorResource(R.drawable.ic_menu_check),
-                                    contentDescription = stringResource(id = androidx.compose.ui.R.string.selected),
-                                    tint = MaterialTheme.colors.primary
-                                )
-                            } else {
-                                Spacer(modifier = Modifier.size(dimensionResource(R.dimen.image_minor_50)))
-                            }
-                        }
-                    }
+                        },
+                    )
                 }
             }
         }
@@ -110,13 +114,13 @@ fun <T> DashboardFilterableCardHeader(
 }
 
 @Composable
-@Preview
+@PreviewLightDark
 private fun DashboardFilterableCardHeaderPreview() {
     val filters = remember {
         listOf("Filter 1", "Filter 2", "Filter 3")
     }
     var currentFilter by remember { mutableStateOf("Filter 1") }
-    WooThemeWithBackground {
+    WooDesignSystemThemeWithBackground {
         DashboardFilterableCardHeader(
             title = "Title",
             currentFilter = currentFilter,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
@@ -45,7 +45,7 @@ import com.woocommerce.android.ui.blaze.detail.BlazeCampaignDetailWebViewViewMod
 import com.woocommerce.android.ui.blaze.detail.BlazeCampaignDetailWebViewViewModel.BlazeAction.None
 import com.woocommerce.android.ui.blaze.detail.BlazeCampaignDetailWebViewViewModel.BlazeAction.PromoteProductAgain
 import com.woocommerce.android.ui.common.webview.AuthenticatedWebViewLauncher
-import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.compose.designsystem.foundation.WooDesignSystemThemeWithBackground
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.ContactSupport
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.FeedbackNegativeAction
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.FeedbackPositiveAction
@@ -150,7 +150,7 @@ class DashboardFragment :
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
 
             setContent {
-                WooThemeWithBackground {
+                WooDesignSystemThemeWithBackground {
                     DashboardContainer(
                         mainActivityViewModel = mainActivityViewModel,
                         dashboardViewModel = dashboardViewModel,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardPrimitives.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardPrimitives.kt
@@ -30,10 +30,12 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
 import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.component.getText
 import com.woocommerce.android.ui.compose.designsystem.WooTheme
 import com.woocommerce.android.ui.compose.designsystem.component.WooIconButton
 import com.woocommerce.android.ui.compose.designsystem.icons.Ellipsis
 import com.woocommerce.android.ui.compose.designsystem.icons.WooIcons
+import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetMenu
 
 @Composable
 internal fun DashboardCardSurface(
@@ -68,10 +70,8 @@ internal fun DashboardCardSurface(
 }
 
 @Composable
-internal fun <T> DashboardOverflowMenu(
-    items: List<T>,
-    onSelected: (T) -> Unit,
-    mapper: @Composable (T) -> String,
+internal fun DashboardOverflowMenu(
+    menu: DashboardWidgetMenu,
     modifier: Modifier = Modifier,
 ) {
     var expanded by remember { mutableStateOf(false) }
@@ -87,18 +87,18 @@ internal fun <T> DashboardOverflowMenu(
             onDismissRequest = { expanded = false },
             containerColor = WooTheme.colors.surface.default,
         ) {
-            items.forEach { item ->
+            menu.items.forEach { item ->
                 DropdownMenuItem(
                     text = {
                         Text(
-                            text = mapper(item),
+                            text = item.title.getText(),
                             style = WooTheme.text.bodyLarge.regular,
                             color = WooTheme.colors.surface.onDefault,
                         )
                     },
                     onClick = {
                         expanded = false
-                        onSelected(item)
+                        item.action()
                     },
                 )
             }
@@ -112,14 +112,10 @@ internal fun DashboardSkeleton(
     height: Dp,
     modifier: Modifier = Modifier,
 ) {
-    Spacer(
+    DashboardSkeleton(
         modifier = modifier
             .width(width)
-            .height(height)
-            .background(
-                brush = dashboardSkeletonBrush(),
-                shape = RoundedCornerShape(WooTheme.radius.small),
-            ),
+            .height(height),
     )
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/StatsInfoFooter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/StatsInfoFooter.kt
@@ -9,19 +9,17 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.colorResource
-import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.woocommerce.android.R
-import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
-import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.compose.designsystem.WooTheme
+import com.woocommerce.android.ui.compose.designsystem.foundation.WooDesignSystemThemeWithBackground
 
 @Composable
 fun StatsInfoFooter(
@@ -35,30 +33,30 @@ fun StatsInfoFooter(
         modifier = modifier
             .fillMaxWidth()
             .clickable(onClick = onInfoClick)
-            .padding(dimensionResource(id = R.dimen.major_100)),
+            .padding(WooTheme.padding.padding5),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.Center
     ) {
         Text(
             text = text,
-            style = MaterialTheme.typography.bodyMedium,
-            color = colorResource(id = R.color.color_on_surface_medium),
+            style = WooTheme.text.bodyMedium.regular,
+            color = WooTheme.colors.surface.onDefault,
             textAlign = TextAlign.Center
         )
-        Spacer(modifier = Modifier.width(dimensionResource(id = R.dimen.minor_50)))
+        Spacer(modifier = Modifier.width(WooTheme.spacing.space2))
         Icon(
             painter = painterResource(id = R.drawable.ic_tintable_info_outline_24dp),
             contentDescription = stringResource(id = R.string.dashboard_stats_info_content_description),
-            tint = colorResource(id = R.color.color_primary),
-            modifier = Modifier.size(dimensionResource(id = R.dimen.major_100))
+            tint = WooTheme.colors.primary,
+            modifier = Modifier.size(WooTheme.iconSize.size16),
         )
     }
 }
 
-@LightDarkThemePreviews
+@PreviewLightDark
 @Composable
 private fun StatsInfoFooterDelayedPreview() {
-    WooThemeWithBackground {
+    WooDesignSystemThemeWithBackground {
         StatsInfoFooter(
             text = stringResource(id = R.string.dashboard_stats_delayed_footer),
             onInfoClick = {}
@@ -66,10 +64,10 @@ private fun StatsInfoFooterDelayedPreview() {
     }
 }
 
-@LightDarkThemePreviews
+@PreviewLightDark
 @Composable
 private fun StatsInfoFooterLastUpdatePreview() {
-    WooThemeWithBackground {
+    WooDesignSystemThemeWithBackground {
         StatsInfoFooter(
             text = "Last update: 8:52 AM",
             onInfoClick = {}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/WCAnalyticsNotEnabledErrorView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/WCAnalyticsNotEnabledErrorView.kt
@@ -5,19 +5,18 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.woocommerce.android.R
-import com.woocommerce.android.ui.compose.component.WCOutlinedButton
-import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.compose.designsystem.WooTheme
+import com.woocommerce.android.ui.compose.designsystem.component.WooOutlinedButton
+import com.woocommerce.android.ui.compose.designsystem.foundation.WooDesignSystemThemeWithBackground
 
 @Composable
 fun WCAnalyticsNotAvailableErrorView(
@@ -25,11 +24,11 @@ fun WCAnalyticsNotAvailableErrorView(
     onContactSupportClick: () -> Unit
 ) {
     Column(
-        verticalArrangement = Arrangement.spacedBy(16.dp),
+        verticalArrangement = Arrangement.spacedBy(WooTheme.spacing.space5),
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = Modifier
             .fillMaxWidth()
-            .padding(16.dp)
+            .padding(WooTheme.padding.padding5)
     ) {
         Image(
             painter = painterResource(id = R.drawable.img_woo_generic_error),
@@ -38,17 +37,19 @@ fun WCAnalyticsNotAvailableErrorView(
 
         Text(
             text = title,
-            style = MaterialTheme.typography.h6,
+            style = WooTheme.text.titleLarge.strong,
+            color = WooTheme.colors.surface.onDefault,
             textAlign = TextAlign.Center
         )
 
         Text(
             text = stringResource(id = R.string.dashboard_wcanalytics_inactive_description),
-            style = MaterialTheme.typography.body1,
+            style = WooTheme.text.bodyLarge.regular,
+            color = WooTheme.colors.surface.onDefault,
             textAlign = TextAlign.Center
         )
 
-        WCOutlinedButton(
+        WooOutlinedButton(
             text = stringResource(id = R.string.dashboard_wcanalytics_inactive_contact_us),
             onClick = onContactSupportClick
         )
@@ -56,9 +57,9 @@ fun WCAnalyticsNotAvailableErrorView(
 }
 
 @Composable
-@Preview
+@PreviewLightDark
 private fun WCAdminNotAvailableErrorViewPreview() {
-    WooThemeWithBackground {
+    WooDesignSystemThemeWithBackground {
         WCAnalyticsNotAvailableErrorView(
             title = stringResource(id = R.string.my_store_stats_plugin_inactive_title),
             onContactSupportClick = {}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/WidgetCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/WidgetCard.kt
@@ -70,9 +70,7 @@ fun WidgetCard(
             )
 
             DashboardOverflowMenu(
-                items = menu.items,
-                onSelected = { item -> item.action() },
-                mapper = { it.title.getText() },
+                menu = menu,
             )
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/WidgetCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/WidgetCard.kt
@@ -3,31 +3,25 @@ package com.woocommerce.android.ui.dashboard
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
-import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Icon
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.res.colorResource
-import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.woocommerce.android.R
-import com.woocommerce.android.ui.compose.component.WCOverflowMenu
-import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.compose.component.getText
-import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.compose.designsystem.WooTheme
+import com.woocommerce.android.ui.compose.designsystem.foundation.WooDesignSystemThemeWithBackground
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetAction
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetMenu
 
@@ -41,78 +35,77 @@ fun WidgetCard(
     isError: Boolean,
     content: @Composable () -> Unit
 ) {
-    val roundedShape = RoundedCornerShape(dimensionResource(id = R.dimen.minor_100))
-    Column(
-        modifier = modifier
-            .border(
-                width = dimensionResource(id = R.dimen.minor_10),
-                color = colorResource(id = R.color.woo_gray_5),
-                shape = roundedShape
-            )
-            .clip(roundedShape)
-            .background(MaterialTheme.colors.surface)
-    ) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
+    DashboardCardSurface(modifier = modifier) {
+        val hasLeadingIcon = isError || iconResource != null
+        Row(
+            modifier = Modifier.padding(start = WooTheme.padding.padding5),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
             if (isError) {
                 Icon(
                     painter = painterResource(id = R.drawable.ic_tintable_info_outline_24dp),
-                    contentDescription = "",
-                    modifier = Modifier
-                        .padding(start = dimensionResource(id = R.dimen.major_100))
-                        .size(dimensionResource(id = R.dimen.major_125)),
-                    tint = colorResource(id = R.color.color_icon)
+                    contentDescription = null,
+                    modifier = Modifier.size(WooTheme.iconSize.size24),
+                    tint = WooTheme.colors.surface.onVariant,
                 )
             } else if (iconResource != null) {
                 Image(
                     painter = painterResource(id = iconResource),
-                    contentDescription = "",
-                    modifier = Modifier
-                        .padding(start = dimensionResource(id = R.dimen.major_100))
-                        .size(dimensionResource(id = R.dimen.major_125))
+                    contentDescription = null,
+                    modifier = Modifier.size(WooTheme.iconSize.size24),
                 )
             }
             Text(
                 modifier = Modifier
                     .weight(1f)
-                    .padding(dimensionResource(id = R.dimen.major_100)),
+                    .padding(
+                        start = if (hasLeadingIcon) WooTheme.padding.padding5 else WooTheme.padding.padding0,
+                        top = WooTheme.padding.padding7,
+                        end = WooTheme.padding.padding5,
+                        bottom = WooTheme.padding.padding7,
+                    ),
                 text = stringResource(id = titleResource),
-                color = colorResource(id = R.color.color_on_surface_high),
-                style = MaterialTheme.typography.h6,
-                fontWeight = FontWeight.Bold
+                color = WooTheme.colors.surface.onDefault,
+                style = WooTheme.text.titleSmall.emphasized,
             )
 
-            WCOverflowMenu(
+            DashboardOverflowMenu(
                 items = menu.items,
                 onSelected = { item -> item.action() },
                 mapper = { it.title.getText() },
-                tint = colorResource(id = R.color.color_on_surface_high)
             )
         }
 
         content()
 
         if (button != null && !isError) {
-            WCTextButton(
+            TextButton(
+                onClick = button.action,
                 modifier = Modifier
                     .padding(
-                        start = dimensionResource(id = R.dimen.minor_100),
-                        bottom = dimensionResource(id = R.dimen.minor_25)
+                        start = WooTheme.padding.padding3,
+                        bottom = WooTheme.padding.padding1,
                     ),
-                onClick = button.action
+                colors = ButtonDefaults.textButtonColors(
+                    contentColor = WooTheme.colors.container.onSecondaryContainer
+                ),
+                shape = RoundedCornerShape(WooTheme.radius.medium),
             ) {
                 Text(
                     text = button.title.getText(),
-                    style = MaterialTheme.typography.body1
+                    style = WooTheme.text.labelLarge.emphasized,
                 )
             }
         }
     }
 }
 
-@Preview
+@PreviewLightDark
+@Preview(name = "Large font", fontScale = 2f)
+@Preview(name = "RTL", locale = "ar")
 @Composable
 fun PreviewWidgetCard() {
-    WooThemeWithBackground {
+    WooDesignSystemThemeWithBackground {
         WidgetCard(
             titleResource = R.string.blaze_campaign_title,
             iconResource = R.drawable.ic_blaze,
@@ -135,8 +128,10 @@ fun PreviewWidgetCard() {
             isError = false
         ) {
             Text(
-                modifier = Modifier.padding(dimensionResource(id = R.dimen.major_100)),
-                text = "Content"
+                modifier = Modifier.padding(WooTheme.padding.padding5),
+                text = "Content",
+                style = WooTheme.text.bodyLarge.regular,
+                color = WooTheme.colors.surface.onDefault,
             )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/WidgetError.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/WidgetError.kt
@@ -5,21 +5,26 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.LocalContentColor
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.LinkInteractionListener
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLinkStyles
+import androidx.compose.ui.text.fromHtml
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.woocommerce.android.R
-import com.woocommerce.android.ui.compose.clickableAnnotatedStringRes
-import com.woocommerce.android.ui.compose.component.WCOutlinedButton
+import com.woocommerce.android.ui.compose.designsystem.WooTheme
+import com.woocommerce.android.ui.compose.designsystem.component.WooOutlinedButton
+import com.woocommerce.android.ui.compose.designsystem.foundation.WooDesignSystemThemeWithBackground
 
 @Composable
 fun WidgetError(
@@ -27,8 +32,8 @@ fun WidgetError(
     onRetryClicked: () -> Unit
 ) {
     Column(
-        modifier = Modifier.padding(16.dp),
-        verticalArrangement = Arrangement.spacedBy(16.dp)
+        modifier = Modifier.padding(WooTheme.padding.padding5),
+        verticalArrangement = Arrangement.spacedBy(WooTheme.spacing.space5),
     ) {
         Image(
             modifier = Modifier
@@ -40,35 +45,58 @@ fun WidgetError(
         Text(
             modifier = Modifier.align(Alignment.CenterHorizontally),
             text = stringResource(id = R.string.dynamic_dashboard_widget_error_title),
-            style = MaterialTheme.typography.h6
+            style = WooTheme.text.titleLarge.strong,
+            color = WooTheme.colors.surface.onDefault,
         )
 
-        val errorMessage = clickableAnnotatedStringRes(
-            stringResId = R.string.dynamic_dashboard_widget_error_description,
-            onUrlClick = { onContactSupportClicked() }
-        )
+        val errorMessage = dashboardWidgetErrorMessage(onContactSupportClicked)
         Text(
             text = errorMessage,
             textAlign = TextAlign.Center,
-            fontSize = 18.sp,
-            color = LocalContentColor.current,
-            modifier = Modifier.padding(horizontal = 32.dp),
+            style = WooTheme.text.bodyLarge.regular,
+            color = WooTheme.colors.surface.onDefault,
+            modifier = Modifier.padding(horizontal = WooTheme.padding.padding8),
         )
 
-        WCOutlinedButton(
+        WooOutlinedButton(
             modifier = Modifier.fillMaxWidth(),
-            onClick = onRetryClicked
-        ) {
-            Text(text = stringResource(id = R.string.retry))
-        }
+            text = stringResource(id = R.string.retry),
+            onClick = onRetryClicked,
+        )
     }
 }
 
 @Composable
-@Preview
-fun WidgetErrorPreview() {
-    WidgetError(
-        onContactSupportClicked = {},
-        onRetryClicked = {}
+private fun dashboardWidgetErrorMessage(onContactSupportClicked: () -> Unit): AnnotatedString {
+    val linkInteractionListener = remember(onContactSupportClicked) {
+        LinkInteractionListener { linkAnnotation ->
+            when (linkAnnotation) {
+                is LinkAnnotation.Url,
+                is LinkAnnotation.Clickable -> onContactSupportClicked()
+                else -> error("Unsupported LinkAnnotation type: $linkAnnotation")
+            }
+        }
+    }
+
+    return AnnotatedString.fromHtml(
+        htmlString = stringResource(id = R.string.dynamic_dashboard_widget_error_description),
+        linkInteractionListener = linkInteractionListener,
+        linkStyles = TextLinkStyles(
+            style = SpanStyle(
+                color = WooTheme.colors.container.onSecondaryContainer,
+                textDecoration = TextDecoration.Underline,
+            ),
+        ),
     )
+}
+
+@Composable
+@PreviewLightDark
+fun WidgetErrorPreview() {
+    WooDesignSystemThemeWithBackground {
+        WidgetError(
+            onContactSupportClicked = {},
+            onRetryClicked = {},
+        )
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/aiassistant/DashboardAIAssistantCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/aiassistant/DashboardAIAssistantCard.kt
@@ -145,6 +145,7 @@ private const val SPARKLE_SCALE_MAX = 1.0f
 private const val SPARKLE_ALPHA_MIN = 0.6f
 private const val SPARKLE_ALPHA_MAX = 1.0f
 private const val SPARKLE_PULSE_DURATION_MS = 800
+
 @PreviewLightDark
 @Composable
 private fun DashboardAIAssistantCardPreview() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/aiassistant/DashboardAIAssistantCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/aiassistant/DashboardAIAssistantCard.kt
@@ -6,9 +6,7 @@ import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
@@ -18,18 +16,13 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.res.colorResource
-import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
@@ -37,10 +30,11 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.dp
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.woocommerce.android.R
-import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
-import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.compose.designsystem.WooTheme
+import com.woocommerce.android.ui.compose.designsystem.foundation.WooDesignSystemThemeWithBackground
+import com.woocommerce.android.ui.dashboard.DashboardCardSurface
 import com.woocommerce.android.aiassistant.R as AiAssistantR
 
 @Composable
@@ -49,8 +43,7 @@ fun DashboardAIAssistantCard(
     modifier: Modifier = Modifier,
 ) {
     val contentDescription = stringResource(R.string.dashboard_ai_assistant_entry_point_content_description)
-    val cardShape = RoundedCornerShape(20.dp)
-    Surface(
+    DashboardCardSurface(
         onClick = onClick,
         modifier = modifier
             .fillMaxWidth()
@@ -58,27 +51,21 @@ fun DashboardAIAssistantCard(
                 this.contentDescription = contentDescription
                 this.role = Role.Button
             },
-        shape = cardShape,
-        color = MaterialTheme.colorScheme.surface,
-        border = BorderStroke(
-            width = dimensionResource(R.dimen.minor_10),
-            color = colorResource(R.color.woo_gray_5),
-        )
     ) {
         Row(
             modifier = Modifier
                 .padding(
-                    horizontal = dimensionResource(R.dimen.major_100),
-                    vertical = dimensionResource(R.dimen.major_75),
+                    horizontal = WooTheme.padding.padding5,
+                    vertical = WooTheme.padding.padding4,
                 ),
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(dimensionResource(R.dimen.major_75)),
+            horizontalArrangement = Arrangement.spacedBy(WooTheme.spacing.space4),
         ) {
             SparkleChip()
             Text(
                 text = stringResource(R.string.dashboard_ai_assistant_entry_point_label),
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                style = MaterialTheme.typography.bodyLarge,
+                color = WooTheme.colors.surface.onDefault,
+                style = WooTheme.text.bodyLarge.regular,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
                 modifier = Modifier.weight(1f),
@@ -90,16 +77,8 @@ fun DashboardAIAssistantCard(
 
 @Composable
 private fun SparkleChip() {
-    val chipBackground = if (isSystemInDarkTheme()) {
-        colorResource(R.color.woo_purple_60).copy(alpha = CHIP_BACKGROUND_ALPHA_DARK)
-    } else {
-        colorResource(R.color.woo_purple_10)
-    }
-    val sparkleTint = if (isSystemInDarkTheme()) {
-        colorResource(R.color.woo_purple_30)
-    } else {
-        colorResource(R.color.woo_purple_40)
-    }
+    val chipBackground = WooTheme.colors.container.secondaryContainer
+    val sparkleTint = WooTheme.colors.container.onSecondaryContainer
 
     val transition = rememberInfiniteTransition(label = "ai-sparkle-pulse")
     val scale by transition.animateFloat(
@@ -123,8 +102,8 @@ private fun SparkleChip() {
 
     Box(
         modifier = Modifier
-            .size(40.dp)
-            .clip(RoundedCornerShape(dimensionResource(R.dimen.minor_100)))
+            .size(WooTheme.spacing.space9)
+            .clip(RoundedCornerShape(WooTheme.radius.medium))
             .background(chipBackground),
         contentAlignment = Alignment.Center,
     ) {
@@ -133,7 +112,7 @@ private fun SparkleChip() {
             contentDescription = null,
             tint = sparkleTint,
             modifier = Modifier
-                .size(20.dp)
+                .size(WooTheme.iconSize.size20)
                 .graphicsLayer {
                     scaleX = scale
                     scaleY = scale
@@ -147,16 +126,16 @@ private fun SparkleChip() {
 private fun SendAffordance() {
     Box(
         modifier = Modifier
-            .size(32.dp)
+            .size(WooTheme.spacing.space8)
             .clip(CircleShape)
-            .background(colorResource(R.color.woo_purple_40)),
+            .background(WooTheme.colors.primary),
         contentAlignment = Alignment.Center,
     ) {
         Icon(
             painter = painterResource(R.drawable.ic_gridicons_arrow_up),
             contentDescription = null,
-            tint = Color.White,
-            modifier = Modifier.size(18.dp),
+            tint = WooTheme.colors.onPrimary,
+            modifier = Modifier.size(WooTheme.iconSize.size18),
         )
     }
 }
@@ -166,12 +145,10 @@ private const val SPARKLE_SCALE_MAX = 1.0f
 private const val SPARKLE_ALPHA_MIN = 0.6f
 private const val SPARKLE_ALPHA_MAX = 1.0f
 private const val SPARKLE_PULSE_DURATION_MS = 800
-private const val CHIP_BACKGROUND_ALPHA_DARK = 0.20f
-
-@LightDarkThemePreviews
+@PreviewLightDark
 @Composable
 private fun DashboardAIAssistantCardPreview() {
-    WooThemeWithBackground {
+    WooDesignSystemThemeWithBackground {
         DashboardAIAssistantCard(onClick = {})
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/blaze/DashboardBlazeCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/blaze/DashboardBlazeCard.kt
@@ -242,13 +242,13 @@ fun BlazeProductItem(
     Box(
         modifier = modifier
             .border(
-                width = dimensionResource(id = R.dimen.minor_10),
+                width = WooTheme.stroke.regular,
                 color = WooTheme.colors.outlineVariant,
                 shape = RoundedCornerShape(WooTheme.radius.medium),
             )
             .clip(shape = RoundedCornerShape(WooTheme.radius.medium))
             .clickable { onProductSelected() }
-            .padding(dimensionResource(id = R.dimen.major_100))
+            .padding(WooTheme.padding.padding5)
     ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             ProductThumbnail(imageUrl = product.imgUrl)
@@ -286,12 +286,12 @@ private fun BlazeCampaignLoading(
     Box(
         modifier = modifier
             .border(
-                width = dimensionResource(id = R.dimen.minor_10),
+                width = WooTheme.stroke.regular,
                 color = WooTheme.colors.outlineVariant,
                 shape = RoundedCornerShape(WooTheme.radius.medium),
             )
             .clip(shape = RoundedCornerShape(WooTheme.radius.medium))
-            .padding(dimensionResource(id = R.dimen.major_100))
+            .padding(WooTheme.padding.padding5)
     ) {
         Column {
             Row(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/blaze/DashboardBlazeCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/blaze/DashboardBlazeCard.kt
@@ -10,9 +10,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Icon
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.livedata.observeAsState
@@ -20,11 +19,10 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.Observer
@@ -40,13 +38,13 @@ import com.woocommerce.android.ui.blaze.BlazeUrlsHelper.BlazeFlowSource
 import com.woocommerce.android.ui.blaze.CampaignStatusUi
 import com.woocommerce.android.ui.blaze.campaigs.BlazeCampaignItem
 import com.woocommerce.android.ui.blaze.creation.BlazeCampaignCreationDispatcher
-import com.woocommerce.android.ui.compose.animations.SkeletonView
 import com.woocommerce.android.ui.compose.component.ProductThumbnail
-import com.woocommerce.android.ui.compose.component.WCOutlinedButton
-import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
+import com.woocommerce.android.ui.compose.designsystem.WooTheme
+import com.woocommerce.android.ui.compose.designsystem.component.WooOutlinedButton
+import com.woocommerce.android.ui.compose.designsystem.foundation.WooDesignSystemThemeWithBackground
 import com.woocommerce.android.ui.compose.rememberNavController
-import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.dashboard.DashboardFragmentDirections
+import com.woocommerce.android.ui.dashboard.DashboardSkeleton
 import com.woocommerce.android.ui.dashboard.DashboardViewModel
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetAction
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetMenu
@@ -193,14 +191,13 @@ fun DashboardBlazeView(
                         onCampaignClicked = state.onCampaignClicked,
                     )
 
-                    WCOutlinedButton(
+                    WooOutlinedButton(
+                        text = stringResource(string.blaze_campaign_create_campaign_button),
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(top = dimensionResource(id = R.dimen.minor_100)),
                         onClick = state.onCreateCampaignClicked,
-                    ) {
-                        Text(stringResource(string.blaze_campaign_create_campaign_button))
-                    }
+                    )
                 }
 
                 is DashboardBlazeCampaignState.NoCampaign -> {
@@ -209,7 +206,8 @@ fun DashboardBlazeView(
                             end = dimensionResource(id = R.dimen.major_300)
                         ),
                         text = stringResource(id = string.blaze_campaign_subtitle),
-                        style = MaterialTheme.typography.body1,
+                        style = WooTheme.text.bodyLarge.regular,
+                        color = WooTheme.colors.surface.onDefault,
                     )
                     BlazeProductItem(
                         product = state.product,
@@ -217,7 +215,8 @@ fun DashboardBlazeView(
                         modifier = Modifier.padding(top = dimensionResource(id = R.dimen.major_100))
                     )
 
-                    WCOutlinedButton(
+                    WooOutlinedButton(
+                        text = stringResource(string.blaze_campaign_create_campaign_button),
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(
@@ -225,9 +224,7 @@ fun DashboardBlazeView(
                                 bottom = dimensionResource(id = R.dimen.major_100)
                             ),
                         onClick = state.onCreateCampaignClicked,
-                    ) {
-                        Text(stringResource(string.blaze_campaign_create_campaign_button))
-                    }
+                    )
                 }
 
                 else -> error("Invalid state")
@@ -246,10 +243,10 @@ fun BlazeProductItem(
         modifier = modifier
             .border(
                 width = dimensionResource(id = R.dimen.minor_10),
-                color = colorResource(R.color.divider_color),
-                shape = RoundedCornerShape(dimensionResource(id = R.dimen.minor_100))
+                color = WooTheme.colors.outlineVariant,
+                shape = RoundedCornerShape(WooTheme.radius.medium),
             )
-            .clip(shape = RoundedCornerShape(dimensionResource(id = R.dimen.minor_100)))
+            .clip(shape = RoundedCornerShape(WooTheme.radius.medium))
             .clickable { onProductSelected() }
             .padding(dimensionResource(id = R.dimen.major_100))
     ) {
@@ -264,18 +261,19 @@ fun BlazeProductItem(
                     modifier = Modifier
                         .padding(bottom = dimensionResource(id = R.dimen.minor_50)),
                     text = stringResource(id = R.string.blaze_campaign_suggested_product_caption),
-                    style = MaterialTheme.typography.caption,
-                    color = colorResource(R.color.color_on_surface_medium)
+                    style = WooTheme.text.bodySmall.regular,
+                    color = WooTheme.colors.surface.onDefault,
                 )
                 Text(
                     text = product.name,
-                    style = MaterialTheme.typography.subtitle1,
-                    fontWeight = FontWeight.Bold
+                    style = WooTheme.text.titleMedium.strong,
+                    color = WooTheme.colors.surface.onDefault,
                 )
             }
             Icon(
                 painter = painterResource(id = R.drawable.ic_arrow_right),
-                contentDescription = null
+                contentDescription = null,
+                tint = WooTheme.colors.surface.onVariant,
             )
         }
     }
@@ -289,24 +287,24 @@ private fun BlazeCampaignLoading(
         modifier = modifier
             .border(
                 width = dimensionResource(id = R.dimen.minor_10),
-                color = colorResource(R.color.divider_color),
-                shape = RoundedCornerShape(dimensionResource(id = R.dimen.minor_100))
+                color = WooTheme.colors.outlineVariant,
+                shape = RoundedCornerShape(WooTheme.radius.medium),
             )
-            .clip(shape = RoundedCornerShape(dimensionResource(id = R.dimen.minor_100)))
+            .clip(shape = RoundedCornerShape(WooTheme.radius.medium))
             .padding(dimensionResource(id = R.dimen.major_100))
     ) {
         Column {
             Row(
                 modifier = Modifier.fillMaxWidth()
             ) {
-                SkeletonView(
+                DashboardSkeleton(
                     width = dimensionResource(id = R.dimen.major_275),
                     height = dimensionResource(id = R.dimen.major_275)
                 )
 
                 Spacer(modifier = Modifier.width(dimensionResource(id = R.dimen.major_100)))
 
-                SkeletonView(
+                DashboardSkeleton(
                     width = dimensionResource(id = R.dimen.skeleton_text_large_width),
                     height = dimensionResource(id = R.dimen.skeleton_text_height_100),
                 )
@@ -317,13 +315,13 @@ private fun BlazeCampaignLoading(
             ) {
                 Spacer(modifier = Modifier.width(dimensionResource(id = R.dimen.major_275)))
                 Spacer(modifier = Modifier.width(dimensionResource(id = R.dimen.major_100)))
-                SkeletonView(
+                DashboardSkeleton(
                     width = dimensionResource(id = R.dimen.skeleton_text_medium_width),
                     height = dimensionResource(id = R.dimen.skeleton_text_height_100),
                 )
                 Spacer(modifier = Modifier.width(dimensionResource(id = R.dimen.major_100)))
 
-                SkeletonView(
+                DashboardSkeleton(
                     width = dimensionResource(id = R.dimen.skeleton_text_medium_width),
                     height = dimensionResource(id = R.dimen.skeleton_text_height_100),
                 )
@@ -332,9 +330,13 @@ private fun BlazeCampaignLoading(
     }
 }
 
-@LightDarkThemePreviews
+@PreviewLightDark
 @Composable
-fun MyStoreBlazeViewCampaignPreview() {
+fun MyStoreBlazeViewCampaignPreview() =
+    WooDesignSystemThemeWithBackground { MyStoreBlazeViewCampaignPreviewContent() }
+
+@Composable
+private fun MyStoreBlazeViewCampaignPreviewContent() {
     val product = BlazeProductUi(
         name = "Product name",
         imgUrl = "",
@@ -369,9 +371,13 @@ fun MyStoreBlazeViewCampaignPreview() {
     )
 }
 
-@LightDarkThemePreviews
+@PreviewLightDark
 @Composable
-fun MyStoreBlazeViewNoCampaignPreview() {
+fun MyStoreBlazeViewNoCampaignPreview() =
+    WooDesignSystemThemeWithBackground { MyStoreBlazeViewNoCampaignPreviewContent() }
+
+@Composable
+private fun MyStoreBlazeViewNoCampaignPreviewContent() {
     DashboardBlazeView(
         state = DashboardBlazeCampaignState.NoCampaign(
             product = BlazeProductUi(
@@ -393,10 +399,10 @@ fun MyStoreBlazeViewNoCampaignPreview() {
     )
 }
 
-@LightDarkThemePreviews
+@PreviewLightDark
 @Composable
 fun DashboardBlazeLoadingPreview() {
-    WooThemeWithBackground {
+    WooDesignSystemThemeWithBackground {
         DashboardBlazeView(
             state = DashboardBlazeCampaignState.Loading,
             onContactSupportClicked = {},

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/coupons/DashboardCouponsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/coupons/DashboardCouponsCard.kt
@@ -213,13 +213,13 @@ private fun DashboardCouponsList(
     onCouponClick: (Long) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    Column(modifier.padding(vertical = 8.dp)) {
+    Column(modifier.padding(vertical = WooTheme.padding.padding3)) {
         Header(
             Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp)
+                .padding(horizontal = WooTheme.padding.padding5)
         )
-        Spacer(modifier = Modifier.height(8.dp))
+        Spacer(modifier = Modifier.height(WooTheme.spacing.space3))
         state.coupons.forEach { couponUiModel ->
             CouponListItem(
                 couponUiModel = couponUiModel,
@@ -239,13 +239,13 @@ private fun CouponListItem(
         verticalArrangement = Arrangement.spacedBy(4.dp),
         modifier = modifier
             .clickable(onClick = onClick)
-            .padding(top = 8.dp)
+            .padding(top = WooTheme.padding.padding3)
     ) {
         Row(
             horizontalArrangement = Arrangement.SpaceBetween,
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp)
+                .padding(horizontal = WooTheme.padding.padding5)
         ) {
             Text(
                 text = couponUiModel.code,
@@ -262,10 +262,10 @@ private fun CouponListItem(
             text = couponUiModel.description,
             style = WooTheme.text.bodyMedium.regular,
             color = WooTheme.colors.surface.onDefault,
-            modifier = Modifier.padding(horizontal = 16.dp)
+            modifier = Modifier.padding(horizontal = WooTheme.padding.padding5)
         )
         Spacer(modifier = Modifier)
-        WooDivider(modifier = Modifier.padding(start = 16.dp))
+        WooDivider(modifier = Modifier.padding(start = WooTheme.padding.padding5))
     }
 }
 
@@ -273,23 +273,23 @@ private fun CouponListItem(
 private fun CouponsLoading(
     modifier: Modifier = Modifier
 ) {
-    Column(modifier.padding(vertical = 8.dp)) {
+    Column(modifier.padding(vertical = WooTheme.padding.padding3)) {
         Header(
             Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp)
+                .padding(horizontal = WooTheme.padding.padding5)
         )
-        Spacer(modifier = Modifier.height(8.dp))
+        Spacer(modifier = Modifier.height(WooTheme.spacing.space3))
         repeat(3) {
             Column(
                 verticalArrangement = Arrangement.spacedBy(4.dp),
-                modifier = Modifier.padding(top = 8.dp)
+                modifier = Modifier.padding(top = WooTheme.padding.padding3)
             ) {
                 Row(
                     horizontalArrangement = Arrangement.SpaceBetween,
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(horizontal = 16.dp)
+                        .padding(horizontal = WooTheme.padding.padding5)
                 ) {
                     DashboardSkeleton(width = 260.dp, height = 16.dp)
                     DashboardSkeleton(width = 40.dp, height = 16.dp)
@@ -297,10 +297,10 @@ private fun CouponsLoading(
                 DashboardSkeleton(
                     modifier = Modifier
                         .size(width = 120.dp, height = 16.dp)
-                        .padding(horizontal = 16.dp)
+                        .padding(horizontal = WooTheme.padding.padding5)
                 )
                 Spacer(modifier = Modifier)
-                WooDivider(Modifier.padding(start = 16.dp))
+                WooDivider(Modifier.padding(start = WooTheme.padding.padding5))
             }
         }
     }
@@ -311,18 +311,18 @@ private fun CouponsEmptyView(
     modifier: Modifier = Modifier
 ) {
     Column(
-        verticalArrangement = Arrangement.spacedBy(16.dp),
+        verticalArrangement = Arrangement.spacedBy(WooTheme.spacing.space5),
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = modifier
             .fillMaxWidth()
-            .padding(16.dp)
+            .padding(WooTheme.padding.padding5)
     ) {
         Image(
             painter = painterResource(id = R.drawable.img_empty_coupon_list),
             contentDescription = null,
             modifier = Modifier
                 .sizeIn(maxWidth = 160.dp, maxHeight = 160.dp)
-                .padding(vertical = 16.dp)
+                .padding(vertical = WooTheme.padding.padding5)
         )
 
         Text(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/coupons/DashboardCouponsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/coupons/DashboardCouponsCard.kt
@@ -36,8 +36,8 @@ import com.woocommerce.android.ui.compose.designsystem.component.WooDivider
 import com.woocommerce.android.ui.compose.rememberNavController
 import com.woocommerce.android.ui.coupons.CouponListFragmentDirections
 import com.woocommerce.android.ui.dashboard.DashboardDateRangeHeader
-import com.woocommerce.android.ui.dashboard.DashboardSkeleton
 import com.woocommerce.android.ui.dashboard.DashboardFragmentDirections
+import com.woocommerce.android.ui.dashboard.DashboardSkeleton
 import com.woocommerce.android.ui.dashboard.DashboardViewModel
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetMenu
 import com.woocommerce.android.ui.dashboard.WCAnalyticsNotAvailableErrorView

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/coupons/DashboardCouponsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/coupons/DashboardCouponsCard.kt
@@ -11,10 +11,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.sizeIn
-import androidx.compose.material.ContentAlpha
-import androidx.compose.material.Divider
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.livedata.observeAsState
@@ -34,10 +31,12 @@ import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.model.DashboardWidget
 import com.woocommerce.android.model.DashboardWidget.Type.COUPONS
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType
-import com.woocommerce.android.ui.compose.animations.SkeletonView
+import com.woocommerce.android.ui.compose.designsystem.WooTheme
+import com.woocommerce.android.ui.compose.designsystem.component.WooDivider
 import com.woocommerce.android.ui.compose.rememberNavController
 import com.woocommerce.android.ui.coupons.CouponListFragmentDirections
 import com.woocommerce.android.ui.dashboard.DashboardDateRangeHeader
+import com.woocommerce.android.ui.dashboard.DashboardSkeleton
 import com.woocommerce.android.ui.dashboard.DashboardFragmentDirections
 import com.woocommerce.android.ui.dashboard.DashboardViewModel
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetMenu
@@ -177,7 +176,7 @@ private fun DashboardCouponsCard(
                     modifier = Modifier.fillMaxWidth()
                 )
 
-                Divider()
+                WooDivider()
             }
 
             when (viewState) {
@@ -250,21 +249,23 @@ private fun CouponListItem(
         ) {
             Text(
                 text = couponUiModel.code,
-                style = MaterialTheme.typography.subtitle1
+                style = WooTheme.text.titleMedium.regular,
+                color = WooTheme.colors.surface.onDefault,
             )
             Text(
                 text = couponUiModel.uses.toString(),
-                style = MaterialTheme.typography.subtitle1
+                style = WooTheme.text.titleMedium.regular,
+                color = WooTheme.colors.surface.onDefault,
             )
         }
         Text(
             text = couponUiModel.description,
-            style = MaterialTheme.typography.body2,
-            color = MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.medium),
+            style = WooTheme.text.bodyMedium.regular,
+            color = WooTheme.colors.surface.onDefault,
             modifier = Modifier.padding(horizontal = 16.dp)
         )
         Spacer(modifier = Modifier)
-        Divider(modifier = Modifier.padding(start = 16.dp))
+        WooDivider(modifier = Modifier.padding(start = 16.dp))
     }
 }
 
@@ -290,16 +291,16 @@ private fun CouponsLoading(
                         .fillMaxWidth()
                         .padding(horizontal = 16.dp)
                 ) {
-                    SkeletonView(width = 260.dp, height = 16.dp)
-                    SkeletonView(width = 40.dp, height = 16.dp)
+                    DashboardSkeleton(width = 260.dp, height = 16.dp)
+                    DashboardSkeleton(width = 40.dp, height = 16.dp)
                 }
-                SkeletonView(
+                DashboardSkeleton(
                     modifier = Modifier
                         .size(width = 120.dp, height = 16.dp)
                         .padding(horizontal = 16.dp)
                 )
                 Spacer(modifier = Modifier)
-                Divider(Modifier.padding(start = 16.dp))
+                WooDivider(Modifier.padding(start = 16.dp))
             }
         }
     }
@@ -326,7 +327,8 @@ private fun CouponsEmptyView(
 
         Text(
             text = stringResource(id = R.string.dashboard_coupons_card_empty_view_message),
-            style = MaterialTheme.typography.body1,
+            style = WooTheme.text.bodyLarge.regular,
+            color = WooTheme.colors.surface.onDefault,
             textAlign = TextAlign.Center
         )
     }
@@ -340,13 +342,13 @@ private fun Header(modifier: Modifier = Modifier) {
     ) {
         Text(
             text = stringResource(id = R.string.dashboard_coupons_card_header_coupons),
-            style = MaterialTheme.typography.subtitle2,
-            color = MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.medium)
+            style = WooTheme.text.titleSmall.emphasized,
+            color = WooTheme.colors.surface.onDefault,
         )
         Text(
             text = stringResource(id = R.string.dashboard_coupons_card_header_uses),
-            style = MaterialTheme.typography.subtitle2,
-            color = MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.medium)
+            style = WooTheme.text.titleSmall.emphasized,
+            color = WooTheme.colors.surface.onDefault,
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/google/DashboardGoogleAdsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/google/DashboardGoogleAdsCard.kt
@@ -167,7 +167,6 @@ private fun GoogleAdsLoading(
                     horizontal = dimensionResource(id = R.dimen.major_100),
                     vertical = dimensionResource(id = R.dimen.major_100)
                 )
-                .background(WooTheme.colors.surface.default)
                 .fillMaxWidth()
         ) {
             Image(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/google/DashboardGoogleAdsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/google/DashboardGoogleAdsCard.kt
@@ -13,20 +13,19 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Icon
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.LiveData
@@ -36,9 +35,11 @@ import com.woocommerce.android.NavGraphMainDirections
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.model.DashboardWidget
-import com.woocommerce.android.ui.compose.animations.SkeletonView
-import com.woocommerce.android.ui.compose.component.WCOutlinedButton
+import com.woocommerce.android.ui.compose.designsystem.WooTheme
+import com.woocommerce.android.ui.compose.designsystem.component.WooOutlinedButton
+import com.woocommerce.android.ui.compose.designsystem.foundation.WooDesignSystemThemeWithBackground
 import com.woocommerce.android.ui.compose.rememberNavController
+import com.woocommerce.android.ui.dashboard.DashboardSkeleton
 import com.woocommerce.android.ui.dashboard.DashboardViewModel
 import com.woocommerce.android.ui.dashboard.WidgetCard
 import com.woocommerce.android.ui.dashboard.WidgetError
@@ -151,22 +152,22 @@ fun DashboardGoogleAdsView(
 private fun GoogleAdsLoading(
     modifier: Modifier = Modifier
 ) {
-    val roundedShape = RoundedCornerShape(dimensionResource(id = R.dimen.minor_100))
+    val roundedShape = RoundedCornerShape(WooTheme.radius.medium)
     Column(modifier = modifier.padding(vertical = 8.dp)) {
         Row(
             verticalAlignment = Alignment.Top,
             modifier = Modifier
                 .border(
                     width = dimensionResource(id = R.dimen.minor_10),
-                    color = colorResource(id = R.color.divider_color),
-                    shape = roundedShape
+                    color = WooTheme.colors.outlineVariant,
+                    shape = roundedShape,
                 )
                 .clip(roundedShape)
                 .padding(
                     horizontal = dimensionResource(id = R.dimen.major_100),
                     vertical = dimensionResource(id = R.dimen.major_100)
                 )
-                .background(MaterialTheme.colors.surface)
+                .background(WooTheme.colors.surface.default)
                 .fillMaxWidth()
         ) {
             Image(
@@ -179,9 +180,9 @@ private fun GoogleAdsLoading(
                     .padding(start = dimensionResource(id = R.dimen.major_100))
                     .weight(1f)
             ) {
-                SkeletonView(width = 200.dp, height = 24.dp)
+                DashboardSkeleton(width = 200.dp, height = 24.dp)
                 Spacer(modifier = Modifier.height(dimensionResource(R.dimen.minor_100)))
-                SkeletonView(width = 250.dp, height = 16.dp)
+                DashboardSkeleton(width = 250.dp, height = 16.dp)
             }
         }
         Spacer(modifier = Modifier.height(8.dp))
@@ -192,18 +193,18 @@ private fun GoogleAdsLoading(
         modifier = Modifier
             .border(
                 width = dimensionResource(id = R.dimen.minor_10),
-                color = colorResource(id = R.color.divider_color),
-                shape = roundedShape
+                color = WooTheme.colors.outlineVariant,
+                shape = roundedShape,
             )
             .clip(roundedShape)
             .padding(
                 horizontal = dimensionResource(id = R.dimen.major_100),
                 vertical = dimensionResource(id = R.dimen.major_100)
             )
-            .background(MaterialTheme.colors.surface)
+            .background(WooTheme.colors.surface.default)
             .fillMaxWidth()
     ) {
-        SkeletonView(width = 200.dp, height = 24.dp)
+        DashboardSkeleton(width = 200.dp, height = 24.dp)
     }
 
     Spacer(modifier = Modifier.height(16.dp))
@@ -214,22 +215,22 @@ private fun GoogleAdsNoCampaigns(
     onCreateCampaignClicked: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val roundedShape = RoundedCornerShape(dimensionResource(id = R.dimen.minor_100))
+    val roundedShape = RoundedCornerShape(WooTheme.radius.medium)
     Column {
         Row(
             verticalAlignment = Alignment.Top,
             modifier = modifier
                 .border(
                     width = dimensionResource(id = R.dimen.minor_10),
-                    color = colorResource(id = R.color.divider_color),
-                    shape = roundedShape
+                    color = WooTheme.colors.outlineVariant,
+                    shape = roundedShape,
                 )
                 .clip(roundedShape)
                 .padding(
                     horizontal = dimensionResource(id = R.dimen.major_100),
                     vertical = dimensionResource(id = R.dimen.major_100)
                 )
-                .background(MaterialTheme.colors.surface)
+                .background(WooTheme.colors.surface.default)
         ) {
             Image(
                 painter = painterResource(id = R.drawable.google_logo),
@@ -243,12 +244,14 @@ private fun GoogleAdsNoCampaigns(
             ) {
                 Text(
                     text = stringResource(R.string.dashboard_google_ads_card_no_campaign_heading),
-                    style = MaterialTheme.typography.h6
+                    style = WooTheme.text.titleLarge.strong,
+                    color = WooTheme.colors.surface.onDefault,
                 )
                 Spacer(modifier = Modifier.height(dimensionResource(R.dimen.minor_100)))
                 Text(
                     text = stringResource(R.string.dashboard_google_ads_card_no_campaign_description),
-                    style = MaterialTheme.typography.body1
+                    style = WooTheme.text.bodyLarge.regular,
+                    color = WooTheme.colors.surface.onDefault,
                 )
             }
         }
@@ -266,22 +269,22 @@ private fun GoogleAdsHasCampaigns(
     onPerformanceAreaClicked: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val roundedShape = RoundedCornerShape(dimensionResource(id = R.dimen.minor_100))
+    val roundedShape = RoundedCornerShape(WooTheme.radius.medium)
     Column {
         Row(
             verticalAlignment = Alignment.Top,
             modifier = modifier
                 .border(
                     width = dimensionResource(id = R.dimen.minor_10),
-                    color = colorResource(id = R.color.divider_color),
-                    shape = roundedShape
+                    color = WooTheme.colors.outlineVariant,
+                    shape = roundedShape,
                 )
                 .clip(roundedShape)
                 .padding(
                     horizontal = dimensionResource(id = R.dimen.major_100),
                     vertical = dimensionResource(id = R.dimen.major_100)
                 )
-                .background(MaterialTheme.colors.surface)
+                .background(WooTheme.colors.surface.default)
         ) {
             Image(
                 painter = painterResource(id = R.drawable.google_logo),
@@ -301,14 +304,15 @@ private fun GoogleAdsHasCampaigns(
                 ) {
                     Text(
                         text = stringResource(R.string.dashboard_google_ads_card_has_campaign_heading),
-                        style = MaterialTheme.typography.body1,
-                        fontWeight = FontWeight.SemiBold,
+                        style = WooTheme.text.bodyLarge.emphasized,
+                        color = WooTheme.colors.surface.onDefault,
                         modifier = Modifier.weight(1f)
                     )
 
                     Icon(
                         painter = painterResource(id = R.drawable.ic_arrow_right),
-                        contentDescription = null
+                        contentDescription = null,
+                        tint = WooTheme.colors.surface.onVariant,
                     )
                 }
                 Spacer(modifier = Modifier.height(dimensionResource(R.dimen.major_100)))
@@ -317,13 +321,14 @@ private fun GoogleAdsHasCampaigns(
                     Column(modifier = Modifier.weight(1f)) {
                         Text(
                             text = stringResource(R.string.dashboard_google_ads_card_has_campaign_impressions),
-                            style = MaterialTheme.typography.body2
+                            style = WooTheme.text.bodyMedium.regular,
+                            color = WooTheme.colors.surface.onDefault,
                         )
                         Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.minor_100)))
                         Text(
                             text = impressions,
-                            style = MaterialTheme.typography.h5,
-                            fontWeight = FontWeight.SemiBold
+                            style = WooTheme.text.headlineSmall.emphasized,
+                            color = WooTheme.colors.surface.onDefault,
                         )
                     }
 
@@ -332,13 +337,14 @@ private fun GoogleAdsHasCampaigns(
                     Column(modifier = Modifier.weight(1f)) {
                         Text(
                             text = stringResource(R.string.dashboard_google_ads_card_has_campaign_clicks),
-                            style = MaterialTheme.typography.body2
+                            style = WooTheme.text.bodyMedium.regular,
+                            color = WooTheme.colors.surface.onDefault,
                         )
                         Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.minor_100)))
                         Text(
                             text = clicks,
-                            style = MaterialTheme.typography.h5,
-                            fontWeight = FontWeight.SemiBold
+                            style = WooTheme.text.headlineSmall.emphasized,
+                            color = WooTheme.colors.surface.onDefault,
                         )
                     }
                 }
@@ -352,15 +358,32 @@ private fun GoogleAdsHasCampaigns(
 
 @Composable
 private fun CreateCampaignButton(onClick: () -> Unit) {
-    WCOutlinedButton(
+    WooOutlinedButton(
+        text = stringResource(R.string.dashboard_google_ads_card_create_campaign_button),
         modifier = Modifier
             .fillMaxWidth()
             .padding(
                 top = dimensionResource(id = R.dimen.minor_100),
                 bottom = dimensionResource(id = R.dimen.major_100)
             ),
-        onClick = onClick
-    ) {
-        Text(stringResource(R.string.dashboard_google_ads_card_create_campaign_button))
+        onClick = onClick,
+    )
+}
+
+@PreviewLightDark
+@Preview(name = "Large font", fontScale = 2f)
+@Preview(name = "RTL", locale = "ar")
+@Composable
+private fun DashboardGoogleAdsNoCampaignsPreview() {
+    WooDesignSystemThemeWithBackground {
+        DashboardGoogleAdsView(
+            viewState = DashboardGoogleAdsState.NoCampaigns(
+                onCreateCampaignClicked = {},
+                menu = DashboardViewModel.DashboardWidgetMenu(emptyList()),
+            ),
+            onContactSupportClicked = {},
+            onRetryOnErrorButtonClicked = {},
+            modifier = Modifier,
+        )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/google/DashboardGoogleAdsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/google/DashboardGoogleAdsCard.kt
@@ -158,14 +158,14 @@ private fun GoogleAdsLoading(
             verticalAlignment = Alignment.Top,
             modifier = Modifier
                 .border(
-                    width = dimensionResource(id = R.dimen.minor_10),
+                    width = WooTheme.stroke.regular,
                     color = WooTheme.colors.outlineVariant,
                     shape = roundedShape,
                 )
                 .clip(roundedShape)
                 .padding(
-                    horizontal = dimensionResource(id = R.dimen.major_100),
-                    vertical = dimensionResource(id = R.dimen.major_100)
+                    horizontal = WooTheme.padding.padding5,
+                    vertical = WooTheme.padding.padding5
                 )
                 .fillMaxWidth()
         ) {
@@ -176,7 +176,7 @@ private fun GoogleAdsLoading(
             )
             Column(
                 modifier = Modifier
-                    .padding(start = dimensionResource(id = R.dimen.major_100))
+                    .padding(start = WooTheme.padding.padding5)
                     .weight(1f)
             ) {
                 DashboardSkeleton(width = 200.dp, height = 24.dp)
@@ -191,14 +191,14 @@ private fun GoogleAdsLoading(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = Modifier
             .border(
-                width = dimensionResource(id = R.dimen.minor_10),
+                width = WooTheme.stroke.regular,
                 color = WooTheme.colors.outlineVariant,
                 shape = roundedShape,
             )
             .clip(roundedShape)
             .padding(
-                horizontal = dimensionResource(id = R.dimen.major_100),
-                vertical = dimensionResource(id = R.dimen.major_100)
+                horizontal = WooTheme.padding.padding5,
+                vertical = WooTheme.padding.padding5
             )
             .background(WooTheme.colors.surface.default)
             .fillMaxWidth()
@@ -220,14 +220,14 @@ private fun GoogleAdsNoCampaigns(
             verticalAlignment = Alignment.Top,
             modifier = modifier
                 .border(
-                    width = dimensionResource(id = R.dimen.minor_10),
+                    width = WooTheme.stroke.regular,
                     color = WooTheme.colors.outlineVariant,
                     shape = roundedShape,
                 )
                 .clip(roundedShape)
                 .padding(
-                    horizontal = dimensionResource(id = R.dimen.major_100),
-                    vertical = dimensionResource(id = R.dimen.major_100)
+                    horizontal = WooTheme.padding.padding5,
+                    vertical = WooTheme.padding.padding5
                 )
                 .background(WooTheme.colors.surface.default)
         ) {
@@ -238,7 +238,7 @@ private fun GoogleAdsNoCampaigns(
             )
             Column(
                 modifier = Modifier
-                    .padding(start = dimensionResource(id = R.dimen.major_100))
+                    .padding(start = WooTheme.padding.padding5)
                     .weight(1f),
             ) {
                 Text(
@@ -274,14 +274,14 @@ private fun GoogleAdsHasCampaigns(
             verticalAlignment = Alignment.Top,
             modifier = modifier
                 .border(
-                    width = dimensionResource(id = R.dimen.minor_10),
+                    width = WooTheme.stroke.regular,
                     color = WooTheme.colors.outlineVariant,
                     shape = roundedShape,
                 )
                 .clip(roundedShape)
                 .padding(
-                    horizontal = dimensionResource(id = R.dimen.major_100),
-                    vertical = dimensionResource(id = R.dimen.major_100)
+                    horizontal = WooTheme.padding.padding5,
+                    vertical = WooTheme.padding.padding5
                 )
                 .background(WooTheme.colors.surface.default)
         ) {
@@ -292,7 +292,7 @@ private fun GoogleAdsHasCampaigns(
             )
             Column(
                 modifier = Modifier
-                    .padding(start = dimensionResource(id = R.dimen.major_100))
+                    .padding(start = WooTheme.padding.padding5)
                     .weight(1f),
             ) {
                 Row(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/inbox/DashboardInboxCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/inbox/DashboardInboxCard.kt
@@ -1,24 +1,37 @@
 package com.woocommerce.android.ui.dashboard.inbox
 
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.material.Divider
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.fromHtml
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -27,15 +40,19 @@ import androidx.lifecycle.Observer
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.navigateSafely
+import com.woocommerce.android.ui.compose.designsystem.WooTheme
+import com.woocommerce.android.ui.compose.designsystem.component.WooDivider
+import com.woocommerce.android.ui.compose.designsystem.component.WooOutlinedButton
+import com.woocommerce.android.ui.compose.designsystem.foundation.WooDesignSystemThemeWithBackground
 import com.woocommerce.android.ui.compose.rememberNavController
+import com.woocommerce.android.ui.dashboard.DashboardSkeleton
 import com.woocommerce.android.ui.dashboard.DashboardFragmentDirections
 import com.woocommerce.android.ui.dashboard.DashboardViewModel
 import com.woocommerce.android.ui.dashboard.WidgetCard
 import com.woocommerce.android.ui.dashboard.WidgetError
 import com.woocommerce.android.ui.dashboard.inbox.DashboardInboxViewModel.NavigateToInbox
 import com.woocommerce.android.ui.dashboard.inbox.DashboardInboxViewModel.ViewState
-import com.woocommerce.android.ui.inbox.InboxNoteItemSkeleton
-import com.woocommerce.android.ui.inbox.InboxNoteRow
+import com.woocommerce.android.ui.inbox.InboxNoteActionUi
 import com.woocommerce.android.ui.inbox.InboxNoteUi
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 
@@ -110,9 +127,9 @@ fun LatestNotes(
             EmptyView()
         } else {
             notes.forEach { note ->
-                InboxNoteRow(note, limitDescription = true)
+                DashboardInboxNoteRow(note, limitDescription = true)
 
-                Divider(
+                WooDivider(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(start = 16.dp)
@@ -126,8 +143,8 @@ fun LatestNotes(
 private fun Loading() {
     Column {
         repeat(3) {
-            InboxNoteItemSkeleton()
-            Divider(
+            DashboardInboxNoteItemSkeleton()
+            WooDivider(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(start = 16.dp)
@@ -153,7 +170,8 @@ fun EmptyView() {
         Text(
             text = stringResource(id = R.string.empty_inbox_title),
             textAlign = TextAlign.Center,
-            style = MaterialTheme.typography.h6,
+            style = WooTheme.text.titleLarge.strong,
+            color = WooTheme.colors.surface.onDefault,
             modifier = Modifier.padding(
                 start = dimensionResource(id = R.dimen.major_150),
                 end = dimensionResource(id = R.dimen.major_150)
@@ -165,11 +183,171 @@ fun EmptyView() {
 @Composable
 @Preview
 fun PreviewEmptyView() {
-    EmptyView()
+    WooDesignSystemThemeWithBackground { EmptyView() }
 }
 
 @Composable
 @Preview
 fun PreviewLoadingCard() {
-    Loading()
+    WooDesignSystemThemeWithBackground { Loading() }
+}
+
+@Composable
+private fun DashboardInboxNoteRow(note: InboxNoteUi, limitDescription: Boolean) {
+    val showMore = remember { mutableStateOf(limitDescription && note.description.length > 100) }
+
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(WooTheme.spacing.space4),
+    ) {
+        Column(
+            modifier = Modifier.padding(horizontal = WooTheme.padding.padding5),
+            verticalArrangement = Arrangement.spacedBy(WooTheme.spacing.space4),
+        ) {
+            Text(
+                modifier = Modifier.padding(top = WooTheme.padding.padding5),
+                text = note.dateCreated,
+                style = WooTheme.text.titleSmall.regular,
+                color = WooTheme.colors.surface.onDefault,
+            )
+            Text(
+                text = note.title,
+                style = if (note.isActioned) {
+                    WooTheme.text.titleMedium.regular
+                } else {
+                    WooTheme.text.titleMedium.strong
+                },
+                color = WooTheme.colors.surface.onDefault,
+            )
+            Text(
+                modifier = Modifier.animateContentSize(),
+                text = AnnotatedString.fromHtml(note.description),
+                style = WooTheme.text.bodyMedium.regular,
+                color = WooTheme.colors.surface.onDefault,
+                maxLines = if (showMore.value) 2 else Int.MAX_VALUE,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+        AnimatedContent(showMore.value, label = "Animated note action bar") { isMoreVisible ->
+            if (isMoreVisible) {
+                DashboardInboxTextAction(
+                    label = stringResource(id = R.string.read_more),
+                    onClick = { showMore.value = false },
+                    modifier = Modifier.padding(start = WooTheme.padding.padding3),
+                )
+            } else if (note.isSurvey) {
+                DashboardInboxSurveyActions(note.actions)
+            } else {
+                DashboardInboxActions(note.actions)
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun DashboardInboxActions(actions: List<InboxNoteActionUi>) {
+    FlowRow(
+        modifier = Modifier
+            .padding(horizontal = WooTheme.padding.padding3)
+            .fillMaxWidth(),
+    ) {
+        actions.forEach { action -> DashboardInboxAction(action) }
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun DashboardInboxSurveyActions(actions: List<InboxNoteActionUi>) {
+    FlowRow(
+        modifier = Modifier.padding(
+            start = WooTheme.padding.padding5,
+            end = WooTheme.padding.padding5,
+            bottom = WooTheme.padding.padding3,
+        ),
+        horizontalArrangement = Arrangement.spacedBy(WooTheme.spacing.space5),
+    ) {
+        if (actions.isEmpty()) {
+            Text(
+                modifier = Modifier.padding(vertical = WooTheme.padding.padding5),
+                text = stringResource(id = R.string.inbox_note_survey_actioned),
+                style = WooTheme.text.bodyMedium.regular,
+                color = WooTheme.colors.surface.onDefault,
+            )
+        } else {
+            actions.forEachIndexed { index, action ->
+                if (index < 2) {
+                    WooOutlinedButton(
+                        text = action.label,
+                        onClick = { action.onClick(action.id, action.parentNoteId) },
+                        enabled = !action.isDismissing,
+                    )
+                } else {
+                    DashboardInboxAction(action)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DashboardInboxAction(action: InboxNoteActionUi) {
+    val actionColor = colorResource(id = action.textColor)
+    TextButton(
+        onClick = { action.onClick(action.id, action.parentNoteId) },
+        enabled = !action.isDismissing,
+        colors = ButtonDefaults.textButtonColors(contentColor = actionColor),
+    ) {
+        if (action.isDismissing) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(WooTheme.iconSize.size24),
+                color = actionColor,
+                strokeWidth = WooTheme.stroke.extraThick,
+            )
+        } else {
+            Text(
+                text = action.label.uppercase(),
+                style = WooTheme.text.labelLarge.emphasized,
+            )
+        }
+    }
+}
+
+@Composable
+private fun DashboardInboxTextAction(
+    label: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    TextButton(
+        onClick = onClick,
+        modifier = modifier,
+        colors = ButtonDefaults.textButtonColors(
+            contentColor = WooTheme.colors.container.onSecondaryContainer
+        ),
+    ) {
+        Text(text = label, style = WooTheme.text.labelLarge.emphasized)
+    }
+}
+
+@Composable
+private fun DashboardInboxNoteItemSkeleton() {
+    Column(modifier = Modifier.padding(WooTheme.padding.padding5)) {
+        DashboardSkeleton(width = 120.dp, height = 16.dp)
+        Spacer(modifier = Modifier.padding(top = WooTheme.padding.padding6))
+        DashboardSkeleton(width = 240.dp, height = 16.dp)
+        Spacer(modifier = Modifier.padding(top = WooTheme.padding.padding5))
+        repeat(3) {
+            DashboardSkeleton(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(16.dp),
+            )
+            Spacer(modifier = Modifier.padding(top = WooTheme.padding.padding2))
+        }
+        Row(horizontalArrangement = Arrangement.spacedBy(WooTheme.spacing.space5)) {
+            DashboardSkeleton(width = 160.dp, height = 16.dp)
+            DashboardSkeleton(width = 56.dp, height = 16.dp)
+        }
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/inbox/DashboardInboxCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/inbox/DashboardInboxCard.kt
@@ -3,11 +3,11 @@ package com.woocommerce.android.ui.dashboard.inbox
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -45,8 +45,8 @@ import com.woocommerce.android.ui.compose.designsystem.component.WooDivider
 import com.woocommerce.android.ui.compose.designsystem.component.WooOutlinedButton
 import com.woocommerce.android.ui.compose.designsystem.foundation.WooDesignSystemThemeWithBackground
 import com.woocommerce.android.ui.compose.rememberNavController
-import com.woocommerce.android.ui.dashboard.DashboardSkeleton
 import com.woocommerce.android.ui.dashboard.DashboardFragmentDirections
+import com.woocommerce.android.ui.dashboard.DashboardSkeleton
 import com.woocommerce.android.ui.dashboard.DashboardViewModel
 import com.woocommerce.android.ui.dashboard.WidgetCard
 import com.woocommerce.android.ui.dashboard.WidgetError

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/onboarding/DashboardOnboardingCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/onboarding/DashboardOnboardingCard.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -182,34 +181,32 @@ fun StoreOnboardingCardContent(
     onTaskClicked: (OnboardingTaskUi) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Box(modifier = modifier.fillMaxWidth()) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(WooTheme.colors.surface.default)
+    ) {
+        @Suppress("MagicNumber")
+        OnboardingCardProgressHeader(
+            tasks = onboardingState.tasks,
+            modifier = Modifier
+                .fillMaxWidth(0.5f)
+                .padding(horizontal = 16.dp)
+        )
         Column(
             modifier = Modifier
+                .padding(top = dimensionResource(id = R.dimen.major_100))
                 .fillMaxWidth()
-                .background(WooTheme.colors.surface.default)
         ) {
-            @Suppress("MagicNumber")
-            OnboardingCardProgressHeader(
-                tasks = onboardingState.tasks,
-                modifier = Modifier
-                    .fillMaxWidth(0.5f)
-                    .padding(horizontal = 16.dp)
-            )
-            Column(
-                modifier = Modifier
-                    .padding(top = dimensionResource(id = R.dimen.major_100))
-                    .fillMaxWidth()
-            ) {
-                onboardingState.tasks
-                    .filter { it.isCompleted.not() }
-                    .take(MAX_NUMBER_OF_TASK_TO_DISPLAY_IN_CARD)
-                    .forEachIndexed { index, task ->
-                        DashboardOnboardingTaskItem(task, onTaskClicked)
-                        if (index < onboardingState.tasks.size - 1) {
-                            WooDivider()
-                        }
+            onboardingState.tasks
+                .filter { it.isCompleted.not() }
+                .take(MAX_NUMBER_OF_TASK_TO_DISPLAY_IN_CARD)
+                .forEachIndexed { index, task ->
+                    DashboardOnboardingTaskItem(task, onTaskClicked)
+                    if (index < onboardingState.tasks.size - 1) {
+                        WooDivider()
                     }
-            }
+                }
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/onboarding/DashboardOnboardingCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/onboarding/DashboardOnboardingCard.kt
@@ -1,7 +1,7 @@
 package com.woocommerce.android.ui.dashboard.onboarding
 
-import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/onboarding/DashboardOnboardingCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/onboarding/DashboardOnboardingCard.kt
@@ -1,7 +1,12 @@
 package com.woocommerce.android.ui.dashboard.onboarding
 
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -11,11 +16,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Divider
-import androidx.compose.material.LinearProgressIndicator
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.ProgressIndicatorDefaults
-import androidx.compose.material.Text
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
@@ -25,9 +26,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.LiveData
@@ -36,10 +39,14 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.woocommerce.android.NavGraphMainDirections
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.navigateSafely
-import com.woocommerce.android.ui.compose.animations.SkeletonView
-import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
+import com.woocommerce.android.ui.compose.designsystem.WooTheme
+import com.woocommerce.android.ui.compose.designsystem.component.WooBadge
+import com.woocommerce.android.ui.compose.designsystem.component.WooDivider
+import com.woocommerce.android.ui.compose.designsystem.component.WooLinearProgressIndicator
+import com.woocommerce.android.ui.compose.designsystem.foundation.WooDesignSystemThemeWithBackground
 import com.woocommerce.android.ui.compose.rememberNavController
 import com.woocommerce.android.ui.dashboard.DashboardFragmentDirections
+import com.woocommerce.android.ui.dashboard.DashboardSkeleton
 import com.woocommerce.android.ui.dashboard.DashboardViewModel
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetMenu
 import com.woocommerce.android.ui.dashboard.WidgetCard
@@ -48,6 +55,7 @@ import com.woocommerce.android.ui.dashboard.onboarding.DashboardOnboardingViewMo
 import com.woocommerce.android.ui.dashboard.onboarding.DashboardOnboardingViewModel.OnboardingDashBoardState
 import com.woocommerce.android.ui.feedback.SurveyType
 import com.woocommerce.android.ui.onboarding.AboutYourStoreTaskRes
+import com.woocommerce.android.ui.onboarding.LaunchStoreTaskRes
 import com.woocommerce.android.ui.onboarding.NavigateToAboutYourStore
 import com.woocommerce.android.ui.onboarding.NavigateToAddProduct
 import com.woocommerce.android.ui.onboarding.NavigateToLaunchStore
@@ -57,7 +65,6 @@ import com.woocommerce.android.ui.onboarding.NavigateToSetupWooPayments
 import com.woocommerce.android.ui.onboarding.NavigateToSurvey
 import com.woocommerce.android.ui.onboarding.OnboardingTaskUi
 import com.woocommerce.android.ui.onboarding.ShowNameYourStoreDialog
-import com.woocommerce.android.ui.onboarding.TaskItem
 import com.woocommerce.android.ui.products.AddProductNavigator
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 
@@ -179,7 +186,7 @@ fun StoreOnboardingCardContent(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .background(MaterialTheme.colors.surface)
+                .background(WooTheme.colors.surface.default)
         ) {
             @Suppress("MagicNumber")
             OnboardingCardProgressHeader(
@@ -197,12 +204,9 @@ fun StoreOnboardingCardContent(
                     .filter { it.isCompleted.not() }
                     .take(MAX_NUMBER_OF_TASK_TO_DISPLAY_IN_CARD)
                     .forEachIndexed { index, task ->
-                        TaskItem(task, onTaskClicked)
+                        DashboardOnboardingTaskItem(task, onTaskClicked)
                         if (index < onboardingState.tasks.size - 1) {
-                            Divider(
-                                color = colorResource(id = R.color.divider_color),
-                                thickness = dimensionResource(id = R.dimen.minor_10)
-                            )
+                            WooDivider()
                         }
                     }
             }
@@ -220,21 +224,25 @@ fun OnboardingCardProgressHeader(
     val progress by remember { mutableFloatStateOf(if (totalTasks == 0) 0f else completedTasks / totalTasks.toFloat()) }
     val animatedProgress = animateFloatAsState(
         targetValue = progress,
-        animationSpec = ProgressIndicatorDefaults.ProgressAnimationSpec,
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioNoBouncy,
+            stiffness = Spring.StiffnessVeryLow,
+            visibilityThreshold = 1 / 1000f,
+        ),
         label = "OnboardingProgressAnimation"
     ).value
     Column(modifier) {
-        LinearProgressIndicator(
+        WooLinearProgressIndicator(
             progress = animatedProgress,
             modifier = Modifier
                 .height(dimensionResource(id = R.dimen.minor_100))
                 .clip(RoundedCornerShape(dimensionResource(id = R.dimen.minor_100))),
-            backgroundColor = colorResource(id = R.color.divider_color),
         )
         Text(
             modifier = Modifier.padding(top = dimensionResource(id = R.dimen.minor_100)),
             text = stringResource(R.string.store_onboarding_completed_tasks_status, completedTasks, totalTasks),
-            style = MaterialTheme.typography.body2,
+            style = WooTheme.text.bodyMedium.regular,
+            color = WooTheme.colors.surface.onDefault,
         )
     }
 }
@@ -246,20 +254,20 @@ private fun StoreOnboardingLoading(modifier: Modifier = Modifier) {
             .fillMaxWidth()
             .padding(horizontal = 16.dp)
     ) {
-        SkeletonView(
+        DashboardSkeleton(
             modifier = Modifier
                 .height(10.dp)
                 .width(200.dp)
         )
         Spacer(modifier = Modifier.height(8.dp))
-        SkeletonView(
+        DashboardSkeleton(
             modifier = Modifier
                 .height(10.dp)
                 .width(80.dp)
         )
         repeat(MAX_NUMBER_OF_TASK_TO_DISPLAY_IN_CARD) {
             OnboardingSkeletonItem()
-            Divider()
+            WooDivider()
         }
     }
 }
@@ -272,7 +280,7 @@ private fun OnboardingSkeletonItem() {
             .fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        SkeletonView(
+        DashboardSkeleton(
             modifier = Modifier
                 .height(42.dp)
                 .width(42.dp)
@@ -283,13 +291,13 @@ private fun OnboardingSkeletonItem() {
                 .padding(start = 16.dp)
                 .weight(1f)
         ) {
-            SkeletonView(
+            DashboardSkeleton(
                 modifier = Modifier
                     .height(12.dp)
                     .width(150.dp)
             )
             Spacer(modifier = Modifier.height(4.dp))
-            SkeletonView(
+            DashboardSkeleton(
                 modifier = Modifier
                     .height(10.dp)
                     .width(250.dp)
@@ -298,9 +306,12 @@ private fun OnboardingSkeletonItem() {
     }
 }
 
-@LightDarkThemePreviews
+@PreviewLightDark
 @Composable
-private fun OnboardingPreview() {
+private fun OnboardingPreview() = WooDesignSystemThemeWithBackground { OnboardingPreviewContent() }
+
+@Composable
+private fun OnboardingPreviewContent() {
     StoreOnboardingCardContent(
         OnboardingDashBoardState(
             title = R.string.store_onboarding_title,
@@ -321,6 +332,57 @@ private fun OnboardingPreview() {
             ),
             onViewAllTapped = {}
         ),
-        onTaskClicked = {}
+        onTaskClicked = {},
     )
+}
+
+@Composable
+private fun DashboardOnboardingTaskItem(
+    task: OnboardingTaskUi,
+    onTaskClicked: (OnboardingTaskUi) -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .clickable { onTaskClicked(task) }
+            .padding(WooTheme.padding.padding5),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(WooTheme.spacing.space5),
+    ) {
+        Image(
+            painter = painterResource(id = task.taskUiResources.icon),
+            contentDescription = null,
+            colorFilter = ColorFilter.tint(WooTheme.colors.surface.onVariant),
+        )
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(
+                WooTheme.spacing.space2 + WooTheme.spacing.space1
+            ),
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = stringResource(id = task.taskUiResources.title),
+                    style = WooTheme.text.titleMedium.strong,
+                    color = WooTheme.colors.surface.onDefault,
+                )
+                if (task.taskUiResources is LaunchStoreTaskRes) {
+                    WooBadge(
+                        text = stringResource(
+                            id = R.string.store_onboarding_launch_store_task_private_tag
+                        ).uppercase(),
+                        modifier = Modifier.padding(start = WooTheme.padding.padding5),
+                    )
+                }
+            }
+            Text(
+                text = stringResource(id = task.taskUiResources.description),
+                style = WooTheme.text.bodyLarge.regular,
+                color = WooTheme.colors.surface.onDefault,
+            )
+        }
+        Image(
+            painter = painterResource(R.drawable.ic_arrow_right),
+            contentDescription = null,
+        )
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/orders/DashboardOrdersCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/orders/DashboardOrdersCard.kt
@@ -8,9 +8,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.layout.width
-import androidx.compose.material.Divider
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.livedata.observeAsState
@@ -19,7 +17,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -31,9 +29,12 @@ import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.navOptions
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.navigateSafely
-import com.woocommerce.android.ui.compose.animations.SkeletonView
+import com.woocommerce.android.ui.compose.designsystem.WooTheme
+import com.woocommerce.android.ui.compose.designsystem.component.WooDivider
+import com.woocommerce.android.ui.compose.designsystem.foundation.WooDesignSystemThemeWithBackground
 import com.woocommerce.android.ui.compose.rememberNavController
 import com.woocommerce.android.ui.dashboard.DashboardFilterableCardHeader
+import com.woocommerce.android.ui.dashboard.DashboardSkeleton
 import com.woocommerce.android.ui.dashboard.DashboardViewModel
 import com.woocommerce.android.ui.dashboard.WidgetCard
 import com.woocommerce.android.ui.dashboard.WidgetError
@@ -146,7 +147,7 @@ private fun Header(
             mapper = { it.label }
         )
 
-        Divider()
+        WooDivider()
     }
 }
 
@@ -173,7 +174,7 @@ fun TopOrders(
                     onClick = { onOrderClicked(order) },
                 )
 
-                Divider(
+                WooDivider(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(start = 16.dp)
@@ -198,7 +199,7 @@ private fun Loading() {
     Column {
         repeat(3) {
             LoadingItem()
-            Divider(
+            WooDivider(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(start = 16.dp)
@@ -216,7 +217,7 @@ private fun LoadingItem() {
             .padding(16.dp)
     ) {
         val (number, date, name, status, total) = createRefs()
-        SkeletonView(
+        DashboardSkeleton(
             modifier = Modifier
                 .height(22.dp)
                 .width(50.dp)
@@ -226,7 +227,7 @@ private fun LoadingItem() {
                 }
         )
 
-        SkeletonView(
+        DashboardSkeleton(
             modifier = Modifier
                 .padding(start = 16.dp)
                 .height(22.dp)
@@ -237,7 +238,7 @@ private fun LoadingItem() {
                 }
         )
 
-        SkeletonView(
+        DashboardSkeleton(
             modifier = Modifier
                 .padding(top = 8.dp)
                 .height(20.dp)
@@ -248,7 +249,7 @@ private fun LoadingItem() {
                 }
         )
 
-        SkeletonView(
+        DashboardSkeleton(
             modifier = Modifier
                 .height(22.dp)
                 .width(100.dp)
@@ -258,7 +259,7 @@ private fun LoadingItem() {
                 },
         )
 
-        SkeletonView(
+        DashboardSkeleton(
             modifier = Modifier
                 .padding(top = 8.dp)
                 .height(20.dp)
@@ -292,21 +293,25 @@ fun EmptyView(
             text = stringResource(
                 R.string.orders_empty_message_for_filtered_orders
             ),
-            style = MaterialTheme.typography.h6,
+            style = WooTheme.text.titleLarge.strong,
+            color = WooTheme.colors.surface.onDefault,
             textAlign = TextAlign.Center
         )
     }
 }
 
 @Composable
-@Preview
+@PreviewLightDark
 fun PreviewEmptyView() {
-    EmptyView()
+    WooDesignSystemThemeWithBackground { EmptyView() }
 }
 
 @Composable
-@Preview
-fun PreviewTopOrders() {
+@PreviewLightDark
+fun PreviewTopOrders() = WooDesignSystemThemeWithBackground { PreviewTopOrdersContent() }
+
+@Composable
+private fun PreviewTopOrdersContent() {
     TopOrders(
         orders = listOf(
             OrderItem(
@@ -351,12 +356,12 @@ fun PreviewTopOrders() {
             )
         ),
         onFilterSelected = {},
-        onOrderClicked = {}
+        onOrderClicked = {},
     )
 }
 
 @Composable
-@Preview
+@PreviewLightDark
 fun PreviewLoadingCard() {
-    Loading()
+    WooDesignSystemThemeWithBackground { Loading() }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/pushnotifications/DashboardPushNotificationsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/pushnotifications/DashboardPushNotificationsCard.kt
@@ -12,7 +12,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.woocommerce.android.R
 import com.woocommerce.android.model.DashboardWidget
-import com.woocommerce.android.ui.compose.component.getText
 import com.woocommerce.android.ui.compose.designsystem.WooTheme
 import com.woocommerce.android.ui.compose.designsystem.foundation.WooDesignSystemThemeWithBackground
 import com.woocommerce.android.ui.dashboard.DashboardCardSurface
@@ -66,9 +65,7 @@ fun DashboardPushNotificationsCard(
                 )
             }
             DashboardOverflowMenu(
-                items = menu.items,
-                onSelected = { item -> item.action() },
-                mapper = { it.title.getText() },
+                menu = menu,
             )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/pushnotifications/DashboardPushNotificationsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/pushnotifications/DashboardPushNotificationsCard.kt
@@ -1,27 +1,22 @@
 package com.woocommerce.android.ui.dashboard.pushnotifications
 
-import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.colorResource
-import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.woocommerce.android.R
 import com.woocommerce.android.model.DashboardWidget
-import com.woocommerce.android.ui.compose.component.WCOverflowMenu
 import com.woocommerce.android.ui.compose.component.getText
-import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
-import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.compose.designsystem.WooTheme
+import com.woocommerce.android.ui.compose.designsystem.foundation.WooDesignSystemThemeWithBackground
+import com.woocommerce.android.ui.dashboard.DashboardCardSurface
+import com.woocommerce.android.ui.dashboard.DashboardOverflowMenu
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetMenu
 import com.woocommerce.android.ui.dashboard.defaultHideMenuEntry
 import com.woocommerce.android.ui.pushnotifications.WordPressWooBadge
@@ -43,50 +38,46 @@ fun DashboardPushNotificationsCard(
         )
     )
 
-    Row(
-        modifier = modifier
-            .clickable(onClick = onClick)
-            .border(
-                width = 1.dp,
-                color = colorResource(id = R.color.woo_gray_5),
-                shape = RoundedCornerShape(8.dp)
-            )
-            .padding(start = 16.dp),
-        horizontalArrangement = Arrangement.spacedBy(16.dp),
-    ) {
-        WordPressWooBadge(
-            iconSize = 32.dp,
-            modifier = Modifier.padding(top = 16.dp)
-        )
-        Column(
-            modifier = Modifier
-                .weight(1f)
-                .padding(vertical = 16.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
+    DashboardCardSurface(modifier = modifier, onClick = onClick) {
+        Row(
+            modifier = Modifier.padding(start = WooTheme.padding.padding5),
+            horizontalArrangement = Arrangement.spacedBy(WooTheme.spacing.space5),
         ) {
-            Text(
-                text = stringResource(id = R.string.my_store_widget_push_notifications_title),
-                style = MaterialTheme.typography.titleLarge,
+            WordPressWooBadge(
+                iconSize = WooTheme.iconSize.size32,
+                modifier = Modifier.padding(top = WooTheme.padding.padding5),
             )
-            Text(
-                text = stringResource(id = R.string.my_store_widget_push_notifications_description),
-                style = MaterialTheme.typography.bodyLarge,
-                modifier = Modifier.padding(top = dimensionResource(id = R.dimen.minor_50))
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(vertical = WooTheme.padding.padding5),
+                verticalArrangement = Arrangement.spacedBy(WooTheme.spacing.space3),
+            ) {
+                Text(
+                    text = stringResource(id = R.string.my_store_widget_push_notifications_title),
+                    style = WooTheme.text.titleLarge.strong,
+                    color = WooTheme.colors.surface.onDefault,
+                )
+                Text(
+                    text = stringResource(id = R.string.my_store_widget_push_notifications_description),
+                    style = WooTheme.text.bodyLarge.regular,
+                    color = WooTheme.colors.surface.onDefault,
+                    modifier = Modifier.padding(top = WooTheme.padding.padding2),
+                )
+            }
+            DashboardOverflowMenu(
+                items = menu.items,
+                onSelected = { item -> item.action() },
+                mapper = { it.title.getText() },
             )
         }
-        WCOverflowMenu(
-            items = menu.items,
-            onSelected = { item -> item.action() },
-            mapper = { it.title.getText() },
-            tint = colorResource(id = R.color.color_on_surface_high)
-        )
     }
 }
 
-@LightDarkThemePreviews
+@PreviewLightDark
 @Composable
 fun DashboardPushNotificationsCardPreview() {
-    WooThemeWithBackground {
+    WooDesignSystemThemeWithBackground {
         DashboardPushNotificationsCard(
             onHideClicked = {},
             onShown = {}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/reviews/DashboardReviewsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/reviews/DashboardReviewsCard.kt
@@ -1,8 +1,8 @@
 package com.woocommerce.android.ui.dashboard.reviews
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/reviews/DashboardReviewsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/reviews/DashboardReviewsCard.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android.ui.dashboard.reviews
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -292,7 +291,6 @@ private fun DashboardReviewListItem(
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .background(WooTheme.colors.surface.default)
             .clickable(onClick = onClicked),
     ) {
         Row(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/reviews/DashboardReviewsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/reviews/DashboardReviewsCard.kt
@@ -1,5 +1,7 @@
 package com.woocommerce.android.ui.dashboard.reviews
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -7,10 +9,10 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.sizeIn
-import androidx.compose.material.Divider
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.livedata.observeAsState
@@ -18,28 +20,40 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.Observer
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.woocommerce.android.R
+import com.woocommerce.android.extensions.fastStripHtml
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.model.DashboardWidget
 import com.woocommerce.android.model.ProductReview
-import com.woocommerce.android.ui.compose.animations.SkeletonView
+import com.woocommerce.android.ui.compose.designsystem.WooTheme
+import com.woocommerce.android.ui.compose.designsystem.component.WooDivider
+import com.woocommerce.android.ui.compose.designsystem.icons.Star
+import com.woocommerce.android.ui.compose.designsystem.icons.WooIcons
 import com.woocommerce.android.ui.compose.rememberNavController
 import com.woocommerce.android.ui.dashboard.DashboardFilterableCardHeader
 import com.woocommerce.android.ui.dashboard.DashboardFragmentDirections
+import com.woocommerce.android.ui.dashboard.DashboardSkeleton
 import com.woocommerce.android.ui.dashboard.DashboardViewModel
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetMenu
 import com.woocommerce.android.ui.dashboard.WidgetCard
 import com.woocommerce.android.ui.dashboard.WidgetError
 import com.woocommerce.android.ui.dashboard.defaultHideMenuEntry
 import com.woocommerce.android.ui.reviews.ProductReviewStatus
-import com.woocommerce.android.ui.reviews.ReviewListItem
+import com.woocommerce.android.util.StringUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 
 @Composable
@@ -167,7 +181,7 @@ private fun ProductReviewsCardContent(
             EmptyView(selectedFilter = viewState.selectedFilter)
         } else {
             viewState.reviews.forEach { productReview ->
-                ReviewListItem(
+                DashboardReviewListItem(
                     review = productReview,
                     onClicked = { onReviewClicked(productReview) }
                 )
@@ -189,16 +203,16 @@ private fun ReviewsLoading(
                 horizontalArrangement = Arrangement.spacedBy(16.dp),
                 modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
             ) {
-                SkeletonView(width = 24.dp, height = 24.dp)
+                DashboardSkeleton(width = 24.dp, height = 24.dp)
 
                 Column(
                     verticalArrangement = Arrangement.spacedBy(4.dp)
                 ) {
-                    SkeletonView(width = 260.dp, height = 16.dp)
-                    SkeletonView(width = 120.dp, height = 16.dp)
-                    SkeletonView(width = 60.dp, height = 16.dp)
+                    DashboardSkeleton(width = 260.dp, height = 16.dp)
+                    DashboardSkeleton(width = 120.dp, height = 16.dp)
+                    DashboardSkeleton(width = 60.dp, height = 16.dp)
                     Spacer(modifier = Modifier)
-                    Divider()
+                    WooDivider()
                 }
             }
         }
@@ -220,7 +234,7 @@ private fun Header(
             mapper = { ProductReviewStatus.getLocalizedLabel(LocalContext.current, it) }
         )
 
-        Divider()
+        WooDivider()
     }
 }
 
@@ -250,7 +264,8 @@ private fun EmptyView(
                     R.string.dashboard_reviews_card_empty_title_filtered
                 }
             ),
-            style = MaterialTheme.typography.h6,
+            style = WooTheme.text.titleLarge.strong,
+            color = WooTheme.colors.surface.onDefault,
             textAlign = TextAlign.Center
         )
 
@@ -262,8 +277,99 @@ private fun EmptyView(
                     R.string.dashboard_reviews_card_empty_message_filtered
                 }
             ),
-            style = MaterialTheme.typography.body1,
+            style = WooTheme.text.bodyLarge.regular,
+            color = WooTheme.colors.surface.onDefault,
             textAlign = TextAlign.Center
         )
+    }
+}
+
+@Composable
+private fun DashboardReviewListItem(
+    review: ProductReview,
+    onClicked: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(WooTheme.colors.surface.default)
+            .clickable(onClick = onClicked),
+    ) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(WooTheme.spacing.space5),
+            modifier = Modifier.padding(
+                horizontal = WooTheme.padding.padding5,
+                vertical = WooTheme.padding.padding3,
+            ),
+        ) {
+            val isPending = review.status == ProductReviewStatus.HOLD.toString()
+            Icon(
+                painter = painterResource(id = R.drawable.ic_comment),
+                contentDescription = null,
+                tint = if (isPending) WooTheme.colors.secondary else WooTheme.colors.surface.onDefault,
+            )
+            Column(
+                verticalArrangement = Arrangement.spacedBy(
+                    WooTheme.spacing.space2 + WooTheme.spacing.space1
+                )
+            ) {
+                Text(
+                    text = if (review.product == null) {
+                        stringResource(R.string.product_review_list_item_title, review.reviewerName)
+                    } else {
+                        stringResource(
+                            R.string.review_list_item_title,
+                            review.reviewerName,
+                            review.product?.name?.fastStripHtml().orEmpty(),
+                        )
+                    },
+                    style = WooTheme.text.titleMedium.emphasized,
+                    color = WooTheme.colors.surface.onDefault,
+                )
+                val reviewText = buildAnnotatedString {
+                    if (isPending) {
+                        withStyle(SpanStyle(color = WooTheme.colors.container.onSecondaryContainer)) {
+                            append(stringResource(id = R.string.pending_review_label))
+                        }
+                        append(" \u2022 ")
+                    }
+                    append(StringUtils.getRawTextFromHtml(review.review))
+                }
+                Text(
+                    text = reviewText,
+                    style = WooTheme.text.bodyMedium.regular,
+                    color = WooTheme.colors.surface.onDefault,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                if (review.rating > 0) {
+                    DashboardReviewRating(rating = review.rating)
+                }
+            }
+        }
+        WooDivider(modifier = Modifier.padding(start = 56.dp))
+    }
+}
+
+@Composable
+private fun DashboardReviewRating(rating: Int) {
+    val ratingDescription = pluralStringResource(
+        R.plurals.dashboard_review_rating_content_description,
+        rating,
+        rating,
+    )
+    Row(
+        modifier = Modifier.semantics {
+            contentDescription = ratingDescription
+        },
+    ) {
+        repeat(rating) {
+            Icon(
+                imageVector = WooIcons.Solid.Star,
+                contentDescription = null,
+                modifier = Modifier.size(WooTheme.iconSize.size16),
+                tint = WooTheme.colors.container.onSecondaryContainer,
+            )
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
@@ -12,8 +12,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
@@ -13,14 +13,16 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.Divider
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
@@ -37,10 +39,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
@@ -54,7 +54,8 @@ import com.woocommerce.android.R
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.model.DashboardWidget
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType
-import com.woocommerce.android.ui.compose.component.WCModalBottomSheet
+import com.woocommerce.android.ui.compose.designsystem.WooTheme
+import com.woocommerce.android.ui.compose.designsystem.component.WooDivider
 import com.woocommerce.android.ui.compose.rememberNavController
 import com.woocommerce.android.ui.dashboard.DashboardDateRangeHeader
 import com.woocommerce.android.ui.dashboard.DashboardFragmentDirections
@@ -199,7 +200,7 @@ private fun DashboardStatsContent(
             modifier = Modifier.fillMaxWidth()
         )
 
-        Divider()
+        WooDivider()
 
         RevenueStatsTypeSelector(
             selectedType = selectedRevenueStatsType,
@@ -338,8 +339,8 @@ private fun RevenueStatsTypeSelector(
 ) {
     val options = DashboardStatsViewModel.RevenueStatsType.OPTIONS
     val segmentedButtonColors = SegmentedButtonDefaults.colors(
-        activeContainerColor = colorResource(id = R.color.color_primary),
-        activeContentColor = colorResource(id = R.color.woo_white),
+        activeContainerColor = WooTheme.colors.primary,
+        activeContentColor = WooTheme.colors.onPrimary,
     )
 
     SingleChoiceSegmentedButtonRow(
@@ -374,10 +375,19 @@ private fun OrderDateTypeBottomSheet(
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
-    WCModalBottomSheet(
+    ModalBottomSheet(
         sheetState = sheetState,
         onDismissRequest = onDismiss,
-        modifier = modifier
+        modifier = modifier,
+        shape = RoundedCornerShape(
+            topStart = WooTheme.radius.extraLarge,
+            topEnd = WooTheme.radius.extraLarge,
+        ),
+        containerColor = WooTheme.colors.surface.default,
+        contentColor = WooTheme.colors.surface.onDefault,
+        dragHandle = {
+            BottomSheetDefaults.DragHandle(color = WooTheme.colors.outline)
+        },
     ) {
         Column(
             modifier = Modifier
@@ -387,9 +397,8 @@ private fun OrderDateTypeBottomSheet(
             Text(
                 modifier = Modifier.padding(horizontal = 24.dp),
                 text = stringResource(id = R.string.dashboard_stats_order_date_type_sheet_title),
-                style = MaterialTheme.typography.titleLarge,
-                fontWeight = FontWeight.Bold,
-                color = MaterialTheme.colorScheme.onSurface
+                style = WooTheme.text.titleLarge.strong,
+                color = WooTheme.colors.surface.onDefault,
             )
 
             Spacer(modifier = Modifier.height(12.dp))
@@ -397,8 +406,8 @@ private fun OrderDateTypeBottomSheet(
             Text(
                 modifier = Modifier.padding(horizontal = 24.dp),
                 text = stringResource(id = R.string.dashboard_stats_order_date_type_sheet_description),
-                style = MaterialTheme.typography.bodyLarge,
-                color = MaterialTheme.colorScheme.onSurface
+                style = WooTheme.text.bodyLarge.regular,
+                color = WooTheme.colors.surface.onDefault,
             )
 
             Spacer(modifier = Modifier.height(28.dp))
@@ -413,12 +422,18 @@ private fun OrderDateTypeBottomSheet(
             }
 
             if (state.hasUpdateError) {
-                Text(
+                Surface(
                     modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp),
-                    text = stringResource(id = R.string.dashboard_stats_order_date_type_update_error),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.error
-                )
+                    color = WooTheme.colors.status.errorContainer,
+                    contentColor = WooTheme.colors.status.onErrorContainer,
+                    shape = RoundedCornerShape(WooTheme.radius.medium),
+                ) {
+                    Text(
+                        modifier = Modifier.padding(horizontal = WooTheme.padding.padding3),
+                        text = stringResource(id = R.string.dashboard_stats_order_date_type_update_error),
+                        style = WooTheme.text.bodyMedium.regular,
+                    )
+                }
             }
 
             Spacer(modifier = Modifier.height(24.dp))
@@ -426,8 +441,8 @@ private fun OrderDateTypeBottomSheet(
             Text(
                 modifier = Modifier.padding(horizontal = 24.dp),
                 text = stringResource(id = R.string.dashboard_stats_order_date_type_sheet_footer),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
+                style = WooTheme.text.bodySmall.regular,
+                color = WooTheme.colors.surface.onDefault,
             )
         }
     }
@@ -461,17 +476,16 @@ private fun OrderDateTypeOptionRow(
         Column(modifier = Modifier.weight(1f)) {
             Text(
                 text = stringResource(id = option.title),
-                style = MaterialTheme.typography.bodyLarge,
-                fontWeight = FontWeight.SemiBold,
-                color = MaterialTheme.colorScheme.onSurface
+                style = WooTheme.text.bodyLarge.emphasized,
+                color = WooTheme.colors.surface.onDefault,
             )
 
             Spacer(modifier = Modifier.height(4.dp))
 
             Text(
                 text = stringResource(id = option.description),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
+                style = WooTheme.text.bodyMedium.regular,
+                color = WooTheme.colors.surface.onDefault,
             )
         }
 
@@ -479,15 +493,16 @@ private fun OrderDateTypeOptionRow(
 
         when {
             isUpdating -> CircularProgressIndicator(
+                color = WooTheme.colors.primary,
                 modifier = Modifier.size(24.dp),
-                strokeWidth = 2.dp
+                strokeWidth = 2.dp,
             )
 
             isSelected -> Icon(
                 modifier = Modifier.size(18.dp),
                 imageVector = ImageVector.vectorResource(R.drawable.ic_check),
                 contentDescription = null,
-                tint = MaterialTheme.colorScheme.primary
+                tint = WooTheme.colors.primary,
             )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsView.kt
@@ -67,6 +67,7 @@ import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
 import org.wordpress.android.util.DisplayUtils
 import java.util.Locale
 import kotlin.math.round
+import com.woocommerce.android.ui.compose.designsystem.R as WooDesignSystemR
 
 @OptIn(FlowPreview::class)
 @Suppress("MagicNumber")
@@ -548,7 +549,7 @@ class DashboardStatsView @JvmOverloads constructor(
         lastUpdated.compoundDrawablePadding = resources.getDimensionPixelSize(R.dimen.minor_50)
         TextViewCompat.setCompoundDrawableTintList(
             lastUpdated,
-            ColorStateList.valueOf(ContextCompat.getColor(context, R.color.color_primary))
+            ColorStateList.valueOf(ContextCompat.getColor(context, WooDesignSystemR.color.woo_ds_color_primary))
         )
         lastUpdated.setOnClickListener { onInfoClick() }
         // Tell screen readers what activating the footer does (the visible text is still read).

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stock/DashboardProductStockCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stock/DashboardProductStockCard.kt
@@ -10,19 +10,16 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Divider
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -34,9 +31,11 @@ import com.woocommerce.android.NavGraphMainDirections
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.model.DashboardWidget
-import com.woocommerce.android.ui.compose.animations.SkeletonView
+import com.woocommerce.android.ui.compose.designsystem.WooTheme
+import com.woocommerce.android.ui.compose.designsystem.component.WooDivider
 import com.woocommerce.android.ui.compose.rememberNavController
 import com.woocommerce.android.ui.dashboard.DashboardFilterableCardHeader
+import com.woocommerce.android.ui.dashboard.DashboardSkeleton
 import com.woocommerce.android.ui.dashboard.DashboardViewModel
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetMenu
 import com.woocommerce.android.ui.dashboard.WCAnalyticsNotAvailableErrorView
@@ -164,7 +163,7 @@ private fun ProductStockLoading(
                     .fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                SkeletonView(
+                DashboardSkeleton(
                     modifier = Modifier
                         .height(42.dp)
                         .width(42.dp)
@@ -176,10 +175,10 @@ private fun ProductStockLoading(
                         .weight(1f),
                     verticalArrangement = Arrangement.spacedBy(4.dp)
                 ) {
-                    SkeletonView(width = 240.dp, height = 16.dp)
-                    SkeletonView(width = 140.dp, height = 12.dp)
+                    DashboardSkeleton(width = 240.dp, height = 16.dp)
+                    DashboardSkeleton(width = 140.dp, height = 12.dp)
                 }
-                SkeletonView(width = 20.dp, height = 14.dp)
+                DashboardSkeleton(width = 20.dp, height = 14.dp)
             }
         }
     }
@@ -199,25 +198,52 @@ private fun ProductStockCardContent(
             Text(
                 modifier = Modifier.weight(1f),
                 text = stringResource(id = R.string.dashboard_product_stock_products),
-                style = MaterialTheme.typography.body2,
-                color = colorResource(id = R.color.color_on_surface_medium_selector),
-                fontWeight = FontWeight.SemiBold,
+                style = WooTheme.text.bodyMedium.emphasized,
+                color = WooTheme.colors.surface.onDefault,
             )
             Text(
                 text = stringResource(id = R.string.dashboard_product_stock_levels),
-                style = MaterialTheme.typography.body2,
-                color = colorResource(id = R.color.color_on_surface_medium_selector),
-                fontWeight = FontWeight.SemiBold,
+                style = WooTheme.text.bodyMedium.emphasized,
+                color = WooTheme.colors.surface.onDefault,
             )
         }
         when {
             productStockItems.isEmpty() -> StockEmptyView()
             else -> productStockItems.forEachIndexed { index, product ->
-                ProductStockRow(
-                    product = product,
-                    onItemClicked = onProductClicked,
-                    displayDivider = index != productStockItems.size - 1
-                )
+                ProductSummaryRow(
+                    title = product.name,
+                    imageUrl = product.imageUrl,
+                    onClick = { onProductClicked(product) },
+                    displayDivider = index != productStockItems.size - 1,
+                    trailingContent = {
+                        Surface(
+                            color = WooTheme.colors.status.errorContainer,
+                            contentColor = WooTheme.colors.status.onErrorContainer,
+                            shape = RoundedCornerShape(WooTheme.radius.medium),
+                        ) {
+                            Text(
+                                modifier = Modifier.padding(horizontal = WooTheme.padding.padding2),
+                                text = product.stockQuantity,
+                                style = WooTheme.text.titleMedium.regular,
+                            )
+                        }
+                    },
+                ) {
+                    ProductSummaryRowInfo(
+                        text = when {
+                            product.itemsSold == 0 -> {
+                                stringResource(R.string.dashboard_product_stock_no_sales_last_30_days)
+                            }
+                            else -> stringResource(
+                                R.string.dashboard_product_stock_sales_last_30_days,
+                                product.itemsSold,
+                            )
+                        },
+                        maxLines = Int.MAX_VALUE,
+                        overflow = TextOverflow.Clip,
+                        style = WooTheme.text.bodyMedium.regular,
+                    )
+                }
             }
         }
     }
@@ -242,42 +268,9 @@ fun StockEmptyView(modifier: Modifier = Modifier) {
 
         Text(
             text = stringResource(id = R.string.dashboard_product_stock_empty_products),
-            style = MaterialTheme.typography.body1,
+            style = WooTheme.text.bodyLarge.regular,
+            color = WooTheme.colors.surface.onDefault,
             textAlign = TextAlign.Center
-        )
-    }
-}
-
-@Composable
-fun ProductStockRow(
-    product: DashboardProductStockViewModel.ProductStockUiItem,
-    onItemClicked: (DashboardProductStockViewModel.ProductStockUiItem) -> Unit,
-    displayDivider: Boolean,
-    modifier: Modifier = Modifier,
-) {
-    ProductSummaryRow(
-        title = product.name,
-        imageUrl = product.imageUrl,
-        onClick = { onItemClicked(product) },
-        displayDivider = displayDivider,
-        modifier = modifier,
-        trailingContent = {
-            Text(
-                text = product.stockQuantity,
-                color = colorResource(id = R.color.color_error),
-                style = MaterialTheme.typography.subtitle1,
-            )
-        },
-    ) {
-        ProductSummaryRowInfo(
-            text = when {
-                product.itemsSold == 0 -> stringResource(R.string.dashboard_product_stock_no_sales_last_30_days)
-                else -> stringResource(R.string.dashboard_product_stock_sales_last_30_days, product.itemsSold)
-            },
-            color = colorResource(id = R.color.color_on_surface_medium_selector),
-            maxLines = Int.MAX_VALUE,
-            overflow = TextOverflow.Clip,
-            style = MaterialTheme.typography.body2,
         )
     }
 }
@@ -296,6 +289,6 @@ private fun Header(
             onFilterSelected = onFilterSelected,
             mapper = { stringResource(id = it.stringResource) }
         )
-        Divider()
+        WooDivider()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topperformers/DashboardTopPerformersWidgetCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topperformers/DashboardTopPerformersWidgetCard.kt
@@ -39,8 +39,8 @@ import com.woocommerce.android.ui.compose.designsystem.component.WooDivider
 import com.woocommerce.android.ui.compose.designsystem.foundation.WooDesignSystemThemeWithBackground
 import com.woocommerce.android.ui.compose.rememberNavController
 import com.woocommerce.android.ui.dashboard.DashboardDateRangeHeader
-import com.woocommerce.android.ui.dashboard.DashboardSkeleton
 import com.woocommerce.android.ui.dashboard.DashboardFragmentDirections
+import com.woocommerce.android.ui.dashboard.DashboardSkeleton
 import com.woocommerce.android.ui.dashboard.DashboardViewModel
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.OpenRangePicker
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetAction

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topperformers/DashboardTopPerformersWidgetCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topperformers/DashboardTopPerformersWidgetCard.kt
@@ -10,9 +10,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Divider
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
@@ -21,11 +19,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.LiveData
@@ -36,11 +33,13 @@ import com.woocommerce.android.R
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.model.DashboardWidget
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType
-import com.woocommerce.android.ui.compose.animations.SkeletonView
 import com.woocommerce.android.ui.compose.component.ProductThumbnail
-import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
+import com.woocommerce.android.ui.compose.designsystem.WooTheme
+import com.woocommerce.android.ui.compose.designsystem.component.WooDivider
+import com.woocommerce.android.ui.compose.designsystem.foundation.WooDesignSystemThemeWithBackground
 import com.woocommerce.android.ui.compose.rememberNavController
 import com.woocommerce.android.ui.dashboard.DashboardDateRangeHeader
+import com.woocommerce.android.ui.dashboard.DashboardSkeleton
 import com.woocommerce.android.ui.dashboard.DashboardFragmentDirections
 import com.woocommerce.android.ui.dashboard.DashboardViewModel
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.OpenRangePicker
@@ -139,7 +138,7 @@ fun DashboardTopPerformersContent(
                 onTabSelected = onTabSelected
             )
         }
-        Divider(modifier = Modifier.padding(bottom = 16.dp))
+        WooDivider(modifier = Modifier.padding(bottom = 16.dp))
 
         when {
             topPerformersState?.isLoading == true -> TopPerformersLoading(
@@ -204,15 +203,13 @@ private fun TopPerformersContent(
             Text(
                 modifier = Modifier.weight(1f),
                 text = stringResource(id = R.string.product),
-                style = MaterialTheme.typography.body2,
-                color = colorResource(id = R.color.color_on_surface_medium_selector),
-                fontWeight = FontWeight.SemiBold,
+                style = WooTheme.text.bodyMedium.emphasized,
+                color = WooTheme.colors.surface.onDefault,
             )
             Text(
                 text = stringResource(id = R.string.dashboard_top_performers_items_sold),
-                style = MaterialTheme.typography.body2,
-                color = colorResource(id = R.color.color_on_surface_medium_selector),
-                fontWeight = FontWeight.SemiBold,
+                style = WooTheme.text.bodyMedium.emphasized,
+                color = WooTheme.colors.surface.onDefault,
             )
         }
         when {
@@ -255,7 +252,7 @@ private fun TopPerformersLoading(modifier: Modifier = Modifier) {
     Column(modifier = modifier.fillMaxWidth()) {
         repeat(5) {
             TopPerformerSkeletonItem()
-            Divider()
+            WooDivider()
         }
     }
 }
@@ -268,7 +265,7 @@ fun TopPerformerSkeletonItem() {
             .fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        SkeletonView(
+        DashboardSkeleton(
             modifier = Modifier
                 .height(42.dp)
                 .width(42.dp)
@@ -279,19 +276,19 @@ fun TopPerformerSkeletonItem() {
                 .padding(start = 16.dp)
                 .weight(1f)
         ) {
-            SkeletonView(
+            DashboardSkeleton(
                 modifier = Modifier
                     .height(14.dp)
                     .width(180.dp)
             )
             Spacer(modifier = Modifier.height(4.dp))
-            SkeletonView(
+            DashboardSkeleton(
                 modifier = Modifier
                     .height(12.dp)
                     .width(150.dp)
             )
         }
-        SkeletonView(
+        DashboardSkeleton(
             modifier = Modifier
                 .height(14.dp)
                 .width(30.dp)
@@ -321,22 +318,24 @@ private fun TopPerformerProductItem(
                 Text(
                     modifier = Modifier.weight(1f),
                     text = topPerformer.name,
-                    style = MaterialTheme.typography.subtitle1,
+                    style = WooTheme.text.titleMedium.regular,
+                    color = WooTheme.colors.surface.onDefault,
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis
                 )
                 Text(
                     text = topPerformer.timesOrdered,
-                    style = MaterialTheme.typography.subtitle1,
+                    style = WooTheme.text.titleMedium.regular,
+                    color = WooTheme.colors.surface.onDefault,
                 )
             }
             Text(
                 text = topPerformer.netSales,
-                style = MaterialTheme.typography.body2,
-                color = colorResource(id = R.color.color_on_surface_medium_selector)
+                style = WooTheme.text.bodyMedium.regular,
+                color = WooTheme.colors.surface.onDefault,
             )
             if (displayDivider) {
-                Divider(modifier = Modifier.padding(top = 8.dp))
+                WooDivider(modifier = Modifier.padding(top = 8.dp))
             }
         }
     }
@@ -352,12 +351,13 @@ private fun TopPerformersEmptyView(modifier: Modifier = Modifier) {
     ) {
         Image(
             painter = painterResource(id = R.drawable.ic_not_found),
-            contentDescription = "",
+            contentDescription = null,
         )
         Text(
             modifier = Modifier.padding(top = 24.dp),
             text = stringResource(id = R.string.dashboard_top_performers_empty),
-            style = MaterialTheme.typography.body2,
+            style = WooTheme.text.bodyMedium.regular,
+            color = WooTheme.colors.surface.onDefault,
         )
     }
 }
@@ -384,9 +384,13 @@ private fun TopPerformersErrorView(
     }
 }
 
-@LightDarkThemePreviews
+@PreviewLightDark
 @Composable
-private fun TopPerformersWidgetCardPreview() {
+private fun TopPerformersWidgetCardPreview() =
+    WooDesignSystemThemeWithBackground { TopPerformersPreviewContent() }
+
+@Composable
+private fun TopPerformersPreviewContent() {
     val selectedDateRange = TopPerformersDateRange(
         SelectionType.TODAY.generateSelectionData(
             referenceStartDate = Date(),
@@ -452,7 +456,9 @@ private fun TopPerformersWidgetCardPreview() {
             onEditCustomRangeTapped = {}
         )
         DashboardTopPerformersContent(
-            topPerformersState = topPerformersState.copy(error = DashboardTopPerformersViewModel.ErrorType.Generic),
+            topPerformersState = topPerformersState.copy(
+                error = DashboardTopPerformersViewModel.ErrorType.Generic
+            ),
             lastUpdateState = "Last update: 8:52 AM",
             selectedDateRange = selectedDateRange,
             showDelayedFooter = false,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/compose/LegacyOrderSummaryRow.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/compose/LegacyOrderSummaryRow.kt
@@ -1,31 +1,30 @@
 package com.woocommerce.android.ui.orders.compose
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Text
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
-import com.woocommerce.android.ui.compose.designsystem.WooTheme
+import com.woocommerce.android.ui.compose.component.WCTag
 
 @Composable
-fun OrderSummaryRow(
+fun LegacyOrderSummaryRow(
     order: OrderSummaryRowModel,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -47,7 +46,7 @@ fun OrderSummaryRow(
                 modifier = contentModifier,
             )
         } else {
-            ExpandedOrderSummaryRow(
+            DashboardOrderSummaryRow(
                 order = order,
                 modifier = contentModifier,
             )
@@ -56,54 +55,46 @@ fun OrderSummaryRow(
 }
 
 @Composable
-private fun ExpandedOrderSummaryRow(
+private fun DashboardOrderSummaryRow(
     order: OrderSummaryRowModel,
-    modifier: Modifier,
+    modifier: Modifier = Modifier,
 ) {
-    Row(
-        modifier = modifier,
-        horizontalArrangement = Arrangement.spacedBy(WooTheme.spacing.space5),
-    ) {
-        Column(modifier = Modifier.weight(1f)) {
-            Row(modifier = Modifier.fillMaxWidth()) {
+    Box(modifier = modifier) {
+        Column(modifier = Modifier.align(Alignment.TopStart)) {
+            Row {
                 Text(
                     text = order.number,
-                    style = WooTheme.text.bodyLarge.regular,
-                    color = WooTheme.colors.surface.onDefault,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
+                    style = MaterialTheme.typography.body1,
+                    color = colorResource(id = R.color.color_on_surface_medium),
                 )
+
                 Text(
                     text = order.date,
-                    style = WooTheme.text.bodyLarge.regular,
-                    color = WooTheme.colors.surface.onDefault,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier
-                        .weight(1f)
-                        .padding(start = WooTheme.padding.padding5),
+                    style = MaterialTheme.typography.body1,
+                    color = colorResource(id = R.color.color_on_surface_medium),
+                    modifier = Modifier.padding(start = 16.dp)
                 )
             }
+
             Text(
                 text = order.customerName,
-                style = WooTheme.text.bodyLarge.regular,
-                color = WooTheme.colors.surface.onDefault,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.padding(top = WooTheme.padding.padding3),
+                style = MaterialTheme.typography.body1,
+                modifier = Modifier.padding(top = 8.dp)
             )
         }
+
         Column(
+            modifier = Modifier.align(Alignment.TopEnd),
             horizontalAlignment = Alignment.End,
         ) {
-            Row(horizontalArrangement = Arrangement.spacedBy(WooTheme.spacing.space3)) {
-                OrderStatusTags(order)
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                OrderStatusTags(order = order)
             }
+
             Text(
                 text = order.totalPrice,
-                style = WooTheme.text.bodyLarge.regular,
-                color = WooTheme.colors.surface.onDefault,
-                modifier = Modifier.padding(top = WooTheme.padding.padding3),
+                style = MaterialTheme.typography.body1,
+                modifier = Modifier.padding(top = 8.dp)
             )
         }
     }
@@ -116,39 +107,39 @@ private fun CompactOrderSummaryRow(
 ) {
     Column(
         modifier = modifier,
-        verticalArrangement = Arrangement.spacedBy(WooTheme.spacing.space3),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
         Row(
             modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(WooTheme.spacing.space3),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(
                 text = order.number,
-                style = WooTheme.text.bodyLarge.regular,
-                color = WooTheme.colors.surface.onDefault,
+                style = MaterialTheme.typography.body1,
+                color = colorResource(id = R.color.color_on_surface_medium),
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
                 modifier = Modifier.weight(1f),
             )
-            Row(horizontalArrangement = Arrangement.spacedBy(WooTheme.spacing.space3)) {
-                OrderStatusTags(order)
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                OrderStatusTags(order = order)
             }
         }
+
         val metadata = listOf(order.customerName, order.date).filter { it.isNotBlank() }
         if (metadata.isNotEmpty()) {
             Text(
                 text = metadata.joinToString("  "),
-                style = WooTheme.text.bodyLarge.regular,
-                color = WooTheme.colors.surface.onDefault,
+                style = MaterialTheme.typography.body1,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
             )
         }
+
         Text(
             text = order.totalPrice,
-            style = WooTheme.text.bodyLarge.regular,
-            color = WooTheme.colors.surface.onDefault,
+            style = MaterialTheme.typography.body1,
             textAlign = TextAlign.End,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
@@ -159,38 +150,21 @@ private fun CompactOrderSummaryRow(
 
 @Composable
 private fun OrderStatusTags(order: OrderSummaryRowModel) {
-    OrderTag(
+    WCTag(
         text = order.status,
         textColor = colorResource(id = R.color.color_on_secondary),
         backgroundColor = colorResource(id = order.statusColor),
+        fontWeight = FontWeight.Normal,
     )
+
     if (order.isPosOrder) {
-        OrderTag(
+        WCTag(
             text = stringResource(id = R.string.pos_badge),
             textColor = colorResource(id = R.color.tag_text_pos),
             backgroundColor = colorResource(id = R.color.tag_bg_pos),
+            fontWeight = FontWeight.Normal,
         )
     }
-}
-
-@Composable
-private fun OrderTag(
-    text: String,
-    textColor: Color,
-    backgroundColor: Color,
-) {
-    Text(
-        text = text,
-        color = textColor,
-        style = WooTheme.text.labelSmall.regular,
-        modifier = Modifier
-            .clip(RoundedCornerShape(WooTheme.radius.small))
-            .background(backgroundColor)
-            .padding(
-                horizontal = WooTheme.padding.padding3 + WooTheme.padding.padding1,
-                vertical = WooTheme.padding.padding2,
-            ),
-    )
 }
 
 private val ROW_PADDING = 16.dp

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/compose/LegacyProductSummaryRow.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/compose/LegacyProductSummaryRow.kt
@@ -10,24 +10,25 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Text
+import androidx.compose.material.Divider
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.ProductThumbnail
-import com.woocommerce.android.ui.compose.designsystem.WooTheme
-import com.woocommerce.android.ui.compose.designsystem.component.WooDivider
-import com.woocommerce.android.ui.compose.designsystem.foundation.WooDesignSystemThemeWithBackground
+import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 
 @Composable
-fun ProductSummaryRow(
+fun LegacyProductSummaryRow(
     title: String,
     imageUrl: String?,
     onClick: () -> Unit,
@@ -42,7 +43,7 @@ fun ProductSummaryRow(
         modifier = modifier
             .fillMaxWidth()
             .clickable(enabled = enabled, onClick = onClick)
-            .padding(horizontal = WooTheme.padding.padding5),
+            .padding(horizontal = 16.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         ProductThumbnail(
@@ -52,43 +53,43 @@ fun ProductSummaryRow(
         Column(
             modifier = Modifier
                 .weight(1f)
-                .padding(start = WooTheme.padding.padding3),
+                .padding(start = 8.dp),
             verticalArrangement = Arrangement.Center,
         ) {
-            Spacer(modifier = Modifier.height(WooTheme.spacing.space4))
+            Spacer(modifier = Modifier.height(12.dp))
             Row(
-                modifier = Modifier.padding(bottom = WooTheme.padding.padding2),
+                modifier = Modifier.padding(bottom = 4.dp),
                 verticalAlignment = Alignment.Top,
             ) {
                 Text(
                     modifier = Modifier
                         .weight(1f)
-                        .padding(end = if (trailingContent == null) 0.dp else WooTheme.padding.padding3),
+                        .padding(end = if (trailingContent == null) 0.dp else 8.dp),
                     text = title,
-                    color = WooTheme.colors.surface.onDefault,
+                    color = MaterialTheme.colors.onSurface,
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis,
-                    style = WooTheme.text.titleMedium.regular,
+                    style = MaterialTheme.typography.subtitle1,
                 )
                 trailingContent?.invoke(this)
             }
             supportingContent()
-            Spacer(modifier = Modifier.height(WooTheme.spacing.space4))
+            Spacer(modifier = Modifier.height(12.dp))
             if (displayDivider) {
-                WooDivider()
+                Divider()
             }
         }
     }
 }
 
 @Composable
-fun ProductSummaryRowInfo(
+fun LegacyProductSummaryRowInfo(
     text: String,
     modifier: Modifier = Modifier,
-    color: Color = WooTheme.colors.surface.onDefault,
+    color: Color = colorResource(id = R.color.color_on_surface_medium),
     maxLines: Int = 1,
     overflow: TextOverflow = TextOverflow.Ellipsis,
-    style: TextStyle = WooTheme.text.bodyMedium.regular,
+    style: TextStyle = MaterialTheme.typography.caption,
 ) {
     Text(
         modifier = modifier,
@@ -100,17 +101,17 @@ fun ProductSummaryRowInfo(
     )
 }
 
-@PreviewLightDark
+@LightDarkThemePreviews
 @Composable
-private fun ProductSummaryRowPreview() {
-    WooDesignSystemThemeWithBackground {
-        ProductSummaryRow(
+private fun LegacyProductSummaryRowPreview() {
+    WooThemeWithBackground {
+        LegacyProductSummaryRow(
             title = "Woo socks",
             imageUrl = "https://example.com/socks.png",
             onClick = {},
         ) {
-            ProductSummaryRowInfo("In stock \u2022 \$9.99")
-            ProductSummaryRowInfo("SKU: woo-socks")
+            LegacyProductSummaryRowInfo("In stock \u2022 \$9.99")
+            LegacyProductSummaryRowInfo("SKU: woo-socks")
         }
     }
 }

--- a/WooCommerce/src/main/res/layout/fragment_dashboard.xml
+++ b/WooCommerce/src/main/res/layout/fragment_dashboard.xml
@@ -5,7 +5,7 @@
     android:id="@+id/my_store_stats_container"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/color_surface"
+    android:background="@color/woo_ds_color_background_section"
     android:descendantFocusability="blocksDescendants"
     android:orientation="vertical"
     tools:context="com.woocommerce.android.ui.dashboard.DashboardFragment">

--- a/WooCommerce/src/main/res/menu/menu_dashboard_fragment.xml
+++ b/WooCommerce/src/main/res/menu/menu_dashboard_fragment.xml
@@ -4,6 +4,7 @@
     <item
         android:id="@+id/menu_share_store"
         android:icon="@drawable/ic_share_24dp"
+        android:title="@string/share_store_button"
         android:visible="false"
         app:showAsAction="ifRoom" />
     <item

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -500,6 +500,10 @@
     <string name="dynamic_dashboard_widget_menu_item_hide">Hide %s</string>
     <string name="dynamic_dashboard_widget_error_title">Unable to load data</string>
     <string name="dynamic_dashboard_widget_error_description"><![CDATA[Try reloading this card. If the issue persists, please <a href="support">contact support</a>.]]></string>
+    <plurals name="dashboard_review_rating_content_description">
+        <item quantity="one">%1$d-star rating</item>
+        <item quantity="other">%1$d-star rating</item>
+    </plurals>
 
     <string name="dashboard_reviews_card_header_title">Status</string>
     <string name="dashboard_reviews_card_empty_title_filtered">No reviews found</string>

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -52,7 +52,7 @@ style:
     ignoreAnnotated: [ 'Composable' ]
   UnusedPrivateMember:
     # WooPosPreview is a meta-annotation that wraps @Preview; detekt does not follow meta-annotations transitively.
-    ignoreAnnotated: [ 'Preview', 'LightDarkThemePreviews', 'OrientationPreviews', 'FontScalePreviews', 'LayoutDirectionPreviews', 'WooPosPreview' ]
+    ignoreAnnotated: [ 'Preview', 'PreviewLightDark', 'LightDarkThemePreviews', 'OrientationPreviews', 'FontScalePreviews', 'LayoutDirectionPreviews', 'WooPosPreview' ]
   MaxLineLength:
     active: false
 


### PR DESCRIPTION
### Description

Part of WOOMOB-3477 — does not close the ticket.

This PR migrates the My Store dashboard content area and cards to the Store Design System while preserving the existing Fragment-hosted top app bar.

It:

- opts the dashboard into the Store Design System theme and section background;
- migrates card surfaces, spacing, typography, colors, buttons, dividers, menus, loading skeletons, and error states;
- replaces the legacy pull-to-refresh implementation with Material 3;
- updates the existing cards across Performance, Orders, Reviews, Inbox, Stock, Coupons, Blaze, Google Ads, onboarding, push notifications, top performers, and the AI assistant;
- adds design-system preview coverage for light and dark themes, large fonts, and RTL layouts;
- improves accessibility descriptions for review ratings and the share-store toolbar action.

Remaining work for WOOMOB-3477: migrate the top app bar, then move the Customize action from the toolbar to the bottom position shown in Figma.

### Test Steps

1. Open the My Store dashboard for a store with several dashboard cards enabled.
2. In light mode, verify the section background, rounded borderless card surfaces, gutters, headers, typography, dividers, menus, buttons, and data presentation.
3. Open the toolbar Customize action, hide and restore cards, and confirm their visibility and ordering update correctly.
4. Exercise the Performance date range, metric selector, card overflow menus, filters, and available card actions.
5. Pull down on the dashboard and confirm the refresh indicator appears and the dashboard refresh completes.
6. Verify available loading, empty, error, retry, and populated card states.
7. Repeat the visual checks in dark mode, paying particular attention to text, icon, divider, button, and card contrast.
8. On a tablet or landscape device, confirm cards flow into multiple columns with consistent spacing and without clipping.
9. Increase the system font size and enable an RTL locale; confirm card content remains readable and usable.

### Images/gif

| Theme | Before | After |
| --- | --- | --- |
| Light | <img src="https://github.com/user-attachments/assets/3b67b07a-0eb6-4698-bd7a-553dcb6190b0" width="320" alt="Dashboard before the Store Design System migration in light mode" /> | <img src="https://github.com/user-attachments/assets/31ef9a89-170a-484e-8c0c-91d211f77ab0" width="320" alt="Dashboard after the Store Design System migration in light mode" /> |
| Dark | <img src="https://github.com/user-attachments/assets/648457c4-7abc-466d-a33b-454ed56db6a7" width="320" alt="Dashboard before the Store Design System migration in dark mode" /> | <img src="https://github.com/user-attachments/assets/15968d3d-8b95-4efa-903f-f03dca895095" width="320" alt="Dashboard after the Store Design System migration in dark mode" /> |

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.