### PR TITLE
[WOOMOB-3562] Remove unused preference-ktx from libs:commons

### DIFF
--- a/libs/commons/build.gradle
+++ b/libs/commons/build.gradle
@@ -49,7 +49,7 @@ dependencies {
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.automattic.tracks.crashlogging)
     implementation(libs.androidx.lifecycle.process)
-    implementation(libs.androidx.preference.ktx)
+    implementation(libs.androidx.preference.main)
     implementation(libs.eventbus.android)
     implementation(libs.google.dagger.hilt.android.main)
     implementation(libs.androidx.compose.material3)


### PR DESCRIPTION
### Description

Fixes WOOMOB-3562

The `:libs:commons` module declared `androidx.preference:preference-ktx`, but none of the `-ktx` Kotlin extensions are actually used. The only androidx.preference usage in the module is `PreferenceManager.getDefaultSharedPreferences(context)` in `SelectedSite.kt`, and `PreferenceManager` lives in the **base** `androidx.preference:preference` artifact — not the `-ktx` one. (The `androidx.core.content.edit` calls come from `androidx.core.ktx`, which is already declared.)

The `dependency.analysis` plugin flagged `preference-ktx` for this reason. This PR swaps it for the base artifact (`libs.androidx.preference.main`), which already exists in the version catalog and is already used by the app module — so no catalog or source changes are needed.

`WooCommerce-Wear` still uses `preference-ktx`; that is out of scope for this issue (commons only).

### Test Steps

This is a build-configuration-only change with no runtime behavior change. Reviewer validation:

1. Confirm `:libs:commons` compiles: `./gradlew :libs:commons:assembleDebug`
2. Confirm dependency-analysis no longer flags `preference-ktx`: `./gradlew :libs:commons:projectHealth`

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.