### PR TITLE
[WOOMOB-3609] Fix system back discarding edits on editor screens

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,11 @@
 -----
 
 
+25.1.1
+-----
+- [**] Fixed product and order edits (stock, price, description, notes, etc.) being discarded when leaving a screen with the system/gesture back button [https://github.com/woocommerce/woocommerce-android/pull/16267]
+
+
 25.1
 -----
 - [*] Fixed a crash when the Play Store age signals service disconnected during the age eligibility check [https://github.com/woocommerce/woocommerce-android/pull/16206]

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt
@@ -1,6 +1,8 @@
 package com.woocommerce.android
 
 import android.app.Application
+import androidx.activity.ActivityFlags
+import androidx.activity.ExperimentalActivityApi
 import androidx.hilt.work.HiltWorkerFactory
 import androidx.work.Configuration
 import com.android.volley.VolleyLog
@@ -28,8 +30,15 @@ open class WooCommerce : Application(), HasAndroidInjector, Configuration.Provid
             .setWorkerFactory(workerFactory)
             .build()
 
+    @OptIn(ExperimentalActivityApi::class)
     override fun onCreate() {
         super.onCreate()
+
+        // Hotfix for WOOMOB-3609: androidx.activity 1.12 changed OnBackPressedDispatcher so a hosting
+        // NavHostFragment's back callback out-prioritizes MainActivity's, which stopped BackPressListener
+        // screens from saving/confirming on system back. Opt back into the previous dispatch order.
+        // Proper follow-up (drop this flag, adopt per-screen callbacks) is tracked in WOOMOB-3614.
+        ActivityFlags.isOnBackPressedLifecycleOrderMaintained = false
 
         // Stripe Tap to Pay library starts it's own process. That causes the crash:
         //  > Caused by: java.lang.IllegalStateException: Default FirebaseApp is not initialized in this process

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/OrderFilterCategoriesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/OrderFilterCategoriesFragment.kt
@@ -4,6 +4,8 @@ import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
+import androidx.activity.OnBackPressedCallback
+import androidx.activity.OnBackPressedDispatcherOwner
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.view.WindowCompat
 import androidx.fragment.app.DialogFragment
@@ -51,10 +53,22 @@ class OrderFilterCategoriesFragment :
 
     private lateinit var orderFilterCategoryAdapter: OrderFilterCategoryAdapter
 
+    // A DialogFragment receives back on its own dialog's OnBackPressedDispatcher, so intercept it here.
+    private val backPressedCallback = object : OnBackPressedCallback(true) {
+        override fun handleOnBackPressed() {
+            if (onRequestAllowBackPress()) {
+                dismiss()
+            }
+        }
+    }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
         _binding = FragmentOrderFilterListBinding.bind(view)
+
+        (requireDialog() as? OnBackPressedDispatcherOwner)?.onBackPressedDispatcher
+            ?.addCallback(viewLifecycleOwner, backPressedCallback)
 
         binding.root.edgeToEdgeHandlingForNavigationAndStatusBar(binding.appBarLayout)
         setupToolbar(binding)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/OrderFilterOptionsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/OrderFilterOptionsFragment.kt
@@ -2,6 +2,8 @@ package com.woocommerce.android.ui.orders.filters
 
 import android.os.Bundle
 import android.view.View
+import androidx.activity.OnBackPressedCallback
+import androidx.activity.OnBackPressedDispatcherOwner
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.view.WindowCompat
 import androidx.fragment.app.DialogFragment
@@ -35,6 +37,13 @@ class OrderFilterOptionsFragment :
     private val viewModel: OrderFilterOptionsViewModel by viewModels()
     lateinit var orderFilterOptionAdapter: OrderFilterOptionAdapter
 
+    // A DialogFragment receives back on its own dialog's OnBackPressedDispatcher, so intercept it here.
+    private val backPressedCallback = object : OnBackPressedCallback(true) {
+        override fun handleOnBackPressed() {
+            onRequestAllowBackPress()
+        }
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setStyle(STYLE_NO_TITLE, R.style.Theme_Woo)
@@ -44,6 +53,9 @@ class OrderFilterOptionsFragment :
         super.onViewCreated(view, savedInstanceState)
 
         _binding = FragmentOrderFilterListBinding.bind(view)
+
+        (requireDialog() as? OnBackPressedDispatcherOwner)?.onBackPressedDispatcher
+            ?.addCallback(viewLifecycleOwner, backPressedCallback)
         binding.root.edgeToEdgeHandlingForNavigationAndStatusBar(binding.appBarLayout)
         setupToolbar(binding)
         setUpObservers(viewModel)


### PR DESCRIPTION
Fixes WOOMOB-3609

### Description

In 25.1 / 25.2-rc-1, editing a value and leaving a screen via the **system/gesture back button** silently discarded the edit. Reported symptom: product **stock** wouldn't save (no Save button appeared). It affects every screen that saves-or-confirms on back.

**Root cause.** These screens implement `MainActivity.BackPressListener` and do their save/discard in `onRequestAllowBackPress()`, which was only invoked from `MainActivity`'s single `OnBackPressedDispatcher` callback. `androidx.activity` 1.12.4 (first shipped in 25.1) changed predictive-back dispatch so a `NavHostFragment`'s own back callback now consumes the gesture **before** MainActivity's callback runs — popping the screen without ever calling `onRequestAllowBackPress()`. The toolbar arrow calls save-and-exit directly, bypassing the dispatcher, so it stayed working.

**Fix.** `BaseFragment` registers its own `OnBackPressedCallback` in `onResume()` when the fragment is a `BackPressListener`, so it out-prioritizes the nav host and routes the gesture back through `onRequestAllowBackPress()` — same semantics MainActivity used (`true` → allow normal back; `false` → fragment handled it). One central change covers all affected screens; no per-screen or ViewModel edits. Mirrors the earlier `OrderCreateEditFormFragment` fix (#15016).

### What changed

- **`BaseFragment`** — the central per-fragment back callback (the fix above).
- **Order filter dialogs** (`OrderFilterCategoriesFragment`, `OrderFilterOptionsFragment`) — these are `DialogFragment`s whose back is dispatched by the **dialog's own** dispatcher, not the activity's, so the `BaseFragment` fix can't reach them; each now registers a callback on its dialog's dispatcher. (Pre-existing gap: system back lost the filter selection / skipped the discard prompt.)
- **`MainActivity`** — removed the now-redundant `BackPressListener` dispatch (every such screen self-handles now); kept the analytics / app-bar / default-back behavior.

> [!WARNING]
> **Back-press analytics is only partially restored by this PR.** The `back_pressed` Tracks event is recorded for `BackPressListener` screens (the consumed path) but remains under-reported on other screens: since androidx.activity 1.12.4 (25.1) a `NavHostFragment`'s back callback consumes the gesture before MainActivity's tracker runs, so the event only fires at nav roots. Fully restoring it needs a nav-observer approach rather than the back dispatcher, and is tracked separately in WOOMOB-3614 to keep this PR focused on the data-loss fix.

### Test Steps

Android 16+ (predictive back active). For each: change a value, leave via **system/gesture back** (not the toolbar arrow), confirm the edit is kept.

1. Products → open a product → **Inventory** → change stock → back → product detail shows **Update/Save** + the new value.
2. Same product → **Price**, then **Description** (Aztec editor) → back → change kept.
4. Orders → **Filters** → change a order stats → back → change saved.
5. Regression: repeat the steps via the **toolbar back arrow** — still works.

Repeat the above steps on the tablet.

### Images/gif

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/ea2ffb0f-27f0-4ee4-a78f-e70d36072062" /> | <video src="https://github.com/user-attachments/assets/24bc6cca-6a86-4492-b916-6af56ac684a5" /> |
| <video src="https://github.com/user-attachments/assets/417a7099-dba1-4f35-8c30-83dc86ec0f5d" /> | <video src="https://github.com/user-attachments/assets/529c72b5-dace-4cc3-b136-d35dde59373f" /> |

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

