### PR TITLE
Support query parameters on PUT requests

### DIFF
--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooNetwork.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooNetwork.kt
@@ -80,13 +80,15 @@ class WooNetwork @Inject constructor(
         site: SiteModel,
         path: String,
         clazz: Class<T>,
-        body: Map<String, Any>
+        body: Map<String, Any>,
+        params: Map<String, String>
     ): WPAPIResponse<T> = handleRequest(site, RequestContext(path, "PUT")) {
         executePutGsonRequest(
             site = site,
             path = path,
             clazz = clazz,
-            body = body
+            body = body,
+            params = params
         )
     }
 

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClientTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClientTest.kt
@@ -299,7 +299,8 @@ class OrderRestClientTest {
                 site = any(),
                 path = any(),
                 clazz = eq(Unit::class.java),
-                body = any()
+                body = any(),
+                params = any()
             )
         ).thenReturn(mockResponse)
 
@@ -312,7 +313,8 @@ class OrderRestClientTest {
             site = eq(testSite),
             path = eq(expectedPath),
             clazz = eq(Unit::class.java),
-            body = bodyCaptor.capture()
+            body = bodyCaptor.capture(),
+            params = any()
         )
 
         assertThat(bodyCaptor.firstValue).isEqualTo(expectedBody)

--- a/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/jetpacktunnel/JetpackTunnelGsonRequestTest.kt
+++ b/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/jetpacktunnel/JetpackTunnelGsonRequestTest.kt
@@ -117,6 +117,22 @@ class JetpackTunnelGsonRequestTest {
     }
 
     @Test
