### PR TITLE
[WOOMOB-3256] Keep order discount codes on one line

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 
 25.3
 -----
+- [*] Fixed long coupon codes wrapping onto a second line in order details [https://github.com/woocommerce/woocommerce-android/pull/16258]
 - [*] Fixed the store login error message showing a placeholder instead of the status code [https://github.com/woocommerce/woocommerce-android/pull/16246]
 - [*] Fixed the order list not scrolling to the top after creating a new order [https://github.com/woocommerce/woocommerce-android/pull/16240]
 

--- a/WooCommerce/src/main/res/layout/order_detail_payment_info.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_payment_info.xml
@@ -80,6 +80,8 @@
                     android:layout_marginStart="@dimen/minor_00"
                     android:layout_marginEnd="@dimen/minor_00"
                     android:layout_weight="1"
+                    android:ellipsize="end"
+                    android:maxLines="1"
                     tools:text="(sale4theday, firstTime, anyothertime, blah)"/>
 
                 <com.google.android.material.textview.MaterialTextView


### PR DESCRIPTION
### Description

Fixes WOOMOB-3256

Long coupon codes wrap onto a second line in the Order Details payment totals.

This change keeps coupon codes on one line and truncates overflowing text with an ellipsis.

### Test Steps

**Prerequisite:** Have an order with a non-zero discount and a long coupon code, such as `wc_points_redemption_27375291_2023_02_07_12_14`.

1. Launch the app.
2. Open the store containing the test order.
3. Tap **Orders** in the bottom navigation.
4. Locate and open the test order.
5. Locate the **Discount** row in the **Payment totals** section.
6. Confirm the coupon code remains on a single line.
7. Confirm overflowing text is truncated with an ellipsis instead of wrapping onto a second line.

### Images/gif
|Before|After|
|-|-|
|<img width="300" alt="image" src="https://github.com/user-attachments/assets/d6f8c41e-75dd-4314-b916-e279e39a5aeb" />|<img width="300" alt="image" src="https://github.com/user-attachments/assets/109174bd-cf78-4e46-9af5-2185933d3a66" />|

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
