### PR TITLE
[WOOMOB-1896] Attach full application logs as a file to Zendesk support tickets

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/zendesk/ZendeskEnvironmentDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/zendesk/ZendeskEnvironmentDataSource.kt
@@ -48,7 +48,9 @@ class ZendeskEnvironmentDataSource @Inject constructor() {
             "${selectedSite.hostURL} (${selectedSite.stateLogInformation})"
         } ?: unknownHostValue
 
-    suspend fun getDeviceLogs() = WooLog.getCurrentLogEntries().joinToString("\n").takeLast(maxLogfileLength)
+    suspend fun getDeviceLogs() = getFullDeviceLogs().takeLast(maxLogfileLength)
+
+    suspend fun getFullDeviceLogs() = WooLog.getCurrentLogEntries().joinToString("\n")
 
     private val SiteModel.hostURL: String
         get() = UrlUtils.removeScheme(url)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/zendesk/ZendeskEnvironmentDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/zendesk/ZendeskEnvironmentDataSource.kt
@@ -48,9 +48,9 @@ class ZendeskEnvironmentDataSource @Inject constructor() {
             "${selectedSite.hostURL} (${selectedSite.stateLogInformation})"
         } ?: unknownHostValue
 
-    suspend fun getDeviceLogs() = getFullDeviceLogs().takeLast(maxLogfileLength)
-
     suspend fun getFullDeviceLogs() = WooLog.getCurrentLogEntries().joinToString("\n")
+
+    fun trimDeviceLogs(logs: String) = logs.takeLast(maxLogfileLength)
 
     private val SiteModel.hostURL: String
         get() = UrlUtils.removeScheme(url)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/zendesk/ZendeskTicketRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/zendesk/ZendeskTicketRepository.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.SiteStore
