### PR TITLE
[WOOMOB-3460] Show the discard dialog when leaving order editing screens

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,7 +5,7 @@
 25.4
 -----
 - [*] Card payments no longer show an error when the payment was actually captured but the backend reported a network/server issue — the app now verifies the payment status and shows success, preventing double charges [https://github.com/woocommerce/woocommerce-android/pull/16295]
-- [*] Leaving the order note or address editor via the toolbar back button now asks to discard unsaved changes instead of silently dropping them [PR URL]
+- [*] Leaving the order note or address editor via the toolbar back button now asks to discard unsaved changes instead of silently dropping them [https://github.com/woocommerce/woocommerce-android/pull/16318]
 
 25.3
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 25.4
 -----
 - [*] Card payments no longer show an error when the payment was actually captured but the backend reported a network/server issue — the app now verifies the payment status and shows success, preventing double charges [https://github.com/woocommerce/woocommerce-android/pull/16295]
+- [*] Leaving the order note or address editor via the toolbar back button now asks to discard unsaved changes instead of silently dropping them [PR URL]
 
 25.3
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/BaseOrderEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/BaseOrderEditingFragment.kt
@@ -138,6 +138,14 @@ abstract class BaseOrderEditingFragment : BaseFragment, BackPressListener {
         }
     }
 
+    protected fun onExitRequested() {
+        if (hasChanges()) {
+            confirmDiscard()
+        } else {
+            navigateUp()
+        }
+    }
+
     private fun confirmDiscard() {
         MultiLiveEvent.Event.ShowDialog.buildDiscardDialogEvent(
             positiveBtnAction = { _, _ ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/CustomerOrderNoteEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/CustomerOrderNoteEditingFragment.kt
@@ -65,7 +65,7 @@ class CustomerOrderNoteEditingFragment :
 
     private fun setupToolbarMenu() {
         binding.toolbar.setNavigationOnClickListener {
-            navigateUp()
+            onExitRequested()
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
@@ -106,7 +106,7 @@ abstract class BaseAddressEditingFragment :
 
     private fun setupToolbarMenu() {
         binding.toolbar.setNavigationOnClickListener {
-            navigateUp()
+            onExitRequested()
         }
     }
 


### PR DESCRIPTION
### Description

Fixes WOOMOB-3460

The customer note and address editors don't ask to discard unsaved changes when leaving via the toolbar back button. It broke on 2024-01-30 when both screens moved from the activity toolbar to their own fragment toolbar ([7ecc0f5](https://github.com/woocommerce/woocommerce-android/commit/7ecc0f5e57a), [5d6966d](https://github.com/woocommerce/woocommerce-android/commit/5d6966de263)): the new navigation click listener calls `navigateUp()` directly and skips the `hasChanges()` check that shows the dialog. This restores that check.

### Test Steps

1. Open an order.
2. Tap the customer provided note.
3. Change the note text.
4. Tap the toolbar back arrow: the discard changes dialog appears.
5. Tap "Keep editing": the editor stays open with the edited text.
6. Tap the toolbar back arrow again.
7. Tap "Discard": the screen closes and the note is not saved.
8. Open the shipping address editor.
9. Edit any field.
10. Tap the toolbar back arrow: the discard changes dialog appears.
11. Tap "Discard".
12. Reopen the shipping address editor and tap the toolbar back arrow without editing anything: the screen closes without a dialog.

### Images/gif

<img width="300" alt="image" src="https://github.com/user-attachments/assets/25d510f7-864b-430d-b50c-843afaac7ccd" /> <img width="300" alt="image" src="https://github.com/user-attachments/assets/4550c0a1-9098-483d-8b3b-0679c72ca5cd" /> 

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.