### PR TITLE
Fix Buildkite analysis secret interpolation

### DIFF
--- a/.buildkite/claude-analysis.yml
+++ b/.buildkite/claude-analysis.yml
@@ -18,8 +18,8 @@ steps:
       - "/tmp/buildkite_logs_${BUILDKITE_BUILD_ID}.txt"
     plugins:
       - $CLAUDE_PLUGIN:
-          api_key: "$ANTHROPIC_API_KEY"
-          buildkite_api_token: "$BUILDKITE_TOKEN_FOR_CLAUDE"
+          api_key: "$$ANTHROPIC_API_KEY"
+          buildkite_api_token: "$$BUILDKITE_TOKEN_FOR_CLAUDE"
           analysis_level: "build"
           build_log_mode: "failed"
           trigger: "on-failure"

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -5,4 +5,4 @@
 
 export CI_TOOLKIT="automattic/a8c-ci-toolkit#5.4.0"
 export TEST_COLLECTOR="test-collector#v1.10.1"
-export CLAUDE_PLUGIN="iangmaia/claude-summarize#iangmaia/add-build-log-mode"
+export CLAUDE_PLUGIN="iangmaia/claude-summarize#ce99c67dd57cdf236c3daca82b86a335fd5e9cc2"


### PR DESCRIPTION
## Description

Defer Buildkite interpolation of the build analysis credentials to avoid credential substitution in the pipeline (see https://github.com/wordpress-mobile/WordPress-iOS/pull/25791) and pin the Buildkite analysis plugin to commit, as the updated plugin version should resolve the $VAR runtime reference.