@@ -71,9 +72,11 @@ class ZendeskTicketRepository @Inject constructor(
 
         val ssr: String? = selectedSite?.let { fetchSSR(it) }
 
+        val deviceLogs = envDataSource.getFullDeviceLogs()
+
         val attachmentTokens = listOfNotNull(
             diagnosticLog?.let { uploadTextAttachment(DIAGNOSTIC_LOG_FILENAME, it) },
-            uploadTextAttachment(APPLICATION_LOG_FILENAME, envDataSource.getFullDeviceLogs())
+            uploadTextAttachment(APPLICATION_LOG_FILENAME, deviceLogs)
         )
 
         val requestCallback = object : ZendeskCallback<Request>() {
@@ -103,7 +106,8 @@ class ZendeskTicketRepository @Inject constructor(
                 allSites = siteStore.sites,
                 selectedSite = selectedSite,
                 ssr = ssr,
-                siteAddress = siteAddress
+                siteAddress = siteAddress,
+                deviceLogs = deviceLogs
             )
 
             this.customFields = buildZendeskCustomFields(zendeskCustomFieldsParams)
@@ -141,27 +145,31 @@ class ZendeskTicketRepository @Inject constructor(
         }
 
         return try {
-            suspendCancellableCoroutine { continuation ->
-                zendeskSettings.uploadProvider?.uploadAttachment(
-                    fileName,
-                    tempFile,
-                    "text/plain",
-                    object : ZendeskCallback<UploadResponse>() {
-                        override fun onSuccess(result: UploadResponse?) {
-                            if (continuation.isActive) {
-                                continuation.resume(result?.token)
+            // Guard against the Zendesk SDK never invoking either callback, which would otherwise
+            // block ticket creation indefinitely. On timeout we treat it as a failed upload (null).
+            withTimeoutOrNull(RequestConstants.attachmentUploadTimeout) {
+                suspendCancellableCoroutine { continuation ->
+                    zendeskSettings.uploadProvider?.uploadAttachment(
+                        fileName,
+                        tempFile,
+                        "text/plain",
+                        object : ZendeskCallback<UploadResponse>() {
+                            override fun onSuccess(result: UploadResponse?) {
+                                if (continuation.isActive) {
+                                    continuation.resume(result?.token)
+                                }
                             }
-                        }
 
-                        override fun onError(error: ErrorResponse?) {
-                            wooLog.e(WooLog.T.SUPPORT, "Failed to upload attachment: $fileName")
-                            if (continuation.isActive) {
-                                continuation.resume(null)
+                            override fun onError(error: ErrorResponse?) {
+                                wooLog.e(WooLog.T.SUPPORT, "Failed to upload attachment: $fileName")
+                                if (continuation.isActive) {
+                                    continuation.resume(null)
+                                }
                             }
                         }
+                    ) ?: run {
+                        continuation.resume(null)
                     }
-                ) ?: run {
-                    continuation.resume(null)
                 }
             }
         } finally {
@@ -178,7 +186,7 @@ class ZendeskTicketRepository @Inject constructor(
             CustomField(TicketCustomField.appVersion, envDataSource.generateVersionName(params.context)),
             CustomField(TicketCustomField.deviceFreeSpace, envDataSource.totalAvailableMemorySize),
             CustomField(TicketCustomField.networkInformation, envDataSource.generateNetworkInformation(params.context)),
-            CustomField(TicketCustomField.logs, envDataSource.getDeviceLogs()),
+            CustomField(TicketCustomField.logs, envDataSource.trimDeviceLogs(params.deviceLogs)),
             CustomField(TicketCustomField.ssr, params.ssr),
             CustomField(TicketCustomField.currentSite, envDataSource.generateHostData(params.selectedSite)),
             CustomField(TicketCustomField.sourcePlatform, ZendeskEnvironmentDataSource.sourcePlatform),
@@ -360,6 +368,7 @@ sealed class ZendeskException(message: String) : Exception(message) {
 
 private object RequestConstants {
     const val requestCreationTimeout = 10000L
+    const val attachmentUploadTimeout = 30000L
     const val requestCreationTimeoutErrorMessage = "Request creation timed out"
     const val requestCreationIdentityNotSetErrorMessage = "Request creation failed: identity not set"
     const val DIAGNOSTIC_LOG_FILENAME = "connectivitytest_log.txt"
@@ -372,5 +381,6 @@ private data class ZendeskCustomFieldsParams(
     val allSites: List<SiteModel>?,
     val selectedSite: SiteModel?,
     val ssr: String?,
-    val siteAddress: String
+    val siteAddress: String,
+    val deviceLogs: String
 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/zendesk/ZendeskTicketRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/zendesk/ZendeskTicketRepository.kt
@@ -5,6 +5,7 @@ import android.os.Parcelable
 import com.woocommerce.android.applicationpasswords.IsAppPasswordsSupportedForJetpackSite
 import com.woocommerce.android.extensions.formatResult
 import com.woocommerce.android.support.help.HelpOrigin
+import com.woocommerce.android.support.zendesk.RequestConstants.APPLICATION_LOG_FILENAME
 import com.woocommerce.android.support.zendesk.RequestConstants.DIAGNOSTIC_LOG_FILENAME
 import com.woocommerce.android.support.zendesk.RequestConstants.requestCreationIdentityNotSetErrorMessage
 import com.woocommerce.android.support.zendesk.RequestConstants.requestCreationTimeoutErrorMessage
@@ -70,11 +71,10 @@ class ZendeskTicketRepository @Inject constructor(
 
         val ssr: String? = selectedSite?.let { fetchSSR(it) }
 
-        val attachmentTokens = if (diagnosticLog != null) {
-            listOfNotNull(uploadDiagnosticLog(diagnosticLog))
-        } else {
-            emptyList()
-        }
+        val attachmentTokens = listOfNotNull(
+            diagnosticLog?.let { uploadTextAttachment(DIAGNOSTIC_LOG_FILENAME, it) },
+            uploadTextAttachment(APPLICATION_LOG_FILENAME, envDataSource.getFullDeviceLogs())
+        )
 
         val requestCallback = object : ZendeskCallback<Request>() {
             override fun onSuccess(result: Request?) {
@@ -130,19 +130,20 @@ class ZendeskTicketRepository @Inject constructor(
         return result.model?.formatResult()
     }
 
-    private suspend fun uploadDiagnosticLog(
-        diagnosticLog: String
+    private suspend fun uploadTextAttachment(
+        fileName: String,
+        content: String
     ): String? {
         val tempFile = withContext(dispatchers.io) {
-            File.createTempFile(DIAGNOSTIC_LOG_FILENAME, null).also {
-                it.writeText(diagnosticLog)
+            File.createTempFile(fileName, null).also {
+                it.writeText(content)
             }
         }
 
         return try {
             suspendCancellableCoroutine { continuation ->
                 zendeskSettings.uploadProvider?.uploadAttachment(
-                    DIAGNOSTIC_LOG_FILENAME,
+                    fileName,
                     tempFile,
                     "text/plain",
                     object : ZendeskCallback<UploadResponse>() {
@@ -153,7 +154,7 @@ class ZendeskTicketRepository @Inject constructor(
                         }
 
                         override fun onError(error: ErrorResponse?) {
-                            wooLog.e(WooLog.T.SUPPORT, "Failed to upload diagnostic log")
+                            wooLog.e(WooLog.T.SUPPORT, "Failed to upload attachment: $fileName")
                             if (continuation.isActive) {
                                 continuation.resume(null)
                             }
@@ -362,6 +363,7 @@ private object RequestConstants {
     const val requestCreationTimeoutErrorMessage = "Request creation timed out"
     const val requestCreationIdentityNotSetErrorMessage = "Request creation failed: identity not set"
     const val DIAGNOSTIC_LOG_FILENAME = "connectivitytest_log.txt"
+    const val APPLICATION_LOG_FILENAME = "application_log.txt"
 }
 
 private data class ZendeskCustomFieldsParams(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/zendesk/ZendeskTicketRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/zendesk/ZendeskTicketRepository.kt
@@ -138,11 +138,15 @@ class ZendeskTicketRepository @Inject constructor(
         fileName: String,
         content: String
     ): String? {
+        // Preparing the file is best-effort: an I/O failure (e.g. low disk space) must not block
+        // ticket creation, so we log it and continue without the attachment.
         val tempFile = withContext(dispatchers.io) {
-            File.createTempFile(fileName, null).also {
-                it.writeText(content)
-            }
-        }
+            runCatching {
+                File.createTempFile(fileName, null).also { it.writeText(content) }
+            }.onFailure {
+                wooLog.e(WooLog.T.SUPPORT, "Failed to prepare attachment file: $fileName")
+            }.getOrNull()
+        } ?: return null
 
         return try {
             // Guard against the Zendesk SDK never invoking either callback, which would otherwise

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatFragment.kt
@@ -165,7 +165,8 @@ class AiSupportChatFragment : Fragment(), MenuProvider {
                 subject = requireNotNull(event.subject),
                 description = event.description,
                 extraTags = event.extraTags,
-                siteAddress = event.siteAddress
+                siteAddress = event.siteAddress,
+                diagnosticLog = event.diagnosticLog
             ).collect { result ->
                 hideProgressDialog()
                 result
@@ -204,7 +205,8 @@ class AiSupportChatFragment : Fragment(), MenuProvider {
                 prefilledSubject = event.subject,
                 prefilledMessage = event.description.takeIf { includeTranscript },
                 prefilledSiteAddress = event.siteAddress,
-                aiSupportChatTicketAnalyticsContext = event.ticketAnalyticsContext
+                aiSupportChatTicketAnalyticsContext = event.ticketAnalyticsContext,
+                diagnosticLog = event.diagnosticLog
             )
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatViewModel.kt
@@ -20,6 +20,7 @@ import com.woocommerce.android.ui.login.AccountRepository
 import com.woocommerce.android.ui.troubleshooting.ConnectivityCheckCardData
 import com.woocommerce.android.ui.troubleshooting.ConnectivityCheckStatus
 import com.woocommerce.android.ui.troubleshooting.ConnectivityCheckType
+import com.woocommerce.android.ui.troubleshooting.toConnectivityDiagnosticLog
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.ResourceProvider
@@ -411,6 +412,7 @@ class AiSupportChatViewModel @Inject constructor(
                 messages = listOf(greetingMessage()),
                 selectedIssueType = SupportIssueType.OTHER,
                 diagnosticResult = result,
+                connectivityDiagnosticLog = checks.toConnectivityDiagnosticLog(),
                 hasProceededToChat = true,
                 canPersistChatHistory = accountRepository.isUserLoggedIn(),
                 showSendError = false
@@ -946,7 +948,8 @@ class AiSupportChatViewModel @Inject constructor(
             extraTags = supportArea.extraTags(_viewState.value.hasReceivedBotResponse),
             siteAddress = siteAddress,
             hasReceivedBotResponse = _viewState.value.hasReceivedBotResponse,
-            ticketAnalyticsContext = supportArea.toTicketAnalyticsContext(_viewState.value.entryPoint)
+            ticketAnalyticsContext = supportArea.toTicketAnalyticsContext(_viewState.value.entryPoint),
+            diagnosticLog = _viewState.value.connectivityDiagnosticLog
         )
     }
 
@@ -1052,6 +1055,7 @@ data class AiSupportChatViewState(
     val selectedIssueLabel: String? = null,
     val launchExtraTags: List<String> = emptyList(),
     val diagnosticResult: DiagnosticResult? = null,
+    val connectivityDiagnosticLog: String? = null,
     val diagnosticSuggestedActionOverride: SuggestedFixAction? = null,
     val isRunningDiagnostics: Boolean = false,
     val isLoadingHistory: Boolean = false,
@@ -1153,7 +1157,8 @@ data class ContactHumanSupport(
     val extraTags: List<String>,
     val siteAddress: String,
     val hasReceivedBotResponse: Boolean,
-    val ticketAnalyticsContext: AiSupportChatTicketAnalyticsContext
+    val ticketAnalyticsContext: AiSupportChatTicketAnalyticsContext,
+    val diagnosticLog: String?
 ) : Event()
 
 data object OpenAppNotificationSettings : Event()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/troubleshooting/ConnectivityCheckCardData.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/troubleshooting/ConnectivityCheckCardData.kt
@@ -86,3 +86,34 @@ enum class FailureType(val message: Int) : Parcelable {
     JETPACK(R.string.orderlist_connectivity_tool_jetpack_error_suggestion),
     GENERIC(R.string.orderlist_connectivity_tool_generic_error_suggestion)
 }
+
+/**
+ * Builds a human-readable diagnostic log from the completed connectivity checks. This is the text
+ * attached as `connectivitytest_log.txt` to Zendesk support requests. Returns null when no check
+ * has completed yet.
+ */
+fun List<ConnectivityCheckCardData>.toConnectivityDiagnosticLog(): String? {
+    val completedChecks = filter {
+        it.status is ConnectivityCheckStatus.Success || it.status is ConnectivityCheckStatus.Failure
+    }
+
+    if (completedChecks.isEmpty()) return null
+
+    return buildString {
+        completedChecks.forEachIndexed { index, check ->
+            appendLine("## ${index + 1}. ${check.type.operationName}")
+            appendLine("Took: ${check.status.durationMs}ms")
+            val resultStr = when (val status = check.status) {
+                is ConnectivityCheckStatus.Success -> "Success"
+                is ConnectivityCheckStatus.Failure -> {
+                    val errorName = status.error?.name ?: "Failed"
+                    val details = status.technicalDetails?.let { "\n$it" } ?: ""
+                    errorName + details
+                }
+                else -> "Unknown"
+            }
+            appendLine("Result: $resultStr")
+            appendLine()
+        }
+    }.trimEnd()
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/troubleshooting/TroubleshootConnectionViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/troubleshooting/TroubleshootConnectionViewModel.kt
@@ -177,31 +177,7 @@ class TroubleshootConnectionViewModel @Inject constructor(
         )
     }
 
-    private fun generateDiagnosticLog(): String? {
-        val completedChecks = checksFlow.value.filter {
-            it.status is Success || it.status is Failure
-        }
-
-        if (completedChecks.isEmpty()) return null
-
-        return buildString {
-            completedChecks.forEachIndexed { index, check ->
-                appendLine("## ${index + 1}. ${check.type.operationName}")
-                appendLine("Took: ${check.status.durationMs}ms")
-                val resultStr = when (val status = check.status) {
-                    is Success -> "Success"
-                    is Failure -> {
-                        val errorName = status.error?.name ?: "Failed"
-                        val details = status.technicalDetails?.let { "\n$it" } ?: ""
-                        errorName + details
-                    }
-                    else -> "Unknown"
-                }
-                appendLine("Result: $resultStr")
-                appendLine()
-            }
-        }.trimEnd()
-    }
+    private fun generateDiagnosticLog(): String? = checksFlow.value.toConnectivityDiagnosticLog()
 
     private fun isAiSupportChatAvailable(): Boolean =
         featureFlagRepository.isEnabled(FeatureFlag.AI_SUPPORT_CHAT)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/support/ZendeskTicketRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/support/ZendeskTicketRepositoryTest.kt
@@ -804,6 +804,85 @@ internal class ZendeskTicketRepositoryTest : BaseUnitTest() {
             assertThat(requestCaptor.firstValue.attachments).isNullOrEmpty()
         }
 
+    @Test
+    fun `given the log upload never returns, when createRequest is called, then it times out and creates the request`() =
+        testBlocking {
+            // given the upload provider never invokes either callback
+            val uploadProvider = mock<UploadProvider>()
+            given(zendeskSettings.uploadProvider).willReturn(uploadProvider)
+            val requestCaptor = argumentCaptor<CreateRequest>()
+
+            // when
+            val job = launch {
+                sut.createRequest(
+                    context = mock(),
+                    origin = HelpOrigin.LOGIN_HELP_NOTIFICATION,
+                    ticketType = TicketType.MobileApp,
+                    selectedSite = null,
+                    subject = "subject",
+                    description = "description",
+                    extraTags = emptyList(),
+                    siteAddress = "siteAddress"
+                ).first()
+            }
+
+            // then the upload times out, is treated as no attachment, and the ticket is still created
+            verify(uploadProvider).uploadAttachment(eq("application_log.txt"), any(), any(), any())
+            advanceUntilIdle()
+            verify(requestProvider).createRequest(requestCaptor.capture(), any())
+            job.cancel()
+
+            assertThat(requestCaptor.firstValue.attachments).isNullOrEmpty()
+        }
+
+    @Test
+    fun `given a diagnostic log, when createRequest is called, then both the diagnostic and full logs are attached`() =
+        testBlocking {
+            // given
+            val diagnosticResponse = mock<UploadResponse> { on { token } doReturn "diagnostic-token" }
+            val appLogResponse = mock<UploadResponse> { on { token } doReturn "app-log-token" }
+            val uploadProvider = mock<UploadProvider>()
+            given(zendeskSettings.uploadProvider).willReturn(uploadProvider)
+            val uploadCaptor = argumentCaptor<ZendeskCallback<UploadResponse>>()
+            val requestCaptor = argumentCaptor<CreateRequest>()
+
+            // when
+            val job = launch {
+                sut.createRequest(
+                    context = mock(),
+                    origin = HelpOrigin.LOGIN_HELP_NOTIFICATION,
+                    ticketType = TicketType.MobileApp,
+                    selectedSite = null,
+                    subject = "subject",
+                    description = "description",
+                    extraTags = emptyList(),
+                    siteAddress = "siteAddress",
+                    diagnosticLog = "diagnostic logs"
+                ).first()
+            }
+
+            // then
+            verify(uploadProvider).uploadAttachment(
+                eq("connectivitytest_log.txt"),
+                any(),
+                any(),
+                uploadCaptor.capture()
+            )
+            uploadCaptor.firstValue.onSuccess(diagnosticResponse)
+            verify(uploadProvider).uploadAttachment(
+                eq("application_log.txt"),
+                any(),
+                any(),
+                uploadCaptor.capture()
+            )
+            uploadCaptor.secondValue.onSuccess(appLogResponse)
+            advanceUntilIdle()
+            verify(requestProvider).createRequest(requestCaptor.capture(), any())
+            job.cancel()
+
+            assertThat(requestCaptor.firstValue.attachments).containsExactly("diagnostic-token", "app-log-token")
+        }
+
     private fun createSUT() {
         sut = ZendeskTicketRepository(
             zendeskSettings = zendeskSettings,
@@ -819,8 +898,8 @@ internal class ZendeskTicketRepositoryTest : BaseUnitTest() {
     private fun mockEnvDataSource() = mock<ZendeskEnvironmentDataSource> {
         on { totalAvailableMemorySize } doReturn "100"
         on { deviceLanguage } doReturn "testLanguage"
-        on { getDeviceLogs() } doReturn "logs"
         on { getFullDeviceLogs() } doReturn "full logs"
+        on { trimDeviceLogs(any()) } doReturn "logs"
         on { generateVersionName(any()) } doReturn "version"
         on { generateNetworkInformation(any()) } doReturn "networkInfo"
         on { generateCombinedLogInformationOfSites(any()) } doReturn "sitesInfo"

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/support/ZendeskTicketRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/support/ZendeskTicketRepositoryTest.kt
@@ -26,6 +26,7 @@ import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.given
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.stub
@@ -40,6 +41,8 @@ import org.wordpress.android.fluxc.store.SiteStore
 import zendesk.support.CreateRequest
 import zendesk.support.Request
 import zendesk.support.RequestProvider
+import zendesk.support.UploadProvider
+import zendesk.support.UploadResponse
 
 @OptIn(ExperimentalCoroutinesApi::class)
 internal class ZendeskTicketRepositoryTest : BaseUnitTest() {
@@ -728,6 +731,79 @@ internal class ZendeskTicketRepositoryTest : BaseUnitTest() {
             assertThat(tags).contains(ZendeskTags.jetpackSiteUsingAppPasswords)
         }
 
+    @Test
+    fun `when createRequest is called, then the full device logs are uploaded as an attachment and its token is set`() =
+        testBlocking {
+            // given
+            val expectedToken = "attachment-token"
+            val uploadResponse = mock<UploadResponse> { on { token } doReturn expectedToken }
+            val uploadProvider = mock<UploadProvider>()
+            given(zendeskSettings.uploadProvider).willReturn(uploadProvider)
+            val uploadCaptor = argumentCaptor<ZendeskCallback<UploadResponse>>()
+            val requestCaptor = argumentCaptor<CreateRequest>()
+
+            // when
+            val job = launch {
+                sut.createRequest(
+                    context = mock(),
+                    origin = HelpOrigin.LOGIN_HELP_NOTIFICATION,
+                    ticketType = TicketType.MobileApp,
+                    selectedSite = null,
+                    subject = "subject",
+                    description = "description",
+                    extraTags = emptyList(),
+                    siteAddress = "siteAddress"
+                ).first()
+            }
+
+            // then
+            verify(uploadProvider).uploadAttachment(
+                eq("application_log.txt"),
+                any(),
+                eq("text/plain"),
+                uploadCaptor.capture()
+            )
+            uploadCaptor.firstValue.onSuccess(uploadResponse)
+            advanceUntilIdle()
+            verify(requestProvider).createRequest(requestCaptor.capture(), any())
+            job.cancel()
+
+            assertThat(requestCaptor.firstValue.attachments).containsExactly(expectedToken)
+        }
+
+    @Test
+    fun `given the log upload fails, when createRequest is called, then the request is still created without attachments`() =
+        testBlocking {
+            // given
+            val uploadProvider = mock<UploadProvider>()
+            given(zendeskSettings.uploadProvider).willReturn(uploadProvider)
+            val uploadCaptor = argumentCaptor<ZendeskCallback<UploadResponse>>()
+            val requestCaptor = argumentCaptor<CreateRequest>()
+
+            // when
+            val job = launch {
+                sut.createRequest(
+                    context = mock(),
+                    origin = HelpOrigin.LOGIN_HELP_NOTIFICATION,
+                    ticketType = TicketType.MobileApp,
+                    selectedSite = null,
+                    subject = "subject",
+                    description = "description",
+                    extraTags = emptyList(),
+                    siteAddress = "siteAddress"
+                ).first()
+            }
+
+            // then
+            verify(uploadProvider).uploadAttachment(any(), any(), any(), uploadCaptor.capture())
+            uploadCaptor.firstValue.onError(mock())
+            advanceUntilIdle()
+            verify(requestProvider).createRequest(requestCaptor.capture(), any())
+            job.cancel()
+
+            assertThat(requestCaptor.firstValue.attachments).isNullOrEmpty()
+        }
+
     private fun createSUT() {
         sut = ZendeskTicketRepository(
             zendeskSettings = zendeskSettings,
@@ -744,6 +820,7 @@ internal class ZendeskTicketRepositoryTest : BaseUnitTest() {
         on { totalAvailableMemorySize } doReturn "100"
         on { deviceLanguage } doReturn "testLanguage"
         on { getDeviceLogs() } doReturn "logs"
+        on { getFullDeviceLogs() } doReturn "full logs"
         on { generateVersionName(any()) } doReturn "version"
         on { generateNetworkInformation(any()) } doReturn "networkInfo"
         on { generateCombinedLogInformationOfSites(any()) } doReturn "sitesInfo"

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatViewModelTest.kt
@@ -1398,6 +1398,42 @@ class AiSupportChatViewModelTest : BaseUnitTest() {
         }
 
     @Test
+    fun `given connectivity launch mode, when contact support is clicked, then event carries the diagnostic log`() =
+        testBlocking {
+            val checks = listOf(
+                ConnectivityCheckCardData(ConnectivityCheckType.INTERNET, ConnectivityCheckStatus.Success()),
+                ConnectivityCheckCardData(ConnectivityCheckType.WP_COM, ConnectivityCheckStatus.Failure())
+            )
+            val events = mutableListOf<MultiLiveEvent.Event>()
+            viewModel.event.observeForever { events.add(it) }
+            viewModel.onLaunchModeLoaded(AiSupportChatLaunchMode.ConnectivityTool(checks))
+
+            viewModel.onContactSupportClicked(
+                source = HumanSupportContactSource.TOOLBAR,
+                canCreateTicketDirectly = false
+            )
+
+            val event = events.filterIsInstance<ContactHumanSupport>().last()
+            assertThat(event.diagnosticLog).isNotNull()
+            assertThat(event.diagnosticLog).contains("Result: Success")
+            assertThat(event.diagnosticLog).contains("Result: Failed")
+        }
+
+    @Test
+    fun `given non-connectivity launch mode, when contact support is clicked, then event has no diagnostic log`() {
+        val events = mutableListOf<MultiLiveEvent.Event>()
+        viewModel.event.observeForever { events.add(it) }
+
+        viewModel.onContactSupportClicked(
+            source = HumanSupportContactSource.TOOLBAR,
+            canCreateTicketDirectly = false
+        )
+
+        val event = events.filterIsInstance<ContactHumanSupport>().last()
+        assertThat(event.diagnosticLog).isNull()
+    }
+
+    @Test
     fun `given launch mode was already loaded, when loaded again, then chat is not started twice`() =
         testBlocking {
             val checks = listOf(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/troubleshooting/ConnectivityDiagnosticLogTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/troubleshooting/ConnectivityDiagnosticLogTest.kt
@@ -1,0 +1,43 @@
+package com.woocommerce.android.ui.troubleshooting
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class ConnectivityDiagnosticLogTest {
+    @Test
+    fun `given no completed checks, when generating the log, then it returns null`() {
+        val checks = listOf(
+            ConnectivityCheckCardData(ConnectivityCheckType.INTERNET, ConnectivityCheckStatus.NotStarted),
+            ConnectivityCheckCardData(ConnectivityCheckType.STORE, ConnectivityCheckStatus.InProgress)
+        )
+
+        assertThat(checks.toConnectivityDiagnosticLog()).isNull()
+    }
+
+    @Test
+    fun `given completed checks, when generating the log, then only completed ones are formatted`() {
+        val checks = listOf(
+            ConnectivityCheckCardData(ConnectivityCheckType.INTERNET, ConnectivityCheckStatus.Success(durationMs = 12)),
+            ConnectivityCheckCardData(
+                ConnectivityCheckType.WP_COM,
+                ConnectivityCheckStatus.Failure(
+                    error = FailureType.JETPACK,
+                    technicalDetails = "boom",
+                    durationMs = 34
+                )
+            ),
+            ConnectivityCheckCardData(ConnectivityCheckType.STORE, ConnectivityCheckStatus.InProgress)
+        )
+
+        val log = checks.toConnectivityDiagnosticLog()
+
+        assertThat(log).isNotNull()
+        assertThat(log).contains("Took: 12ms")
+        assertThat(log).contains("Result: Success")
+        assertThat(log).contains("Took: 34ms")
+        assertThat(log).contains("Result: JETPACK")
+        assertThat(log).contains("boom")
+        // The in-progress check is excluded, so only the two completed checks are numbered.
+        assertThat(log!!.lines().count { it.startsWith("## ") }).isEqualTo(2)
+    }
+}


### PR DESCRIPTION
### Description

Fixes WOOMOB-1896


This PR keeps the trimmed logs in the sidebar field (unchanged, for convenience) **and additionally attaches the full, untruncated logs as an `application_log.txt` file** to every support request. This mirrors the iOS counterpart [WOOMOB-1800](https://linear.app/a8c/issue/WOOMOB-1800), which shipped the same approach in [woocommerce-ios#16445](https://github.com/woocommerce/woocommerce-ios/pull/16445) and has been running in production.


### Test Steps

1. Log in to a store.
2. Go to **Settings → Help & Support → Contact Support**.
3. Fill in the form and submit a support request.
4. In Zendesk, open the created ticket and verify **both**:
   - the trimmed logs still appear in the left sidebar `logs` field, and
   - an `application_log.txt` file is attached, containing the full (untruncated) logs.
5. Trigger the connectivity-test support flow and confirm it still attaches `connectivitytest_log.txt` (both attachments can coexist).


### Images/gif

N/A

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.