### PR TITLE
[WOOMOB-3704] Send a Mobile Status Report to Zendesk - Part 2

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -53,6 +53,10 @@ open class AppPrefsWrapper @Inject constructor() {
 
     var jetpackAppPasswordsEnabled by AppPrefs::jetpackAppPasswordsEnabled
 
+    var isProductAddonsEnabled by AppPrefs::isProductAddonsEnabled
+
+    var wooPosLocalCatalogEnabled by AppPrefs::wooPosLocalCatalogEnabled
+
     var wooCorePushDeviceUUID by AppPrefs::wooCorePushDeviceUUID
 
     var remoteFeatureFlagsDeviceId by AppPrefs::remoteFeatureFlagsDeviceId
@@ -74,6 +78,13 @@ open class AppPrefsWrapper @Inject constructor() {
 
     fun isCardReaderPluginExplicitlySelected(localSiteId: Int, remoteSiteId: Long, selfHostedSiteId: Long) =
         AppPrefs.isCardReaderPluginExplicitlySelected(localSiteId, remoteSiteId, selfHostedSiteId)
+
+    fun getCardReaderOnboardingStatus(localSiteId: Int, remoteSiteId: Long, selfHostedSiteId: Long) =
+        AppPrefs.getCardReaderOnboardingStatus(localSiteId, remoteSiteId, selfHostedSiteId)
+
+    fun isPOSTabVisibleForSite(localSiteId: Int) = AppPrefs.isPOSTabVisibleForSite(localSiteId)
+
+    fun isPOSLaunchableForSite(localSiteId: Int) = AppPrefs.isPOSLaunchableForSite(localSiteId)
 
     fun getCardReaderPreferredPlugin(
         localSiteId: Int,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/background/BackgroundUpdatesDisabled.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/background/BackgroundUpdatesDisabled.kt
@@ -1,38 +1,15 @@
 package com.woocommerce.android.background
 
-import android.app.ActivityManager
-import android.content.Context
-import android.net.ConnectivityManager
-import android.net.ConnectivityManager.RESTRICT_BACKGROUND_STATUS_ENABLED
-import android.os.Build
-import android.os.PowerManager
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import javax.inject.Inject
 
 class BackgroundUpdatesDisabled @Inject constructor(
-    private val appContext: Context,
+    private val getBackgroundRestrictions: GetBackgroundRestrictions,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper
 ) {
     operator fun invoke() {
-        // Checks user’s Data Saver settings
-        val isNetworkRestricted =
-            (appContext.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager)?.let {
-                it.restrictBackgroundStatus == RESTRICT_BACKGROUND_STATUS_ENABLED
-            } ?: false
-
-        // Checks user’s Power Save Mode settings.
-        val isPowerSaveModeEnabled =
-            (appContext.getSystemService(Context.POWER_SERVICE) as? PowerManager)?.isPowerSaveMode ?: false
-
-        // Checks user’s background updates are disabled
-        val isBackgroundUpdatesDisabled = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-            (appContext.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager)?.isBackgroundRestricted ?: false
-        } else {
-            false
-        }
-
-        if (isNetworkRestricted || isPowerSaveModeEnabled || isBackgroundUpdatesDisabled) {
+        if (getBackgroundRestrictions().isAnyRestrictionActive) {
             analyticsTrackerWrapper.track(AnalyticsEvent.BACKGROUND_UPDATES_DISABLED)
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/background/GetBackgroundRestrictions.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/background/GetBackgroundRestrictions.kt
@@ -1,0 +1,36 @@
+package com.woocommerce.android.background
+
+import android.app.ActivityManager
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.ConnectivityManager.RESTRICT_BACKGROUND_STATUS_ENABLED
+import android.os.Build
+import android.os.PowerManager
+import javax.inject.Inject
+
+class GetBackgroundRestrictions @Inject constructor(
+    private val appContext: Context
+) {
+    operator fun invoke() = BackgroundRestrictions(
+        isDataSaverEnabled = (appContext.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager)
+            ?.let { it.restrictBackgroundStatus == RESTRICT_BACKGROUND_STATUS_ENABLED } ?: false,
+
+        isPowerSaveModeEnabled = (appContext.getSystemService(Context.POWER_SERVICE) as? PowerManager)
+            ?.isPowerSaveMode ?: false,
+
+        isBackgroundRestricted = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            (appContext.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager)?.isBackgroundRestricted ?: false
+        } else {
+            false
+        }
+    )
+
+    data class BackgroundRestrictions(
+        val isDataSaverEnabled: Boolean,
+        val isPowerSaveModeEnabled: Boolean,
+        val isBackgroundRestricted: Boolean
+    ) {
+        val isAnyRestrictionActive: Boolean
+            get() = isDataSaverEnabled || isPowerSaveModeEnabled || isBackgroundRestricted
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/zendesk/MobileStatusProvider.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/zendesk/MobileStatusProvider.kt
@@ -6,18 +6,31 @@ import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.BuildConfig
 import com.woocommerce.android.background.GetBackgroundRestrictions
 import com.woocommerce.android.extensions.logInformation
+import com.woocommerce.android.extensions.semverCompareTo
 import com.woocommerce.android.notifications.NotificationChannelsHandler
 import com.woocommerce.android.notifications.NotificationChannelsHandler.NewOrderNotificationSoundStatus
+import com.woocommerce.android.tools.connectionTypeOrNull
+import com.woocommerce.android.ui.payments.cardreader.onboarding.PluginType
 import com.woocommerce.android.ui.troubleshooting.useCases.NotificationSystemStatusProvider
+import com.woocommerce.android.ui.woopos.util.datastore.WooPosSyncTimestampManager
 import com.woocommerce.android.util.DeviceFeatures
 import com.woocommerce.android.util.DeviceInfoWrapper
 import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.FeatureFlagRepository
+import com.woocommerce.android.util.GetWooCorePluginCachedVersion
 import com.woocommerce.android.util.locale.LocaleProvider
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.plugin.SitePluginModel
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.fluxc.store.WooCommerceStore
+import org.wordpress.android.fluxc.store.pos.localcatalog.WooPosLocalCatalogStore
+import java.time.Instant
+import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 
 /**
@@ -37,9 +50,13 @@ class MobileStatusProvider @Inject constructor(
     private val notificationChannelsHandler: NotificationChannelsHandler,
     private val getBackgroundRestrictions: GetBackgroundRestrictions,
     private val deviceFeatures: DeviceFeatures,
+    private val getWooCorePluginCachedVersion: GetWooCorePluginCachedVersion,
     private val appPrefs: AppPrefsWrapper,
     private val accountStore: AccountStore,
-    private val siteStore: SiteStore
+    private val siteStore: SiteStore,
+    private val wooCommerceStore: WooCommerceStore,
+    private val posLocalCatalogStore: WooPosLocalCatalogStore,
+    private val syncTimestampManager: WooPosSyncTimestampManager
 ) {
     /**
      * @param siteAddress the address the merchant typed into the support form, which can differ from the selected
@@ -56,7 +73,21 @@ class MobileStatusProvider @Inject constructor(
         appendSection(HEADING_ACCOUNT) { accountSection(siteAddress) }
         appendSection(HEADING_FEATURE_FLAGS) { featureFlagsSection() }
         appendSection(HEADING_EXPERIMENTAL) { experimentalFeaturesSection() }
+
+        // Everything above describes the whole app on this device, everything below only the named store. The
+        // band says so once, instead of every heading carrying a scope and a legend explaining what it means.
+        appendLine()
+        appendLine(selectedSite?.let { "# Selected store: ${it.storeLabel()}" } ?: HEADING_NO_STORE)
+        if (selectedSite == null) return@buildString
+
+        appendSection(HEADING_STORE) { storeSection(selectedSite) }
+        appendSection(HEADING_PAYMENTS) { paymentsSection(selectedSite) }
+        appendSection(HEADING_POS) { posSection(selectedSite) }
     }
+
+    private fun SiteModel.storeLabel() = url.orEmpty()
+        .ifBlank { name.orEmpty() }
+        .ifBlank { "local id $id" }
 
     private fun appSection(): List<String> {
         val versionName = envDataSource.generateVersionName(context)
@@ -116,6 +147,18 @@ class MobileStatusProvider @Inject constructor(
         ) + allSites()
     }
 
+    private suspend fun storeSection(selectedSite: SiteModel) = with(selectedSite) {
+        listOf(
+            entry("Blog ID", siteId.takeIf { it != 0L } ?: NOT_SET),
+            entry("Store ID", appPrefs.getWCStoreID(siteId).orEmpty().ifEmpty { NOT_SET }),
+            entry("Auth method", connectionTypeOrNull?.name ?: UNKNOWN),
+            entry("Site supports app passwords", isApplicationPasswordsSupported),
+            entry("Jetpack", "installed=$isJetpackInstalled connected=$isJetpackConnected CP=$isJetpackCPConnected"),
+            entry("Plan", "${planShortName.orEmpty().ifEmpty { UNKNOWN }} ($planId)"),
+            entry("Woo core version", getWooCorePluginCachedVersion() ?: UNKNOWN)
+        )
+    }
+
     // Non-Woo sites are excluded here and from the count: the site store holds every site on the WPCom account.
     private fun wooSites() = siteStore.sites.filter { it.hasWooCommerce }
 
@@ -124,6 +167,97 @@ class MobileStatusProvider @Inject constructor(
         ?.map { entry(it.url.orEmpty().ifEmpty { UNKNOWN }, it.logInformation) }
         ?.let { listOf("", "All connected stores:") + it }
         .orEmpty()
+
+    private suspend fun paymentsSection(selectedSite: SiteModel): List<String> {
+        // Read from the plugin cache rather than fetching, to keep ticket creation off the network.
+        val plugins = wooCommerceStore.getSitePlugins(selectedSite)
+        val installState = if (plugins.isEmpty()) {
+            listOf(entry("Payment plugins", UNKNOWN))
+        } else {
+            listOf(
+                entry("WooPayments", plugins.stateOf(PluginType.WOOCOMMERCE_PAYMENTS)),
+                entry("Stripe extension", plugins.stateOf(PluginType.STRIPE_EXTENSION_GATEWAY))
+            )
+        }
+
+        return installState + inPersonPayments(selectedSite)
+    }
+
+    // Read straight from the prefs rather than through `GetActivePaymentsPlugin`, which falls back to a fetch.
+    private fun inPersonPayments(site: SiteModel): List<String> {
+        val preferredPlugin = appPrefs.getCardReaderPreferredPlugin(site.id, site.siteId, site.selfHostedSiteId)
+        val version = preferredPlugin?.let {
+            appPrefs.getCardReaderPreferredPluginVersion(site.id, site.siteId, site.selfHostedSiteId, it)
+        }
+        val explicitlySelected =
+            appPrefs.isCardReaderPluginExplicitlySelected(site.id, site.siteId, site.selfHostedSiteId)
+        return listOf(
+            entry(
+                "In-person payments plugin",
+                preferredPlugin?.let { "${it.name} ${version.orEmpty().ifEmpty { UNKNOWN }}" } ?: NOT_SET
+            ),
+            entry("In-person payments plugin chosen by merchant", explicitlySelected),
+            entry(
+                "In-person payments onboarding",
+                appPrefs.getCardReaderOnboardingStatus(site.id, site.siteId, site.selfHostedSiteId).name
+            )
+        )
+    }
+
+    private fun List<SitePluginModel>.stateOf(type: PluginType): String {
+        val plugin = firstOrNull { it.name.endsWith(type.pluginName) } ?: return "not installed"
+        val state = if (plugin.isActive) "active" else "installed, not active"
+        return "$state ${plugin.version.orEmpty().ifEmpty { UNKNOWN }}"
+    }
+
+    // The prefs are read directly because `WooPosTabShouldBeVisible` and `WooPosCanBeLaunchedInTab` write them as
+    // a side effect of evaluating, and a status report must not mutate what it reports.
+    private suspend fun posSection(selectedSite: SiteModel): List<String> {
+        val tabVisible = appPrefs.isPOSTabVisibleForSite(selectedSite.id)
+        val launchable = appPrefs.isPOSLaunchableForSite(selectedSite.id)
+        return listOfNotNull(
+            entry("POS tab visible", tabVisible),
+            entry("POS launchable", launchable),
+            entry("Catalog strategy", catalogStrategy(tabVisible, launchable)),
+            // `unknown` rather than `0` on a failed query: an empty catalog and an unreadable one are
+            // different findings, and the sync repository's own accessors collapse both to zero.
+            safeEntry("Local catalog products") {
+                posLocalCatalogStore.getProductCount(LocalId(selectedSite.id)).getOrNull() ?: UNKNOWN
+            },
+            safeEntry("Local catalog variations") {
+                posLocalCatalogStore.getVariationCount(LocalId(selectedSite.id)).getOrNull() ?: UNKNOWN
+            },
+            // The sync timestamps parse stored strings, so a malformed value throws rather than reading as absent.
+            safeEntry("Local catalog full sync") {
+                syncTimestampManager.getFullSyncLastCompletedTimestamp().asUtcOrNever()
+            },
+            safeEntry("Products timestamp") { syncTimestampManager.getProductsLastSyncTimestamp().asUtcOrNever() },
+            safeEntry("Variations timestamp") {
+                syncTimestampManager.getVariationsLastSyncTimestamp().asUtcOrNever()
+            },
+            safeEntry("Catalog file blocked") { syncTimestampManager.isCatalogFileBlocked() }
+        )
+    }
+
+    /**
+     * Mirrors `WooPosIsLocalCatalogSupported`, which the report cannot call: it evaluates POS visibility and
+     * launchability (writing prefs as it goes) and can fall back to a network fetch for the Woo version. This
+     * reads the cached results of those same inputs instead, so it is the decision as of the last evaluation.
+     * `WooPosIsLocalCatalogSupported` logs its real verdict, so the log on the same ticket settles any
+     * disagreement between the two.
+     */
+    private fun catalogStrategy(tabVisible: Boolean, launchable: Boolean): String {
+        val wooVersion = getWooCorePluginCachedVersion()
+        val fileSyncSupported = wooVersion != null &&
+            wooVersion.semverCompareTo(WC_FILE_BASED_SYNC_MIN_VERSION) >= 0
+        val localCatalog = featureFlagRepository.isEnabled(FeatureFlag.WOO_POS_LOCAL_CATALOG_M1) &&
+            appPrefs.wooPosLocalCatalogEnabled &&
+            fileSyncSupported && tabVisible && launchable
+        return if (localCatalog) "local catalog" else "remote"
+    }
+
+    private fun Long?.asUtcOrNever() =
+        this?.let { DateTimeFormatter.ISO_INSTANT.format(Instant.ofEpochMilli(it)) } ?: NEVER
 
     private fun featureFlagsSection(): List<String> {
         val states = FeatureFlag.entries.map { featureFlagRepository.getFlagState(it) }
@@ -167,6 +301,12 @@ class MobileStatusProvider @Inject constructor(
 
     private fun entry(key: String, value: Any?) = "$key: $value"
 
+    // Confines a failing lookup to the field that caused it, rather than losing the whole section with it.
+    private suspend fun safeEntry(key: String, value: suspend () -> Any?) =
+        runCatching { entry(key, value()) }
+            .onFailure { currentCoroutineContext().ensureActive() }
+            .getOrElse { entry(key, UNKNOWN) }
+
     private suspend fun StringBuilder.appendSection(heading: String, content: suspend () -> List<String>) {
         appendLine()
         appendLine(heading)
@@ -178,11 +318,15 @@ class MobileStatusProvider @Inject constructor(
     companion object {
         private const val REPORT_HEADING = "### Mobile Status Report generated via the WooCommerce Android app ###"
 
+        private const val HEADING_NO_STORE = "# No store selected"
         private const val HEADING_APP = "## App"
         private const val HEADING_DEVICE = "## Device"
         private const val HEADING_CONNECTIVITY = "## Connectivity"
         private const val HEADING_NOTIFICATIONS = "## Notifications"
         private const val HEADING_ACCOUNT = "## Account & Stores"
+        private const val HEADING_STORE = "## Store Details"
+        private const val HEADING_PAYMENTS = "## Payments"
+        private const val HEADING_POS = "## Point of Sale"
         private const val HEADING_FEATURE_FLAGS = "## Feature Flags"
         private const val HEADING_EXPERIMENTAL = "## Experimental Features"
 
@@ -191,7 +335,12 @@ class MobileStatusProvider @Inject constructor(
         private const val SIDELOADED = "sideloaded"
         private const val NONE = "none"
         private const val MISSING = "missing"
+        private const val NOT_SET = "not set"
         private const val NOT_LOGGED_IN = "not logged in"
+        private const val NEVER = "never"
         private const val REDACTED_TOKEN_LENGTH = 6
+
+        // Kept in step with `WooPosIsLocalCatalogSupported`.
+        private const val WC_FILE_BASED_SYNC_MIN_VERSION = "10.5.0"
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/zendesk/MobileStatusProvider.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/zendesk/MobileStatusProvider.kt
@@ -6,12 +6,12 @@ import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.BuildConfig
 import com.woocommerce.android.background.GetBackgroundRestrictions
 import com.woocommerce.android.extensions.logInformation
-import com.woocommerce.android.extensions.semverCompareTo
 import com.woocommerce.android.notifications.NotificationChannelsHandler
 import com.woocommerce.android.notifications.NotificationChannelsHandler.NewOrderNotificationSoundStatus
 import com.woocommerce.android.tools.connectionTypeOrNull
 import com.woocommerce.android.ui.payments.cardreader.onboarding.PluginType
 import com.woocommerce.android.ui.troubleshooting.useCases.NotificationSystemStatusProvider
+import com.woocommerce.android.ui.woopos.localcatalog.WooPosIsLocalCatalogSupported
 import com.woocommerce.android.ui.woopos.util.datastore.WooPosSyncTimestampManager
 import com.woocommerce.android.util.DeviceFeatures
 import com.woocommerce.android.util.DeviceInfoWrapper
@@ -56,7 +56,8 @@ class MobileStatusProvider @Inject constructor(
     private val siteStore: SiteStore,
     private val wooCommerceStore: WooCommerceStore,
     private val posLocalCatalogStore: WooPosLocalCatalogStore,
-    private val syncTimestampManager: WooPosSyncTimestampManager
+    private val syncTimestampManager: WooPosSyncTimestampManager,
+    private val isLocalCatalogSupported: WooPosIsLocalCatalogSupported
 ) {
     /**
      * @param siteAddress the address the merchant typed into the support form, which can differ from the selected
@@ -239,22 +240,8 @@ class MobileStatusProvider @Inject constructor(
         )
     }
 
-    /**
-     * Mirrors `WooPosIsLocalCatalogSupported`, which the report cannot call: it evaluates POS visibility and
-     * launchability (writing prefs as it goes) and can fall back to a network fetch for the Woo version. This
-     * reads the cached results of those same inputs instead, so it is the decision as of the last evaluation.
-     * `WooPosIsLocalCatalogSupported` logs its real verdict, so the log on the same ticket settles any
-     * disagreement between the two.
-     */
-    private fun catalogStrategy(tabVisible: Boolean, launchable: Boolean): String {
-        val wooVersion = getWooCorePluginCachedVersion()
-        val fileSyncSupported = wooVersion != null &&
-            wooVersion.semverCompareTo(WC_FILE_BASED_SYNC_MIN_VERSION) >= 0
-        val localCatalog = featureFlagRepository.isEnabled(FeatureFlag.WOO_POS_LOCAL_CATALOG_M1) &&
-            appPrefs.wooPosLocalCatalogEnabled &&
-            fileSyncSupported && tabVisible && launchable
-        return if (localCatalog) "local catalog" else "remote"
-    }
+    private fun catalogStrategy(tabVisible: Boolean, launchable: Boolean) =
+        if (isLocalCatalogSupported.asOfLastEvaluation(tabVisible, launchable)) "local catalog" else "remote"
 
     private fun Long?.asUtcOrNever() =
         this?.let { DateTimeFormatter.ISO_INSTANT.format(Instant.ofEpochMilli(it)) } ?: NEVER
@@ -339,8 +326,5 @@ class MobileStatusProvider @Inject constructor(
         private const val NOT_LOGGED_IN = "not logged in"
         private const val NEVER = "never"
         private const val REDACTED_TOKEN_LENGTH = 6
-
-        // Kept in step with `WooPosIsLocalCatalogSupported`.
-        private const val WC_FILE_BASED_SYNC_MIN_VERSION = "10.5.0"
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/zendesk/MobileStatusProvider.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/zendesk/MobileStatusProvider.kt
@@ -12,6 +12,7 @@ import com.woocommerce.android.tools.connectionTypeOrNull
 import com.woocommerce.android.ui.payments.cardreader.onboarding.PluginType
 import com.woocommerce.android.ui.troubleshooting.useCases.NotificationSystemStatusProvider
 import com.woocommerce.android.ui.woopos.localcatalog.WooPosIsLocalCatalogSupported
+import com.woocommerce.android.ui.woopos.util.datastore.WooPosPreferencesRepository
 import com.woocommerce.android.ui.woopos.util.datastore.WooPosSyncTimestampManager
 import com.woocommerce.android.util.DeviceFeatures
 import com.woocommerce.android.util.DeviceInfoWrapper
@@ -22,6 +23,7 @@ import com.woocommerce.android.util.locale.LocaleProvider
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.flow.first
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.plugin.SitePluginModel
@@ -57,6 +59,7 @@ class MobileStatusProvider @Inject constructor(
     private val wooCommerceStore: WooCommerceStore,
     private val posLocalCatalogStore: WooPosLocalCatalogStore,
     private val syncTimestampManager: WooPosSyncTimestampManager,
+    private val posPreferencesRepository: WooPosPreferencesRepository,
     private val isLocalCatalogSupported: WooPosIsLocalCatalogSupported
 ) {
     /**
@@ -220,6 +223,9 @@ class MobileStatusProvider @Inject constructor(
             entry("POS tab visible", tabVisible),
             entry("POS launchable", launchable),
             entry("Catalog strategy", catalogStrategy(tabVisible, launchable)),
+            // The background full sync stops running once POS has gone unopened for long enough, so a catalog
+            // that is stale for no other visible reason is explained by this date rather than by a sync failure.
+            safeEntry("POS last opened") { posPreferencesRepository.getLastUsedTimestamp().asUtcOrNever() },
             // `unknown` rather than `0` on a failed query: an empty catalog and an unreadable one are
             // different findings, and the sync repository's own accessors collapse both to zero.
             safeEntry("Local catalog products") {
@@ -236,7 +242,12 @@ class MobileStatusProvider @Inject constructor(
             safeEntry("Variations timestamp") {
                 syncTimestampManager.getVariationsLastSyncTimestamp().asUtcOrNever()
             },
-            safeEntry("Catalog file blocked") { syncTimestampManager.isCatalogFileBlocked() }
+            safeEntry("Catalog file blocked") { syncTimestampManager.isCatalogFileBlocked() },
+            // Never disables the background sync, only narrows when it may run, so a merchant who turned this off
+            // on a device that is rarely on Wi-Fi has a catalog that falls behind without anything failing.
+            safeEntry("Full sync on cellular allowed") {
+                posPreferencesRepository.allowCellularDataUpdate.first()
+            }
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/zendesk/MobileStatusProvider.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/zendesk/MobileStatusProvider.kt
@@ -2,11 +2,22 @@ package com.woocommerce.android.support.zendesk
 
 import android.content.Context
 import android.os.Build
+import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.BuildConfig
+import com.woocommerce.android.background.GetBackgroundRestrictions
+import com.woocommerce.android.extensions.logInformation
+import com.woocommerce.android.notifications.NotificationChannelsHandler
+import com.woocommerce.android.notifications.NotificationChannelsHandler.NewOrderNotificationSoundStatus
+import com.woocommerce.android.ui.troubleshooting.useCases.NotificationSystemStatusProvider
+import com.woocommerce.android.util.DeviceFeatures
 import com.woocommerce.android.util.DeviceInfoWrapper
+import com.woocommerce.android.util.FeatureFlag
+import com.woocommerce.android.util.FeatureFlagRepository
 import com.woocommerce.android.util.locale.LocaleProvider
 import dagger.hilt.android.qualifiers.ApplicationContext
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.AccountStore
+import org.wordpress.android.fluxc.store.SiteStore
 import javax.inject.Inject
 
 /**
@@ -20,15 +31,31 @@ class MobileStatusProvider @Inject constructor(
     @ApplicationContext private val context: Context,
     private val envDataSource: ZendeskEnvironmentDataSource,
     private val deviceInfo: DeviceInfoWrapper,
-    private val localeProvider: LocaleProvider
+    private val localeProvider: LocaleProvider,
+    private val featureFlagRepository: FeatureFlagRepository,
+    private val notificationSystemStatusProvider: NotificationSystemStatusProvider,
+    private val notificationChannelsHandler: NotificationChannelsHandler,
+    private val getBackgroundRestrictions: GetBackgroundRestrictions,
+    private val deviceFeatures: DeviceFeatures,
+    private val appPrefs: AppPrefsWrapper,
+    private val accountStore: AccountStore,
+    private val siteStore: SiteStore
 ) {
-    @Suppress("UnusedParameter")
-    suspend operator fun invoke(selectedSite: SiteModel?): String = buildString {
+    /**
+     * @param siteAddress the address the merchant typed into the support form, which can differ from the selected
+     * site when they are contacting us precisely because the app picked up the wrong store. Absent when the report
+     * is produced outside the support form.
+     */
+    suspend operator fun invoke(selectedSite: SiteModel?, siteAddress: String? = null): String = buildString {
         appendLine(REPORT_HEADING)
 
         appendSection(HEADING_APP) { appSection() }
         appendSection(HEADING_DEVICE) { deviceSection() }
         appendSection(HEADING_CONNECTIVITY) { connectivitySection() }
+        appendSection(HEADING_NOTIFICATIONS) { notificationsSection() }
+        appendSection(HEADING_ACCOUNT) { accountSection(siteAddress) }
+        appendSection(HEADING_FEATURE_FLAGS) { featureFlagsSection() }
+        appendSection(HEADING_EXPERIMENTAL) { experimentalFeaturesSection() }
     }
 
     private fun appSection(): List<String> {
@@ -53,6 +80,72 @@ class MobileStatusProvider @Inject constructor(
     // Reuses the Zendesk network field's lookup, which already returns `Key: Value` lines.
     private fun connectivitySection() = envDataSource.generateNetworkInformation(context).lines()
 
+    // Push registration is not here: it is keyed on a store, so it sits with the store it belongs to.
+    private fun notificationsSection(): List<String> {
+        val disabledChannels = notificationSystemStatusProvider.disabledWooNotificationChannels()
+        return listOf(
+            entry("Play Services", if (deviceFeatures.isGooglePlayServicesAvailable()) "available" else "unavailable"),
+            entry("Permission granted", notificationSystemStatusProvider.hasPostNotificationsPermission()),
+            entry("App notifications enabled", notificationSystemStatusProvider.areAppNotificationsEnabled()),
+            entry("Disabled channels", disabledChannels.joinToString().ifEmpty { NONE }),
+            entry("New order sound", notificationChannelsHandler.checkNewOrderNotificationSound().describe()),
+            entry("Push token", pushTokenState())
+        ) + backgroundRestrictions()
+    }
+
+    private fun NewOrderNotificationSoundStatus.describe() = when (this) {
+        NewOrderNotificationSoundStatus.DEFAULT -> "default"
+        NewOrderNotificationSoundStatus.DISABLED -> "disabled"
+        NewOrderNotificationSoundStatus.SOUND_MODIFIED -> "changed from the default"
+    }
+
+    private fun backgroundRestrictions() = with(getBackgroundRestrictions()) {
+        listOf(
+            entry("Background restricted", isBackgroundRestricted),
+            entry("Power save mode", isPowerSaveModeEnabled),
+            entry("Data saver", isDataSaverEnabled)
+        )
+    }
+
+    private fun accountSection(siteAddress: String?): List<String> {
+        val userId = accountStore.account?.userId ?: 0L
+        return listOfNotNull(
+            entry("WPCom user ID", userId.takeIf { it != 0L } ?: NOT_LOGGED_IN),
+            siteAddress?.takeIf { it.isNotBlank() }?.let { entry("Address given in the form", it) },
+            entry("Connected stores", wooSites().size)
+        ) + allSites()
+    }
+
+    // Non-Woo sites are excluded here and from the count: the site store holds every site on the WPCom account.
+    private fun wooSites() = siteStore.sites.filter { it.hasWooCommerce }
+
+    private fun allSites() = wooSites()
+        .takeIf { it.isNotEmpty() }
+        ?.map { entry(it.url.orEmpty().ifEmpty { UNKNOWN }, it.logInformation) }
+        ?.let { listOf("", "All connected stores:") + it }
+        .orEmpty()
+
+    private fun featureFlagsSection(): List<String> {
+        val states = FeatureFlag.entries.map { featureFlagRepository.getFlagState(it) }
+        return listOf(entry("Remote values loaded", states.any { it.remoteValue != null })) +
+            states
+                .sortedBy { it.flag.remoteFlagKey }
+                .map { entry(it.flag.remoteFlagKey, "${it.effectiveValue} (${it.source()})") }
+    }
+
+    private fun FeatureFlagRepository.FeatureFlagState.source() = when {
+        overrideValue != null -> "debug override"
+        remoteValue != null -> "remote"
+        else -> "compiled-in default"
+    }
+
+    // Kept in sync by hand with the toggles in `BetaFeaturesFragment`, which carries a matching reminder.
+    private fun experimentalFeaturesSection() = listOf(
+        entry("Product add-ons", appPrefs.isProductAddonsEnabled),
+        entry("Jetpack app passwords", appPrefs.jetpackAppPasswordsEnabled),
+        entry("POS local catalog", appPrefs.wooPosLocalCatalogEnabled)
+    )
+
     // A missing installer of record means the APK was sideloaded; a failed lookup means we could not tell.
     private fun installSource() = runCatching {
         val packageManager = context.packageManager
@@ -66,6 +159,11 @@ class MobileStatusProvider @Inject constructor(
         onSuccess = { installer -> installer ?: SIDELOADED },
         onFailure = { UNKNOWN }
     )
+
+    private fun pushTokenState() = appPrefs.getFCMToken()
+        .takeIf { it.isNotBlank() }
+        ?.let { "present (…${it.takeLast(REDACTED_TOKEN_LENGTH)})" }
+        ?: MISSING
 
     private fun entry(key: String, value: Any?) = "$key: $value"
 
@@ -83,9 +181,17 @@ class MobileStatusProvider @Inject constructor(
         private const val HEADING_APP = "## App"
         private const val HEADING_DEVICE = "## Device"
         private const val HEADING_CONNECTIVITY = "## Connectivity"
+        private const val HEADING_NOTIFICATIONS = "## Notifications"
+        private const val HEADING_ACCOUNT = "## Account & Stores"
+        private const val HEADING_FEATURE_FLAGS = "## Feature Flags"
+        private const val HEADING_EXPERIMENTAL = "## Experimental Features"
 
         private const val SECTION_UNAVAILABLE = "Info not found"
         private const val UNKNOWN = "unknown"
         private const val SIDELOADED = "sideloaded"
+        private const val NONE = "none"
+        private const val MISSING = "missing"
+        private const val NOT_LOGGED_IN = "not logged in"
+        private const val REDACTED_TOKEN_LENGTH = 6
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/zendesk/ZendeskTicketRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/zendesk/ZendeskTicketRepository.kt
@@ -74,7 +74,7 @@ class ZendeskTicketRepository @Inject constructor(
 
         val ssr: String? = selectedSite?.let { fetchSSR(it) }
 
-        val msr = mobileStatusProvider(selectedSite)
+        val msr = mobileStatusProvider(selectedSite, siteAddress)
 
         val deviceLogs = envDataSource.getFullDeviceLogs()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/BetaFeaturesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/BetaFeaturesFragment.kt
@@ -44,6 +44,8 @@ class BetaFeaturesFragment : Fragment(R.layout.fragment_settings_beta) {
         super.onViewCreated(view, savedInstanceState)
 
         with(FragmentSettingsBetaBinding.bind(view)) {
+            // When adding a toggle here, add it to MobileStatusProvider.experimentalFeaturesSection too,
+            // otherwise support tickets won't show that the merchant has it switched on.
             bindProductAddonsToggle()
             bindJetpackAppPasswordsToggle()
             bindWooPosLocalCatalogToggle()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosIsFileBasedSyncSupported.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosIsFileBasedSyncSupported.kt
@@ -1,0 +1,23 @@
+package com.woocommerce.android.ui.woopos.localcatalog
+
+import com.woocommerce.android.extensions.semverCompareTo
+import com.woocommerce.android.util.FetchActiveWCPluginVersion
+import com.woocommerce.android.util.GetWooCorePluginCachedVersion
+import javax.inject.Inject
+
+class WooPosIsFileBasedSyncSupported @Inject constructor(
+    private val getWooVersion: GetWooCorePluginCachedVersion,
+    private val fetchWooVersion: FetchActiveWCPluginVersion,
+) {
+    suspend operator fun invoke(): Boolean = supports(getWooVersion() ?: fetchWooVersion())
+
+    /** The same check without the network fallback, for callers that must not fetch. */
+    fun fromCachedVersion(): Boolean = supports(getWooVersion())
+
+    private fun supports(wooVersion: String?) =
+        wooVersion != null && wooVersion.semverCompareTo(MIN_WC_VERSION) >= 0
+
+    companion object {
+        const val MIN_WC_VERSION = "10.5.0"
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosIsLocalCatalogSupported.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosIsLocalCatalogSupported.kt
@@ -44,7 +44,9 @@ class WooPosIsLocalCatalogSupported @Inject constructor(
             }
         }
 
-        return true
+        // The Mobile Status Report derives this same verdict from cached prefs, because evaluating it here
+        // writes them. Logging the real answer lets support tell the two apart on a ticket.
+        return true.also { wooPosLogWrapper.d("Local Catalog supported: POS is using the local catalog.") }
     }
 
     private suspend fun isSyncApproachSupported(): Boolean {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosIsLocalCatalogSupported.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosIsLocalCatalogSupported.kt
@@ -1,19 +1,15 @@
 package com.woocommerce.android.ui.woopos.localcatalog
 
-import com.woocommerce.android.extensions.semverCompareTo
 import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
 import com.woocommerce.android.ui.woopos.featureflags.WooPosLocalCatalogM1Enabled
 import com.woocommerce.android.ui.woopos.tab.WooPosCanBeLaunchedInTab
 import com.woocommerce.android.ui.woopos.tab.WooPosLaunchability
 import com.woocommerce.android.ui.woopos.tab.WooPosTabShouldBeVisible
-import com.woocommerce.android.util.FetchActiveWCPluginVersion
-import com.woocommerce.android.util.GetWooCorePluginCachedVersion
 import javax.inject.Inject
 
 class WooPosIsLocalCatalogSupported @Inject constructor(
     private val wooPosLocalCatalogM1Enabled: WooPosLocalCatalogM1Enabled,
-    private val getWooVersion: GetWooCorePluginCachedVersion,
-    private val fetchWooVersion: FetchActiveWCPluginVersion,
+    private val isFileBasedSyncSupported: WooPosIsFileBasedSyncSupported,
     private val posTabShouldBeVisible: WooPosTabShouldBeVisible,
     private val posCanBeLaunchedInTab: WooPosCanBeLaunchedInTab,
     private val wooPosLogWrapper: WooPosLogWrapper,
@@ -26,8 +22,13 @@ class WooPosIsLocalCatalogSupported @Inject constructor(
             }
         }
 
-        if (!isSyncApproachSupported()) {
-            return false
+        if (!isFileBasedSyncSupported()) {
+            return false.also {
+                wooPosLogWrapper.d(
+                    "Local Catalog not supported: WooCommerce version does not support" +
+                        " file-based sync (requires ${WooPosIsFileBasedSyncSupported.MIN_WC_VERSION})."
+                )
+            }
         }
 
         val tabVisibleResult = posTabShouldBeVisible()
@@ -44,28 +45,15 @@ class WooPosIsLocalCatalogSupported @Inject constructor(
             }
         }
 
-        // The Mobile Status Report derives this same verdict from cached prefs, because evaluating it here
-        // writes them. Logging the real answer lets support tell the two apart on a ticket.
         return true.also { wooPosLogWrapper.d("Local Catalog supported: POS is using the local catalog.") }
     }
 
-    private suspend fun isSyncApproachSupported(): Boolean {
-        if (!isFileBasedSyncSupported()) {
-            wooPosLogWrapper.d(
-                "Local Catalog not supported: WooCommerce version does not support" +
-                    " file-based sync (requires $WC_FILE_BASED_SYNC_MIN_VERSION)."
-            )
-            return false
-        }
-        return true
-    }
-
-    private suspend fun isFileBasedSyncSupported(): Boolean {
-        val wooVersion = getWooVersion() ?: fetchWooVersion() ?: return false
-        return wooVersion.semverCompareTo(WC_FILE_BASED_SYNC_MIN_VERSION) >= 0
-    }
-
-    companion object {
-        private const val WC_FILE_BASED_SYNC_MIN_VERSION = "10.5.0"
-    }
+    /**
+     * The same verdict from state that has already been recorded: [tabVisible] and [launchable] are the prefs
+     * [invoke] writes as it evaluates, and the Woo version comes from the cache rather than a fetch. For callers
+     * that must not mutate or block on what they report — the Mobile Status Report is one. [invoke] logs its real
+     * answer, so the log on the same ticket settles any disagreement between the two.
+     */
+    fun asOfLastEvaluation(tabVisible: Boolean, launchable: Boolean): Boolean =
+        wooPosLocalCatalogM1Enabled() && isFileBasedSyncSupported.fromCachedVersion() && tabVisible && launchable
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/background/BackgroundUpdatesDisabledTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/background/BackgroundUpdatesDisabledTest.kt
@@ -1,0 +1,82 @@
+package com.woocommerce.android.background
+
+import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.background.GetBackgroundRestrictions.BackgroundRestrictions
+import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.stub
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+
+class BackgroundUpdatesDisabledTest {
+    private val getBackgroundRestrictions: GetBackgroundRestrictions = mock()
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper = mock()
+
+    private val sut = BackgroundUpdatesDisabled(
+        getBackgroundRestrictions = getBackgroundRestrictions,
+        analyticsTrackerWrapper = analyticsTrackerWrapper
+    )
+
+    @Test
+    fun `given no restriction is active, when invoked, then nothing is tracked`() {
+        stubRestrictions()
+
+        sut()
+
+        verifyNoInteractions(analyticsTrackerWrapper)
+    }
+
+    @Test
+    fun `given data saver is enabled, when invoked, then background updates disabled is tracked`() {
+        stubRestrictions(isDataSaverEnabled = true)
+
+        sut()
+
+        verify(analyticsTrackerWrapper).track(AnalyticsEvent.BACKGROUND_UPDATES_DISABLED)
+    }
+
+    @Test
+    fun `given power save mode is enabled, when invoked, then background updates disabled is tracked`() {
+        stubRestrictions(isPowerSaveModeEnabled = true)
+
+        sut()
+
+        verify(analyticsTrackerWrapper).track(AnalyticsEvent.BACKGROUND_UPDATES_DISABLED)
+    }
+
+    @Test
+    fun `given background is restricted, when invoked, then background updates disabled is tracked`() {
+        stubRestrictions(isBackgroundRestricted = true)
+
+        sut()
+
+        verify(analyticsTrackerWrapper).track(AnalyticsEvent.BACKGROUND_UPDATES_DISABLED)
+    }
+
+    @Test
+    fun `given every restriction is active, when invoked, then the event is tracked once`() {
+        stubRestrictions(
+            isDataSaverEnabled = true,
+            isPowerSaveModeEnabled = true,
+            isBackgroundRestricted = true
+        )
+
+        sut()
+
+        verify(analyticsTrackerWrapper).track(AnalyticsEvent.BACKGROUND_UPDATES_DISABLED)
+    }
+
+    private fun stubRestrictions(
+        isDataSaverEnabled: Boolean = false,
+        isPowerSaveModeEnabled: Boolean = false,
+        isBackgroundRestricted: Boolean = false
+    ) = getBackgroundRestrictions.stub {
+        on { invoke() } doReturn BackgroundRestrictions(
+            isDataSaverEnabled = isDataSaverEnabled,
+            isPowerSaveModeEnabled = isPowerSaveModeEnabled,
+            isBackgroundRestricted = isBackgroundRestricted
+        )
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/support/MobileStatusProviderTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/support/MobileStatusProviderTest.kt
@@ -13,6 +13,7 @@ import com.woocommerce.android.support.zendesk.MobileStatusProvider
 import com.woocommerce.android.support.zendesk.ZendeskEnvironmentDataSource
 import com.woocommerce.android.ui.payments.cardreader.onboarding.PluginType
 import com.woocommerce.android.ui.troubleshooting.useCases.NotificationSystemStatusProvider
+import com.woocommerce.android.ui.woopos.localcatalog.WooPosIsLocalCatalogSupported
 import com.woocommerce.android.ui.woopos.util.datastore.WooPosSyncTimestampManager
 import com.woocommerce.android.util.DeviceFeatures
 import com.woocommerce.android.util.DeviceInfoWrapper
@@ -64,7 +65,6 @@ class MobileStatusProviderTest : BaseUnitTest() {
     }
 
     private val featureFlagRepository: FeatureFlagRepository = mock {
-        on { isEnabled(any()) } doReturn true
         on { getFlagState(any()) } doAnswer { invocation ->
             FeatureFlagState(
                 flag = invocation.getArgument(0),
@@ -121,6 +121,10 @@ class MobileStatusProviderTest : BaseUnitTest() {
         on { getVariationCount(any()) } doReturn Result.success(3420)
     }
 
+    private val isLocalCatalogSupported: WooPosIsLocalCatalogSupported = mock {
+        on { asOfLastEvaluation(any(), any()) } doReturn true
+    }
+
     private val syncTimestampManager: WooPosSyncTimestampManager = mock {
         on { getFullSyncLastCompletedTimestamp() } doReturn FULL_SYNC_MILLIS
         on { getProductsLastSyncTimestamp() } doReturn PRODUCTS_SYNC_MILLIS
@@ -162,7 +166,8 @@ class MobileStatusProviderTest : BaseUnitTest() {
         siteStore = siteStore,
         wooCommerceStore = wooCommerceStore,
         posLocalCatalogStore = posLocalCatalogStore,
-        syncTimestampManager = syncTimestampManager
+        syncTimestampManager = syncTimestampManager,
+        isLocalCatalogSupported = isLocalCatalogSupported
     )
 
     /**
@@ -357,9 +362,9 @@ class MobileStatusProviderTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given the local catalog toggle is off, when the report is generated, then the strategy is remote`() =
+    fun `given the local catalog is not supported, when the report is generated, then the strategy is remote`() =
         testBlocking {
-            appPrefs.stub { on { wooPosLocalCatalogEnabled } doReturn false }
+            isLocalCatalogSupported.stub { on { asOfLastEvaluation(any(), any()) } doReturn false }
 
             val report = sut(SiteModel().apply { url = "https://example.com" })
 
@@ -367,22 +372,12 @@ class MobileStatusProviderTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given Woo is too old for file based sync, when the report is generated, then the strategy is remote`() =
-        testBlocking {
-            getWooCorePluginCachedVersion.stub { on { invoke() } doReturn "10.4.0" }
-
-            val report = sut(SiteModel().apply { url = "https://example.com" })
-
-            assertThat(report).contains("Catalog strategy: remote")
-        }
-
-    @Test
-    fun `given POS cannot be launched, when the report is generated, then the strategy is remote`() = testBlocking {
+    fun `given POS cannot be launched, when the report is generated, then it says so`() = testBlocking {
         appPrefs.stub { on { isPOSLaunchableForSite(any()) } doReturn false }
 
         val report = sut(SiteModel().apply { url = "https://example.com" })
 
-        assertThat(report).contains("Catalog strategy: remote")
+        assertThat(report).contains("POS launchable: false")
     }
 
     @Test
@@ -443,7 +438,8 @@ class MobileStatusProviderTest : BaseUnitTest() {
         siteStore = siteStore,
         wooCommerceStore = wooCommerceStore,
         posLocalCatalogStore = posLocalCatalogStore,
-        syncTimestampManager = syncTimestampManager
+        syncTimestampManager = syncTimestampManager,
+        isLocalCatalogSupported = isLocalCatalogSupported
     )
 
     private fun sitePlugin(name: String, isActive: Boolean, version: String) = SitePluginModel(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/support/MobileStatusProviderTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/support/MobileStatusProviderTest.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.support
 
 import android.content.Context
 import android.content.pm.PackageManager
+import com.woocommerce.android.AppPrefs.CardReaderOnboardingStatus
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.background.GetBackgroundRestrictions
 import com.woocommerce.android.background.GetBackgroundRestrictions.BackgroundRestrictions
@@ -10,11 +11,14 @@ import com.woocommerce.android.notifications.NotificationChannelsHandler
 import com.woocommerce.android.notifications.NotificationChannelsHandler.NewOrderNotificationSoundStatus
 import com.woocommerce.android.support.zendesk.MobileStatusProvider
 import com.woocommerce.android.support.zendesk.ZendeskEnvironmentDataSource
+import com.woocommerce.android.ui.payments.cardreader.onboarding.PluginType
 import com.woocommerce.android.ui.troubleshooting.useCases.NotificationSystemStatusProvider
+import com.woocommerce.android.ui.woopos.util.datastore.WooPosSyncTimestampManager
 import com.woocommerce.android.util.DeviceFeatures
 import com.woocommerce.android.util.DeviceInfoWrapper
 import com.woocommerce.android.util.FeatureFlagRepository
 import com.woocommerce.android.util.FeatureFlagRepository.FeatureFlagState
+import com.woocommerce.android.util.GetWooCorePluginCachedVersion
 import com.woocommerce.android.util.locale.LocaleProvider
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -27,9 +31,13 @@ import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.stub
 import org.wordpress.android.fluxc.model.AccountModel
+import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.plugin.SitePluginModel
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.fluxc.store.WooCommerceStore
+import org.wordpress.android.fluxc.store.pos.localcatalog.WooPosLocalCatalogStore
 import java.util.Locale
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -56,6 +64,7 @@ class MobileStatusProviderTest : BaseUnitTest() {
     }
 
     private val featureFlagRepository: FeatureFlagRepository = mock {
+        on { isEnabled(any()) } doReturn true
         on { getFlagState(any()) } doAnswer { invocation ->
             FeatureFlagState(
                 flag = invocation.getArgument(0),
@@ -88,11 +97,35 @@ class MobileStatusProviderTest : BaseUnitTest() {
         on { isGooglePlayServicesAvailable() } doReturn true
     }
 
+    private val getWooCorePluginCachedVersion: GetWooCorePluginCachedVersion = mock {
+        on { invoke() } doReturn "10.9.2"
+    }
+
     private val appPrefs: AppPrefsWrapper = mock {
         on { getFCMToken() } doReturn "abcdefghijklmnop"
+        on { getWCStoreID(any()) } doReturn "store-uuid"
         on { isProductAddonsEnabled } doReturn true
         on { jetpackAppPasswordsEnabled } doReturn false
         on { wooPosLocalCatalogEnabled } doReturn true
+        on { getCardReaderPreferredPlugin(any(), any(), any()) } doReturn PluginType.WOOCOMMERCE_PAYMENTS
+        on { getCardReaderPreferredPluginVersion(any(), any(), any(), any()) } doReturn "11.0.0"
+        on { isCardReaderPluginExplicitlySelected(any(), any(), any()) } doReturn true
+        on { getCardReaderOnboardingStatus(any(), any(), any()) } doReturn
+            CardReaderOnboardingStatus.CARD_READER_ONBOARDING_COMPLETED
+        on { isPOSTabVisibleForSite(any()) } doReturn true
+        on { isPOSLaunchableForSite(any()) } doReturn true
+    }
+
+    private val posLocalCatalogStore: WooPosLocalCatalogStore = mock {
+        on { getProductCount(any()) } doReturn Result.success(1250)
+        on { getVariationCount(any()) } doReturn Result.success(3420)
+    }
+
+    private val syncTimestampManager: WooPosSyncTimestampManager = mock {
+        on { getFullSyncLastCompletedTimestamp() } doReturn FULL_SYNC_MILLIS
+        on { getProductsLastSyncTimestamp() } doReturn PRODUCTS_SYNC_MILLIS
+        on { getVariationsLastSyncTimestamp() } doReturn VARIATIONS_SYNC_MILLIS
+        on { isCatalogFileBlocked() } doReturn false
     }
 
     private val accountStore: AccountStore = mock {
@@ -107,6 +140,12 @@ class MobileStatusProviderTest : BaseUnitTest() {
         )
     }
 
+    private val wooCommerceStore: WooCommerceStore = mock {
+        on { getSitePlugins(any<SiteModel>()) } doReturn listOf(
+            sitePlugin("woocommerce-payments/woocommerce-payments", isActive = true, version = "8.1.0")
+        )
+    }
+
     private val sut = MobileStatusProvider(
         context = mock(),
         envDataSource = envDataSource,
@@ -117,9 +156,13 @@ class MobileStatusProviderTest : BaseUnitTest() {
         notificationChannelsHandler = notificationChannelsHandler,
         getBackgroundRestrictions = getBackgroundRestrictions,
         deviceFeatures = deviceFeatures,
+        getWooCorePluginCachedVersion = getWooCorePluginCachedVersion,
         appPrefs = appPrefs,
         accountStore = accountStore,
-        siteStore = siteStore
+        siteStore = siteStore,
+        wooCommerceStore = wooCommerceStore,
+        posLocalCatalogStore = posLocalCatalogStore,
+        syncTimestampManager = syncTimestampManager
     )
 
     /**
@@ -129,23 +172,61 @@ class MobileStatusProviderTest : BaseUnitTest() {
      * express — branches, and values it has no second combination for.
      */
     @Test
-    fun `when the report is generated, then it matches the expected report`() =
+    fun `given a selected store, when the report is generated, then it matches the expected report`() =
         testBlocking {
-            val report = sut(SiteModel())
+            val report = sut(SiteModel().apply { url = "https://example.com" })
 
             assertThat(report.trimEnd()).isEqualTo(EXPECTED_REPORT)
+        }
+
+    @Test
+    fun `given no selected store, when the report is generated, then the store sections are omitted`() =
+        testBlocking {
+            val report = sut(null)
+
+            assertThat(report).endsWith("# No store selected\n")
+            assertThat(report).doesNotContain("## Store Details")
+            assertThat(report).doesNotContain("## Store Notifications")
+            assertThat(report).doesNotContain("## Payments")
+            assertThat(report).doesNotContain("## Point of Sale")
+            // The app-wide half is still reported in full.
+            assertThat(report).contains("## Device")
+            assertThat(report).contains("Connected stores: 3")
+        }
+
+    @Test
+    fun `given a store with no url, when the report is generated, then the band names it another way`() =
+        testBlocking {
+            val report = sut(SiteModel().apply { name = "Jirka's Store" })
+
+            assertThat(report).contains("# Selected store: Jirka's Store")
         }
 
     @Test
     fun `given a section fails, when the report is generated, then only that section degrades`() = testBlocking {
         deviceInfo.stub { on { name } doThrow RuntimeException("boom") }
 
-        val report = sut(SiteModel())
+        val report = sut(SiteModel().apply { url = "https://example.com" })
 
         assertThat(report.section("## Device")).isEqualTo("Info not found")
         assertThat(report).contains("Play Services: available")
         assertThat(report).contains("Product add-ons: true")
     }
+
+    @Test
+    fun `given a single field fails, when the report is generated, then the rest of its section survives`() =
+        testBlocking {
+            syncTimestampManager.stub {
+                on { getProductsLastSyncTimestamp() } doThrow NumberFormatException("malformed")
+            }
+
+            val report = sut(SiteModel().apply { url = "https://example.com" })
+
+            val pos = report.section("## Point of Sale")
+            assertThat(pos).contains("Products timestamp: unknown")
+            assertThat(pos).doesNotContain("Info not found")
+            assertThat(pos).contains("Local catalog full sync: 2026-07-29T09:29:49Z")
+        }
 
     /**
      * The golden report covers data saver on with the other two off. Three booleans cannot be told apart by a
@@ -156,7 +237,7 @@ class MobileStatusProviderTest : BaseUnitTest() {
         testBlocking {
             stubRestrictions(isPowerSaveModeEnabled = true, isBackgroundRestricted = true)
 
-            val report = sut(SiteModel())
+            val report = sut(SiteModel().apply { url = "https://example.com" })
 
             assertThat(report).contains("Background restricted: true")
             assertThat(report).contains("Power save mode: true")
@@ -173,7 +254,7 @@ class MobileStatusProviderTest : BaseUnitTest() {
                 )
             }
 
-            val report = sut(SiteModel())
+            val report = sut(SiteModel().apply { url = "https://example.com" })
 
             assertThat(report).contains("Connected stores: 1")
             assertThat(report).contains("https://store.example.com")
@@ -184,10 +265,40 @@ class MobileStatusProviderTest : BaseUnitTest() {
     fun `given no push token, when the report is generated, then it is reported as missing`() = testBlocking {
         appPrefs.stub { on { getFCMToken() } doReturn "" }
 
-        val report = sut(SiteModel())
+        val report = sut(SiteModel().apply { url = "https://example.com" })
 
         assertThat(report).contains("Push token: missing")
     }
+
+    @Test
+    fun `given a Jetpack connected store, when the report is generated, then the auth method says so`() =
+        testBlocking {
+            val site = SiteModel().apply {
+                url = "https://example.com"
+                origin = SiteModel.ORIGIN_WPCOM_REST
+                setIsJetpackConnected(true)
+            }
+
+            val report = sut(site)
+
+            assertThat(report).contains("Auth method: Jetpack")
+        }
+
+    /**
+     * `connectionType` answers `Jetpack` for this site in production, which the report would state as fact.
+     */
+    @Test
+    fun `given a store the app cannot classify, when the report is generated, then the auth method is unknown`() =
+        testBlocking {
+            val site = SiteModel().apply {
+                url = "https://example.com"
+                origin = SiteModel.ORIGIN_WPCOM_REST
+            }
+
+            val report = sut(site)
+
+            assertThat(report).contains("Auth method: unknown")
+        }
 
     @Test
     fun `given no remote flag values, when the report is generated, then they are reported as not loaded`() =
@@ -203,10 +314,20 @@ class MobileStatusProviderTest : BaseUnitTest() {
                 }
             }
 
-            val report = sut(SiteModel())
+            val report = sut(SiteModel().apply { url = "https://example.com" })
 
             assertThat(report).contains("Remote values loaded: false")
             assertThat(report).contains("ai_support_chat: false (compiled-in default)")
+        }
+
+    @Test
+    fun `given no plugins are cached, when the report is generated, then the plugins are unknown`() =
+        testBlocking {
+            wooCommerceStore.stub { on { getSitePlugins(any<SiteModel>()) } doReturn emptyList() }
+
+            val report = sut(SiteModel().apply { url = "https://example.com" })
+
+            assertThat(report).contains("Payment plugins: unknown")
         }
 
     @Test
@@ -234,6 +355,56 @@ class MobileStatusProviderTest : BaseUnitTest() {
 
             assertThat(report).contains("Install source: unknown")
         }
+
+    @Test
+    fun `given the local catalog toggle is off, when the report is generated, then the strategy is remote`() =
+        testBlocking {
+            appPrefs.stub { on { wooPosLocalCatalogEnabled } doReturn false }
+
+            val report = sut(SiteModel().apply { url = "https://example.com" })
+
+            assertThat(report).contains("Catalog strategy: remote")
+        }
+
+    @Test
+    fun `given Woo is too old for file based sync, when the report is generated, then the strategy is remote`() =
+        testBlocking {
+            getWooCorePluginCachedVersion.stub { on { invoke() } doReturn "10.4.0" }
+
+            val report = sut(SiteModel().apply { url = "https://example.com" })
+
+            assertThat(report).contains("Catalog strategy: remote")
+        }
+
+    @Test
+    fun `given POS cannot be launched, when the report is generated, then the strategy is remote`() = testBlocking {
+        appPrefs.stub { on { isPOSLaunchableForSite(any()) } doReturn false }
+
+        val report = sut(SiteModel().apply { url = "https://example.com" })
+
+        assertThat(report).contains("Catalog strategy: remote")
+    }
+
+    @Test
+    fun `given the catalog file is blocked, when the report is generated, then it says so`() = testBlocking {
+        syncTimestampManager.stub { on { isCatalogFileBlocked() } doReturn true }
+
+        val report = sut(SiteModel().apply { url = "https://example.com" })
+
+        assertThat(report).contains("Catalog file blocked: true")
+    }
+
+    @Test
+    fun `given the catalog count cannot be read, when the report is generated, then it is unknown`() = testBlocking {
+        posLocalCatalogStore.stub {
+            on { getProductCount(any()) } doReturn Result.failure(RuntimeException("db gone"))
+        }
+
+        val report = sut(SiteModel().apply { url = "https://example.com" })
+
+        assertThat(report).contains("Local catalog products: unknown")
+        assertThat(report).contains("Local catalog variations: 3420")
+    }
 
     /** The lines of one section, without its heading, so a section can be asserted on as a whole. */
     private fun String.section(heading: String) =
@@ -266,9 +437,22 @@ class MobileStatusProviderTest : BaseUnitTest() {
         notificationChannelsHandler = notificationChannelsHandler,
         getBackgroundRestrictions = getBackgroundRestrictions,
         deviceFeatures = deviceFeatures,
+        getWooCorePluginCachedVersion = getWooCorePluginCachedVersion,
         appPrefs = appPrefs,
         accountStore = accountStore,
-        siteStore = siteStore
+        siteStore = siteStore,
+        wooCommerceStore = wooCommerceStore,
+        posLocalCatalogStore = posLocalCatalogStore,
+        syncTimestampManager = syncTimestampManager
+    )
+
+    private fun sitePlugin(name: String, isActive: Boolean, version: String) = SitePluginModel(
+        siteId = LocalId(1),
+        name = name,
+        version = version,
+        slug = name.substringAfterLast('/'),
+        authorName = "author",
+        isActive = isActive
     )
 
     private fun wooSite(url: String = "") = SiteModel().apply {
@@ -365,9 +549,43 @@ class MobileStatusProviderTest : BaseUnitTest() {
             Product add-ons: true
             Jetpack app passwords: false
             POS local catalog: true
+
+            # Selected store: https://example.com
+
+            ## Store Details
+            Blog ID: not set
+            Store ID: store-uuid
+            Auth method: ApplicationPasswords
+            Site supports app passwords: false
+            Jetpack: installed=false connected=false CP=false
+            Plan: unknown (0)
+            Woo core version: 10.9.2
+
+            ## Payments
+            WooPayments: active 8.1.0
+            Stripe extension: not installed
+            In-person payments plugin: WOOCOMMERCE_PAYMENTS 11.0.0
+            In-person payments plugin chosen by merchant: true
+            In-person payments onboarding: CARD_READER_ONBOARDING_COMPLETED
+
+            ## Point of Sale
+            POS tab visible: true
+            POS launchable: true
+            Catalog strategy: local catalog
+            Local catalog products: 1250
+            Local catalog variations: 3420
+            Local catalog full sync: 2026-07-29T09:29:49Z
+            Products timestamp: 2026-07-29T09:29:50Z
+            Variations timestamp: 2026-07-29T09:29:51Z
+            Catalog file blocked: false
         """.trimIndent().trim()
 
         const val PLAY_STORE = "com.android.vending"
         const val PACKAGE_NAME = "com.woocommerce.android"
+
+        // 2026-07-29T09:29:49Z, :50Z and :51Z
+        const val FULL_SYNC_MILLIS = 1785317389000L
+        const val PRODUCTS_SYNC_MILLIS = 1785317390000L
+        const val VARIATIONS_SYNC_MILLIS = 1785317391000L
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/support/MobileStatusProviderTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/support/MobileStatusProviderTest.kt
@@ -14,6 +14,7 @@ import com.woocommerce.android.support.zendesk.ZendeskEnvironmentDataSource
 import com.woocommerce.android.ui.payments.cardreader.onboarding.PluginType
 import com.woocommerce.android.ui.troubleshooting.useCases.NotificationSystemStatusProvider
 import com.woocommerce.android.ui.woopos.localcatalog.WooPosIsLocalCatalogSupported
+import com.woocommerce.android.ui.woopos.util.datastore.WooPosPreferencesRepository
 import com.woocommerce.android.ui.woopos.util.datastore.WooPosSyncTimestampManager
 import com.woocommerce.android.util.DeviceFeatures
 import com.woocommerce.android.util.DeviceInfoWrapper
@@ -23,6 +24,7 @@ import com.woocommerce.android.util.GetWooCorePluginCachedVersion
 import com.woocommerce.android.util.locale.LocaleProvider
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.any
@@ -132,6 +134,11 @@ class MobileStatusProviderTest : BaseUnitTest() {
         on { isCatalogFileBlocked() } doReturn false
     }
 
+    private val posPreferencesRepository: WooPosPreferencesRepository = mock {
+        on { allowCellularDataUpdate } doReturn flowOf(true)
+        on { getLastUsedTimestamp() } doReturn POS_LAST_USED_MILLIS
+    }
+
     private val accountStore: AccountStore = mock {
         on { account } doReturn AccountModel().apply { userId = 12345678L }
     }
@@ -167,6 +174,7 @@ class MobileStatusProviderTest : BaseUnitTest() {
         wooCommerceStore = wooCommerceStore,
         posLocalCatalogStore = posLocalCatalogStore,
         syncTimestampManager = syncTimestampManager,
+        posPreferencesRepository = posPreferencesRepository,
         isLocalCatalogSupported = isLocalCatalogSupported
     )
 
@@ -381,6 +389,24 @@ class MobileStatusProviderTest : BaseUnitTest() {
     }
 
     @Test
+    fun `given POS has never been opened, when the report is generated, then it says never`() = testBlocking {
+        posPreferencesRepository.stub { on { getLastUsedTimestamp() } doReturn null }
+
+        val report = sut(SiteModel().apply { url = "https://example.com" })
+
+        assertThat(report).contains("POS last opened: never")
+    }
+
+    @Test
+    fun `given cellular full sync is off, when the report is generated, then it says so`() = testBlocking {
+        posPreferencesRepository.stub { on { allowCellularDataUpdate } doReturn flowOf(false) }
+
+        val report = sut(SiteModel().apply { url = "https://example.com" })
+
+        assertThat(report).contains("Full sync on cellular allowed: false")
+    }
+
+    @Test
     fun `given the catalog file is blocked, when the report is generated, then it says so`() = testBlocking {
         syncTimestampManager.stub { on { isCatalogFileBlocked() } doReturn true }
 
@@ -439,6 +465,7 @@ class MobileStatusProviderTest : BaseUnitTest() {
         wooCommerceStore = wooCommerceStore,
         posLocalCatalogStore = posLocalCatalogStore,
         syncTimestampManager = syncTimestampManager,
+        posPreferencesRepository = posPreferencesRepository,
         isLocalCatalogSupported = isLocalCatalogSupported
     )
 
@@ -568,18 +595,21 @@ class MobileStatusProviderTest : BaseUnitTest() {
             POS tab visible: true
             POS launchable: true
             Catalog strategy: local catalog
+            POS last opened: 2026-07-29T09:29:48Z
             Local catalog products: 1250
             Local catalog variations: 3420
             Local catalog full sync: 2026-07-29T09:29:49Z
             Products timestamp: 2026-07-29T09:29:50Z
             Variations timestamp: 2026-07-29T09:29:51Z
             Catalog file blocked: false
+            Full sync on cellular allowed: true
         """.trimIndent().trim()
 
         const val PLAY_STORE = "com.android.vending"
         const val PACKAGE_NAME = "com.woocommerce.android"
 
         // 2026-07-29T09:29:49Z, :50Z and :51Z
+        const val POS_LAST_USED_MILLIS = 1785317388000L
         const val FULL_SYNC_MILLIS = 1785317389000L
         const val PRODUCTS_SYNC_MILLIS = 1785317390000L
         const val VARIATIONS_SYNC_MILLIS = 1785317391000L

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/support/MobileStatusProviderTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/support/MobileStatusProviderTest.kt
@@ -2,9 +2,19 @@ package com.woocommerce.android.support
 
 import android.content.Context
 import android.content.pm.PackageManager
+import com.woocommerce.android.AppPrefsWrapper
+import com.woocommerce.android.background.GetBackgroundRestrictions
+import com.woocommerce.android.background.GetBackgroundRestrictions.BackgroundRestrictions
+import com.woocommerce.android.notifications.NotificationChannelType
+import com.woocommerce.android.notifications.NotificationChannelsHandler
+import com.woocommerce.android.notifications.NotificationChannelsHandler.NewOrderNotificationSoundStatus
 import com.woocommerce.android.support.zendesk.MobileStatusProvider
 import com.woocommerce.android.support.zendesk.ZendeskEnvironmentDataSource
+import com.woocommerce.android.ui.troubleshooting.useCases.NotificationSystemStatusProvider
+import com.woocommerce.android.util.DeviceFeatures
 import com.woocommerce.android.util.DeviceInfoWrapper
+import com.woocommerce.android.util.FeatureFlagRepository
+import com.woocommerce.android.util.FeatureFlagRepository.FeatureFlagState
 import com.woocommerce.android.util.locale.LocaleProvider
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -16,7 +26,10 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.stub
+import org.wordpress.android.fluxc.model.AccountModel
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.AccountStore
+import org.wordpress.android.fluxc.store.SiteStore
 import java.util.Locale
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -42,11 +55,71 @@ class MobileStatusProviderTest : BaseUnitTest() {
         on { provideLocale() } doReturn Locale.UK
     }
 
+    private val featureFlagRepository: FeatureFlagRepository = mock {
+        on { getFlagState(any()) } doAnswer { invocation ->
+            FeatureFlagState(
+                flag = invocation.getArgument(0),
+                localValue = false,
+                remoteValue = true,
+                overrideValue = null
+            )
+        }
+    }
+
+    private val notificationSystemStatusProvider: NotificationSystemStatusProvider = mock {
+        on { hasPostNotificationsPermission() } doReturn true
+        on { areAppNotificationsEnabled() } doReturn true
+        on { disabledWooNotificationChannels() } doReturn listOf(NotificationChannelType.REVIEW)
+    }
+
+    private val notificationChannelsHandler: NotificationChannelsHandler = mock {
+        on { checkNewOrderNotificationSound() } doReturn NewOrderNotificationSoundStatus.SOUND_MODIFIED
+    }
+
+    private val getBackgroundRestrictions: GetBackgroundRestrictions = mock {
+        on { invoke() } doReturn BackgroundRestrictions(
+            isDataSaverEnabled = true,
+            isPowerSaveModeEnabled = false,
+            isBackgroundRestricted = false
+        )
+    }
+
+    private val deviceFeatures: DeviceFeatures = mock {
+        on { isGooglePlayServicesAvailable() } doReturn true
+    }
+
+    private val appPrefs: AppPrefsWrapper = mock {
+        on { getFCMToken() } doReturn "abcdefghijklmnop"
+        on { isProductAddonsEnabled } doReturn true
+        on { jetpackAppPasswordsEnabled } doReturn false
+        on { wooPosLocalCatalogEnabled } doReturn true
+    }
+
+    private val accountStore: AccountStore = mock {
+        on { account } doReturn AccountModel().apply { userId = 12345678L }
+    }
+
+    private val siteStore: SiteStore = mock {
+        on { sites } doReturn listOf(
+            wooSite("https://first.example.com"),
+            wooSite("https://second.example.com"),
+            wooSite("https://third.example.com")
+        )
+    }
+
     private val sut = MobileStatusProvider(
         context = mock(),
         envDataSource = envDataSource,
         deviceInfo = deviceInfo,
-        localeProvider = localeProvider
+        localeProvider = localeProvider,
+        featureFlagRepository = featureFlagRepository,
+        notificationSystemStatusProvider = notificationSystemStatusProvider,
+        notificationChannelsHandler = notificationChannelsHandler,
+        getBackgroundRestrictions = getBackgroundRestrictions,
+        deviceFeatures = deviceFeatures,
+        appPrefs = appPrefs,
+        accountStore = accountStore,
+        siteStore = siteStore
     )
 
     /**
@@ -56,11 +129,12 @@ class MobileStatusProviderTest : BaseUnitTest() {
      * express — branches, and values it has no second combination for.
      */
     @Test
-    fun `when the report is generated, then it matches the expected report`() = testBlocking {
-        val report = sut(SiteModel())
+    fun `when the report is generated, then it matches the expected report`() =
+        testBlocking {
+            val report = sut(SiteModel())
 
-        assertThat(report.trimEnd()).isEqualTo(EXPECTED_REPORT)
-    }
+            assertThat(report.trimEnd()).isEqualTo(EXPECTED_REPORT)
+        }
 
     @Test
     fun `given a section fails, when the report is generated, then only that section degrades`() = testBlocking {
@@ -69,14 +143,76 @@ class MobileStatusProviderTest : BaseUnitTest() {
         val report = sut(SiteModel())
 
         assertThat(report.section("## Device")).isEqualTo("Info not found")
-        assertThat(report).contains("Version: 21.3 (2103003)")
-        assertThat(report).contains("Network Type: WiFi")
+        assertThat(report).contains("Play Services: available")
+        assertThat(report).contains("Product add-ons: true")
     }
+
+    /**
+     * The golden report covers data saver on with the other two off. Three booleans cannot be told apart by a
+     * single combination, so this pins the remaining two labels to their own fields.
+     */
+    @Test
+    fun `given power save and background restriction are on, when the report is generated, then each is labelled`() =
+        testBlocking {
+            stubRestrictions(isPowerSaveModeEnabled = true, isBackgroundRestricted = true)
+
+            val report = sut(SiteModel())
+
+            assertThat(report).contains("Background restricted: true")
+            assertThat(report).contains("Power save mode: true")
+            assertThat(report).contains("Data saver: false")
+        }
+
+    @Test
+    fun `given non Woo sites on the account, when the report is generated, then only stores are reported`() =
+        testBlocking {
+            siteStore.stub {
+                on { sites } doReturn listOf(
+                    wooSite("https://store.example.com"),
+                    SiteModel().apply { url = "https://personal-blog.example.com" }
+                )
+            }
+
+            val report = sut(SiteModel())
+
+            assertThat(report).contains("Connected stores: 1")
+            assertThat(report).contains("https://store.example.com")
+            assertThat(report).doesNotContain("personal-blog")
+        }
+
+    @Test
+    fun `given no push token, when the report is generated, then it is reported as missing`() = testBlocking {
+        appPrefs.stub { on { getFCMToken() } doReturn "" }
+
+        val report = sut(SiteModel())
+
+        assertThat(report).contains("Push token: missing")
+    }
+
+    @Test
+    fun `given no remote flag values, when the report is generated, then they are reported as not loaded`() =
+        testBlocking {
+            featureFlagRepository.stub {
+                on { getFlagState(any()) } doAnswer { invocation ->
+                    FeatureFlagState(
+                        flag = invocation.getArgument(0),
+                        localValue = false,
+                        remoteValue = null,
+                        overrideValue = null
+                    )
+                }
+            }
+
+            val report = sut(SiteModel())
+
+            assertThat(report).contains("Remote values loaded: false")
+            assertThat(report).contains("ai_support_chat: false (compiled-in default)")
+        }
 
     @Test
     fun `given the app was installed from Play, when the report is generated, then the installer is reported`() =
         testBlocking {
-            val report = providerWithInstaller { PLAY_STORE }(SiteModel())
+            val report = providerWithInstaller { PLAY_STORE }(SiteModel().apply { url = "https://example.com" })
 
             assertThat(report).contains("Install source: $PLAY_STORE")
         }
@@ -84,7 +220,7 @@ class MobileStatusProviderTest : BaseUnitTest() {
     @Test
     fun `given no installer of record, when the report is generated, then the app is reported as sideloaded`() =
         testBlocking {
-            val report = providerWithInstaller { null }(SiteModel())
+            val report = providerWithInstaller { null }(SiteModel().apply { url = "https://example.com" })
 
             assertThat(report).contains("Install source: sideloaded")
         }
@@ -92,7 +228,9 @@ class MobileStatusProviderTest : BaseUnitTest() {
     @Test
     fun `given the installer lookup fails, when the report is generated, then the source is unknown`() =
         testBlocking {
-            val report = providerWithInstaller { throw IllegalArgumentException("nope") }(SiteModel())
+            val report = providerWithInstaller { throw IllegalArgumentException("nope") }(
+                SiteModel().apply { url = "https://example.com" }
+            )
 
             assertThat(report).contains("Install source: unknown")
         }
@@ -110,21 +248,49 @@ class MobileStatusProviderTest : BaseUnitTest() {
         val packageManager = mock<PackageManager> {
             on { getInstallerPackageName(PACKAGE_NAME) } doAnswer { installer() }
         }
-        return MobileStatusProvider(
-            context = mock<Context> {
+        return providerWith(
+            mock<Context> {
                 on { this.packageManager } doReturn packageManager
                 on { packageName } doReturn PACKAGE_NAME
-            },
-            envDataSource = envDataSource,
-            deviceInfo = deviceInfo,
-            localeProvider = localeProvider
+            }
+        )
+    }
+
+    private fun providerWith(context: Context) = MobileStatusProvider(
+        context = context,
+        envDataSource = envDataSource,
+        deviceInfo = deviceInfo,
+        localeProvider = localeProvider,
+        featureFlagRepository = featureFlagRepository,
+        notificationSystemStatusProvider = notificationSystemStatusProvider,
+        notificationChannelsHandler = notificationChannelsHandler,
+        getBackgroundRestrictions = getBackgroundRestrictions,
+        deviceFeatures = deviceFeatures,
+        appPrefs = appPrefs,
+        accountStore = accountStore,
+        siteStore = siteStore
+    )
+
+    private fun wooSite(url: String = "") = SiteModel().apply {
+        hasWooCommerce = true
+        this.url = url
+        planShortName = "Business"
+        planId = 1008L
+    }
+
+    private fun stubRestrictions(
+        isDataSaverEnabled: Boolean = false,
+        isPowerSaveModeEnabled: Boolean = false,
+        isBackgroundRestricted: Boolean = false
+    ) = getBackgroundRestrictions.stub {
+        on { invoke() } doReturn BackgroundRestrictions(
+            isDataSaverEnabled = isDataSaverEnabled,
+            isPowerSaveModeEnabled = isPowerSaveModeEnabled,
+            isBackgroundRestricted = isBackgroundRestricted
         )
     }
 
     private companion object {
-        const val PLAY_STORE = "com.android.vending"
-        const val PACKAGE_NAME = "com.woocommerce.android"
-
         private val EXPECTED_REPORT = """
             ### Mobile Status Report generated via the WooCommerce Android app ###
 
@@ -145,6 +311,63 @@ class MobileStatusProviderTest : BaseUnitTest() {
             Network Type: WiFi
             Carrier: Test Carrier
             Country Code: GB
+
+            ## Notifications
+            Play Services: available
+            Permission granted: true
+            App notifications enabled: true
+            Disabled channels: REVIEW
+            New order sound: changed from the default
+            Push token: present (…klmnop)
+            Background restricted: false
+            Power save mode: false
+            Data saver: true
+
+            ## Account & Stores
+            WPCom user ID: 12345678
+            Connected stores: 3
+
+            All connected stores:
+            https://first.example.com: <Type: (Self-hosted + Jetpack) Plan: Business (1008)>
+            https://second.example.com: <Type: (Self-hosted + Jetpack) Plan: Business (1008)>
+            https://third.example.com: <Type: (Self-hosted + Jetpack) Plan: Business (1008)>
+
+            ## Feature Flags
+            Remote values loaded: true
+            age_eligibility_checks: true (remote)
+            ai_support_chat: true (remote)
+            better_customer_search_m2: true (remote)
+            logged_out_ff_panel: true (remote)
+            order_creation_auto_tax_rate: true (remote)
+            pos_products_fts: true (remote)
+            smarter_notifications: true (remote)
+            wc_shipping_banner: true (remote)
+            woo_app_passwords_for_jetpack_sites: true (remote)
+            woo_ipp_australia_woopayments: true (remote)
+            woo_ipp_country_expansion: true (remote)
+            woo_ipp_country_expansion_eu_extended: true (remote)
+            woo_mobile_ai_assistant: true (remote)
+            woo_notification_1d_after_free_trial_expires: true (remote)
+            woo_notification_1d_before_free_trial_expires: true (remote)
+            woo_notification_store_creation_ready: true (remote)
+            woo_pos_all_countries: true (remote)
+            woo_pos_local_catalog_m1: true (remote)
+            woo_pos_mark_order_as_complete: true (remote)
+            woo_pos_phone: true (remote)
+            woo_pos_refund_v4: true (remote)
+            woo_pos_scan_to_pay: true (remote)
+            woo_pos_tablet_promo_banner: true (remote)
+            woo_pos_tap_to_pay: true (remote)
+            woo_qr_code_login: true (remote)
+            woo_self_driven_push_notifications_m1: true (remote)
+
+            ## Experimental Features
+            Product add-ons: true
+            Jetpack app passwords: false
+            POS local catalog: true
         """.trimIndent().trim()
+
+        const val PLAY_STORE = "com.android.vending"
+        const val PACKAGE_NAME = "com.woocommerce.android"
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/support/ZendeskTicketRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/support/ZendeskTicketRepositoryTest.kt
@@ -58,7 +58,7 @@ internal class ZendeskTicketRepositoryTest : BaseUnitTest() {
     }
     private val isAppPasswordsSupportedForJetpackSite: IsAppPasswordsSupportedForJetpackSite = mock()
     private val mobileStatusProvider: MobileStatusProvider = mock {
-        on { invoke(anyOrNull()) } doReturn MSR_REPORT
+        on { invoke(anyOrNull(), anyOrNull()) } doReturn MSR_REPORT
     }
 
     @Before

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosIsLocalCatalogSupportedTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosIsLocalCatalogSupportedTest.kt
@@ -13,6 +13,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 @ExperimentalCoroutinesApi
@@ -36,8 +38,7 @@ class WooPosIsLocalCatalogSupportedTest : BaseUnitTest() {
 
         isLocalCatalogSupported = WooPosIsLocalCatalogSupported(
             wooPosLocalCatalogM1Enabled = featureFlagM1Enabled,
-            getWooVersion = getWooVersion,
-            fetchWooVersion = fetchWooVersion,
+            isFileBasedSyncSupported = WooPosIsFileBasedSyncSupported(getWooVersion, fetchWooVersion),
             posTabShouldBeVisible = posTabShouldBeVisible,
             posCanBeLaunchedInTab = posCanBeLaunchedInTab,
             wooPosLogWrapper = logger,
@@ -142,6 +143,64 @@ class WooPosIsLocalCatalogSupportedTest : BaseUnitTest() {
         val result = isLocalCatalogSupported()
 
         // THEN
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `given all conditions met, when asked as of last evaluation, then returns true`() {
+        val result = isLocalCatalogSupported.asOfLastEvaluation(tabVisible = true, launchable = true)
+
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `given feature flag disabled, when asked as of last evaluation, then returns false`() {
+        // GIVEN
+        whenever(featureFlagM1Enabled.invoke()).thenReturn(false)
+
+        // WHEN
+        val result = isLocalCatalogSupported.asOfLastEvaluation(tabVisible = true, launchable = true)
+
+        // THEN
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `given WC version below minimum, when asked as of last evaluation, then returns false`() {
+        // GIVEN
+        whenever(getWooVersion()).thenReturn("10.4.9")
+
+        // WHEN
+        val result = isLocalCatalogSupported.asOfLastEvaluation(tabVisible = true, launchable = true)
+
+        // THEN
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `given no cached WC version, when asked as of last evaluation, then it does not fetch one`() = testBlocking {
+        // GIVEN
+        whenever(getWooVersion()).thenReturn(null)
+
+        // WHEN
+        val result = isLocalCatalogSupported.asOfLastEvaluation(tabVisible = true, launchable = true)
+
+        // THEN
+        assertThat(result).isFalse()
+        verify(fetchWooVersion, never()).invoke()
+    }
+
+    @Test
+    fun `given POS tab not visible, when asked as of last evaluation, then returns false`() {
+        val result = isLocalCatalogSupported.asOfLastEvaluation(tabVisible = false, launchable = true)
+
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `given POS not launchable, when asked as of last evaluation, then returns false`() {
+        val result = isLocalCatalogSupported.asOfLastEvaluation(tabVisible = true, launchable = false)
+
         assertThat(result).isFalse()
     }
 }

--- a/libs/commons/src/main/java/com/woocommerce/android/tools/SiteConnectionType.kt
+++ b/libs/commons/src/main/java/com/woocommerce/android/tools/SiteConnectionType.kt
@@ -8,24 +8,34 @@ enum class SiteConnectionType {
     Jetpack, JetpackConnectionPackage, ApplicationPasswords
 }
 
-val SiteModel.connectionType
+/**
+ * The connection type, or `null` when the site does not fall into any of the known cases.
+ *
+ * Prefer this over [connectionType] when the value is going to be *reported* rather than acted on: [connectionType]
+ * has to return something, so in production it answers `Jetpack` for a site it could not classify, and a caller
+ * cannot tell that apart from a real Jetpack connection.
+ */
+val SiteModel.connectionTypeOrNull: SiteConnectionType?
     get() = when {
         origin != SiteModel.ORIGIN_WPCOM_REST -> SiteConnectionType.ApplicationPasswords
         isJetpackConnected -> SiteConnectionType.Jetpack
         isJetpackCPConnected -> SiteConnectionType.JetpackConnectionPackage
-        else -> {
-            if (BuildConfig.DEBUG) {
-                error("Can't determine site connection status")
-            } else {
-                WooLog.w(
-                    WooLog.T.UTILS,
-                    """Can't determine site connection status:
-                        "Origin: $origin, Jetpack Connected: $isJetpackConnected,
-                        "Jetpack CP Connected: $isJetpackCPConnected"""
-                )
-                // A site that doesn't fall into the above conditions, it shouldn't happen,
-                // but if it does in production, pretend it's a Jetpack connection
-                SiteConnectionType.Jetpack
-            }
+        else -> null
+    }
+
+val SiteModel.connectionType
+    get() = connectionTypeOrNull ?: run {
+        if (BuildConfig.DEBUG) {
+            error("Can't determine site connection status")
+        } else {
+            WooLog.w(
+                WooLog.T.UTILS,
+                """Can't determine site connection status:
+                    "Origin: $origin, Jetpack Connected: $isJetpackConnected,
+                    "Jetpack CP Connected: $isJetpackCPConnected"""
+            )
+            // A site that doesn't fall into the above conditions, it shouldn't happen,
+            // but if it does in production, pretend it's a Jetpack connection
+            SiteConnectionType.Jetpack
         }
     }

--- a/libs/commons/src/test/java/com/woocommerce/android/tools/SiteConnectionTypeTest.kt
+++ b/libs/commons/src/test/java/com/woocommerce/android/tools/SiteConnectionTypeTest.kt
@@ -1,0 +1,49 @@
+package com.woocommerce.android.tools
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.wordpress.android.fluxc.model.SiteModel
+
+class SiteConnectionTypeTest {
+    @Test
+    fun `given a site not from the WPCom REST origin, when the type is read, then it is application passwords`() {
+        val site = SiteModel().apply { origin = SiteModel.ORIGIN_WPAPI }
+
+        assertThat(site.connectionTypeOrNull).isEqualTo(SiteConnectionType.ApplicationPasswords)
+    }
+
+    @Test
+    fun `given a Jetpack connected site, when the type is read, then it is Jetpack`() {
+        val site = SiteModel().apply {
+            origin = SiteModel.ORIGIN_WPCOM_REST
+            setIsJetpackConnected(true)
+        }
+
+        assertThat(site.connectionTypeOrNull).isEqualTo(SiteConnectionType.Jetpack)
+    }
+
+    @Test
+    fun `given a Jetpack CP connected site, when the type is read, then it is the connection package`() {
+        val site = SiteModel().apply {
+            origin = SiteModel.ORIGIN_WPCOM_REST
+            setIsJetpackCPConnected(true)
+        }
+
+        assertThat(site.connectionTypeOrNull).isEqualTo(SiteConnectionType.JetpackConnectionPackage)
+    }
+
+    /**
+     * The case `connectionType` cannot express: it has to return a value, so in production it answers `Jetpack`
+     * here, which a caller reporting the value would pass off as a real Jetpack connection.
+     */
+    @Test
+    fun `given a site matching no known case, when the nullable type is read, then it is null`() {
+        val site = SiteModel().apply {
+            origin = SiteModel.ORIGIN_WPCOM_REST
+            setIsJetpackConnected(false)
+            setIsJetpackCPConnected(false)
+        }
+
+        assertThat(site.connectionTypeOrNull).isNull()
+    }
+}


### PR DESCRIPTION
### Description

Fixes WOOMOB-3704

Stacked on #16325, which adds the MSR itself with the App / Device / Connectivity sections. This PR adds more sections. 

Every heading states whether its values are app-wide or belong to the selected store, and store-scoped headings name the store, since a merchant with several stores gets one report covering all of them.

- **Notifications** (app-wide) — Play Services, permission, disabled channels, new-order sound status, FCM token (redacted), and background/power-save/data-saver restrictions. `GetBackgroundRestrictions` is extracted out of `BackgroundUpdatesDisabled`, which already computed those values and threw them away; analytics behaviour is unchanged.
- **Account & Stores** (app-wide) — WPCom user, the store count, and every connected site.
- **Store Details** (selected store) — Blog ID, Store ID, auth method, Jetpack state, plan, Woo version and push registration. The first two fail in opposite conditions: `blog_id` is `0` for every application-password site, which is exactly the population filing login tickets, while `store_id` is absent until the first successful `system_status` fetch.
- **Payments** (selected store) — WooPayments/Stripe install state from the plugin cache, plus the plugin actually driving in-person payments (`getCardReaderPreferredPlugin`), which is not derivable from install state when both are present.
- **Point of Sale** (selected store) — tab visible / launchable, and local-catalog sync timestamps. When a flag is false the report points at `application_log.txt` for the reason rather than recomputing it, because the use cases that determine it write those prefs as a side effect.
- **Feature flags and beta toggles** (app-wide) — every flag with its effective value and where that value came from: remote, compiled-in default, or debug override. An "enabled" list would be ambiguous between disabled, renamed and deleted, and the value alone doesn't say whether a rollout reached the device.

### Test Steps

Run tests on the last PR in this chain.

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
