### PR TITLE
[WOOMOB-3630] Price added products in the order's currency

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -12,6 +12,7 @@
 - [*] Fixed a crash when toggling the "Unread reviews only" filter with more than one store connected [https://github.com/woocommerce/woocommerce-android/pull/16260]
 - [*] Fixed the product selector showing store-currency prices when adding products to an order in a different currency [https://github.com/woocommerce/woocommerce-android/pull/16281]
 - [*] Removed the outdated store setup feedback survey [https://github.com/woocommerce/woocommerce-android/pull/16273]
+- [*] Fixed products added to an order in a non-default currency being priced in the store's base currency
 - [*] Fixed the store name incorrectly appearing in the toolbar when opening a review from a notification [https://github.com/woocommerce/woocommerce-android/pull/16264]
 - [*] In-Person Payments onboarding no longer hard-blocks when your Stripe account has overdue requirements; you can skip and continue taking payments [https://github.com/woocommerce/woocommerce-android/pull/16208]
 - [*****] [Internal] Updated the Android Gradle Plugin to 9.2.1 and migrated to Kotlin support built into it [https://github.com/woocommerce/woocommerce-android/pull/16228]

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -13,6 +13,7 @@
 - [*] Fixed the product selector showing store-currency prices when adding products to an order in a different currency [https://github.com/woocommerce/woocommerce-android/pull/16281]
 - [*] Removed the outdated store setup feedback survey [https://github.com/woocommerce/woocommerce-android/pull/16273]
 - [*] Fixed products added to an order in a non-default currency being priced in the store's base currency
+- [*] Fixed products added to an order in a non-default currency being priced in the store's base currency [https://github.com/woocommerce/woocommerce-android/pull/16285]
 - [*] Fixed the store name incorrectly appearing in the toolbar when opening a review from a notification [https://github.com/woocommerce/woocommerce-android/pull/16264]
 - [*] In-Person Payments onboarding no longer hard-blocks when your Stripe account has overdue requirements; you can skip and continue taking payments [https://github.com/woocommerce/woocommerce-android/pull/16208]
 - [*****] [Internal] Updated the Android Gradle Plugin to 9.2.1 and migrated to Kotlin support built into it [https://github.com/woocommerce/woocommerce-android/pull/16228]

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -12,7 +12,6 @@
 - [*] Fixed a crash when toggling the "Unread reviews only" filter with more than one store connected [https://github.com/woocommerce/woocommerce-android/pull/16260]
 - [*] Fixed the product selector showing store-currency prices when adding products to an order in a different currency [https://github.com/woocommerce/woocommerce-android/pull/16281]
 - [*] Removed the outdated store setup feedback survey [https://github.com/woocommerce/woocommerce-android/pull/16273]
-- [*] Fixed products added to an order in a non-default currency being priced in the store's base currency
 - [*] Fixed products added to an order in a non-default currency being priced in the store's base currency [https://github.com/woocommerce/woocommerce-android/pull/16285]
 - [*] Fixed the store name incorrectly appearing in the toolbar when opening a review from a notification [https://github.com/woocommerce/woocommerce-android/pull/16264]
 - [*] In-Person Payments onboarding no longer hard-blocks when your Stripe account has overdue requirements; you can skip and continue taking payments [https://github.com/woocommerce/woocommerce-android/pull/16208]

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditRepository.kt
@@ -48,6 +48,7 @@ class OrderCreateEditRepository @Inject constructor(
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
     private val listItemMapper: ListItemMapper,
     private val getWooVersion: GetWooCorePluginCachedVersion,
+    private val isCurrencyQueryParamSupported: IsCurrencyQueryParamSupported,
 ) {
     suspend fun createOrUpdateOrder(order: Order, source: OrderCreationSource, giftCard: String = ""): Result<Order> {
         val request = UpdateOrderRequest(
@@ -74,7 +75,7 @@ class OrderCreateEditRepository @Inject constructor(
                 site = selectedSite.get(),
                 orderId = order.id,
                 updateRequest = request,
-                orderCurrency = order.currency
+                orderCurrency = order.currency.takeIf { isCurrencyQueryParamSupported() }
             )
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditRepository.kt
@@ -73,7 +73,8 @@ class OrderCreateEditRepository @Inject constructor(
             orderUpdateStore.updateOrder(
                 site = selectedSite.get(),
                 orderId = order.id,
-                updateRequest = request
+                updateRequest = request,
+                orderCurrency = order.currency
             )
         }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditRepositoryTest.kt
@@ -19,6 +19,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -51,6 +52,7 @@ class OrderCreateEditRepositoryTest : BaseUnitTest() {
     private lateinit var selectedSite: SelectedSite
     private lateinit var wooCommerceStore: WooCommerceStore
     private val getWooVersion: GetWooCorePluginCachedVersion = mock()
+    private val isCurrencyQueryParamSupported: IsCurrencyQueryParamSupported = mock()
 
     private val defaultSiteModel = SiteModel()
 
@@ -81,6 +83,7 @@ class OrderCreateEditRepositoryTest : BaseUnitTest() {
             analyticsTrackerWrapper = trackerWrapper,
             listItemMapper = mock(),
             getWooVersion = getWooVersion,
+            isCurrencyQueryParamSupported = isCurrencyQueryParamSupported,
         )
     }
 
@@ -241,6 +244,38 @@ class OrderCreateEditRepositoryTest : BaseUnitTest() {
 
         verify(orderUpdateStore).createOrder(defaultSiteModel, request, OrderAttributionOrigin.Mobile.SOURCE_TYPE_VALUE)
     }
+
+    @Test
+    fun `given the store takes the currency query param, when an order is updated, then the currency is sent`() =
+        testBlocking {
+            // GIVEN
+            whenever(isCurrencyQueryParamSupported()).thenReturn(true)
+            whenever(orderUpdateStore.updateOrder(any(), any(), any(), anyOrNull()))
+                .thenReturn(WooResult(OrderTestUtils.generateOrder()))
+            val order = Order.getEmptyOrder(Date(), Date()).copy(id = 123L, currency = "EUR")
+
+            // WHEN
+            sut.createOrUpdateOrder(order, source = OrderCreationSource.STORE_MANAGEMENT)
+
+            // THEN
+            verify(orderUpdateStore).updateOrder(eq(defaultSiteModel), eq(123L), any(), eq("EUR"))
+        }
+
+    @Test
+    fun `given the store can't take the currency query param, when an order is updated, then it isn't sent`() =
+        testBlocking {
+            // GIVEN
+            whenever(isCurrencyQueryParamSupported()).thenReturn(false)
+            whenever(orderUpdateStore.updateOrder(any(), any(), any(), anyOrNull()))
+                .thenReturn(WooResult(OrderTestUtils.generateOrder()))
+            val order = Order.getEmptyOrder(Date(), Date()).copy(id = 123L, currency = "EUR")
+
+            // WHEN
+            sut.createOrUpdateOrder(order, source = OrderCreationSource.STORE_MANAGEMENT)
+
+            // THEN
+            verify(orderUpdateStore).updateOrder(eq(defaultSiteModel), eq(123L), any(), isNull())
+        }
 
     @Test
     fun `when tax based on store address fetched, then it should be parsed correctly`() = testBlocking {

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -878,9 +878,7 @@ class OrderRestClient @Inject constructor(
     }
 
     /**
-     * [orderCurrency] is sent as a query parameter because WooPayments Multi-Currency reads it from there. Without
-     * it, it forces the store's base currency for REST requests and disables price conversion, so line items sent
-     * without an explicit price would be priced in the store's currency rather than the order's.
+     * [orderCurrency] has to go in the query string, not the body — that's where WooPayments Multi-Currency reads it.
      */
     suspend fun updateOrder(
         site: SiteModel,

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -877,10 +877,16 @@ class OrderRestClient @Inject constructor(
         }
     }
 
+    /**
+     * [orderCurrency] is sent as a query parameter because WooPayments Multi-Currency reads it from there. Without
+     * it, it forces the store's base currency for REST requests and disables price conversion, so line items sent
+     * without an explicit price would be priced in the store's currency rather than the order's.
+     */
     suspend fun updateOrder(
         site: SiteModel,
         orderId: Long,
-        request: UpdateOrderRequest
+        request: UpdateOrderRequest,
+        orderCurrency: String? = null
     ): WooPayload<OrderEntity> {
         val url = WOOCOMMERCE.orders.id(orderId).pathV3
         val body = request.toNetworkRequest()
@@ -889,7 +895,10 @@ class OrderRestClient @Inject constructor(
             site = site,
             path = url,
             clazz = OrderDto::class.java,
-            body = body
+            body = body,
+            params = orderCurrency?.takeIf { it.isNotBlank() }
+                ?.let { mapOf("currency" to it) }
+                .orEmpty()
         )
 
         return response.toWooPayload { orderDto ->

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/OrderUpdateStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/OrderUpdateStore.kt
@@ -254,10 +254,11 @@ class OrderUpdateStore @Inject internal constructor(
     suspend fun updateOrder(
         site: SiteModel,
         orderId: Long,
-        updateRequest: UpdateOrderRequest
+        updateRequest: UpdateOrderRequest,
+        orderCurrency: String? = null
     ): WooResult<OrderEntity> {
         return coroutineEngine.withDefaultContext(T.API, this, "updateOrder") {
-            val result = wcOrderRestClient.updateOrder(site, orderId, updateRequest)
+            val result = wcOrderRestClient.updateOrder(site, orderId, updateRequest, orderCurrency)
 
             return@withDefaultContext if (result.isError) {
                 WooResult(result.error)

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClientTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClientTest.kt
@@ -18,10 +18,12 @@ import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCOrderListDescriptor
+import org.wordpress.android.fluxc.model.order.UpdateOrderRequest
 import org.wordpress.android.fluxc.network.BaseRequest
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetworkError
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
+import org.wordpress.android.fluxc.persistence.entity.OrderEntity
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderListResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.OrderErrorType
 import org.wordpress.android.fluxc.tools.CoroutineEngine
@@ -467,5 +469,59 @@ class OrderRestClientTest {
             assertThat(actionCaptor.firstValue.payload.error?.type).isEqualTo(OrderErrorType.GENERIC_ERROR)
         }
 
+    @Test
+    fun `given an order currency, when updateOrder is called, then currency is sent as a query parameter`() = runTest {
+        // Given
+        val orderId = 123L
+        stubUpdateOrderResponse()
+
+        // When
+        orderRestClient.updateOrder(testSite, orderId, UpdateOrderRequest(), orderCurrency = "EUR")
+
+        // Then
+        verify(wooNetwork).executePutGsonRequest(
+            site = eq(testSite),
+            path = eq(WOOCOMMERCE.orders.id(orderId).pathV3),
+            clazz = eq(OrderDto::class.java),
+            body = any(),
+            params = eq(mapOf("currency" to "EUR"))
+        )
+    }
+
+    @Test
+    fun `given no order currency, when updateOrder is called, then no query parameter is sent`() = runTest {
+        // Given
+        val orderId = 123L
+        stubUpdateOrderResponse()
+
+        // When
+        orderRestClient.updateOrder(testSite, orderId, UpdateOrderRequest())
+
+        // Then
+        verify(wooNetwork).executePutGsonRequest(
+            site = eq(testSite),
+            path = eq(WOOCOMMERCE.orders.id(orderId).pathV3),
+            clazz = eq(OrderDto::class.java),
+            body = any(),
+            params = eq(emptyMap())
+        )
+    }
+
     /* HELPER */
+
+    private suspend fun stubUpdateOrderResponse() {
+        val orderDto = OrderDto()
+        whenever(
+            wooNetwork.executePutGsonRequest(
+                site = any(),
+                path = any(),
+                clazz = eq(OrderDto::class.java),
+                body = any(),
+                params = any()
+            )
+        ).thenReturn(WPAPIResponse.Success(orderDto, emptyList()))
+        whenever(orderDtoMapper.toDatabaseEntity(eq(orderDto), any())).thenReturn(
+            OrderEntity(localSiteId = testSite.localId(), orderId = 123L) to emptyList()
+        )
+    }
 }

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/store/OrderUpdateStoreTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/store/OrderUpdateStoreTest.kt
@@ -473,7 +473,7 @@ class OrderUpdateStoreTest {
         setUp {
             orderRestClient = mock {
                 on {
-                    updateOrder(any(), any(), any())
+                    updateOrder(any(), any(), any(), anyOrNull())
                 }.doReturn(
                     WooPayload(updatedOrder)
                 )


### PR DESCRIPTION
### Description

Fixes WOOMOB-3630

Stacked on #16284 (query-param support) — review that first.

Adding a product to a non-default-currency order priced the line item in the store's base currency (a EUR order got the USD number verbatim). The app posts new line items without a price so the server stays the pricing authority, but WooPayments Multi-Currency forces the store currency and disables conversion for any REST request without a `currency` query param. So we now send it on order updates.

Verified on device on both networking transports (Jetpack tunnel and Application Passwords). Stores using Jetpack Tunnel without [this fix](https://github.com/woocommerce/woocommerce/pull/66816) load currency from `session` so requests without an explicit currency use the last provided currency which is wrong - fixed in https://github.com/woocommerce/woocommerce/pull/66816.

### Test Steps

**Note: Consider running tests on [the following pr branch](https://github.com/woocommerce/woocommerce-android/pull/16290).**

Prerequisites:
1. Multi-Currency enabled in WooPayments.
2. WooCommerce with [this fix](https://github.com/woocommerce/woocommerce/pull/66816) - let me know, and I can share zip.
----
1. Create an order on the web in non-default currency (I enabled currency switcher setting under `/wp-admin/admin.php?page=wc-settings&tab=wcpay_multi_currency`)
1. Open the non-default currency order in the app → tap **Edit** → tap **+** → add a product.
3. The line item should be priced from the product's price in the *order's* currency. Before this change it used the base-currency price. (This PR is not about the currency symbol but about the amount - e.g. a product might cost 9euros or 10 usd, before this PR, the UI said correctly EUR but used value 10 instead of 9)


Make sure to test this flow with Application password enabled and disabled - you can switch the toggle in Settings -> Experimental -> Application Password, given you are logged in to your .com account.

### Images/gif

https://github.com/user-attachments/assets/2c273b91-57d6-403c-b53f-4ddf6690a4f1


- [x] I have considered if this change warrants release notes and have added them to \`RELEASE-NOTES.txt\` if necessary. Use the "[Internal]" label for non-user-facing changes.