### PR TITLE
[WOOMOB-3178] Fix stale store-name subtitle on the toolbar when opening a review from a notification

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,6 +10,7 @@
 - [*] Fixed product sale dates and coupon expiry dates being read in the device timezone instead of GMT [https://github.com/woocommerce/woocommerce-android/pull/16252]
 - [*] Analytics Hub now shows a 0% change when the previous period has no data instead of hiding the comparison [https://github.com/woocommerce/woocommerce-android/pull/16251]
 - [*] Fixed a crash when toggling the "Unread reviews only" filter with more than one store connected [https://github.com/woocommerce/woocommerce-android/pull/16260]
+- [*] Fixed the store name incorrectly appearing in the toolbar when opening a review from a notification [https://github.com/woocommerce/woocommerce-android/pull/16264]
 
 25.2
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
@@ -231,7 +231,13 @@ class DashboardFragment :
             }
         }
         dashboardViewModel.storeName.observe(viewLifecycleOwner) { storeName ->
-            ((activity) as MainActivity).setSubtitle(storeName)
+            // Only drive the shared toolbar subtitle while the dashboard is actually the visible screen. When it's
+            // in the back stack (e.g. a review opened from a notification is on top) its view lifecycle is still
+            // STARTED, so a late storeName emission would otherwise paint the store name onto that screen's toolbar.
+            // On return to the dashboard, BaseFragment.onResume restores the subtitle via getFragmentSubtitle().
+            if (isResumed) {
+                (activity as MainActivity).setSubtitle(storeName)
+            }
         }
         dashboardViewModel.jetpackBenefitsBannerState.observe(viewLifecycleOwner) { jetpackBenefitsBanner ->
             onVisitorStatsUnavailable(jetpackBenefitsBanner)


### PR DESCRIPTION
Fixes WOOMOB-3178

### Description

When a product-review push notification is tapped, the app opens the Review detail screen and its shared collapsing toolbar shows a "weird navbar": the store name appears as a clipped subtitle under the pinned "Review" title, and the app bar looks half-expanded. It only happens on the notification entry path — opening the same review normally (More menu → Reviews → detail) looks fine.

Root cause: the main app uses a single shared collapsing toolbar owned by `MainActivity`; fragments describe the state they want and `MainActivity` applies it. `DashboardFragment` is a special case — it drives the toolbar **subtitle** (the store name) reactively from a `storeName` LiveData observer bound to `viewLifecycleOwner`.

Opening a review from a notification navigates straight to the review detail via a global action, from whatever top-level tab is showing (the dashboard on cold start). Once the review detail is pushed on top, the dashboard's view lifecycle stays `STARTED` in the back stack, so its observer is still active. A `storeName` emission then calls `MainActivity.setSubtitle(storeName)` and paints the store name onto the review screen's toolbar (which also expands the app-bar area, since a subtitle grows the expanded title space). The review detail had already cleared the subtitle on resume, so this later emission is what leaks through.

Fix: only let the dashboard write the shared subtitle while it is actually the visible (resumed) screen. When the dashboard returns to the front, `BaseFragment.onResume()` restores the subtitle via `getFragmentSubtitle()` (which already returns `storeName.value`), so the normal case is unchanged.

The stale subtitle was confirmed via the layout inspector on the review screen (`toolbar_subtitle` = the store name) while the review detail was on top.

### Test Steps

1. Sign in to a store whose name is long enough to be visible (e.g. "Scrumptiously Sure Duck").
2. Fully close the app (cold start).
3. Trigger/tap a product **review** notification so it opens the Review detail screen.
4. Verify the toolbar shows only "← Review" — no store-name subtitle underneath and no half-expanded app bar.
5. Back out to the Reviews list and then to My Store; verify the store name still appears correctly as the My Store toolbar subtitle.
6. Repeat with the app already open in the background (warm start) and confirm the same result.

### Images/gif

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/a7f84095-85fb-4e65-af07-18f5eea77015"/> | <video src="https://github.com/user-attachments/assets/ffab5d63-5076-43aa-a23b-a0b228bbaf65"/> |

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.