### PR TITLE
[WOOMOB-3630] ApiFaker: match query parameters of tunneled non-GET requests

### DIFF
--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/EndpointProcessor.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/EndpointProcessor.kt
@@ -132,7 +132,7 @@ internal class EndpointProcessor @Inject constructor(
         val query = jsonObjectProvider.parseString(readBody()).getString("path")
             .split("&")
             .drop(1)
-            .filterNot { it.startsWith("_method") }
+            .filterNot { it.startsWith("_method=") }
             .joinToString(separator = "&")
 
         // Parsed as a URL so that percent-encoded values are decoded the same way as on the direct path

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/EndpointProcessor.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/EndpointProcessor.kt
@@ -8,12 +8,14 @@ import com.woocommerce.android.apifaker.models.QueryParameter
 import com.woocommerce.android.apifaker.models.Response
 import com.woocommerce.android.apifaker.util.JSONObjectProvider
 import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.Request
 import okio.Buffer
 import javax.inject.Inject
 
 private const val WPCOM_HOST = "public-api.wordpress.com"
 private const val JETPACK_TUNNEL_REGEX = "/rest/v1.1/jetpack-blogs/\\d+/rest-api"
+private const val QUERY_PARSING_BASE_URL = "https://example.com/"
 
 internal class EndpointProcessor @Inject constructor(
     private val endpointDao: EndpointDao,
@@ -29,7 +31,7 @@ internal class EndpointProcessor @Inject constructor(
         return with(endpointData) {
             endpointDao.queryEndpoint(apiType, httpMethod, path.trimEnd('/'), body.orEmpty())
         }.filter {
-            request.url.checkQueryParameters(it.request.queryParameters)
+            request.checkQueryParameters(it.request.queryParameters)
         }.also {
             if (it.size > 1) {
                 Log.w(
@@ -105,23 +107,38 @@ internal class EndpointProcessor @Inject constructor(
         )
     }
 
-    private fun HttpUrl.checkQueryParameters(mockedQueryParameters: List<QueryParameter>): Boolean {
+    private fun Request.checkQueryParameters(mockedQueryParameters: List<QueryParameter>): Boolean {
         if (mockedQueryParameters.isEmpty()) return true
 
-        val requestQueryParameters = if (isJetpackTunnelRequest) {
-            queryParameter("query")?.let {
+        val requestQueryParameters = when {
+            !url.isJetpackTunnelRequest -> url.queryParameterNames.associateWith { url.queryParameter(it) }
+            method == "GET" -> url.queryParameter("query")?.let {
                 val json = jsonObjectProvider.parseString(it)
                 json.keys().asSequence().map { key ->
                     key to json.getString(key)
                 }.toMap()
             } ?: emptyMap()
-        } else {
-            queryParameterNames.associateWith { queryParameter(it) }
+            // Other methods carry the endpoint's query parameters in the body, appended to the path with `&`,
+            // e.g. "/wc/v3/orders/1&currency=EUR&_method=put"
+            else -> tunneledBodyQueryParameters()
         }
 
         return mockedQueryParameters.all { queryParameter ->
             requestQueryParameters[queryParameter.name] == queryParameter.value
         }
+    }
+
+    private fun Request.tunneledBodyQueryParameters(): Map<String, String?> {
+        val query = jsonObjectProvider.parseString(readBody()).getString("path")
+            .split("&")
+            .drop(1)
+            .filterNot { it.startsWith("_method") }
+            .joinToString(separator = "&")
+
+        // Parsed as a URL so that percent-encoded values are decoded the same way as on the direct path
+        return "$QUERY_PARSING_BASE_URL?$query".toHttpUrlOrNull()
+            ?.let { url -> url.queryParameterNames.associateWith { url.queryParameter(it) } }
+            .orEmpty()
     }
 
     private fun Request.readBody(): String {

--- a/libs/apifaker/src/test/java/com/woocommerce/android/apifaker/EndpointProcessorTest.kt
+++ b/libs/apifaker/src/test/java/com/woocommerce/android/apifaker/EndpointProcessorTest.kt
@@ -261,6 +261,46 @@ class EndpointProcessorTest {
     }
 
     @Test
+    fun `when processing a PUT jetpack tunnel endpoint with query parameters, then check query parameters`() {
+        val mockEndpoint = mockedTunnelPutEndpoint(QueryParameter("currency", "EUR"))
+        val request = tunnelPutRequest(path = "/wc/v3/orders/1&currency=EUR&_method=put")
+
+        val response = endpointProcessor.fakeRequestIfNeeded(request)
+
+        assert(response?.statusCode == mockEndpoint.response.statusCode)
+    }
+
+    @Test
+    fun `given query parameters don't match, when processing a PUT jetpack tunnel endpoint, then don't fake it`() {
+        mockedTunnelPutEndpoint(QueryParameter("currency", "EUR"))
+        val request = tunnelPutRequest(path = "/wc/v3/orders/1&currency=USD&_method=put")
+
+        val response = endpointProcessor.fakeRequestIfNeeded(request)
+
+        assert(response == null)
+    }
+
+    @Test
+    fun `when processing a PUT jetpack tunnel endpoint with encoded query parameters, then decode them`() {
+        val mockEndpoint = mockedTunnelPutEndpoint(QueryParameter("search", "a b&c"))
+        val request = tunnelPutRequest(path = "/wc/v3/orders/1&search=a%20b%26c&_method=put")
+
+        val response = endpointProcessor.fakeRequestIfNeeded(request)
+
+        assert(response?.statusCode == mockEndpoint.response.statusCode)
+    }
+
+    @Test
+    fun `given the tunneled path has no query parameters, when processing a PUT, then still match the endpoint`() {
+        val mockEndpoint = mockedTunnelPutEndpoint()
+        val request = tunnelPutRequest(path = "/wc/v3/orders/1&_method=put&")
+
+        val response = endpointProcessor.fakeRequestIfNeeded(request)
+
+        assert(response?.statusCode == mockEndpoint.response.statusCode)
+    }
+
+    @Test
     fun `when processing a regular endpoint with query parameters, then check query parameters`() {
         val mockEndpoint = MockedEndpoint(
             request = Request(
@@ -294,5 +334,45 @@ class EndpointProcessorTest {
 
         val response = endpointProcessor.fakeRequestIfNeeded(request)
         assert(response?.statusCode == 200)
+    }
+
+    private fun mockedTunnelPutEndpoint(vararg queryParameters: QueryParameter): MockedEndpoint {
+        val mockEndpoint = MockedEndpoint(
+            request = Request(
+                id = 0,
+                type = ApiType.WPApi,
+                httpMethod = HttpMethod.PUT,
+                path = "/wc/v3/orders/1",
+                queryParameters = queryParameters.toList(),
+                body = null
+            ),
+            response = Response(
+                endpointId = 0,
+                statusCode = 200
+            )
+        )
+        whenever(
+            endpointDaoMock.queryEndpoint(
+                type = mockEndpoint.request.type,
+                httpMethod = mockEndpoint.request.httpMethod!!,
+                path = mockEndpoint.request.path,
+                body = ""
+            )
+        ).thenReturn(listOf(mockEndpoint))
+        return mockEndpoint
+    }
+
+    private fun tunnelPutRequest(path: String): OkHttpRequest {
+        val body = """{"path": "$path", "json": "true"}"""
+        val jsonObject = mock<JSONObject> {
+            on { getString("path") } doReturn path
+            on { optString("body") } doReturn ""
+        }
+        whenever(jsonObjectProvider.parseString(body)).thenReturn(jsonObject)
+
+        return OkHttpRequest.Builder()
+            .method("POST", body.toRequestBody())
+            .url("https://public-api.wordpress.com/rest/v1.1/jetpack-blogs/161477129/rest-api")
+            .build()
     }
 }


### PR DESCRIPTION
### Description

Follow-up to the review feedback on #16284.

ApiFaker reads a request's query parameters from the URL. That works for direct requests and for tunneled GETs, but tunneled PUT/POST/DELETE send their parameters inside the request body instead, so ApiFaker never saw them and a mock set up with `currency=EUR` never matched.

It now reads them from the body for those requests.

Debug tooling only, so no release note.

### Test Steps

Needs #16285 on top (that's what sends the `currency` parameter) and a store on WooCommerce 11.1.0+.

1. Mock the update endpoint of an editable order (status `pending` or `on-hold`):
   ```
   adb shell am broadcast -p com.woocommerce.android.dev \
     -a com.woocommerce.android.apifaker.ADD_ENDPOINT \
     --es api_type "wp-api" --es path "/wc/v3/orders/<ORDER_ID>" --es http_method "PUT" \
     --es query_params "currency=<ORDER_CURRENCY>" --ei response_status_code 500 \
     --es response_body "'{\"code\":\"apifaker_mock\",\"message\":\"MOCK MATCHED\"}'"
   adb shell am broadcast -p com.woocommerce.android.dev \
     -a com.woocommerce.android.apifaker.SET_STATUS --ez enabled true
   ```
2. Open the order, tap Edit and switch the status between `pending` and `on-hold` to trigger a sync. (Switching to `processing` makes the order non-editable and sends nothing.)
3. `adb logcat -s WCApiFaker` should log `Matched request` and serve the mock. On trunk it only logs `Intercepting request` and the call goes to the network.
4. Change the mock to a different currency and repeat — it shouldn't match anymore.

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
