### PR TITLE
[Design System] Guard against mixed Store theme imports

### DIFF
--- a/libs/detektrules/src/main/kotlin/com/woocommerce/android/detektrules/StoreRuleSetProvider.kt
+++ b/libs/detektrules/src/main/kotlin/com/woocommerce/android/detektrules/StoreRuleSetProvider.kt
@@ -1,0 +1,17 @@
+package com.woocommerce.android.detektrules
+
+import com.woocommerce.android.detektrules.store.MixedStoreThemeImportsRule
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.RuleSet
+import io.gitlab.arturbosch.detekt.api.RuleSetProvider
+
+class StoreRuleSetProvider : RuleSetProvider {
+    override val ruleSetId: String = "StoreRules"
+
+    override fun instance(config: Config) = RuleSet(
+        ruleSetId,
+        listOf(
+            MixedStoreThemeImportsRule(config),
+        )
+    )
+}

--- a/libs/detektrules/src/main/kotlin/com/woocommerce/android/detektrules/store/MixedStoreThemeImportsRule.kt
+++ b/libs/detektrules/src/main/kotlin/com/woocommerce/android/detektrules/store/MixedStoreThemeImportsRule.kt
@@ -1,0 +1,56 @@
+package com.woocommerce.android.detektrules.store
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.psi.KtFile
+
+class MixedStoreThemeImportsRule(config: Config) : Rule(config) {
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Style,
+        "Store files should use either the legacy theme or Store Design System imports, not both.",
+        Debt.FIVE_MINS
+    )
+
+    override fun visitKtFile(file: KtFile) {
+        if (!file.isStoreFile()) return
+
+        super.visitKtFile(file)
+
+        val imports = file.importDirectives.mapNotNull { it.importPath?.pathStr }
+        val importsLegacyTheme = imports.any { it.isWithinPackage(LEGACY_THEME_PACKAGE) }
+        val importsStoreDesignSystem = imports.any { it.isWithinPackage(STORE_DESIGN_SYSTEM_PACKAGE) }
+
+        if (importsLegacyTheme && importsStoreDesignSystem) {
+            report(
+                CodeSmell(
+                    issue,
+                    Entity.from(file),
+                    "Use one Store theme root per file and migrate the remaining imports so only the legacy theme " +
+                        "or Store Design System root remains."
+                )
+            )
+        }
+    }
+
+    private fun KtFile.isStoreFile(): Boolean {
+        val packageName = packageFqName.asString()
+        return packageName.isWithinPackage(STORE_UI_PACKAGE) &&
+            !packageName.isWithinPackage(WOO_POS_PACKAGE)
+    }
+
+    private fun String.isWithinPackage(packageRoot: String): Boolean =
+        this == packageRoot || startsWith("$packageRoot.")
+
+    companion object {
+        private const val STORE_UI_PACKAGE = "com.woocommerce.android.ui"
+        private const val WOO_POS_PACKAGE = "com.woocommerce.android.ui.woopos"
+        private const val LEGACY_THEME_PACKAGE = "com.woocommerce.android.ui.compose.theme"
+        private const val STORE_DESIGN_SYSTEM_PACKAGE = "com.woocommerce.android.ui.compose.designsystem"
+    }
+}

--- a/libs/detektrules/src/main/resources/META-INF/services/io.gitlab.arturbosch.detekt.api.RuleSetProvider
+++ b/libs/detektrules/src/main/resources/META-INF/services/io.gitlab.arturbosch.detekt.api.RuleSetProvider
@@ -1,2 +1,3 @@
 com.woocommerce.android.detektrules.WooPosRuleSetProvider
 com.woocommerce.android.detektrules.TestRuleSetProvider
+com.woocommerce.android.detektrules.StoreRuleSetProvider

--- a/libs/detektrules/src/main/resources/config/config.yml
+++ b/libs/detektrules/src/main/resources/config/config.yml
@@ -17,3 +17,7 @@ WooPosRules:
 TestRules:
   UnitTestNamingRule:
     active: true
+
+StoreRules:
+  MixedStoreThemeImportsRule:
+    active: true

