### PR TITLE
[WOOMOB-3630] Block editing orders in another currency below WooCommerce 11.1

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -13,7 +13,7 @@
 - [*] Fixed the product selector showing store-currency prices when adding products to an order in a different currency [https://github.com/woocommerce/woocommerce-android/pull/16281]
 - [*] Removed the outdated store setup feedback survey [https://github.com/woocommerce/woocommerce-android/pull/16273]
 - [*] Fixed products added to an order in a non-default currency being priced in the store's base currency [https://github.com/woocommerce/woocommerce-android/pull/16285]
-- [*] Orders in a currency other than the store's are now read-only in the app on WooCommerce below 11.1, where their totals can't be calculated correctly
+- [*] Orders in a currency other than the store's are now read-only in the app on WooCommerce below 11.1, where their totals can't be calculated correctly [https://github.com/woocommerce/woocommerce-android/pull/16290]
 - [*] Fixed the store name incorrectly appearing in the toolbar when opening a review from a notification [https://github.com/woocommerce/woocommerce-android/pull/16264]
 - [*] In-Person Payments onboarding no longer hard-blocks when your Stripe account has overdue requirements; you can skip and continue taking payments [https://github.com/woocommerce/woocommerce-android/pull/16208]
 - [*****] [Internal] Updated the Android Gradle Plugin to 9.2.1 and migrated to Kotlin support built into it [https://github.com/woocommerce/woocommerce-android/pull/16228]

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -13,6 +13,7 @@
 - [*] Fixed the product selector showing store-currency prices when adding products to an order in a different currency [https://github.com/woocommerce/woocommerce-android/pull/16281]
 - [*] Removed the outdated store setup feedback survey [https://github.com/woocommerce/woocommerce-android/pull/16273]
 - [*] Fixed products added to an order in a non-default currency being priced in the store's base currency [https://github.com/woocommerce/woocommerce-android/pull/16285]
+- [*] Orders in a currency other than the store's are now read-only in the app on WooCommerce below 11.1, where their totals can't be calculated correctly
 - [*] Fixed the store name incorrectly appearing in the toolbar when opening a review from a notification [https://github.com/woocommerce/woocommerce-android/pull/16264]
 - [*] In-Person Payments onboarding no longer hard-blocks when your Stripe account has overdue requirements; you can skip and continue taking payments [https://github.com/woocommerce/woocommerce-android/pull/16208]
 - [*****] [Internal] Updated the Android Gradle Plugin to 9.2.1 and migrated to Kotlin support built into it [https://github.com/woocommerce/woocommerce-android/pull/16228]

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -535,7 +535,7 @@ class OrderCreateEditFormFragment :
                 if (isEditable) {
                     binding.showEditableControls(new)
                 } else {
-                    binding.hideEditableControls()
+                    binding.hideEditableControls(new)
                 }
             }
             new.isCouponButtonEnabled.takeIfNotEqualTo(old?.isCouponButtonEnabled) {
@@ -1316,8 +1316,20 @@ class OrderCreateEditFormFragment :
         }
     }
 
-    private fun FragmentOrderCreateEditFormBinding.hideEditableControls() {
-        messageNoEditableFields.visibility = View.VISIBLE
+    private fun FragmentOrderCreateEditFormBinding.hideEditableControls(
+        state: OrderCreateEditViewModel.ViewState
+    ) {
+        messageNoEditableFields.apply {
+            state.currencyMismatch?.let { mismatch ->
+                title = getString(R.string.order_editing_currency_mismatch_title)
+                message = getString(
+                    R.string.order_editing_currency_mismatch_message,
+                    mismatch.orderCurrency,
+                    mismatch.storeCurrency
+                )
+            }
+            visibility = View.VISIBLE
+        }
         productsSection.apply {
             isLocked = true
             isEachAddButtonEnabled = false

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -94,6 +94,7 @@ import com.woocommerce.android.ui.barcodescanner.BarcodeScanningTracker
 import com.woocommerce.android.ui.common.CurrencyCode
 import com.woocommerce.android.ui.feedback.FeedbackRepository
 import com.woocommerce.android.ui.orders.CustomAmountUIModel
+import com.woocommerce.android.ui.orders.IsStoreCurrencyMatch
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewOrderStatusSelector
 import com.woocommerce.android.ui.orders.creation.CreateUpdateOrder.OrderUpdateStatus
 import com.woocommerce.android.ui.orders.creation.GoogleBarcodeFormatMapper.BarcodeFormat
@@ -213,6 +214,7 @@ class OrderCreateEditViewModel @Inject constructor(
     private val fetchProductByIdentifier: FetchProductByIdentifier,
     private val wooPosSurveysNotificationScheduler: WooPosSurveysNotificationScheduler,
     private val isCurrencyQueryParamSupported: IsCurrencyQueryParamSupported,
+    private val isStoreCurrencyMatch: IsStoreCurrencyMatch,
     dateUtils: DateUtils,
     autoSyncOrder: AutoSyncOrder,
     autoSyncPriceModifier: AutoSyncPriceModifier,
@@ -445,12 +447,15 @@ class OrderCreateEditViewModel @Inject constructor(
 
             is Mode.Edit -> {
                 viewModelScope.launch {
+                    val currencyMismatch = currencyMismatchBlockingEditing()
+                    isEditingBlockedByCurrency = currencyMismatch != null
                     orderDetailRepository.getOrderById(mode.orderId)?.let { order ->
                         _orderDraft.value = order
                         viewState = viewState.copy(
                             isUpdatingOrderDraft = false,
                             showOrderUpdateSnackbar = false,
-                            isEditable = order.isEditable
+                            isEditable = order.isEditable && !isEditingBlockedByCurrency,
+                            currencyMismatch = currencyMismatch
                         )
                         monitorOrderChanges()
                         updateCouponAndDiscountButtonsState(order)
@@ -463,6 +468,21 @@ class OrderCreateEditViewModel @Inject constructor(
             }
         }
     }
+
+    /**
+     * Below the fix version the store prices any line item we add in its own currency, so editing an order in
+     * another currency would silently corrupt its totals. See [IsCurrencyQueryParamSupported].
+     */
+    private suspend fun currencyMismatchBlockingEditing(): CurrencyMismatch? {
+        val orderCurrency = args.orderCurrency ?: return null
+        val currencyMatch = isStoreCurrencyMatch(orderCurrency)
+        val storeCurrency = currencyMatch.storeCurrency
+        if (currencyMatch.isMatch || storeCurrency == null || isCurrencyQueryParamSupported()) return null
+
+        return CurrencyMismatch(orderCurrency = orderCurrency, storeCurrency = storeCurrency)
+    }
+
+    private var isEditingBlockedByCurrency = false
 
     private var _isFirstShippingLineChange = true
 
@@ -1543,7 +1563,7 @@ class OrderCreateEditViewModel @Inject constructor(
         (this.throwable as? WooException)?.error?.type == WooErrorType.INVALID_COUPON
 
     private fun isOrderEditable(updateStatus: OrderUpdateStatus.Succeeded) =
-        updateStatus.order.isEditable || mode is Mode.Creation
+        (updateStatus.order.isEditable || mode is Mode.Creation) && !isEditingBlockedByCurrency
 
     private fun trackOrderCreationFailure(it: Throwable) {
         tracker.track(
@@ -2060,6 +2080,12 @@ class OrderCreateEditViewModel @Inject constructor(
     }
 
     @Parcelize
+    data class CurrencyMismatch(
+        val orderCurrency: String,
+        val storeCurrency: String
+    ) : Parcelable
+
+    @Parcelize
     data class ViewState(
         val isProgressDialogShown: Boolean = false,
         val willUpdateOrderDraft: Boolean = false,
@@ -2080,6 +2106,7 @@ class OrderCreateEditViewModel @Inject constructor(
         val isTwoPaneLayout: Boolean = false,
         val isRecalculateNeeded: Boolean = false,
         val showShippingFeedback: Boolean = false,
+        val currencyMismatch: CurrencyMismatch? = null,
     ) : Parcelable {
         @IgnoredOnParcel
         val canCreateOrder: Boolean =

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -826,6 +826,8 @@
     -->
     <string name="order_editing_non_editable_title">Parts of this order are not currently editable</string>
     <string name="order_editing_non_editable_message">To edit Products or Payment Details, change the status to Pending Payment.</string>
+    <string name="order_editing_currency_mismatch_title">This order can\'t be edited in the app</string>
+    <string name="order_editing_currency_mismatch_message">Sorry, you can only edit this order on the web, as it uses %1$s, and your site\'s currency is %2$s.</string>
     <string name="order_editing_locked_content_description">locked</string>
     <string name="order_editing_barcode_content_description">Scan barcode</string>
     <string name="order_editing_add_content_description">Add product</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/EditFocusedOrderCreateEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/EditFocusedOrderCreateEditViewModelTest.kt
@@ -6,6 +6,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_DEVICE
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_DEVICE_TYPE_REGULAR
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_FLOW_EDITING
 import com.woocommerce.android.model.Order
+import com.woocommerce.android.ui.orders.CurrencyMatchResult
 import com.woocommerce.android.ui.orders.creation.CreateUpdateOrder.OrderUpdateStatus.Succeeded
 import com.woocommerce.android.ui.orders.creation.GoogleBarcodeFormatMapper.BarcodeFormat
 import com.woocommerce.android.ui.orders.creation.OrderCreateEditViewModel.Mode
@@ -766,6 +767,48 @@ class EditFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTest() 
         assertThat(lastReceivedEvent).isInstanceOf(OrderCreateEditNavigationTarget.SelectItems::class.java)
         val event = lastReceivedEvent as OrderCreateEditNavigationTarget.SelectItems
         assertThat(event.orderCurrency).isEqualTo("EUR")
+    }
+
+    @Test
+    fun `given currency mismatch and store below the fix version, when editing, then the order is not editable`() {
+        val order = defaultOrderValue.copy(isEditable = true)
+        orderDetailRepository.stub {
+            on { getOrderById(defaultOrderValue.id) }.doReturn(order)
+        }
+        isStoreCurrencyMatch.stub {
+            on { invoke(any()) } doReturn CurrencyMatchResult(isMatch = false, storeCurrency = "USD")
+        }
+        isCurrencyQueryParamSupported.stub {
+            on { invoke() } doReturn false
+        }
+        createSut()
+        var lastReceivedState: OrderCreateEditViewModel.ViewState? = null
+        sut.viewStateData.liveData.observeForever { lastReceivedState = it }
+
+        assertThat(lastReceivedState?.isEditable).isEqualTo(false)
+        assertThat(lastReceivedState?.currencyMismatch).isEqualTo(
+            OrderCreateEditViewModel.CurrencyMismatch(orderCurrency = "EUR", storeCurrency = "USD")
+        )
+    }
+
+    @Test
+    fun `given currency mismatch and store on the fix version, when editing, then the order stays editable`() {
+        val order = defaultOrderValue.copy(isEditable = true)
+        orderDetailRepository.stub {
+            on { getOrderById(defaultOrderValue.id) }.doReturn(order)
+        }
+        isStoreCurrencyMatch.stub {
+            on { invoke(any()) } doReturn CurrencyMatchResult(isMatch = false, storeCurrency = "USD")
+        }
+        isCurrencyQueryParamSupported.stub {
+            on { invoke() } doReturn true
+        }
+        createSut()
+        var lastReceivedState: OrderCreateEditViewModel.ViewState? = null
+        sut.viewStateData.liveData.observeForever { lastReceivedState = it }
+
+        assertThat(lastReceivedState?.isEditable).isEqualTo(true)
+        assertThat(lastReceivedState?.currencyMismatch).isNull()
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
@@ -22,6 +22,8 @@ import com.woocommerce.android.model.WooPlugin
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.barcodescanner.BarcodeScanningTracker
 import com.woocommerce.android.ui.feedback.FeedbackRepository
+import com.woocommerce.android.ui.orders.CurrencyMatchResult
+import com.woocommerce.android.ui.orders.IsStoreCurrencyMatch
 import com.woocommerce.android.ui.orders.OrderTestUtils
 import com.woocommerce.android.ui.orders.creation.CreateUpdateOrder.OrderUpdateStatus.Failed
 import com.woocommerce.android.ui.orders.creation.CreateUpdateOrder.OrderUpdateStatus.Succeeded
@@ -68,6 +70,7 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.spy
+import org.mockito.kotlin.stub
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.network.BaseRequest
@@ -109,6 +112,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
     protected lateinit var fetchProductByIdentifier: FetchProductByIdentifier
     private lateinit var wooPosSurveysNotificationScheduler: WooPosSurveysNotificationScheduler
     protected lateinit var isCurrencyQueryParamSupported: IsCurrencyQueryParamSupported
+    protected lateinit var isStoreCurrencyMatch: IsStoreCurrencyMatch
 
     protected val defaultOrderValue = Order.getEmptyOrder(Date(), Date()).copy(id = 123)
 
@@ -232,6 +236,14 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
         fetchProductByIdentifier = mock()
         wooPosSurveysNotificationScheduler = mock()
         isCurrencyQueryParamSupported = mock()
+        isStoreCurrencyMatch = mock()
+        // Only consulted when the screen was opened with an order currency, so stubbing it otherwise
+        // would trip the strict stubbing check.
+        if (orderCurrency != null) {
+            isStoreCurrencyMatch.stub {
+                on { invoke(any()) } doReturn CurrencyMatchResult(isMatch = true, storeCurrency = "USD")
+            }
+        }
     }
 
     protected abstract val tracksFlow: String
@@ -2190,6 +2202,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
             fetchProductByIdentifier = fetchProductByIdentifier,
             wooPosSurveysNotificationScheduler = wooPosSurveysNotificationScheduler,
             isCurrencyQueryParamSupported = isCurrencyQueryParamSupported,
+            isStoreCurrencyMatch = isStoreCurrencyMatch,
         )
     }
 


### PR DESCRIPTION
Part of WOOMOB-3630. Stacked on #16285 — review that first.

### Description

WooPayments Multi-Currency only honours a `currency` query parameter on requests WooCommerce recognises as REST, and before 11.1.0 `is_rest_api_request()` missed the `?rest_route=` form the Jetpack tunnel uses. #16285 added the parameter and gated it on WooCommerce 11.1+ for that reason.

That gate leaves a gap. On a store below 11.1, opening an order whose currency differs from the store's still lets the merchant edit it — but the app can't send the currency, so the store prices every line item it adds in the store's base currency. The edit looks like it worked and quietly writes wrong totals.

This makes those orders read-only instead. When the order currency doesn't match the store's and the store can't take the currency parameter, the edit form opens with `isEditable = false` — the same mechanism already used for orders whose status makes them non-editable — and the existing lock banner explains why:

> **This order can't be edited in the app**
> Sorry, you can only edit this order on the web, as it uses EUR, and your site's currency is USD.

Reusing `isEditable` rather than intercepting the Edit button means the whole screen is already wired for the read-only state — locked product list, disabled add buttons, disabled coupon/shipping/gift-card actions — with no new UI.

### Test Steps

Needs a multi-currency store (WooPayments) running WooCommerce **below** 11.1, and an order in a non-default currency.

1. Open the non-default-currency order → tap **Edit**.
2. The form should open locked: the banner reads "This order can't be edited in the app" with the two currency codes, the product list is locked and the add/coupon/shipping buttons are disabled.
3. Open an order in the store's own currency → tap **Edit**. It should be fully editable, with no banner.
4. Regression, existing behaviour: open a **completed** order in the store's currency → tap **Edit**. The banner should still read "Parts of this order are not currently editable / To edit Products or Payment Details, change the status to Pending Payment."
5. On a store running WooCommerce **11.1 or later**, the non-default-currency order from step 1 should be fully editable.

### Images/gif

<img  height="400" alt="Screenshot_1784716593" src="https://github.com/user-attachments/assets/d72427c9-7109-49f8-a533-c419ce44743c" />


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.