+    fun `given params with reserved characters, when creating a put request, then they are encoded`() {
+        val url = "/wc/v3/orders/7997"
+
+        val request = JetpackTunnelGsonRequest.buildPutRequest(url, DUMMY_SITE_ID, mapOf(),
+            Any::class.java,
+            { _: Any?, _: Any? -> },
+            { _ -> },
+            params = mapOf("search" to "a b&c")
+        )
+
+        val body = String(request?.body!!)
+        val generatedBody = gson.fromJson(body, HashMap<String, String>()::class.java)
+        assertEquals("/wc/v3/orders/7997&search=a%20b%26c&_method=put", generatedBody["path"])
+    }
+
+    @Test
     fun testCreatePatchRequest() {
         val url = "/wp/v2/settings/"
 

--- a/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/jetpacktunnel/JetpackTunnelGsonRequestTest.kt
+++ b/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/jetpacktunnel/JetpackTunnelGsonRequestTest.kt
@@ -101,6 +101,22 @@ class JetpackTunnelGsonRequestTest {
     }
 
     @Test
+    fun `given params, when creating a put request, then they are appended to the path with an ampersand`() {
+        val url = "/wc/v3/orders/7997"
+
+        val request = JetpackTunnelGsonRequest.buildPutRequest(url, DUMMY_SITE_ID, mapOf(),
+            Any::class.java,
+            { _: Any?, _: Any? -> },
+            { _ -> },
+            params = mapOf("currency" to "EUR")
+        )
+
+        val body = String(request?.body!!)
+        val generatedBody = gson.fromJson(body, HashMap<String, String>()::class.java)
+        assertEquals("/wc/v3/orders/7997&currency=EUR&_method=put", generatedBody["path"])
+    }
+
+    @Test
     fun testCreatePatchRequest() {
         val url = "/wp/v2/settings/"
 

--- a/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/plugin/PluginWPApiRestClientTest.kt
+++ b/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/plugin/PluginWPApiRestClientTest.kt
@@ -7,6 +7,7 @@ import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 import org.junit.runners.Parameterized.Parameters
 import org.mockito.kotlin.KArgumentCaptor
+import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -124,7 +125,8 @@ class PluginWPApiRestClientTest(private val site: SiteModel) {
                 eq(site),
                 urlCaptor.capture(),
                 eq(PluginResponseModel::class.java),
-                bodyCaptor.capture()
+                bodyCaptor.capture(),
+                any()
             )
         ).thenReturn(response)
         return response

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/CookieNonceWPAPINetwork.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/CookieNonceWPAPINetwork.kt
@@ -61,7 +61,8 @@ class CookieNonceWPAPINetwork @Inject constructor(
         site: SiteModel,
         path: String,
         clazz: Class<T>,
-        body: Map<String, Any>
+        body: Map<String, Any>,
+        params: Map<String, String>
     ): WPAPIResponse<T> {
         return cookieNonceAuthenticator.makeAuthenticatedWPAPIRequest(site) { nonce ->
             wpApiGsonRequestBuilder.syncPutRequest(
@@ -69,7 +70,8 @@ class CookieNonceWPAPINetwork @Inject constructor(
                 url = site.buildUrl(path),
                 body = body,
                 clazz = clazz,
-                nonce = nonce.value
+                nonce = nonce.value,
+                params = params
             )
         }
     }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/WPAPIGsonRequest.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/WPAPIGsonRequest.java
@@ -21,28 +21,19 @@ public class WPAPIGsonRequest<T> extends GsonRequest<T> {
     public WPAPIGsonRequest(int method, String url, Map<String, String> params, Map<String, Object> body,
                             Class<T> clazz, Listener<T> listener, OnWPAPIErrorListener errorListener) {
         super(method, params, body, url, clazz, null, listener, new WPAPIErrorListenerWrapper(errorListener));
-        // If it's a GET request, add the parameters to the URL
-        if (method == Method.GET) {
-            addQueryParameters(params);
-        }
+        addQueryParameters(params);
     }
 
     public WPAPIGsonRequest(int method, String url, Map<String, String> params, Map<String, Object> body,
                             Class<T> clazz, ResponseListener<T> listener, OnWPAPIErrorListener errorListener) {
         super(method, params, body, url, clazz, null, listener, new WPAPIErrorListenerWrapper(errorListener));
-        // If it's a GET request, add the parameters to the URL
-        if (method == Method.GET) {
-            addQueryParameters(params);
-        }
+        addQueryParameters(params);
     }
 
     public WPAPIGsonRequest(int method, String url, Map<String, String> params, Map<String, Object> body,
                             Type type, ResponseListener<T> listener, OnWPAPIErrorListener errorListener) {
         super(method, params, body, url, null, type, listener, new WPAPIErrorListenerWrapper(errorListener));
-        // If it's a GET request, add the parameters to the URL
-        if (method == Method.GET) {
-            addQueryParameters(params);
-        }
+        addQueryParameters(params);
     }
 
     @Override

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/WPAPIGsonRequestBuilder.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/WPAPIGsonRequestBuilder.kt
@@ -52,7 +52,7 @@ class WPAPIGsonRequestBuilder @Inject constructor() {
         body: Map<String, Any> = emptyMap(),
         clazz: Class<T>,
         nonce: String? = null,
-        params: Map<String, String>? = null
+        params: Map<String, String> = emptyMap()
     ) = suspendCancellableCoroutine<WPAPIResponse<T>> { cont ->
         callMethod(Method.PUT, url, params, body, clazz, cont, false, 0, nonce, restClient)
     }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/WPAPIGsonRequestBuilder.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/WPAPIGsonRequestBuilder.kt
@@ -51,9 +51,10 @@ class WPAPIGsonRequestBuilder @Inject constructor() {
         url: String,
         body: Map<String, Any> = emptyMap(),
         clazz: Class<T>,
-        nonce: String? = null
+        nonce: String? = null,
+        params: Map<String, String>? = null
     ) = suspendCancellableCoroutine<WPAPIResponse<T>> { cont ->
-        callMethod(Method.PUT, url, null, body, clazz, cont, false, 0, nonce, restClient)
+        callMethod(Method.PUT, url, params, body, clazz, cont, false, 0, nonce, restClient)
     }
 
     suspend fun <T> syncDeleteRequest(

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/WPAPINetwork.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/WPAPINetwork.kt
@@ -27,7 +27,8 @@ interface WPAPINetwork {
         site: SiteModel,
         path: String,
         clazz: Class<T>,
-        body: Map<String, Any> = emptyMap()
+        body: Map<String, Any> = emptyMap(),
+        params: Map<String, String> = emptyMap()
     ): WPAPIResponse<T>
 
     suspend fun <T : Any> executeDeleteGsonRequest(

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsNetwork.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsNetwork.kt
@@ -175,7 +175,8 @@ class ApplicationPasswordsNetwork @Inject constructor(
         path: String,
         clazz: Class<T>,
         body: Map<String, Any>,
-    ) = executeGsonRequest(site, HttpMethod.PUT, path, clazz, body = body)
+        params: Map<String, String>
+    ) = executeGsonRequest(site, HttpMethod.PUT, path, clazz, params = params, body = body)
 
     override suspend fun <T : Any> executeDeleteGsonRequest(
         site: SiteModel,

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/JetpackTunnelWPAPINetwork.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/JetpackTunnelWPAPINetwork.kt
@@ -80,14 +80,16 @@ class JetpackTunnelWPAPINetwork @Inject constructor(
         site: SiteModel,
         path: String,
         clazz: Class<T>,
-        body: Map<String, Any>
+        body: Map<String, Any>,
+        params: Map<String, String>
     ): WPAPIResponse<T> {
         return jetpackTunnelGsonRequestBuilder.syncPutRequest(
             restClient = this,
             site = site,
             url = path,
             clazz = clazz,
-            body = body
+            body = body,
+            params = params
         ).toWPAPIResponse()
     }
 

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTunnelGsonRequest.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTunnelGsonRequest.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel
 
+import android.net.Uri
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST
@@ -309,7 +310,11 @@ object JetpackTunnelGsonRequest {
      * The tunnel expects the endpoint's query parameters appended to the path with `&` rather than as a regular
      * query string, e.g. `/wc/v3/orders/1&currency=EUR&_method=put`. A `?` would be treated as part of the route
      * and the request would fail with `rest_no_route`.
+     *
+     * Keys and values are percent-encoded, matching what [android.net.Uri.Builder.appendQueryParameter] does on the
+     * direct (non-tunnel) path. The tunnel splits the path on `&` before decoding, so an encoded separator stays
+     * inside its value instead of introducing a spurious parameter.
      */
     private fun Map<String, String>.toTunnelQuery(): String =
-        entries.joinToString(separator = "") { "&${it.key}=${it.value}" }
+        entries.joinToString(separator = "") { "&${Uri.encode(it.key)}=${Uri.encode(it.value)}" }
 }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTunnelGsonRequest.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTunnelGsonRequest.kt
@@ -194,6 +194,7 @@ object JetpackTunnelGsonRequest {
      * @param type the Type defining the expected response
      * @param listener the success listener
      * @param errorListener the error listener
+     * @param params the parameters to append to the endpoint's query string
      *
      * @param T the expected response object from the WP-API endpoint
      */
@@ -204,9 +205,10 @@ object JetpackTunnelGsonRequest {
         body: Map<String, Any>,
         type: Type,
         listener: (T?, List<Header>) -> Unit,
-        errorListener: WPComErrorListener
+        errorListener: WPComErrorListener,
+        params: Map<String, String> = emptyMap()
     ): WPComGsonRequest<JetpackTunnelResponse<T>>? {
-        val wrappedBody = createTunnelBody(method = "put", body = body, path = wpApiEndpoint)
+        val wrappedBody = createTunnelBody(method = "put", body = body, path = wpApiEndpoint, params = params)
         return buildWrappedPostRequest(siteId, wrappedBody, type, listener, "PUT", wpApiEndpoint, errorListener)
     }
 
@@ -289,11 +291,12 @@ object JetpackTunnelGsonRequest {
     private fun createTunnelBody(
         method: String,
         body: Map<String, Any> = mapOf(),
-        path: String
+        path: String,
+        params: Map<String, String> = emptyMap()
     ): MutableMap<String, Any> {
         val finalBody = mutableMapOf<String, Any>()
         with(finalBody) {
-            put("path", "$path&_method=$method")
+            put("path", "$path${params.toTunnelQuery()}&_method=$method")
             put("json", "true")
             if (body.isNotEmpty()) {
                 put("body", gson.toJson(body, object : TypeToken<Map<String, Any>>() {}.type))
@@ -301,4 +304,12 @@ object JetpackTunnelGsonRequest {
         }
         return finalBody
     }
+
+    /**
+     * The tunnel expects the endpoint's query parameters appended to the path with `&` rather than as a regular
+     * query string, e.g. `/wc/v3/orders/1&currency=EUR&_method=put`. A `?` would be treated as part of the route
+     * and the request would fail with `rest_no_route`.
+     */
+    private fun Map<String, String>.toTunnelQuery(): String =
+        entries.joinToString(separator = "") { "&${it.key}=${it.value}" }
 }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTunnelGsonRequestBuilder.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTunnelGsonRequestBuilder.kt
@@ -159,12 +159,14 @@ class JetpackTunnelGsonRequestBuilder @Inject constructor() {
         site: SiteModel,
         url: String,
         body: Map<String, Any>,
-        clazz: Class<T>
+        clazz: Class<T>,
+        params: Map<String, String> = emptyMap()
     ) = suspendCancellableCoroutine<JetpackResponse<T>> { cont ->
         val request = JetpackTunnelGsonRequest.buildPutRequest<T>(
             url, site.siteId, body, clazz,
             listener = { data, headers -> cont.resume(JetpackSuccess(data, headers)) },
-            errorListener = { cont.resume(JetpackError(it)) }
+            errorListener = { cont.resume(JetpackError(it)) },
+            params = params
         )
         cont.invokeOnCancellation {
             request?.cancel()


### PR DESCRIPTION
Prerequisite for https://github.com/woocommerce/woocommerce-android/pull/16285

### Description
`executePutGsonRequest` couldn't send query parameters — only GET and DELETE could. On top of that, `WPAPIGsonRequest` only moved params into the URL for GET, so params passed to any other method were silently dropped. This adds a `params` argument to the PUT path and makes `WPAPIGsonRequest` append params to the URL for every method. The Jetpack tunnel appends them to the path with `&` (a `?` gets read as part of the route and 404s); the direct transports build a real URL.

**Heads up for review: removing the GET-only guard means DELETE now sends its params too. `deleteOrder` passes `force`, which on the Application Passwords transport was previously dropped (so it always trashed instead of force-deleting). That's a latent bug this fixes, but it's a behaviour change worth a conscious sign-off.**

### Test Steps

No user-facing behaviour on its own — covered by unit tests. The order-currency PR stacked on top exercises it end-to-end.

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to \`RELEASE-NOTES.txt\` if necessary. Use the "[Internal]" label for non-user-facing changes.