### PR TITLE
[WOOMOB-3667] Send a persistent device id in remote feature flag requests

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 
 25.3
 -----
+- [Internal] Send a persistent device id in remote feature flag requests so logins without a WordPress.com account are included in progressive rollouts [https://github.com/woocommerce/woocommerce-android/pull/16300]
 - [*] Improved product duplication to preserve product details managed by WooCommerce [https://github.com/woocommerce/woocommerce-android/pull/16262]
 - [*] Fixed the store login error message showing a placeholder instead of the status code [https://github.com/woocommerce/woocommerce-android/pull/16246]
 - [*] Fixed the order list not scrolling to the top after creating a new order [https://github.com/woocommerce/woocommerce-android/pull/16240]

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -234,7 +234,10 @@ object AppPrefs {
 
         IS_USER_AGE_ELIGIBLE_FOR_APP_USE,
 
-        QR_LOGIN_ROLLOUT_BUCKET
+        QR_LOGIN_ROLLOUT_BUCKET,
+
+        // Anonymous device id sent in remote feature flag requests to keep rollout bucketing stable
+        REMOTE_FEATURE_FLAGS_DEVICE_ID
     }
 
     fun init(context: Context) {
@@ -362,6 +365,10 @@ object AppPrefs {
     var wooCorePushDeviceUUID: String
         get() = getString(DeletablePrefKey.WOO_CORE_PUSH_DEVICE_UUID, "")
         set(value) = setString(DeletablePrefKey.WOO_CORE_PUSH_DEVICE_UUID, value)
+
+    var remoteFeatureFlagsDeviceId: String
+        get() = getString(UndeletablePrefKey.REMOTE_FEATURE_FLAGS_DEVICE_ID, "")
+        set(value) = setString(UndeletablePrefKey.REMOTE_FEATURE_FLAGS_DEVICE_ID, value)
 
     var isUserAgeEligibleForAppUse: Boolean
         get() = getBoolean(key = UndeletablePrefKey.IS_USER_AGE_ELIGIBLE_FOR_APP_USE, default = true)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -55,6 +55,8 @@ open class AppPrefsWrapper @Inject constructor() {
 
     var wooCorePushDeviceUUID by AppPrefs::wooCorePushDeviceUUID
 
+    var remoteFeatureFlagsDeviceId by AppPrefs::remoteFeatureFlagsDeviceId
+
     fun getAppInstallationDate() = AppPrefs.installationDate
 
     fun getReceiptUrl(localSiteId: Int, remoteSiteId: Long, selfHostedSiteId: Long, orderId: Long) =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/config/WPComRemoteFeatureFlagRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/config/WPComRemoteFeatureFlagRepository.kt
@@ -1,14 +1,17 @@
 package com.woocommerce.android.config
 
+import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.OnChangedException
 import com.woocommerce.android.util.WooLog
 import org.wordpress.android.fluxc.store.mobile.FeatureFlagsStore
+import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class WPComRemoteFeatureFlagRepository @Inject constructor(
-    private val featureFlagsStore: FeatureFlagsStore
+    private val featureFlagsStore: FeatureFlagsStore,
+    private val appPrefsWrapper: AppPrefsWrapper
 ) {
     companion object {
         private const val PLATFORM_NAME = "android"
@@ -24,7 +27,7 @@ class WPComRemoteFeatureFlagRepository @Inject constructor(
         // Empty string are parameters not used by this app.
         val result = featureFlagsStore.fetchFeatureFlags(
             buildNumber = "",
-            deviceId = "",
+            deviceId = getOrGenerateDeviceId(),
             identifier = "",
             marketingVersion = appVersion,
             platform = PLATFORM_NAME
@@ -38,4 +41,9 @@ class WPComRemoteFeatureFlagRepository @Inject constructor(
             Result.success(Unit)
         }
     }
+
+    private fun getOrGenerateDeviceId(): String =
+        appPrefsWrapper.remoteFeatureFlagsDeviceId.ifEmpty {
+            UUID.randomUUID().toString().also { appPrefsWrapper.remoteFeatureFlagsDeviceId = it }
+        }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/config/WPComRemoteFeatureFlagRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/config/WPComRemoteFeatureFlagRepositoryTest.kt
@@ -1,12 +1,17 @@
 package com.woocommerce.android.config
 
+import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.network.rest.wpcom.mobile.FeatureFlagsError
 import org.wordpress.android.fluxc.network.rest.wpcom.mobile.FeatureFlagsErrorType
@@ -15,12 +20,16 @@ import org.wordpress.android.fluxc.store.mobile.FeatureFlagsStore
 @OptIn(ExperimentalCoroutinesApi::class)
 class WPComRemoteFeatureFlagRepositoryTest : BaseUnitTest() {
     private val featureFlagStore: FeatureFlagsStore = mock()
+    private val appPrefsWrapper: AppPrefsWrapper = mock {
+        on { remoteFeatureFlagsDeviceId } doReturn DEVICE_ID
+    }
     private lateinit var sut: WPComRemoteFeatureFlagRepository
 
     @Before
     fun setup() {
         sut = WPComRemoteFeatureFlagRepository(
-            featureFlagStore
+            featureFlagStore,
+            appPrefsWrapper
         )
     }
 
@@ -46,4 +55,46 @@ class WPComRemoteFeatureFlagRepositoryTest : BaseUnitTest() {
             val result = sut.fetchAndCacheFeatureFlags()
             assertThat(result.isFailure).isTrue()
         }
+
+    @Test
+    fun `given a stored device id, when fetchAndCacheFeatureFlags is called, then it is sent as the device id`() =
+        testBlocking {
+            whenever(featureFlagStore.fetchFeatureFlags(any(), any(), any(), any(), any()))
+                .thenReturn(FeatureFlagsStore.FeatureFlagsResult(emptyMap()))
+
+            sut.fetchAndCacheFeatureFlags()
+
+            verify(featureFlagStore).fetchFeatureFlags(
+                buildNumber = any(),
+                deviceId = eq(DEVICE_ID),
+                identifier = any(),
+                marketingVersion = any(),
+                platform = any()
+            )
+        }
+
+    @Test
+    fun `given no stored device id, when fetchAndCacheFeatureFlags is called, then one is generated and stored`() =
+        testBlocking {
+            whenever(appPrefsWrapper.remoteFeatureFlagsDeviceId).thenReturn("")
+            whenever(featureFlagStore.fetchFeatureFlags(any(), any(), any(), any(), any()))
+                .thenReturn(FeatureFlagsStore.FeatureFlagsResult(emptyMap()))
+
+            sut.fetchAndCacheFeatureFlags()
+
+            val deviceIdCaptor = argumentCaptor<String>()
+            verify(appPrefsWrapper).remoteFeatureFlagsDeviceId = deviceIdCaptor.capture()
+            assertThat(deviceIdCaptor.firstValue).isNotEmpty()
+            verify(featureFlagStore).fetchFeatureFlags(
+                buildNumber = any(),
+                deviceId = eq(deviceIdCaptor.firstValue),
+                identifier = any(),
+                marketingVersion = any(),
+                platform = any()
+            )
+        }
+
+    private companion object {
+        const val DEVICE_ID = "device-id"
+    }
 }


### PR DESCRIPTION
### Description

Fixes WOOMOB-3667

The app sends an empty string as `device_id` when it fetches remote feature flags. The endpoint expects a non-empty device id for the percentage rollout to work, so logins without a WordPress.com account are not spread across the rollout percentages. Logins with a WordPress.com account are unaffected.

This sends a persistent anonymous UUID instead, generated once and stored in undeletable preferences, matching what the [WordPress iOS app](https://github.com/wordpress-mobile/WordPress-iOS/blob/57bed95278c682ed2857fd76c4f28f66aec4ed23/WordPress/Classes/Stores/RemoteFeatureFlagStore.swift#L17-L28) does.

Before, on trunk:

```
D FeatureFlagsRequest: https://public-api.wordpress.com/wpcom/v2/mobile/feature-flags/?build_number=&device_id=&identifier=&marketing_version=25.2-rc-2&platform=android&os_version=17
```

After, on this branch:

```
D FeatureFlagsRequest: https://public-api.wordpress.com/wpcom/v2/mobile/feature-flags/?build_number=&device_id=42bb1086-****-****-****-********c021&identifier=&marketing_version=25.2-rc-2&platform=android&os_version=17
```

### Test Steps
[log-feature-flags-request.patch](https://github.com/user-attachments/files/30312627/log-feature-flags-request.patch)
1. Log in.
2. Apply the logging patch.
3. Build and install the app.
4. Launch the app.
5. Filter logcat by the `FeatureFlagsRequest` tag and confirm `device_id` carries a UUID.
6. Relaunch the app and confirm the same UUID is sent.

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.