--- a/libs/detektrules/src/test/kotlin/com/woocommerce/android/detektrules/store/MixedStoreThemeImportsRuleTest.kt
+++ b/libs/detektrules/src/test/kotlin/com/woocommerce/android/detektrules/store/MixedStoreThemeImportsRuleTest.kt
@@ -1,0 +1,154 @@
+package com.woocommerce.android.detektrules.store
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
+import io.gitlab.arturbosch.detekt.test.compileAndLint
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+@KotlinCoreEnvironmentTest
+class MixedStoreThemeImportsRuleTest {
+
+    @Test
+    fun `given a Store file imports only the legacy theme, when linting, then no violation is reported`() {
+        val code = """
+            package com.woocommerce.android.ui.orders
+
+            import com.woocommerce.android.ui.compose.theme.WooTheme
+        """.trimIndent()
+
+        val findings = MixedStoreThemeImportsRule(Config.empty).compileAndLint(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `given a Store file imports only the design system, when linting, then no violation is reported`() {
+        val code = """
+            package com.woocommerce.android.ui.orders
+
+            import com.woocommerce.android.ui.compose.designsystem.component.WooButton
+        """.trimIndent()
+
+        val findings = MixedStoreThemeImportsRule(Config.empty).compileAndLint(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `given a Store file imports both theme roots, when linting, then one actionable violation is reported`() {
+        val code = """
+            package com.woocommerce.android.ui.orders
+
+            import com.woocommerce.android.ui.compose.designsystem.component.WooButton
+            import com.woocommerce.android.ui.compose.theme.WooTheme
+        """.trimIndent()
+
+        val findings = MixedStoreThemeImportsRule(Config.empty).compileAndLint(code)
+
+        assertThat(findings).hasSize(1)
+        assertThat(findings.single().message)
+            .contains("Use one Store theme root per file")
+            .contains("migrate the remaining imports")
+    }
+
+    @Test
+    fun `given mixed theme imports use aliases, when linting, then one violation is reported`() {
+        val code = """
+            package com.woocommerce.android.ui.orders
+
+            import com.woocommerce.android.ui.compose.designsystem.foundation.WooTheme as StoreTheme
+            import com.woocommerce.android.ui.compose.theme.WooTheme as LegacyTheme
+        """.trimIndent()
+
+        val findings = MixedStoreThemeImportsRule(Config.empty).compileAndLint(code)
+
+        assertThat(findings).hasSize(1)
+    }
+
+    @Test
+    fun `given multiple imports from both theme roots, when linting, then only one violation is reported`() {
+        val code = """
+            package com.woocommerce.android.ui.orders
+
+            import com.woocommerce.android.ui.compose.designsystem.component.WooButton
+            import com.woocommerce.android.ui.compose.designsystem.foundation.WooTheme
+            import com.woocommerce.android.ui.compose.theme.WooColors
+            import com.woocommerce.android.ui.compose.theme.WooTheme
+        """.trimIndent()
+
+        val findings = MixedStoreThemeImportsRule(Config.empty).compileAndLint(code)
+
+        assertThat(findings).hasSize(1)
+    }
+
+    @Test
+    fun `given a lookalike legacy theme package, when linting, then no violation is reported`() {
+        val code = """
+            package com.woocommerce.android.ui.orders
+
+            import com.woocommerce.android.ui.compose.designsystem.component.WooButton
+            import com.woocommerce.android.ui.compose.themes.WooTheme
+        """.trimIndent()
+
+        val findings = MixedStoreThemeImportsRule(Config.empty).compileAndLint(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `given a lookalike design system package, when linting, then no violation is reported`() {
+        val code = """
+            package com.woocommerce.android.ui.orders
+
+            import com.woocommerce.android.ui.compose.designsystems.component.WooButton
+            import com.woocommerce.android.ui.compose.theme.WooTheme
+        """.trimIndent()
+
+        val findings = MixedStoreThemeImportsRule(Config.empty).compileAndLint(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `given a WooPos file imports both Store theme roots, when linting, then no violation is reported`() {
+        val code = """
+            package com.woocommerce.android.ui.woopos.orders
+
+            import com.woocommerce.android.ui.compose.designsystem.component.WooButton
+            import com.woocommerce.android.ui.compose.theme.WooTheme
+        """.trimIndent()
+
+        val findings = MixedStoreThemeImportsRule(Config.empty).compileAndLint(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `given a similarly named Store package imports both roots, when linting, then one violation is reported`() {
+        val code = """
+            package com.woocommerce.android.ui.wooposition
+
+            import com.woocommerce.android.ui.compose.designsystem.component.WooButton
+            import com.woocommerce.android.ui.compose.theme.WooTheme
+        """.trimIndent()
+
+        val findings = MixedStoreThemeImportsRule(Config.empty).compileAndLint(code)
+
+        assertThat(findings).hasSize(1)
+    }
+
+    @Test
+    fun `given a non-Store file imports both theme roots, when linting, then no violation is reported`() {
+        val code = """
+            package com.example.feature
+
+            import com.woocommerce.android.ui.compose.designsystem.component.WooButton
+            import com.woocommerce.android.ui.compose.theme.WooTheme
+        """.trimIndent()
+
+        val findings = MixedStoreThemeImportsRule(Config.empty).compileAndLint(code)
+
+        assertThat(findings).isEmpty()
+    }
+}


### PR DESCRIPTION
### Description

Fixes WOOMOB-3515

Adds a Store-specific Detekt rule that reports Kotlin files importing both the legacy Compose theme root and the new Store Design System root. The rule is scoped to Store UI packages, excludes WooPos, reports once per file, and provides migration guidance.

The custom rule is registered and enabled alongside focused coverage for allowed single-root imports, rejected mixed imports, aliases, lookalike packages, multiple imports, and the Store/POS boundary.

### Test Steps

1. Add temporary imports from both `com.woocommerce.android.ui.compose.theme` and `com.woocommerce.android.ui.compose.designsystem` to a Kotlin file under a Store UI package.
2. Run `./gradlew detektAll` and confirm `MixedStoreThemeImportsRule` reports one actionable finding for that file.
3. Remove either theme-root import and rerun Detekt; confirm the finding is cleared.
4. Confirm an equivalent temporary file under `com.woocommerce.android.ui.woopos` is not reported by this Store-specific rule.

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.