### PR TITLE
Resolve unused dependency warnings in commons

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -226,6 +226,7 @@ google-dagger-compiler = { module = "com.google.dagger:dagger-compiler", version
 google-dagger-hilt-android-main = { group = "com.google.dagger", name = "hilt-android", version.ref = "google-dagger" }
 google-dagger-hilt-android-testing = { group = "com.google.dagger", name = "hilt-android-testing", version.ref = "google-dagger" }
 google-dagger-hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "google-dagger" }
+google-dagger-hilt-core = { group = "com.google.dagger", name = "hilt-core", version.ref = "google-dagger" }
 google-firebase-analytics = { group = "com.google.firebase", name = "firebase-analytics" }
 google-firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "google-firebase-bom" }
 google-firebase-config = { group = "com.google.firebase", name = "firebase-config" }

--- a/libs/commons/build.gradle
+++ b/libs/commons/build.gradle
@@ -67,5 +67,4 @@ dependencies {
     testFixturesCompileOnly(libs.junit)
     testFixturesCompileOnly(libs.mockito.kotlin)
     testFixturesCompileOnly(libs.androidx.arch.core.testing)
-    testFixturesImplementation(project(":libs:fluxc-plugin"))
 }

--- a/libs/commons/build.gradle
+++ b/libs/commons/build.gradle
@@ -68,3 +68,12 @@ dependencies {
     testFixturesCompileOnly(libs.mockito.kotlin)
     testFixturesCompileOnly(libs.androidx.arch.core.testing)
 }
+
+dependencyAnalysis {
+    issues {
+        onUnusedDependencies {
+            // This dependency is required by the Hilt Gradle plugin, otherwise the build fails to configure.
+            exclude(libs.google.dagger.hilt.android.main.get().module.toString())
+        }
+    }
+}

--- a/libs/commons/build.gradle
+++ b/libs/commons/build.gradle
@@ -58,7 +58,7 @@ dependencies {
     testImplementation(libs.assertj.core)
     testImplementation(libs.junit)
     testImplementation(libs.mockito.kotlin)
-    testImplementation(libs.androidx.arch.core.testing)
+    testRuntimeOnly(libs.androidx.arch.core.testing)
     testImplementation(libs.androidx.lifecycle.runtime.testing)
 
     testFixturesImplementation(platform(libs.androidx.compose.bom))

--- a/libs/commons/build.gradle
+++ b/libs/commons/build.gradle
@@ -3,7 +3,6 @@ plugins {
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.parcelize)
     alias(libs.plugins.ksp)
-    alias(libs.plugins.google.dagger.hilt)
     alias(libs.plugins.dependency.analysis)
 }
 
@@ -44,7 +43,7 @@ dependencies {
     implementation(libs.androidx.lifecycle.process)
     implementation(libs.androidx.preference.main)
     implementation(libs.eventbus.android)
-    implementation(libs.google.dagger.hilt.android.main)
+    implementation(libs.google.dagger.hilt.core)
     implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.compose.ui.tooling.preview)
     implementation(libs.wordpress.utils)
@@ -67,13 +66,4 @@ dependencies {
     testFixturesCompileOnly(libs.junit)
     testFixturesCompileOnly(libs.mockito.kotlin)
     testFixturesCompileOnly(libs.androidx.arch.core.testing)
-}
-
-dependencyAnalysis {
-    issues {
-        onUnusedDependencies {
-            // This dependency is required by the Hilt Gradle plugin, otherwise the build fails to configure.
-            exclude(libs.google.dagger.hilt.android.main.get().module.toString())
-        }
-    }
 }


### PR DESCRIPTION
### Description

This fixes the three `:libs:commons` entries from the [dependency analysis alert](https://a8c.slack.com/archives/C8ZFBDQC9/p1784439678537379).

The report listed these:

```text
Advice for :libs:commons
Unused dependencies which should be removed:
  implementation libs.google.dagger.hilt.android.main
  testFixturesImplementation project(':libs:fluxc-plugin')
  testImplementation libs.androidx.arch.core.testing
```

Each one needed something different.

`testFixturesImplementation project(':libs:fluxc-plugin')` is really unused. Nothing in the test fixtures uses it, and the two modules that consume the fixtures already declare `fluxc-plugin` themselves. So I removed it.

`testImplementation libs.androidx.arch.core.testing` is not really unused. `BaseUnitTest` in the test fixtures uses `InstantTaskExecutorRule` from it, so the tests need it at runtime. If I remove it, the commons tests fail with `NoClassDefFoundError`. I changed it to `testRuntimeOnly` instead, which is what it actually is, and that is not reported as unused.

`implementation libs.google.dagger.hilt.android.main` was only needed by the Hilt Gradle plugin. Commons only uses the `hilt-core` annotations, so nothing points at `hilt-android` in the code, but the plugin does not let the module configure without it:

```text
The Hilt Android Gradle plugin is applied but no com.google.dagger:hilt-android dependency was found.
```

Since commons has no `@AndroidEntryPoint` classes, it does not need the plugin at all. So I removed the plugin and replaced the dependency with `hilt-core`.

There is one more unused dependency in `:libs:store-design-system`, but it appeared on trunk after this alert was sent, so it is out of scope here.

### Test Steps

1. Open the [dependency analysis alert](https://a8c.slack.com/archives/C8ZFBDQC9/p1784439678537379) and follow its instructions to find the latest scheduled build.
2. Open the `dependency analysis` job.
3. Download the `build-health-report.txt` artifact.
4. Confirm that under `Advice for :libs:commons` the report lists:
   ```text
   Unused dependencies which should be removed:
     implementation libs.google.dagger.hilt.android.main
     testFixturesImplementation project(':libs:fluxc-plugin')
     testImplementation libs.androidx.arch.core.testing
   ```
5. Check out this branch.
6. Run `./gradlew buildHealth --console=plain`.
7. Open `build/reports/dependency-analysis/build-health-report.txt`.
8. Confirm that `Advice for :libs:commons` no longer has an `Unused dependencies which should be removed` section.

### Images/gif

N/A

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
