### PR TITLE
[WOOMOB-3630] Send the order currency when creating or updating an order

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -11,7 +11,7 @@
 - [*] Analytics Hub now shows a 0% change when the previous period has no data instead of hiding the comparison [https://github.com/woocommerce/woocommerce-android/pull/16251]
 - [*] Fixed a crash when toggling the "Unread reviews only" filter with more than one store connected [https://github.com/woocommerce/woocommerce-android/pull/16260]
 - [*] Fixed the product selector showing store-currency prices when adding products to an order in a different currency [https://github.com/woocommerce/woocommerce-android/pull/16281]
-- [*] Fixed products added to an order in a non-default currency being priced in the store's base currency
+- [*] Fixed products added to an order in a non-default currency being priced in the store's base currency [https://github.com/woocommerce/woocommerce-android/pull/16282]
 - [*] Fixed the store name incorrectly appearing in the toolbar when opening a review from a notification [https://github.com/woocommerce/woocommerce-android/pull/16264]
 - [*****] [Internal] Updated the Android Gradle Plugin to 9.2.1 and migrated to Kotlin support built into it [https://github.com/woocommerce/woocommerce-android/pull/16228]
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -11,6 +11,7 @@
 - [*] Analytics Hub now shows a 0% change when the previous period has no data instead of hiding the comparison [https://github.com/woocommerce/woocommerce-android/pull/16251]
 - [*] Fixed a crash when toggling the "Unread reviews only" filter with more than one store connected [https://github.com/woocommerce/woocommerce-android/pull/16260]
 - [*] Fixed the product selector showing store-currency prices when adding products to an order in a different currency [https://github.com/woocommerce/woocommerce-android/pull/16281]
+- [*] Fixed products added to an order in a non-default currency being priced in the store's base currency
 - [*] Fixed the store name incorrectly appearing in the toolbar when opening a review from a notification [https://github.com/woocommerce/woocommerce-android/pull/16264]
 - [*****] [Internal] Updated the Android Gradle Plugin to 9.2.1 and migrated to Kotlin support built into it [https://github.com/woocommerce/woocommerce-android/pull/16228]
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditRepository.kt
@@ -67,13 +67,15 @@ class OrderCreateEditRepository @Inject constructor(
             orderUpdateStore.createOrder(
                 site = selectedSite.get(),
                 createOrderRequest = request,
-                attributionSourceType = OrderAttributionOrigin.Mobile.SOURCE_TYPE_VALUE
+                attributionSourceType = OrderAttributionOrigin.Mobile.SOURCE_TYPE_VALUE,
+                orderCurrency = order.currency
             )
         } else {
             orderUpdateStore.updateOrder(
                 site = selectedSite.get(),
                 orderId = order.id,
-                updateRequest = request
+                updateRequest = request,
+                orderCurrency = order.currency
             )
         }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditRepositoryTest.kt
@@ -129,7 +129,7 @@ class OrderCreateEditRepositoryTest : BaseUnitTest() {
     fun `when AUTO_DRAFT is not supported then status is changed to PENDING`() = testBlocking {
         // Given a site using a version that doesn't support AUTO_DRAFT
         whenever(getWooVersion()).thenReturn("6.2.0")
-        whenever(orderUpdateStore.createOrder(any(), any(), anyOrNull()))
+        whenever(orderUpdateStore.createOrder(any(), any(), anyOrNull(), anyOrNull()))
             .thenReturn(WooResult(OrderTestUtils.generateOrder()))
 
         val order = Order.getEmptyOrder(Date(), Date()).copy(
@@ -152,14 +152,19 @@ class OrderCreateEditRepositoryTest : BaseUnitTest() {
             couponLines = emptyList(),
         )
 
-        verify(orderUpdateStore).createOrder(defaultSiteModel, request, OrderAttributionOrigin.Mobile.SOURCE_TYPE_VALUE)
+        verify(orderUpdateStore).createOrder(
+            defaultSiteModel,
+            request,
+            OrderAttributionOrigin.Mobile.SOURCE_TYPE_VALUE,
+            order.currency
+        )
     }
 
     @Test
     fun `when AUTO_DRAFT is supported then status is keep as AUTO_DRAFT`() = testBlocking {
         // Given a site using a version that support AUTO_DRAFT
         whenever(getWooVersion()).thenReturn(OrderCreateEditRepository.AUTO_DRAFT_SUPPORTED_VERSION)
-        whenever(orderUpdateStore.createOrder(any(), any(), anyOrNull()))
+        whenever(orderUpdateStore.createOrder(any(), any(), anyOrNull(), anyOrNull()))
             .thenReturn(WooResult(OrderTestUtils.generateOrder()))
 
         val order = Order.getEmptyOrder(Date(), Date()).copy(
@@ -182,13 +187,18 @@ class OrderCreateEditRepositoryTest : BaseUnitTest() {
             couponLines = emptyList(),
         )
 
-        verify(orderUpdateStore).createOrder(defaultSiteModel, request, OrderAttributionOrigin.Mobile.SOURCE_TYPE_VALUE)
+        verify(orderUpdateStore).createOrder(
+            defaultSiteModel,
+            request,
+            OrderAttributionOrigin.Mobile.SOURCE_TYPE_VALUE,
+            order.currency
+        )
     }
 
     @Test
     fun `given the order is updated, when source is store management then createdVia value is null`() = testBlocking {
         // GIVEN
-        whenever(orderUpdateStore.createOrder(any(), any(), anyOrNull()))
+        whenever(orderUpdateStore.createOrder(any(), any(), anyOrNull(), anyOrNull()))
             .thenReturn(WooResult(OrderTestUtils.generateOrder()))
 
         val order = Order.getEmptyOrder(Date(), Date()).copy(
@@ -211,12 +221,17 @@ class OrderCreateEditRepositoryTest : BaseUnitTest() {
             createdVia = null,
         )
 
-        verify(orderUpdateStore).createOrder(defaultSiteModel, request, OrderAttributionOrigin.Mobile.SOURCE_TYPE_VALUE)
+        verify(orderUpdateStore).createOrder(
+            defaultSiteModel,
+            request,
+            OrderAttributionOrigin.Mobile.SOURCE_TYPE_VALUE,
+            order.currency
+        )
     }
 
     @Test
     fun `when source is point of sale then createdVia value is pos-rest-api`() = testBlocking {
-        whenever(orderUpdateStore.createOrder(any(), any(), anyOrNull()))
+        whenever(orderUpdateStore.createOrder(any(), any(), anyOrNull(), anyOrNull()))
             .thenReturn(WooResult(OrderTestUtils.generateOrder()))
 
         val order = Order.getEmptyOrder(Date(), Date()).copy(
@@ -239,7 +254,12 @@ class OrderCreateEditRepositoryTest : BaseUnitTest() {
             createdVia = "pos-rest-api",
         )
 
-        verify(orderUpdateStore).createOrder(defaultSiteModel, request, OrderAttributionOrigin.Mobile.SOURCE_TYPE_VALUE)
+        verify(orderUpdateStore).createOrder(
+            defaultSiteModel,
+            request,
+            OrderAttributionOrigin.Mobile.SOURCE_TYPE_VALUE,
+            order.currency
+        )
     }
 
     @Test

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -849,9 +849,10 @@ class OrderRestClient @Inject constructor(
     suspend fun createOrder(
         site: SiteModel,
         request: UpdateOrderRequest,
-        attributionSourceType: String?
+        attributionSourceType: String?,
+        orderCurrency: String? = null
     ): WooPayload<OrderEntity> {
-        val url = WOOCOMMERCE.orders.pathV3
+        val url = WOOCOMMERCE.orders.pathV3.withCurrency(orderCurrency)
         val metaData = mapOf(
             "meta_data" to listOfNotNull(
                 attributionSourceType?.let {
@@ -880,9 +881,10 @@ class OrderRestClient @Inject constructor(
     suspend fun updateOrder(
         site: SiteModel,
         orderId: Long,
-        request: UpdateOrderRequest
+        request: UpdateOrderRequest,
+        orderCurrency: String? = null
     ): WooPayload<OrderEntity> {
-        val url = WOOCOMMERCE.orders.id(orderId).pathV3
+        val url = WOOCOMMERCE.orders.id(orderId).pathV3.withCurrency(orderCurrency)
         val body = request.toNetworkRequest()
 
         val response = wooNetwork.executePutGsonRequest(
@@ -1206,6 +1208,14 @@ class OrderRestClient @Inject constructor(
 
         return providers
     }
+
+    /**
+     * WooPayments Multi-Currency reads the currency from the query string. Without it, it forces the store's
+     * base currency for REST requests and disables price conversion, so line items added without an explicit
+     * price would be priced in the store currency rather than the order's.
+     */
+    private fun String.withCurrency(currency: String?): String =
+        currency?.takeIf { it.isNotBlank() }?.let { "$this?currency=$it" } ?: this
 
     companion object {
         private val ORDER_FIELDS = arrayOf(

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/OrderUpdateStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/OrderUpdateStore.kt
@@ -236,10 +236,11 @@ class OrderUpdateStore @Inject internal constructor(
     suspend fun createOrder(
         site: SiteModel,
         createOrderRequest: UpdateOrderRequest,
-        attributionSourceType: String? = null
+        attributionSourceType: String? = null,
+        orderCurrency: String? = null
     ): WooResult<OrderEntity> {
         return coroutineEngine.withDefaultContext(T.API, this, "createOrder") {
-            val result = wcOrderRestClient.createOrder(site, createOrderRequest, attributionSourceType)
+            val result = wcOrderRestClient.createOrder(site, createOrderRequest, attributionSourceType, orderCurrency)
 
             return@withDefaultContext if (result.isError) {
                 WooResult(result.error)
@@ -254,10 +255,11 @@ class OrderUpdateStore @Inject internal constructor(
     suspend fun updateOrder(
         site: SiteModel,
         orderId: Long,
-        updateRequest: UpdateOrderRequest
+        updateRequest: UpdateOrderRequest,
+        orderCurrency: String? = null
     ): WooResult<OrderEntity> {
         return coroutineEngine.withDefaultContext(T.API, this, "updateOrder") {
-            val result = wcOrderRestClient.updateOrder(site, orderId, updateRequest)
+            val result = wcOrderRestClient.updateOrder(site, orderId, updateRequest, orderCurrency)
 
             return@withDefaultContext if (result.isError) {
                 WooResult(result.error)

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClientTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClientTest.kt
@@ -18,10 +18,12 @@ import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCOrderListDescriptor
+import org.wordpress.android.fluxc.model.order.UpdateOrderRequest
 import org.wordpress.android.fluxc.network.BaseRequest
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetworkError
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
+import org.wordpress.android.fluxc.persistence.entity.OrderEntity
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderListResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.OrderErrorType
 import org.wordpress.android.fluxc.tools.CoroutineEngine
@@ -465,5 +467,59 @@ class OrderRestClientTest {
             assertThat(actionCaptor.firstValue.payload.error?.type).isEqualTo(OrderErrorType.GENERIC_ERROR)
         }
 
+    @Test
+    fun `given an order currency, when updateOrder is called, then currency is appended to the request path`() =
+        runTest {
+            // Given
+            val orderId = 123L
+            val expectedPath = "${WOOCOMMERCE.orders.id(orderId).pathV3}?currency=EUR"
+            stubUpdateOrderResponse()
+
+            // When
+            orderRestClient.updateOrder(testSite, orderId, UpdateOrderRequest(), orderCurrency = "EUR")
+
+            // Then
+            verify(wooNetwork).executePutGsonRequest(
+                site = eq(testSite),
+                path = eq(expectedPath),
+                clazz = eq(OrderDto::class.java),
+                body = any()
+            )
+        }
+
+    @Test
+    fun `given no order currency, when updateOrder is called, then the request path is left untouched`() = runTest {
+        // Given
+        val orderId = 123L
+        val expectedPath = WOOCOMMERCE.orders.id(orderId).pathV3
+        stubUpdateOrderResponse()
+
+        // When
+        orderRestClient.updateOrder(testSite, orderId, UpdateOrderRequest())
+
+        // Then
+        verify(wooNetwork).executePutGsonRequest(
+            site = eq(testSite),
+            path = eq(expectedPath),
+            clazz = eq(OrderDto::class.java),
+            body = any()
+        )
+    }
+
     /* HELPER */
+
+    private suspend fun stubUpdateOrderResponse() {
+        val orderDto = OrderDto()
+        whenever(
+            wooNetwork.executePutGsonRequest(
+                site = any(),
+                path = any(),
+                clazz = eq(OrderDto::class.java),
+                body = any()
+            )
+        ).thenReturn(WPAPIResponse.Success(orderDto, emptyList()))
+        whenever(orderDtoMapper.toDatabaseEntity(eq(orderDto), any())).thenReturn(
+            OrderEntity(localSiteId = testSite.localId(), orderId = 123L) to emptyList()
+        )
+    }
 }

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/store/OrderUpdateStoreTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/store/OrderUpdateStoreTest.kt
@@ -431,7 +431,7 @@ class OrderUpdateStoreTest {
         setUp {
             orderRestClient = mock {
                 on {
-                    createOrder(any(), any(), anyOrNull())
+                    createOrder(any(), any(), anyOrNull(), anyOrNull())
                 }.doReturn(
                     WooPayload(newOrder)
                 )
@@ -473,7 +473,7 @@ class OrderUpdateStoreTest {
         setUp {
             orderRestClient = mock {
                 on {
-                    updateOrder(any(), any(), any())
+                    updateOrder(any(), any(), any(), anyOrNull())
                 }.doReturn(
                     WooPayload(updatedOrder)
                 )


### PR DESCRIPTION
### Description

Fixes WOOMOB-3630

Stacked on #16281 — review that one first.

Adding a product to a non-default-currency order priced the line item in the store's base currency (a EUR order got the USD number verbatim). The app deliberately posts new line items without a price so the server stays the pricing authority, but WooPayments Multi-Currency forces the store currency and disables conversion for any REST request without a `currency` query param. So we now send it on order create/update.

Went with appending to the URL rather than adding query-param support to `executePutGsonRequest`/`executePostGsonRequest` — verified on device that the param survives the transport.

### Test Steps

Needs a multi-currency store and a product with a manually set price in both the store's base currency and a second one.

1. Open an existing order in the non-default currency → **Edit** → **+** → add that product.
2. The added line item should be priced from the product's price in the *order's* currency. Before this change it used the base-currency price.
3. Regression: start a new order on the same store and add the same product — it should still use the base-currency price.

### Images/gif

N/A

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.