### PR TITLE
[WOOMOB-3586] Use WooCommerce's product duplication endpoint

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 
 25.3
 -----
+- [*] Improved product duplication to preserve product details managed by WooCommerce [https://github.com/woocommerce/woocommerce-android/pull/16262]
 - [*] Fixed the store login error message showing a placeholder instead of the status code [https://github.com/woocommerce/woocommerce-android/pull/16246]
 - [*] Fixed the order list not scrolling to the top after creating a new order [https://github.com/woocommerce/woocommerce-android/pull/16240]
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/DuplicateProduct.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/DuplicateProduct.kt
@@ -10,6 +10,7 @@ import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.ResourceProvider
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.NETWORK_ERROR
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.API_NOT_FOUND
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.GENERIC_ERROR
 import javax.inject.Inject
 
@@ -20,6 +21,21 @@ class DuplicateProduct @Inject constructor(
 ) {
 
     suspend operator fun invoke(productAggregate: ProductAggregate): Result<Long> {
+        val coreResult = productDetailRepository.duplicateProduct(productAggregate.remoteId)
+        if (coreResult.isSuccess) return coreResult
+
+        val error = (coreResult.exceptionOrNull() as? WooException)?.error
+        val shouldUseLegacyFlow = error?.run {
+            type == API_NOT_FOUND && apiErrorCode == REST_NO_ROUTE_ERROR_CODE
+        } == true
+        return if (shouldUseLegacyFlow) {
+            duplicateProductWithLegacyFlow(productAggregate)
+        } else {
+            coreResult
+        }
+    }
+
+    private suspend fun duplicateProductWithLegacyFlow(productAggregate: ProductAggregate): Result<Long> {
         val newProduct = productAggregate.copy(
             product = productAggregate.product.copy(
                 remoteId = 0,
@@ -91,5 +107,9 @@ class DuplicateProduct @Inject constructor(
                 Result.failure(it)
             }
         )
+    }
+
+    private companion object {
+        const val REST_NO_ROUTE_ERROR_CODE = "rest_no_route"
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailRepository.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.products.details
 
 import com.woocommerce.android.AppConstants
+import com.woocommerce.android.WooException
 import com.woocommerce.android.analytics.AnalyticsEvent.PRODUCT_DETAIL_UPDATE_ERROR
 import com.woocommerce.android.analytics.AnalyticsEvent.PRODUCT_DETAIL_UPDATE_SUCCESS
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -41,6 +42,8 @@ import org.wordpress.android.fluxc.action.WCProductAction.UPDATE_PRODUCT_PASSWOR
 import org.wordpress.android.fluxc.generated.WCProductActionBuilder
 import org.wordpress.android.fluxc.model.metadata.MetadataChanges
 import org.wordpress.android.fluxc.model.metadata.WCMetaData
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.INVALID_RESPONSE
 import org.wordpress.android.fluxc.store.WCGlobalAttributeStore
 import org.wordpress.android.fluxc.store.WCProductStore
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductSkuAvailabilityPayload
@@ -54,6 +57,7 @@ import org.wordpress.android.fluxc.store.WCTaxStore
 import javax.inject.Inject
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.resume
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.INVALID_RESPONSE as INVALID_RESPONSE_ORIGINAL
 
 class ProductDetailRepository @Inject constructor(
     private val dispatcher: Dispatcher,
@@ -188,6 +192,24 @@ class ProductDetailRepository @Inject constructor(
      * @return the result of the action as a [Boolean]
      */
     suspend fun addProduct(product: Product): Pair<Boolean, Long> = addProduct(ProductAggregate(product, null))
+
+    suspend fun duplicateProduct(remoteProductId: Long): Result<Long> {
+        val result = productStore.duplicateProduct(selectedSite.get(), remoteProductId)
+        val duplicatedProductId = result.model
+        return when {
+            result.isError -> Result.failure(WooException(result.error))
+            duplicatedProductId != null -> Result.success(duplicatedProductId)
+            else -> Result.failure(
+                WooException(
+                    WooError(
+                        type = INVALID_RESPONSE,
+                        original = INVALID_RESPONSE_ORIGINAL,
+                        message = "Product duplication returned no product ID"
+                    )
+                )
+            )
+        }
+    }
 
     /**
      * Fires the request to update the product password

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel.kt
@@ -363,6 +363,7 @@ class ProductDetailViewModel @Inject constructor(
                 viewProductOption = showViewProductOption,
                 shareOption = showShareOption,
                 showShareOptionAsActionWithText = showShareOptionAsActionWithText,
+                duplicateOption = isProductStoredAtSite,
                 trashOption = !isProductUnderCreation && isTrashEnabled
             )
         }.asLiveData()
@@ -2537,20 +2538,37 @@ class ProductDetailViewModel @Inject constructor(
     }
 
     fun onDuplicateProduct() {
+        val storedProduct = storedProductAggregate.value
+            ?.takeIf { it.remoteId > DEFAULT_ADD_NEW_PRODUCT_ID }
+            ?: return
+
+        tracker.track(AnalyticsEvent.PRODUCT_DETAIL_DUPLICATE_BUTTON_TAPPED)
+        if (viewState.productAggregateDraft?.isSame(storedProduct) == false) {
+            triggerEvent(
+                ShowDialog(
+                    titleId = R.string.product_duplicate_discard_changes_title,
+                    messageId = R.string.product_duplicate_discard_changes_message,
+                    positiveButtonId = R.string.product_duplicate_discard_changes_action,
+                    negativeButtonId = R.string.cancel,
+                    positiveBtnAction = { _, _ -> duplicateStoredProduct(storedProduct) }
+                )
+            )
+        } else {
+            duplicateStoredProduct(storedProduct)
+        }
+    }
+
+    private fun duplicateStoredProduct(storedProduct: ProductAggregate) {
         launch {
-            tracker.track(AnalyticsEvent.PRODUCT_DETAIL_DUPLICATE_BUTTON_TAPPED)
-            viewState.productAggregateDraft?.let { product ->
+            triggerEvent(ShowDuplicateProductInProgress)
+            val result = duplicateProduct(storedProduct)
 
-                triggerEvent(ShowDuplicateProductInProgress)
-                val result = duplicateProduct(product)
-
-                if (result.isSuccess) {
-                    tracker.track(AnalyticsEvent.DUPLICATE_PRODUCT_SUCCESS)
-                    triggerEvent(OpenProductDetails(result.getOrThrow()))
-                } else {
-                    tracker.track(AnalyticsEvent.DUPLICATE_PRODUCT_FAILED)
-                    triggerEvent(ShowDuplicateProductError)
-                }
+            if (result.isSuccess) {
+                tracker.track(AnalyticsEvent.DUPLICATE_PRODUCT_SUCCESS)
+                triggerEvent(OpenProductDetails(result.getOrThrow()))
+            } else {
+                tracker.track(AnalyticsEvent.DUPLICATE_PRODUCT_FAILED)
+                triggerEvent(ShowDuplicateProductError)
             }
         }
     }
@@ -2838,6 +2856,7 @@ class ProductDetailViewModel @Inject constructor(
         val viewProductOption: Boolean,
         val shareOption: Boolean,
         val showShareOptionAsActionWithText: Boolean,
+        val duplicateOption: Boolean,
         val trashOption: Boolean
     )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailsToolbarHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailsToolbarHelper.kt
@@ -205,6 +205,7 @@ class ProductDetailsToolbarHelper @Inject constructor() :
                 }
             )
         }
+        findItem(R.id.menu_duplicate)?.isVisible = state.duplicateOption
         findItem(R.id.menu_trash_product)?.isVisible = state.trashOption
     }
 

--- a/WooCommerce/src/main/res/menu/menu_product_detail_fragment.xml
+++ b/WooCommerce/src/main/res/menu/menu_product_detail_fragment.xml
@@ -40,6 +40,7 @@
     <item
         android:id="@+id/menu_duplicate"
         android:title="@string/product_duplicate"
+        android:visible="false"
         app:showAsAction="withText" />
 
     <item

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2028,6 +2028,9 @@
     <string name="product_duplicate_progress_title">Duplicating your product…</string>
     <string name="product_duplicate_progress_body">Please wait while we save a copy of this product to your store</string>
     <string name="product_duplicate_copied_product_name">%1$s Copy</string>
+    <string name="product_duplicate_discard_changes_title">Discard changes and duplicate?</string>
+    <string name="product_duplicate_discard_changes_message">Your unsaved changes will be lost. The duplicate will use the last saved version.</string>
+    <string name="product_duplicate_discard_changes_action">Discard &amp; duplicate</string>
     <string name="product_trash">Trash product</string>
     <string name="product_confirm_trash">Do you want to move this product to the Trash?</string>
     <string name="product_trash_yes">Move to trash</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/DuplicateProductTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/DuplicateProductTest.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.products
 
+import com.woocommerce.android.WooException
 import com.woocommerce.android.model.ProductAggregate
 import com.woocommerce.android.model.ProductVariation
 import com.woocommerce.android.ui.products.details.ProductDetailRepository
@@ -15,8 +16,14 @@ import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.stub
 import org.mockito.kotlin.verify
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.NETWORK_ERROR
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.NOT_FOUND
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.API_ERROR
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.API_NOT_FOUND
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class DuplicateProductTest : BaseUnitTest() {
@@ -31,6 +38,9 @@ class DuplicateProductTest : BaseUnitTest() {
 
     @Before
     fun setUp() {
+        productDetailRepository.stub {
+            on { duplicateProduct(any()) } doReturn Result.failure(WooException(ROUTE_MISSING_ERROR))
+        }
         sut = DuplicateProduct(
             productDetailRepository,
             variationRepository,
@@ -39,43 +49,137 @@ class DuplicateProductTest : BaseUnitTest() {
     }
 
     @Test
-    fun `should duplicate a product and set expected properties`() = testBlocking {
-        // GIVEN
-        val productToDuplicate = ProductAggregate(
-            ProductTestUtils.generateProduct().copy(
-                sku = SOURCE_SKU,
-                slug = SOURCE_SLUG,
-                permalink = SOURCE_PERMALINK,
+    fun `given core route is missing, when duplicating a product, then legacy product is created with expected properties`() =
+        testBlocking {
+            // GIVEN
+            val productToDuplicate = ProductAggregate(
+                ProductTestUtils.generateProduct().copy(
+                    sku = SOURCE_SKU,
+                    slug = SOURCE_SLUG,
+                    permalink = SOURCE_PERMALINK,
+                )
             )
-        )
-        productDetailRepository.stub {
-            on { addProduct(any<ProductAggregate>()) } doReturn Pair(true, 123)
+            productDetailRepository.stub {
+                on { addProduct(any<ProductAggregate>()) } doReturn Pair(true, 123)
+            }
+
+            // WHEN
+            val result = sut.invoke(productToDuplicate)
+
+            // THEN
+            val duplicationRequestCapture = argumentCaptor<ProductAggregate>()
+            verify(productDetailRepository).duplicateProduct(productToDuplicate.remoteId)
+            verify(productDetailRepository).addProduct(duplicationRequestCapture.capture())
+            assertThat(result).isEqualTo(Result.success(123L))
+
+            assertThat(duplicationRequestCapture.firstValue)
+                .matches {
+                    it.remoteId == 0L && it.product.name == "copied name" &&
+                        it.product.sku == "" && it.product.status == ProductStatus.DRAFT &&
+                        it.product.slug == "" && it.product.permalink == ""
+                }
+                .usingRecursiveComparison()
+                .ignoringFields(
+                    "product.remoteId",
+                    "product.name",
+                    "product.sku",
+                    "product.status",
+                    "product.slug",
+                    "product.permalink"
+                )
+                .isEqualTo(productToDuplicate)
         }
 
-        // WHEN
-        sut.invoke(productToDuplicate)
-
-        // THEN
-        val duplicationRequestCapture = argumentCaptor<ProductAggregate>()
-        verify(productDetailRepository).addProduct(duplicationRequestCapture.capture())
-
-        assertThat(duplicationRequestCapture.firstValue)
-            .matches {
-                it.remoteId == 0L && it.product.name == "copied name" &&
-                    it.product.sku == "" && it.product.status == ProductStatus.DRAFT &&
-                    it.product.slug == "" && it.product.permalink == ""
+    @Test
+    fun `given core duplication succeeds, when duplicating a product, then ID is returned without legacy calls`() =
+        testBlocking {
+            // GIVEN
+            val productToDuplicate = ProductAggregate(ProductTestUtils.generateProduct().copy(numVariations = 10))
+            productDetailRepository.stub {
+                on { duplicateProduct(productToDuplicate.remoteId) } doReturn Result.success(DUPLICATED_PRODUCT_ID)
             }
-            .usingRecursiveComparison()
-            .ignoringFields(
-                "product.remoteId",
-                "product.name",
-                "product.sku",
-                "product.status",
-                "product.slug",
-                "product.permalink"
+
+            // WHEN
+            val result = sut(productToDuplicate)
+
+            // THEN
+            assertThat(result).isEqualTo(Result.success(DUPLICATED_PRODUCT_ID))
+            verify(productDetailRepository, never()).addProduct(any<ProductAggregate>())
+            verify(variationRepository, never()).fetchProductVariations(any(), any())
+            verify(variationRepository, never()).createVariations(any(), any())
+        }
+
+    @Test
+    fun `given core route is missing and legacy creation fails, when duplicating a product, then failure is returned once`() =
+        testBlocking {
+            // GIVEN
+            val productToDuplicate = ProductAggregate(ProductTestUtils.generateProduct())
+            productDetailRepository.stub {
+                on { addProduct(any<ProductAggregate>()) } doReturn Pair(false, 0L)
+            }
+
+            // WHEN
+            val result = sut(productToDuplicate)
+
+            // THEN
+            assertThat(result.isFailure).isTrue()
+            verify(productDetailRepository).duplicateProduct(productToDuplicate.remoteId)
+            verify(productDetailRepository).addProduct(any<ProductAggregate>())
+        }
+
+    @Test
+    fun `given core duplication fails for a non-route error, when duplicating a product, then legacy flow is not called`() =
+        testBlocking {
+            // GIVEN
+            val productToDuplicate = ProductAggregate(ProductTestUtils.generateProduct())
+            val endpointError = WooError(
+                type = API_NOT_FOUND,
+                original = NOT_FOUND,
+                apiErrorCode = "woocommerce_rest_product_invalid_id"
             )
-            .isEqualTo(productToDuplicate)
-    }
+            productDetailRepository.stub {
+                on { duplicateProduct(productToDuplicate.remoteId) } doReturn
+                    Result.failure(WooException(endpointError))
+            }
+
+            // WHEN
+            val result = sut(productToDuplicate)
+
+            // THEN
+            assertThat(result.exceptionOrNull()).isInstanceOf(WooException::class.java)
+            assertThat((result.exceptionOrNull() as WooException).error).isEqualTo(endpointError)
+            verify(productDetailRepository, never()).addProduct(any<ProductAggregate>())
+            verify(variationRepository, never()).fetchProductVariations(any(), any())
+            verify(variationRepository, never()).createVariations(any(), any())
+        }
+
+    @Test
+    fun `given rest no route code has non-not-found type, when duplicating a product, then legacy flow is not called`() =
+        testBlocking {
+            // GIVEN
+            val productToDuplicate = ProductAggregate(
+                ProductTestUtils.generateProduct().copy(numVariations = 10)
+            )
+            val endpointError = WooError(
+                type = API_ERROR,
+                original = NETWORK_ERROR,
+                apiErrorCode = "rest_no_route"
+            )
+            productDetailRepository.stub {
+                on { duplicateProduct(productToDuplicate.remoteId) } doReturn
+                    Result.failure(WooException(endpointError))
+            }
+
+            // WHEN
+            val result = sut(productToDuplicate)
+
+            // THEN
+            assertThat(result.exceptionOrNull()).isInstanceOf(WooException::class.java)
+            assertThat((result.exceptionOrNull() as WooException).error).isEqualTo(endpointError)
+            verify(productDetailRepository, never()).addProduct(any<ProductAggregate>())
+            verify(variationRepository, never()).fetchProductVariations(any(), any())
+            verify(variationRepository, never()).createVariations(any(), any())
+        }
 
     @Test
     fun `given product has slug and permalink, when duplicated, then source product slug and permalink are unchanged`() =
@@ -141,8 +245,14 @@ class DuplicateProductTest : BaseUnitTest() {
         }
 
     private companion object {
+        const val DUPLICATED_PRODUCT_ID = 123L
         const val SOURCE_SKU = "not an empty value"
         const val SOURCE_SLUG = "acme-water"
         const val SOURCE_PERMALINK = "https://example.com/product/acme-water"
+        val ROUTE_MISSING_ERROR = WooError(
+            type = API_NOT_FOUND,
+            original = NOT_FOUND,
+            apiErrorCode = "rest_no_route"
+        )
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailRepositoryTest.kt
@@ -1,0 +1,99 @@
+package com.woocommerce.android.ui.products.details
+
+import com.woocommerce.android.WooException
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.util.CoroutineDispatchers
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.json.JSONObject
+import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.NETWORK_ERROR
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.API_ERROR
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.INVALID_RESPONSE
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+import org.wordpress.android.fluxc.store.WCGlobalAttributeStore
+import org.wordpress.android.fluxc.store.WCProductStore
+import org.wordpress.android.fluxc.store.WCTaxStore
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.INVALID_RESPONSE as INVALID_RESPONSE_ORIGINAL
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ProductDetailRepositoryTest : BaseUnitTest() {
+    private val site = SiteModel()
+    private val productStore: WCProductStore = mock()
+    private val selectedSite: SelectedSite = mock {
+        on { get() } doReturn site
+    }
+    private val sut = ProductDetailRepository(
+        dispatcher = mock<Dispatcher>(),
+        productStore = productStore,
+        globalAttributeStore = mock<WCGlobalAttributeStore>(),
+        selectedSite = selectedSite,
+        taxStore = mock<WCTaxStore>(),
+        coroutineDispatchers = mock<CoroutineDispatchers>()
+    )
+
+    @Test
+    fun `given product store duplication succeeds, when duplicating product, then return successful ID`() = testBlocking {
+        // GIVEN
+        givenProductStoreReturns(WooResult(DUPLICATED_PRODUCT_ID))
+
+        // WHEN
+        val result = sut.duplicateProduct(SOURCE_PRODUCT_ID)
+
+        // THEN
+        assertThat(result).isEqualTo(Result.success(DUPLICATED_PRODUCT_ID))
+    }
+
+    @Test
+    fun `given product store duplication fails, when duplicating product, then preserve exact error in failure`() =
+        testBlocking {
+            // GIVEN
+            val expectedError = WooError(
+                type = API_ERROR,
+                original = NETWORK_ERROR,
+                message = "Unable to duplicate product",
+                apiErrorCode = "woocommerce_rest_product_invalid_id",
+                errorData = mock<JSONObject>()
+            )
+            givenProductStoreReturns(WooResult(expectedError))
+
+            // WHEN
+            val result = sut.duplicateProduct(SOURCE_PRODUCT_ID)
+
+            // THEN
+            assertThat(result.exceptionOrNull()).isInstanceOf(WooException::class.java)
+            assertThat((result.exceptionOrNull() as WooException).error).isEqualTo(expectedError)
+        }
+
+    @Test
+    fun `given product store duplication returns no model or error, when duplicating product, then return invalid response failure`() =
+        testBlocking {
+            // GIVEN
+            givenProductStoreReturns(WooResult())
+
+            // WHEN
+            val result = sut.duplicateProduct(SOURCE_PRODUCT_ID)
+
+            // THEN
+            assertThat(result.exceptionOrNull()).isInstanceOf(WooException::class.java)
+            val error = (result.exceptionOrNull() as WooException).error
+            assertThat(error.type).isEqualTo(INVALID_RESPONSE)
+            assertThat(error.original).isEqualTo(INVALID_RESPONSE_ORIGINAL)
+        }
+
+    private suspend fun givenProductStoreReturns(result: WooResult<Long>) {
+        whenever(productStore.duplicateProduct(site, SOURCE_PRODUCT_ID)).thenReturn(result)
+    }
+
+    private companion object {
+        const val SOURCE_PRODUCT_ID = 42L
+        const val DUPLICATED_PRODUCT_ID = 84L
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModelTest.kt
@@ -18,6 +18,7 @@ import com.woocommerce.android.ui.blaze.IsBlazeEnabled
 import com.woocommerce.android.ui.common.webview.CanAutoAuthenticateInWebView
 import com.woocommerce.android.ui.customfields.CustomFieldsRepository
 import com.woocommerce.android.ui.media.MediaFileUploadHandler
+import com.woocommerce.android.ui.products.DuplicateProduct
 import com.woocommerce.android.ui.products.ParameterRepository
 import com.woocommerce.android.ui.products.ProductHelper
 import com.woocommerce.android.ui.products.ProductStatus
@@ -76,6 +77,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
     companion object {
         private const val PRODUCT_REMOTE_ID = 1L
         private const val OFFLINE_PRODUCT_REMOTE_ID = 2L
+        private const val DUPLICATED_PRODUCT_REMOTE_ID = 3L
         private val SALE_END_DATE = Date.from(
             LocalDateTime.of(2020, 4, 1, 8, 0)
                 .toInstant(ZoneOffset.UTC)
@@ -128,6 +130,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
         on(it.getParameters(any(), any<SavedStateHandle>())).thenReturn(siteParams)
     }
     private val generateVariationCandidates: GenerateVariationCandidates = mock()
+    private val duplicateProduct: DuplicateProduct = mock()
     private val tracker: AnalyticsTrackerWrapper = mock()
 
     private val prefsWrapper: AppPrefsWrapper = mock()
@@ -277,7 +280,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
                 appPrefsWrapper = prefsWrapper,
                 addonRepository = addonRepository,
                 generateVariationCandidates = generateVariationCandidates,
-                duplicateProduct = mock(),
+                duplicateProduct = duplicateProduct,
                 tracker = tracker,
                 selectedSite = selectedSite,
                 getBundledProductsCount = mock(),
@@ -301,7 +304,8 @@ class ProductDetailViewModelTest : BaseUnitTest() {
             productImagesServiceWrapper,
             resources,
             productCategoriesRepository,
-            productTagsRepository
+            productTagsRepository,
+            duplicateProduct
         )
     }
 
@@ -1415,6 +1419,150 @@ class ProductDetailViewModelTest : BaseUnitTest() {
                     screenTitle = UiStringText(productAggregate.product.name)
                 )
             )
+        }
+
+    @Test
+    fun `given a persisted product, when it is edited, then duplicate option remains visible`() = testBlocking {
+        // GIVEN
+        given(productRepository.getProductAggregate(any())).willReturn(productAggregate)
+        viewModel.productDetailViewStateData.observeForever { _, _ -> }
+        var menuButtonsState: ProductDetailViewModel.MenuButtonsState? = null
+        viewModel.menuButtonsState.observeForever { menuButtonsState = it }
+
+        // WHEN
+        viewModel.start()
+
+        // THEN
+        Assertions.assertThat(menuButtonsState?.duplicateOption).isTrue()
+
+        // WHEN
+        viewModel.onProductTitleChanged("Unsaved title")
+
+        // THEN
+        Assertions.assertThat(menuButtonsState?.duplicateOption).isTrue()
+    }
+
+    @Test
+    fun `given an unchanged persisted product, when duplicate is tapped, then duplicate immediately succeeds`() =
+        testBlocking {
+            // GIVEN
+            given(productRepository.getProductAggregate(any())).willReturn(productAggregate)
+            doReturn(Result.success(DUPLICATED_PRODUCT_REMOTE_ID)).whenever(duplicateProduct).invoke(productAggregate)
+            viewModel.start()
+            val events = mutableListOf<MultiLiveEvent.Event>()
+            viewModel.event.observeForever(events::add)
+
+            // WHEN
+            viewModel.onDuplicateProduct()
+
+            // THEN
+            Assertions.assertThat(events).containsExactly(
+                ProductDetailViewModel.ShowDuplicateProductInProgress,
+                ProductDetailViewModel.OpenProductDetails(DUPLICATED_PRODUCT_REMOTE_ID)
+            )
+            verify(duplicateProduct).invoke(productAggregate)
+            verify(tracker).track(AnalyticsEvent.PRODUCT_DETAIL_DUPLICATE_BUTTON_TAPPED)
+            verify(tracker).track(AnalyticsEvent.DUPLICATE_PRODUCT_SUCCESS)
+            verify(tracker, never()).track(AnalyticsEvent.DUPLICATE_PRODUCT_FAILED)
+        }
+
+    @Test
+    fun `given an edited persisted product, when duplicate is tapped, then confirmation is shown before duplication`() =
+        testBlocking {
+            // GIVEN
+            given(productRepository.getProductAggregate(any())).willReturn(productAggregate)
+            viewModel.start()
+            viewModel.onProductTitleChanged("Unsaved title")
+
+            // WHEN
+            viewModel.onDuplicateProduct()
+
+            // THEN
+            val dialog = viewModel.event.value as MultiLiveEvent.Event.ShowDialog
+            Assertions.assertThat(dialog.titleId).isEqualTo(R.string.product_duplicate_discard_changes_title)
+            Assertions.assertThat(dialog.messageId).isEqualTo(R.string.product_duplicate_discard_changes_message)
+            Assertions.assertThat(dialog.positiveButtonId)
+                .isEqualTo(R.string.product_duplicate_discard_changes_action)
+            Assertions.assertThat(dialog.negativeButtonId).isEqualTo(R.string.cancel)
+            verify(duplicateProduct, never()).invoke(any<ProductAggregate>())
+            verify(tracker).track(AnalyticsEvent.PRODUCT_DETAIL_DUPLICATE_BUTTON_TAPPED)
+            verify(tracker, never()).track(AnalyticsEvent.DUPLICATE_PRODUCT_SUCCESS)
+            verify(tracker, never()).track(AnalyticsEvent.DUPLICATE_PRODUCT_FAILED)
+        }
+
+    @Test
+    fun `given an edited persisted product, when duplicate is confirmed, then stored product is duplicated`() =
+        testBlocking {
+            // GIVEN
+            given(productRepository.getProductAggregate(any())).willReturn(productAggregate)
+            doReturn(Result.success(DUPLICATED_PRODUCT_REMOTE_ID)).whenever(duplicateProduct)
+                .invoke(any<ProductAggregate>())
+            viewModel.start()
+            viewModel.onProductTitleChanged("Unsaved title")
+            viewModel.onDuplicateProduct()
+            val dialog = viewModel.event.value as MultiLiveEvent.Event.ShowDialog
+
+            // WHEN
+            val events = viewModel.event.runAndCaptureValues {
+                requireNotNull(dialog.positiveBtnAction).onClick(null, 0)
+            }
+
+            // THEN
+            Assertions.assertThat(events.filterNot { it is MultiLiveEvent.Event.ShowDialog }).containsExactly(
+                ProductDetailViewModel.ShowDuplicateProductInProgress,
+                ProductDetailViewModel.OpenProductDetails(DUPLICATED_PRODUCT_REMOTE_ID)
+            )
+            verify(duplicateProduct).invoke(productAggregate)
+            Assertions.assertThat(viewModel.getProduct().productDraft?.name).isEqualTo("Unsaved title")
+            verify(tracker, times(1)).track(AnalyticsEvent.PRODUCT_DETAIL_DUPLICATE_BUTTON_TAPPED)
+            verify(tracker, times(1)).track(AnalyticsEvent.DUPLICATE_PRODUCT_SUCCESS)
+            verify(tracker, never()).track(AnalyticsEvent.DUPLICATE_PRODUCT_FAILED)
+        }
+
+    @Test
+    fun `given an edited persisted product, when duplicate confirmation is cancelled, then product is not duplicated`() =
+        testBlocking {
+            // GIVEN
+            given(productRepository.getProductAggregate(any())).willReturn(productAggregate)
+            viewModel.start()
+            viewModel.onProductTitleChanged("Unsaved title")
+            viewModel.onDuplicateProduct()
+            val dialog = viewModel.event.value as MultiLiveEvent.Event.ShowDialog
+
+            // WHEN
+            val negativeAction = dialog.negativeBtnAction
+
+            // THEN
+            Assertions.assertThat(negativeAction).isNull()
+            Assertions.assertThat(viewModel.getProduct().productDraft?.name).isEqualTo("Unsaved title")
+            verify(duplicateProduct, never()).invoke(any<ProductAggregate>())
+            verify(tracker, times(1)).track(AnalyticsEvent.PRODUCT_DETAIL_DUPLICATE_BUTTON_TAPPED)
+            verify(tracker, never()).track(AnalyticsEvent.DUPLICATE_PRODUCT_SUCCESS)
+            verify(tracker, never()).track(AnalyticsEvent.DUPLICATE_PRODUCT_FAILED)
+        }
+
+    @Test
+    fun `given an edited persisted product, when confirmed duplication fails, then draft and failure UX are preserved`() =
+        testBlocking {
+            // GIVEN
+            given(productRepository.getProductAggregate(any())).willReturn(productAggregate)
+            doReturn(Result.failure<Long>(IllegalStateException("Duplication failed"))).whenever(duplicateProduct)
+                .invoke(any<ProductAggregate>())
+            viewModel.start()
+            viewModel.onProductTitleChanged("Unsaved title")
+            viewModel.onDuplicateProduct()
+            val dialog = viewModel.event.value as MultiLiveEvent.Event.ShowDialog
+
+            // WHEN
+            dialog.positiveBtnAction?.onClick(null, 0)
+
+            // THEN
+            Assertions.assertThat(viewModel.getProduct().productDraft?.name).isEqualTo("Unsaved title")
+            Assertions.assertThat(viewModel.event.value).isEqualTo(ProductDetailViewModel.ShowDuplicateProductError)
+            verify(duplicateProduct).invoke(productAggregate)
+            verify(tracker).track(AnalyticsEvent.PRODUCT_DETAIL_DUPLICATE_BUTTON_TAPPED)
+            verify(tracker).track(AnalyticsEvent.DUPLICATE_PRODUCT_FAILED)
+            verify(tracker, never()).track(AnalyticsEvent.DUPLICATE_PRODUCT_SUCCESS)
         }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel_AddFlowTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel_AddFlowTest.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.products.details
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
+import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.media.MediaFilesRepository
 import com.woocommerce.android.media.ProductImagesServiceWrapper
@@ -12,6 +13,7 @@ import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.blaze.IsBlazeEnabled
 import com.woocommerce.android.ui.media.MediaFileUploadHandler
+import com.woocommerce.android.ui.products.DuplicateProduct
 import com.woocommerce.android.ui.products.ParameterRepository
 import com.woocommerce.android.ui.products.ProductStatus
 import com.woocommerce.android.ui.products.ProductTestUtils
@@ -43,6 +45,7 @@ import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.clearInvocations
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.spy
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
@@ -102,6 +105,7 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
         on(it.getParameters(any(), any<SavedStateHandle>())).thenReturn(siteParams)
     }
     private val generateVariationCandidates: GenerateVariationCandidates = mock()
+    private val duplicateProduct: DuplicateProduct = mock()
     private val tracker: AnalyticsTrackerWrapper = mock()
 
     private val prefs: AppPrefsWrapper = mock {
@@ -182,7 +186,7 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
                 appPrefsWrapper = prefs,
                 addonRepository = addonRepository,
                 generateVariationCandidates = generateVariationCandidates,
-                duplicateProduct = mock(),
+                duplicateProduct = duplicateProduct,
                 tracker = tracker,
                 selectedSite = selectedSite,
                 getBundledProductsCount = mock(),
@@ -208,7 +212,8 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
             productImagesServiceWrapper,
             resources,
             productCategoriesRepository,
-            productTagsRepository
+            productTagsRepository,
+            duplicateProduct
         )
     }
 
@@ -494,6 +499,33 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
         viewModel.updateProductDraft(title = "name")
 
         Assertions.assertThat(menuButtonsState?.saveOption).isFalse()
+    }
+
+    @Test
+    fun `given a never-saved product, when menu state loads, then duplicate option is hidden`() = testBlocking {
+        // GIVEN
+        viewModel.productDetailViewStateData.observeForever { _, _ -> }
+        var menuButtonsState: ProductDetailViewModel.MenuButtonsState? = null
+        viewModel.menuButtonsState.observeForever { menuButtonsState = it }
+
+        // WHEN
+        viewModel.start()
+
+        // THEN
+        Assertions.assertThat(menuButtonsState?.duplicateOption).isFalse()
+    }
+
+    @Test
+    fun `given a never-saved product, when duplicate handler is called, then duplication is ignored`() = testBlocking {
+        // GIVEN
+        viewModel.start()
+
+        // WHEN
+        viewModel.onDuplicateProduct()
+
+        // THEN
+        verify(duplicateProduct, never()).invoke(any<ProductAggregate>())
+        verify(tracker, never()).track(AnalyticsEvent.PRODUCT_DETAIL_DUPLICATE_BUTTON_TAPPED)
     }
 
     @Test

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/DuplicateProductApiResponse.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/DuplicateProductApiResponse.kt
@@ -1,0 +1,7 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.product
+
+import com.google.gson.annotations.SerializedName
+
+data class DuplicateProductApiResponse(
+    @SerializedName("id") val id: Long?
+)

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -1835,6 +1835,19 @@ class ProductRestClient @Inject constructor(
         }
     }
 
+    suspend fun duplicateProduct(
+        site: SiteModel,
+        productId: Long
+    ): WooPayload<DuplicateProductApiResponse> {
+        val response = wooNetwork.executePostGsonRequest(
+            site = site,
+            path = WOOCOMMERCE.products.id(productId).duplicate.pathV3,
+            body = emptyMap(),
+            clazz = DuplicateProductApiResponse::class.java
+        )
+        return response.toWooPayload()
+    }
+
     /**
      * Makes a POST request to `/wp-json/wc/v3/products` to add a product
      *

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -1139,6 +1139,25 @@ class WCProductStore @Inject internal constructor(
         return productsDao.getCompositeProducts(site, remoteProductId)
     }
 
+    suspend fun duplicateProduct(site: SiteModel, productId: Long): WooResult<Long> =
+        coroutineEngine.withDefaultContext(API, this, "duplicateProduct") {
+            val result = wcProductRestClient.duplicateProduct(site, productId)
+            if (result.isError) {
+                return@withDefaultContext WooResult(result.error)
+            }
+
+            val duplicatedProductId = result.result?.id?.takeIf { it > 0 }
+                ?: return@withDefaultContext WooResult(
+                    WooError(
+                        type = INVALID_RESPONSE,
+                        original = GenericErrorType.INVALID_RESPONSE,
+                        message = "Success response with missing or invalid product ID"
+                    )
+                )
+
+            WooResult(duplicatedProductId)
+        }
+
     suspend fun submitProductAttributeChanges(
         site: SiteModel,
         productId: Long,

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClientTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClientTest.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.wc.product
 
+import com.google.gson.Gson
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
@@ -17,8 +18,13 @@ import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCProductModel
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.NOT_FOUND
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetworkError
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComNetwork
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.API_NOT_FOUND
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.INVALID_ID
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
 import org.wordpress.android.fluxc.store.WCProductStore
 import org.wordpress.android.fluxc.utils.initCoroutineEngine
@@ -41,6 +47,98 @@ class ProductRestClientTest {
     @Before fun setUp() {
         sut = ProductRestClient(mock(), wooNetwork, wpComNetwork, initCoroutineEngine(), mock(), mock())
     }
+
+    @Test
+    fun `when duplicating a product, then exact endpoint and empty body are used and duplicated ID is parsed`() =
+        runTest {
+            // GIVEN
+            val response = Gson().fromJson(
+                """
+                    {
+                      "id": 123,
+                      "name": "Coffee (Copy)",
+                      "slug": "coffee-copy",
+                      "date_created": {"date": "2026-07-14 12:00:00", "timezone_type": 3, "timezone": "UTC"},
+                      "category_ids": [12],
+                      "image_id": 8,
+                      "gallery_image_ids": [9],
+                      "meta_data": [{"id": 9, "key": "_subscription_price", "value": "10"}],
+                      "downloads": []
+                    }
+                """.trimIndent(),
+                DuplicateProductApiResponse::class.java
+            )
+            whenever(
+                wooNetwork.executePostGsonRequest(
+                    site = any(),
+                    path = any(),
+                    clazz = eq(DuplicateProductApiResponse::class.java),
+                    body = any()
+                )
+            ).thenReturn(WPAPIResponse.Success(response, emptyList()))
+
+            // WHEN
+            val result = sut.duplicateProduct(site, productId)
+
+            // THEN
+            verify(wooNetwork).executePostGsonRequest(
+                site = eq(site),
+                path = eq(WOOCOMMERCE.products.id(productId).duplicate.pathV3),
+                clazz = eq(DuplicateProductApiResponse::class.java),
+                body = eq(emptyMap())
+            )
+            assertThat(result.result?.id).isEqualTo(123L)
+        }
+
+    @Test
+    fun `given duplicate route is missing, when duplicating a product, then rest no route error is preserved`() =
+        runTest {
+            // GIVEN
+            val networkError = WPAPINetworkError(
+                BaseNetworkError(NOT_FOUND, "No route"),
+                errorCode = "rest_no_route"
+            )
+            whenever(
+                wooNetwork.executePostGsonRequest(
+                    site = any(),
+                    path = any(),
+                    clazz = eq(DuplicateProductApiResponse::class.java),
+                    body = any()
+                )
+            ).thenReturn(WPAPIResponse.Error(networkError))
+
+            // WHEN
+            val result = sut.duplicateProduct(site, productId)
+
+            // THEN
+            assertThat(result.error?.type).isEqualTo(API_NOT_FOUND)
+            assertThat(result.error?.apiErrorCode).isEqualTo("rest_no_route")
+        }
+
+    @Test
+    fun `given source product is invalid, when duplicating a product, then invalid ID error is not treated as missing route`() =
+        runTest {
+            // GIVEN
+            val networkError = WPAPINetworkError(
+                BaseNetworkError(NOT_FOUND, "Invalid product ID"),
+                errorCode = "woocommerce_rest_product_invalid_id"
+            )
+            whenever(
+                wooNetwork.executePostGsonRequest(
+                    site = any(),
+                    path = any(),
+                    clazz = eq(DuplicateProductApiResponse::class.java),
+                    body = any()
+                )
+            ).thenReturn(WPAPIResponse.Error(networkError))
+
+            // WHEN
+            val result = sut.duplicateProduct(site, productId)
+
+            // THEN
+            assertThat(result.error?.type).isEqualTo(INVALID_ID)
+            assertThat(result.error?.apiErrorCode).isEqualTo("woocommerce_rest_product_invalid_id")
+        }
 
     @Test
     fun `send only updated parameters with id if products differ`() = runTest {

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/store/WCProductStoreTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/store/WCProductStoreTest.kt
@@ -9,6 +9,7 @@ import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
+import org.json.JSONObject
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -35,13 +36,17 @@ import org.wordpress.android.fluxc.model.WCProductVariationModel
 import org.wordpress.android.fluxc.model.WCProductVariationModel.ProductVariantOption
 import org.wordpress.android.fluxc.model.metadata.WCMetaData
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.NETWORK_ERROR
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.NOT_FOUND
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.API_NOT_FOUND
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.GENERIC_ERROR
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.INVALID_RESPONSE
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.BatchProductUpdateApiResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.BatchProductUpdateResult
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.BatchProductVariationsApiResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductStockStatus
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.DuplicateProductApiResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductVariationApiResponse
 import org.wordpress.android.fluxc.persistence.DatabaseTestRule
@@ -117,6 +122,59 @@ class WCProductStoreTest {
             productReviewsDao = wcDatabaseRule.db.productReviewsDao,
         )
     }
+
+    @Test
+    fun `given core duplication succeeds, when duplicating product, then duplicated product ID is returned`() = runTest {
+        // GIVEN
+        val site = SiteModel()
+        whenever(productRestClient.duplicateProduct(site, 42L))
+            .thenReturn(WooPayload(DuplicateProductApiResponse(84L)))
+
+        // WHEN
+        val result = productStore.duplicateProduct(site, 42L)
+
+        // THEN
+        assertThat(result.model).isEqualTo(84L)
+    }
+
+    @Test
+    fun `given core duplication response has missing or invalid ID, when duplicating product, then invalid response is returned`() =
+        runTest {
+            // GIVEN
+            val site = SiteModel()
+            listOf(null, 0L, -1L).forEach { responseId ->
+                whenever(productRestClient.duplicateProduct(site, 42L))
+                    .thenReturn(WooPayload(DuplicateProductApiResponse(responseId)))
+
+                // WHEN
+                val result = productStore.duplicateProduct(site, 42L)
+
+                // THEN
+                assertThat(result.error.type).isEqualTo(INVALID_RESPONSE)
+            }
+        }
+
+    @Test
+    fun `given core duplication returns an error, when duplicating product, then full error is forwarded unchanged`() =
+        runTest {
+            // GIVEN
+            val site = SiteModel()
+            val expectedError = WooError(
+                type = API_NOT_FOUND,
+                original = NOT_FOUND,
+                message = "No route was found matching the URL and request method",
+                apiErrorCode = "rest_no_route",
+                errorData = JSONObject().put("status", 404)
+            )
+            whenever(productRestClient.duplicateProduct(site, 42L))
+                .thenReturn(WooPayload(expectedError))
+
+            // WHEN
+            val result = productStore.duplicateProduct(site, 42L)
+
+            // THEN
+            assertThat(result.error).isEqualTo(expectedError)
+        }
 
     @Test
     fun testSimpleInsertionAndRetrieval() = runTest {

--- a/libs/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
+++ b/libs/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
@@ -11,6 +11,7 @@
 
 /products/<id>/
 /products/<id>/availability/
+/products/<id>/duplicate
 /products/<id>/variations/
 /products/<id>/variations/<variation_id>
 /products/<id>/variations/batch

--- a/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/endpoints/WCWPAPIEndpointTest.kt
+++ b/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/endpoints/WCWPAPIEndpointTest.kt
@@ -30,4 +30,9 @@ class WCWPAPIEndpointTest {
         assertEquals("/wc/v4/refunds/", WOOCOMMERCE.refunds.pathV4)
         assertEquals("/wc/v4/refunds/preview/", WOOCOMMERCE.refunds.preview.pathV4)
     }
+
+    @Test
+    fun `when building product duplicate path, then v3 route is correct`() {
+        assertEquals("/wc/v3/products/123/duplicate/", WOOCOMMERCE.products.id(123).duplicate.pathV3)
+    }
 }


### PR DESCRIPTION
### Description
Fixes WOOMOB-3586

Android now calls WooCommerce Core's server-side product duplicate endpoint so duplicated products preserve the data managed by WooCommerce. The existing client-side implementation remains as a compatibility fallback only when the endpoint is conclusively absent: the error must be `API_NOT_FOUND` with the `rest_no_route` API code.

Saved products with unsaved local edits keep the Duplicate action available, but now ask for confirmation before duplication. Confirming duplicates the captured last-saved `ProductAggregate` through the server endpoint, and the same saved aggregate is used if the exact route-absence response requires the legacy fallback. Cancel keeps the unsaved edit and performs no duplication. Never-saved products hide Duplicate because they do not have a server product to copy.

Other or ambiguous errors remain terminal. Product duplication is non-idempotent, so retrying with the local implementation after an uncertain server response could create two products.

The network response intentionally maps only the duplicated product ID. WooCommerce Core returns raw product data from this endpoint rather than the canonical REST product representation, and the destination product screen performs the normal canonical fetch and cache flow.

`ProductDetailRepository` exposes the operation as Kotlin `Result<Long>`. Once duplication begins, the existing progress dialog, destination navigation, and analytics behavior remain unchanged.

### Test Steps
1. On a WooCommerce 8.9+ test store, choose a saved product with images, a description, a price, inventory, shipping details, and a category.
2. Without editing the product, select the overflow menu > Duplicate. Verify duplication starts immediately without confirmation, the progress dialog appears, and the app opens one distinct Draft with the server-style `(Copy)` suffix and the saved fields populated.
3. Return to the saved source product, make a visible local edit such as changing its title, and do not save it. Select the overflow menu > Duplicate.
4. Verify the confirmation title is “Discard changes and duplicate?”, the message is “Your unsaved changes will be lost. The duplicate will use the last saved version.”, and the actions are “Cancel” and “Discard & duplicate”.
5. Select Cancel. Verify the local edit remains visible and no duplicate is created.
6. Select Duplicate again, then select Discard & duplicate. Verify exactly one Draft is created from the source's last saved version rather than the unsaved edit.
7. Start the New Product flow and open its overflow menu. Verify Duplicate is not shown.
8. To verify the compatibility fallback, configure ApiFaker with exactly one WP API endpoint matching `POST /wc/v3/products/<source-id>/duplicate`, status 404, and this response body:
   ```json
   {"code":"rest_no_route","message":"No route was found matching the URL and request method.","data":{"status":404}}
   ```
9. Enable ApiFaker and duplicate an unchanged saved source once. Verify logcat shows the exact `/duplicate` endpoint match followed by one legacy `ADD_PRODUCT` request, the app opens one new Draft, and no second duplicate is created.
10. Clear the ApiFaker endpoint, then configure the same request with status 404 and this regular invalid-product response body:
    ```json
    {"code":"woocommerce_rest_product_invalid_id","message":"Invalid product ID.","data":{"status":404}}
    ```
11. Duplicate the saved source once. Verify the app shows “Cannot duplicate product,” remains on the source product, creates no Draft, and logcat contains no `ADD_PRODUCT` request.

### Images/gif
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.