### PR TITLE
[WOOMOB-3636] Don't show the new order notification for card reader and POS payments

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NewOrderNotificationSuppressionCache.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NewOrderNotificationSuppressionCache.kt
@@ -31,10 +31,12 @@ class NewOrderNotificationSuppressionCache @Inject constructor() {
 
     /**
      * For payments confirmed on this device where the backend decides the resulting status,
-     * which is always a notifiable one.
+     * which is always a notifiable one, so only the previous status decides.
      */
-    fun onOrderPaidRemotely(siteId: Long, orderId: Long) {
-        entries += Entry(siteId, orderId)
+    fun onOrderPaidRemotely(siteId: Long, orderId: Long, previousStatusKey: String?) {
+        if (previousStatusKey !in NOTIFIABLE_STATUSES) {
+            entries += Entry(siteId, orderId)
+        }
     }
 
     fun consume(siteId: Long, orderId: Long): Boolean = entries.remove(Entry(siteId, orderId))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NewOrderNotificationSuppressionCache.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NewOrderNotificationSuppressionCache.kt
@@ -19,6 +19,14 @@ class NewOrderNotificationSuppressionCache @Inject constructor() {
         }
     }
 
+    /**
+     * For payments confirmed on this device where the backend decides the resulting status,
+     * which is always a notifiable one.
+     */
+    fun onOrderPaidRemotely(siteId: Long, orderId: Long) {
+        entries += Entry(siteId, orderId)
+    }
+
     fun consume(siteId: Long, orderId: Long): Boolean = entries.remove(Entry(siteId, orderId))
 
     private data class Entry(val siteId: Long, val orderId: Long)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentViewModel.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.cardreader.payments.PaymentData
 import com.woocommerce.android.di.StoreManagementMode
+import com.woocommerce.android.notifications.push.MarkedAsPaidOrdersCache
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboardingChecker
@@ -56,6 +57,7 @@ class CardReaderPaymentViewModel @Inject constructor(
     cardReaderOnboardingChecker: CardReaderOnboardingChecker,
     paymentReceiptShare: PaymentReceiptShare,
     paymentStateMapper: CardReaderPaymentStateToViewStateMapper,
+    markedAsPaidOrdersCache: MarkedAsPaidOrdersCache,
 ) : ScopedViewModel(savedState) {
     private val arguments: CardReaderPaymentDialogFragmentArgs by savedState.navArgs()
 
@@ -85,6 +87,7 @@ class CardReaderPaymentViewModel @Inject constructor(
         paymentReceiptHelper = paymentReceiptHelper,
         cardReaderOnboardingChecker = cardReaderOnboardingChecker,
         paymentReceiptShare = paymentReceiptShare,
+        markedAsPaidOrdersCache = markedAsPaidOrdersCache,
         paymentOrRefund = arguments.paymentOrRefund,
         cardReaderType = arguments.cardReaderType,
         isTTPPaymentInProgress = ::isTTPPaymentInProgress,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentViewModel.kt
@@ -9,7 +9,7 @@ import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.cardreader.payments.PaymentData
 import com.woocommerce.android.di.StoreManagementMode
-import com.woocommerce.android.notifications.push.MarkedAsPaidOrdersCache
+import com.woocommerce.android.notifications.push.NewOrderNotificationSuppressionCache
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboardingChecker
@@ -57,7 +57,7 @@ class CardReaderPaymentViewModel @Inject constructor(
     cardReaderOnboardingChecker: CardReaderOnboardingChecker,
     paymentReceiptShare: PaymentReceiptShare,
     paymentStateMapper: CardReaderPaymentStateToViewStateMapper,
-    markedAsPaidOrdersCache: MarkedAsPaidOrdersCache,
+    newOrderNotificationSuppressionCache: NewOrderNotificationSuppressionCache,
 ) : ScopedViewModel(savedState) {
     private val arguments: CardReaderPaymentDialogFragmentArgs by savedState.navArgs()
 
@@ -87,7 +87,7 @@ class CardReaderPaymentViewModel @Inject constructor(
         paymentReceiptHelper = paymentReceiptHelper,
         cardReaderOnboardingChecker = cardReaderOnboardingChecker,
         paymentReceiptShare = paymentReceiptShare,
-        markedAsPaidOrdersCache = markedAsPaidOrdersCache,
+        newOrderNotificationSuppressionCache = newOrderNotificationSuppressionCache,
         paymentOrRefund = arguments.paymentOrRefund,
         cardReaderType = arguments.cardReaderType,
         isTTPPaymentInProgress = ::isTTPPaymentInProgress,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentController.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentController.kt
@@ -85,7 +85,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import kotlin.reflect.KMutableProperty0
 
@@ -469,10 +468,9 @@ class CardReaderPaymentController(
     ) {
         paymentReceiptHelper.storeReceiptUrl(orderId, paymentStatus.receiptUrl)
         appPrefs.setCardReaderSuccessfulPaymentTime()
-        newOrderNotificationSuppressionCache.onOrderMovedToPaidStatus(
+        newOrderNotificationSuppressionCache.onOrderPaidRemotely(
             siteId = selectedSite.get().siteId,
             orderId = orderId,
-            newStatusKey = CoreOrderStatus.PROCESSING.value,
         )
 
         triggerEvent(CardReaderPaymentEvent.PlaySuccessfulPaymentSound)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentController.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentController.kt
@@ -42,7 +42,7 @@ import com.woocommerce.android.cardreader.payments.RefundConfig
 import com.woocommerce.android.cardreader.payments.RefundParams
 import com.woocommerce.android.cardreader.payments.StatementDescriptor
 import com.woocommerce.android.model.Order
-import com.woocommerce.android.notifications.push.MarkedAsPaidOrdersCache
+import com.woocommerce.android.notifications.push.NewOrderNotificationSuppressionCache
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam
@@ -112,7 +112,7 @@ class CardReaderPaymentController(
     private val paymentReceiptHelper: PaymentReceiptHelper,
     private val cardReaderOnboardingChecker: CardReaderOnboardingChecker,
     private val paymentReceiptShare: PaymentReceiptShare,
-    private val markedAsPaidOrdersCache: MarkedAsPaidOrdersCache,
+    private val newOrderNotificationSuppressionCache: NewOrderNotificationSuppressionCache,
     private val paymentOrRefund: CardReaderFlowParam.PaymentOrRefund,
     private val cardReaderType: CardReaderType,
     private val isTTPPaymentInProgress: KMutableProperty0<Boolean>,
@@ -469,7 +469,7 @@ class CardReaderPaymentController(
     ) {
         paymentReceiptHelper.storeReceiptUrl(orderId, paymentStatus.receiptUrl)
         appPrefs.setCardReaderSuccessfulPaymentTime()
-        markedAsPaidOrdersCache.onOrderMovedToPaidStatus(
+        newOrderNotificationSuppressionCache.onOrderMovedToPaidStatus(
             siteId = selectedSite.get().siteId,
             orderId = orderId,
             newStatusKey = CoreOrderStatus.PROCESSING.value,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentController.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentController.kt
@@ -42,6 +42,7 @@ import com.woocommerce.android.cardreader.payments.RefundConfig
 import com.woocommerce.android.cardreader.payments.RefundParams
 import com.woocommerce.android.cardreader.payments.StatementDescriptor
 import com.woocommerce.android.model.Order
+import com.woocommerce.android.notifications.push.MarkedAsPaidOrdersCache
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam
@@ -84,6 +85,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import kotlin.reflect.KMutableProperty0
 
@@ -110,6 +112,7 @@ class CardReaderPaymentController(
     private val paymentReceiptHelper: PaymentReceiptHelper,
     private val cardReaderOnboardingChecker: CardReaderOnboardingChecker,
     private val paymentReceiptShare: PaymentReceiptShare,
+    private val markedAsPaidOrdersCache: MarkedAsPaidOrdersCache,
     private val paymentOrRefund: CardReaderFlowParam.PaymentOrRefund,
     private val cardReaderType: CardReaderType,
     private val isTTPPaymentInProgress: KMutableProperty0<Boolean>,
@@ -466,6 +469,11 @@ class CardReaderPaymentController(
     ) {
         paymentReceiptHelper.storeReceiptUrl(orderId, paymentStatus.receiptUrl)
         appPrefs.setCardReaderSuccessfulPaymentTime()
+        markedAsPaidOrdersCache.onOrderMovedToPaidStatus(
+            siteId = selectedSite.get().siteId,
+            orderId = orderId,
+            newStatusKey = CoreOrderStatus.PROCESSING.value,
+        )
 
         triggerEvent(CardReaderPaymentEvent.PlaySuccessfulPaymentSound)
         showPaymentSuccessfulState()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentController.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentController.kt
@@ -264,8 +264,9 @@ class CardReaderPaymentController(
         paymentFlowJob = scope.launch {
             _paymentState.value = CardReaderPaymentState.LoadingData(::onCancelPaymentFlow)
             delay(ARTIFICIAL_RETRY_DELAY)
+            val previousStatusKey = orderRepository.getOrderById(orderId)?.status?.value
             cardReaderManager.retryCollectPayment(orderId, paymentData).collect { paymentStatus ->
-                onPaymentStatusChanged(orderId, billingEmail, paymentStatus, amountLabel)
+                onPaymentStatusChanged(orderId, previousStatusKey, billingEmail, paymentStatus, amountLabel)
             }
         }
     }
@@ -313,6 +314,7 @@ class CardReaderPaymentController(
         ).collect { paymentStatus ->
             onPaymentStatusChanged(
                 order.id,
+                order.status.value,
                 customerEmail,
                 paymentStatus,
                 cardReaderPaymentOrderHelper.getAmountLabel(order)
@@ -323,6 +325,7 @@ class CardReaderPaymentController(
     @Suppress("LongMethod")
     private fun onPaymentStatusChanged(
         orderId: Long,
+        previousStatusKey: String?,
         billingEmail: String,
         paymentStatus: CardPaymentStatus,
         amountLabel: String
@@ -360,7 +363,7 @@ class CardReaderPaymentController(
 
             is PaymentCompleted -> {
                 tracker.trackPaymentSucceeded()
-                onPaymentCompleted(paymentStatus, orderId)
+                onPaymentCompleted(paymentStatus, orderId, previousStatusKey)
             }
 
             WaitingForInput -> {
@@ -465,12 +468,14 @@ class CardReaderPaymentController(
     private fun onPaymentCompleted(
         paymentStatus: PaymentCompleted,
         orderId: Long,
+        previousStatusKey: String?,
     ) {
         paymentReceiptHelper.storeReceiptUrl(orderId, paymentStatus.receiptUrl)
         appPrefs.setCardReaderSuccessfulPaymentTime()
         newOrderNotificationSuppressionCache.onOrderPaidRemotely(
             siteId = selectedSite.get().siteId,
             orderId = orderId,
+            previousStatusKey = previousStatusKey,
         )
 
         triggerEvent(CardReaderPaymentEvent.PlaySuccessfulPaymentSound)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cashpayment/WooPosCashPaymentRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cashpayment/WooPosCashPaymentRepository.kt
@@ -50,6 +50,8 @@ class WooPosCashPaymentRepository @Inject constructor(
             label = Order.Status.Completed.value
         )
 
+        val previousStatusKey = orderStore.getOrderByIdAndSite(orderId, selectedSite.get())?.status
+
         orderStore.updateOrderStatusAndPaymentDetails(
             orderId = orderId,
             site = selectedSite.get(),
@@ -64,9 +66,10 @@ class WooPosCashPaymentRepository @Inject constructor(
                     WooLog.e(T.POS, "Order completion failed - ${result.event.error.message}")
                     Result.failure(Exception(result.event.error.message))
                 } else {
-                    newOrderNotificationSuppressionCache.onOrderMovedToPaidStatus(
+                    newOrderNotificationSuppressionCache.recordOrderStatusChanged(
                         siteId = selectedSite.get().siteId,
                         orderId = orderId,
+                        previousStatusKey = previousStatusKey,
                         newStatusKey = Order.Status.Completed.value,
                     )
                     Result.success(Unit)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cashpayment/WooPosCashPaymentRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cashpayment/WooPosCashPaymentRepository.kt
@@ -66,7 +66,7 @@ class WooPosCashPaymentRepository @Inject constructor(
                     WooLog.e(T.POS, "Order completion failed - ${result.event.error.message}")
                     Result.failure(Exception(result.event.error.message))
                 } else {
-                    newOrderNotificationSuppressionCache.recordOrderStatusChanged(
+                    newOrderNotificationSuppressionCache.onOrderStatusChanged(
                         siteId = selectedSite.get().siteId,
                         orderId = orderId,
                         previousStatusKey = previousStatusKey,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cashpayment/WooPosCashPaymentRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cashpayment/WooPosCashPaymentRepository.kt
@@ -2,7 +2,7 @@ package com.woocommerce.android.ui.woopos.cashpayment
 
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.OrderMapper
-import com.woocommerce.android.notifications.push.MarkedAsPaidOrdersCache
+import com.woocommerce.android.notifications.push.NewOrderNotificationSuppressionCache
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.products.models.CurrencyFormattingParameters
 import com.woocommerce.android.ui.products.models.SiteParameters
@@ -26,7 +26,7 @@ class WooPosCashPaymentRepository @Inject constructor(
     private val orderStore: WCOrderStore,
     private val orderMapper: OrderMapper,
     private val gatewayStore: WCGatewayStore,
-    private val markedAsPaidOrdersCache: MarkedAsPaidOrdersCache,
+    private val newOrderNotificationSuppressionCache: NewOrderNotificationSuppressionCache,
 ) {
 
     private var cachedParameters: SiteParameters? = null
@@ -64,7 +64,7 @@ class WooPosCashPaymentRepository @Inject constructor(
                     WooLog.e(T.POS, "Order completion failed - ${result.event.error.message}")
                     Result.failure(Exception(result.event.error.message))
                 } else {
-                    markedAsPaidOrdersCache.onOrderMovedToPaidStatus(
+                    newOrderNotificationSuppressionCache.onOrderMovedToPaidStatus(
                         siteId = selectedSite.get().siteId,
                         orderId = orderId,
                         newStatusKey = Order.Status.Completed.value,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cashpayment/WooPosCashPaymentRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cashpayment/WooPosCashPaymentRepository.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.woopos.cashpayment
 
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.OrderMapper
+import com.woocommerce.android.notifications.push.MarkedAsPaidOrdersCache
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.products.models.CurrencyFormattingParameters
 import com.woocommerce.android.ui.products.models.SiteParameters
@@ -25,6 +26,7 @@ class WooPosCashPaymentRepository @Inject constructor(
     private val orderStore: WCOrderStore,
     private val orderMapper: OrderMapper,
     private val gatewayStore: WCGatewayStore,
+    private val markedAsPaidOrdersCache: MarkedAsPaidOrdersCache,
 ) {
 
     private var cachedParameters: SiteParameters? = null
@@ -62,6 +64,11 @@ class WooPosCashPaymentRepository @Inject constructor(
                     WooLog.e(T.POS, "Order completion failed - ${result.event.error.message}")
                     Result.failure(Exception(result.event.error.message))
                 } else {
+                    markedAsPaidOrdersCache.onOrderMovedToPaidStatus(
+                        siteId = selectedSite.get().siteId,
+                        orderId = orderId,
+                        newStatusKey = Order.Status.Completed.value,
+                    )
                     Result.success(Unit)
                 }
             }.first()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosCardReaderPaymentControllerFactory.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosCardReaderPaymentControllerFactory.kt
@@ -3,7 +3,7 @@ package com.woocommerce.android.ui.woopos.home.totals
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.di.PointOfSaleMode
-import com.woocommerce.android.notifications.push.MarkedAsPaidOrdersCache
+import com.woocommerce.android.notifications.push.NewOrderNotificationSuppressionCache
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam.PaymentOrRefund
@@ -49,7 +49,7 @@ class WooPosCardReaderPaymentControllerFactory @Inject constructor(
     private val paymentReceiptHelper: PaymentReceiptHelper,
     private val cardReaderOnboardingChecker: CardReaderOnboardingChecker,
     private val paymentReceiptShare: PaymentReceiptShare,
-    private val markedAsPaidOrdersCache: MarkedAsPaidOrdersCache,
+    private val newOrderNotificationSuppressionCache: NewOrderNotificationSuppressionCache,
 ) {
     fun create(
         orderId: Long,
@@ -76,7 +76,7 @@ class WooPosCardReaderPaymentControllerFactory @Inject constructor(
         paymentReceiptHelper = paymentReceiptHelper,
         cardReaderOnboardingChecker = cardReaderOnboardingChecker,
         paymentReceiptShare = paymentReceiptShare,
-        markedAsPaidOrdersCache = markedAsPaidOrdersCache,
+        newOrderNotificationSuppressionCache = newOrderNotificationSuppressionCache,
         paymentOrRefund = PaymentOrRefund.Payment(
             orderId = orderId,
             paymentType = paymentType
@@ -109,7 +109,7 @@ class WooPosCardReaderPaymentControllerFactory @Inject constructor(
         paymentReceiptHelper = paymentReceiptHelper,
         cardReaderOnboardingChecker = cardReaderOnboardingChecker,
         paymentReceiptShare = paymentReceiptShare,
-        markedAsPaidOrdersCache = markedAsPaidOrdersCache,
+        newOrderNotificationSuppressionCache = newOrderNotificationSuppressionCache,
         paymentOrRefund = PaymentOrRefund.Refund(
             orderId = orderId,
             refundAmount = refundAmount

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosCardReaderPaymentControllerFactory.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosCardReaderPaymentControllerFactory.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.woopos.home.totals
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.di.PointOfSaleMode
+import com.woocommerce.android.notifications.push.MarkedAsPaidOrdersCache
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam.PaymentOrRefund
@@ -48,6 +49,7 @@ class WooPosCardReaderPaymentControllerFactory @Inject constructor(
     private val paymentReceiptHelper: PaymentReceiptHelper,
     private val cardReaderOnboardingChecker: CardReaderOnboardingChecker,
     private val paymentReceiptShare: PaymentReceiptShare,
+    private val markedAsPaidOrdersCache: MarkedAsPaidOrdersCache,
 ) {
     fun create(
         orderId: Long,
@@ -74,6 +76,7 @@ class WooPosCardReaderPaymentControllerFactory @Inject constructor(
         paymentReceiptHelper = paymentReceiptHelper,
         cardReaderOnboardingChecker = cardReaderOnboardingChecker,
         paymentReceiptShare = paymentReceiptShare,
+        markedAsPaidOrdersCache = markedAsPaidOrdersCache,
         paymentOrRefund = PaymentOrRefund.Payment(
             orderId = orderId,
             paymentType = paymentType
@@ -106,6 +109,7 @@ class WooPosCardReaderPaymentControllerFactory @Inject constructor(
         paymentReceiptHelper = paymentReceiptHelper,
         cardReaderOnboardingChecker = cardReaderOnboardingChecker,
         paymentReceiptShare = paymentReceiptShare,
+        markedAsPaidOrdersCache = markedAsPaidOrdersCache,
         paymentOrRefund = PaymentOrRefund.Refund(
             orderId = orderId,
             refundAmount = refundAmount

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/markorderascomplete/WooPosMarkOrderAsCompleteRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/markorderascomplete/WooPosMarkOrderAsCompleteRepository.kt
@@ -2,7 +2,7 @@ package com.woocommerce.android.ui.woopos.markorderascomplete
 
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.OrderMapper
-import com.woocommerce.android.notifications.push.MarkedAsPaidOrdersCache
+import com.woocommerce.android.notifications.push.NewOrderNotificationSuppressionCache
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T
@@ -18,7 +18,7 @@ class WooPosMarkOrderAsCompleteRepository @Inject constructor(
     private val selectedSite: SelectedSite,
     private val orderStore: WCOrderStore,
     private val orderMapper: OrderMapper,
-    private val markedAsPaidOrdersCache: MarkedAsPaidOrdersCache,
+    private val newOrderNotificationSuppressionCache: NewOrderNotificationSuppressionCache,
 ) {
     suspend fun getOrderById(orderId: Long): Order? = withContext(Dispatchers.IO) {
         orderStore.getOrderByIdAndSite(orderId, selectedSite.get())?.let { orderMapper.toAppModel(it) }
@@ -51,7 +51,7 @@ class WooPosMarkOrderAsCompleteRepository @Inject constructor(
             return@withContext MarkOrderAsCompleteOutcome.Failure
         }
 
-        markedAsPaidOrdersCache.onOrderMovedToPaidStatus(
+        newOrderNotificationSuppressionCache.onOrderMovedToPaidStatus(
             siteId = selectedSite.get().siteId,
             orderId = orderId,
             newStatusKey = Order.Status.Completed.value,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/markorderascomplete/WooPosMarkOrderAsCompleteRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/markorderascomplete/WooPosMarkOrderAsCompleteRepository.kt
@@ -53,7 +53,7 @@ class WooPosMarkOrderAsCompleteRepository @Inject constructor(
             return@withContext MarkOrderAsCompleteOutcome.Failure
         }
 
-        newOrderNotificationSuppressionCache.recordOrderStatusChanged(
+        newOrderNotificationSuppressionCache.onOrderStatusChanged(
             siteId = selectedSite.get().siteId,
             orderId = orderId,
             previousStatusKey = previousStatusKey,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/markorderascomplete/WooPosMarkOrderAsCompleteRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/markorderascomplete/WooPosMarkOrderAsCompleteRepository.kt
@@ -36,6 +36,8 @@ class WooPosMarkOrderAsCompleteRepository @Inject constructor(
             label = Order.Status.Completed.value,
         )
 
+        val previousStatusKey = orderStore.getOrderByIdAndSite(orderId, selectedSite.get())?.status
+
         val updateResult = orderStore.updateOrderStatusAndPaymentDetails(
             orderId = orderId,
             site = selectedSite.get(),
@@ -51,9 +53,10 @@ class WooPosMarkOrderAsCompleteRepository @Inject constructor(
             return@withContext MarkOrderAsCompleteOutcome.Failure
         }
 
-        newOrderNotificationSuppressionCache.onOrderMovedToPaidStatus(
+        newOrderNotificationSuppressionCache.recordOrderStatusChanged(
             siteId = selectedSite.get().siteId,
             orderId = orderId,
+            previousStatusKey = previousStatusKey,
             newStatusKey = Order.Status.Completed.value,
         )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/markorderascomplete/WooPosMarkOrderAsCompleteRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/markorderascomplete/WooPosMarkOrderAsCompleteRepository.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.woopos.markorderascomplete
 
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.OrderMapper
+import com.woocommerce.android.notifications.push.MarkedAsPaidOrdersCache
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T
@@ -17,6 +18,7 @@ class WooPosMarkOrderAsCompleteRepository @Inject constructor(
     private val selectedSite: SelectedSite,
     private val orderStore: WCOrderStore,
     private val orderMapper: OrderMapper,
+    private val markedAsPaidOrdersCache: MarkedAsPaidOrdersCache,
 ) {
     suspend fun getOrderById(orderId: Long): Order? = withContext(Dispatchers.IO) {
         orderStore.getOrderByIdAndSite(orderId, selectedSite.get())?.let { orderMapper.toAppModel(it) }
@@ -48,6 +50,12 @@ class WooPosMarkOrderAsCompleteRepository @Inject constructor(
             WooLog.e(T.POS, "Mark order as complete failed - ${updateResult.event.error.message}")
             return@withContext MarkOrderAsCompleteOutcome.Failure
         }
+
+        markedAsPaidOrdersCache.onOrderMovedToPaidStatus(
+            siteId = selectedSite.get().siteId,
+            orderId = orderId,
+            newStatusKey = Order.Status.Completed.value,
+        )
 
         val trimmedNote = customerNote?.takeIf { it.isNotBlank() }
             ?: return@withContext MarkOrderAsCompleteOutcome.Success

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/NewOrderNotificationSuppressionCacheTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/NewOrderNotificationSuppressionCacheTest.kt
@@ -65,6 +65,24 @@ class NewOrderNotificationSuppressionCacheTest {
     }
 
     @Test
+    fun `given an order in a non notifiable status, when it is paid remotely, then the entry is recorded`() {
+        // GIVEN
+        cache.onOrderPaidRemotely(SITE_ID, ORDER_ID, previousStatusKey = "pending")
+
+        // THEN
+        assertThat(cache.consume(SITE_ID, ORDER_ID)).isTrue()
+    }
+
+    @Test
+    fun `given an order already in a notifiable status, when it is paid remotely, then nothing is recorded`() {
+        // GIVEN
+        cache.onOrderPaidRemotely(SITE_ID, ORDER_ID, previousStatusKey = "on-hold")
+
+        // THEN
+        assertThat(cache.consume(SITE_ID, ORDER_ID)).isFalse()
+    }
+
+    @Test
     fun `when every notifiable status is recorded, then each one produces an entry`() {
         val notifiableStatuses = listOf(
             "processing",

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderPaymentViewModelTest.kt
@@ -204,6 +204,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
             paymentReceiptShare = paymentReceiptShare,
             paymentStateProvider = paymentStateProvider,
             paymentStateMapper = paymentStateMapper,
+            markedAsPaidOrdersCache = mock(),
         )
 
         whenever(orderRepository.getOrderById(any())).thenReturn(mockedOrder)
@@ -2699,6 +2700,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
             paymentReceiptShare = paymentReceiptShare,
             paymentStateProvider = paymentStateProvider,
             paymentStateMapper = paymentStateMapper,
+            markedAsPaidOrdersCache = mock(),
         )
         viewModel.event.observeForever {}
         viewModel.viewStateData.observeForever {}
@@ -2737,6 +2739,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
             paymentReceiptShare = paymentReceiptShare,
             paymentStateProvider = paymentStateProvider,
             paymentStateMapper = paymentStateMapper,
+            markedAsPaidOrdersCache = mock(),
         )
         viewModel.event.observeForever {}
         viewModel.viewStateData.observeForever {}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderPaymentViewModelTest.kt
@@ -219,6 +219,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
         whenever(mockedOrder.orderKey).thenReturn("wc_order_j0LMK3bFhalEL")
         whenever(mockedOrder.id).thenReturn(ORDER_ID)
         whenever(mockedOrder.chargeId).thenReturn("chargeId")
+        whenever(mockedOrder.status).thenReturn(Order.Status.Pending)
         whenever(orderRepository.fetchOrderById(ORDER_ID)).thenReturn(mockedOrder)
         whenever(cardReaderManager.readerStatus).thenReturn(MutableStateFlow(CardReaderStatus.Connected(mock())))
         whenever(cardReaderManager.collectPayment(any())).thenAnswer {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderPaymentViewModelTest.kt
@@ -204,7 +204,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
             paymentReceiptShare = paymentReceiptShare,
             paymentStateProvider = paymentStateProvider,
             paymentStateMapper = paymentStateMapper,
-            markedAsPaidOrdersCache = mock(),
+            newOrderNotificationSuppressionCache = mock(),
         )
 
         whenever(orderRepository.getOrderById(any())).thenReturn(mockedOrder)
@@ -2700,7 +2700,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
             paymentReceiptShare = paymentReceiptShare,
             paymentStateProvider = paymentStateProvider,
             paymentStateMapper = paymentStateMapper,
-            markedAsPaidOrdersCache = mock(),
+            newOrderNotificationSuppressionCache = mock(),
         )
         viewModel.event.observeForever {}
         viewModel.viewStateData.observeForever {}
@@ -2739,7 +2739,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
             paymentReceiptShare = paymentReceiptShare,
             paymentStateProvider = paymentStateProvider,
             paymentStateMapper = paymentStateMapper,
-            markedAsPaidOrdersCache = mock(),
+            newOrderNotificationSuppressionCache = mock(),
         )
         viewModel.event.observeForever {}
         viewModel.viewStateData.observeForever {}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentControllerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentControllerTest.kt
@@ -103,7 +103,6 @@ import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import java.math.BigDecimal
 import kotlin.reflect.KMutableProperty0
@@ -1409,10 +1408,9 @@ class CardReaderPaymentControllerTest : BaseUnitTest() {
 
             controller.start()
 
-            verify(newOrderNotificationSuppressionCache).onOrderMovedToPaidStatus(
+            verify(newOrderNotificationSuppressionCache).onOrderPaidRemotely(
                 siteId = eq(siteModel.siteId),
                 orderId = eq(ORDER_ID),
-                newStatusKey = eq(CoreOrderStatus.PROCESSING.value),
             )
         }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentControllerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentControllerTest.kt
@@ -162,6 +162,7 @@ class CardReaderPaymentControllerTest : BaseUnitTest() {
         whenever(mockedAddress.lastName).thenReturn("Test")
         whenever(mockedOrder.orderKey).thenReturn("wc_order_j0LMK3bFhalEL")
         whenever(mockedOrder.id).thenReturn(ORDER_ID)
+        whenever(mockedOrder.status).thenReturn(Order.Status.Pending)
 
         whenever(paymentCollectibilityChecker.isCollectable(any(), any())).thenReturn(true)
         whenever(selectedSite.get()).thenReturn(siteModel)
@@ -1411,6 +1412,24 @@ class CardReaderPaymentControllerTest : BaseUnitTest() {
             verify(newOrderNotificationSuppressionCache).onOrderPaidRemotely(
                 siteId = eq(siteModel.siteId),
                 orderId = eq(ORDER_ID),
+                previousStatusKey = eq(Order.Status.Pending.value),
+            )
+        }
+
+    @Test
+    fun `given an order already in a notifiable status, when payment succeeds, then the previous status is passed`() =
+        testBlocking {
+            whenever(mockedOrder.status).thenReturn(Order.Status.OnHold)
+            whenever(cardReaderManager.collectPayment(any())).thenAnswer {
+                flow { emit(PaymentCompleted("testUrl")) }
+            }
+
+            controller.start()
+
+            verify(newOrderNotificationSuppressionCache).onOrderPaidRemotely(
+                siteId = eq(siteModel.siteId),
+                orderId = eq(ORDER_ID),
+                previousStatusKey = eq(Order.Status.OnHold.value),
             )
         }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentControllerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentControllerTest.kt
@@ -38,7 +38,7 @@ import com.woocommerce.android.cardreader.payments.RefundParams
 import com.woocommerce.android.model.Address
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.UiString.UiStringText
-import com.woocommerce.android.notifications.push.MarkedAsPaidOrdersCache
+import com.woocommerce.android.notifications.push.NewOrderNotificationSuppressionCache
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam.PaymentOrRefund
@@ -133,7 +133,7 @@ class CardReaderPaymentControllerTest : BaseUnitTest() {
     private val paymentReceiptHelper: PaymentReceiptHelper = mock()
     private val cardReaderOnboardingChecker: CardReaderOnboardingChecker = mock()
     private val paymentReceiptShare: PaymentReceiptShare = mock()
-    private val markedAsPaidOrdersCache: MarkedAsPaidOrdersCache = mock()
+    private val newOrderNotificationSuppressionCache: NewOrderNotificationSuppressionCache = mock()
 
     private var isTTPinProgress = false
     private val isTTPinProgressProp: KMutableProperty0<Boolean> = ::isTTPinProgress
@@ -226,7 +226,7 @@ class CardReaderPaymentControllerTest : BaseUnitTest() {
             paymentReceiptHelper = paymentReceiptHelper,
             cardReaderOnboardingChecker = cardReaderOnboardingChecker,
             paymentReceiptShare = paymentReceiptShare,
-            markedAsPaidOrdersCache = markedAsPaidOrdersCache,
+            newOrderNotificationSuppressionCache = newOrderNotificationSuppressionCache,
             paymentOrRefund = cardReaderFlowParam,
             cardReaderType = cardReaderType,
             isTTPPaymentInProgress = isTTPinProgressProp,
@@ -1409,7 +1409,7 @@ class CardReaderPaymentControllerTest : BaseUnitTest() {
 
             controller.start()
 
-            verify(markedAsPaidOrdersCache).onOrderMovedToPaidStatus(
+            verify(newOrderNotificationSuppressionCache).onOrderMovedToPaidStatus(
                 siteId = eq(siteModel.siteId),
                 orderId = eq(ORDER_ID),
                 newStatusKey = eq(CoreOrderStatus.PROCESSING.value),
@@ -1427,7 +1427,7 @@ class CardReaderPaymentControllerTest : BaseUnitTest() {
 
             controller.start()
 
-            verifyNoInteractions(markedAsPaidOrdersCache)
+            verifyNoInteractions(newOrderNotificationSuppressionCache)
         }
 
     @Test
@@ -3898,7 +3898,7 @@ class CardReaderPaymentControllerTest : BaseUnitTest() {
             paymentReceiptHelper = paymentReceiptHelper,
             cardReaderOnboardingChecker = cardReaderOnboardingChecker,
             paymentReceiptShare = paymentReceiptShare,
-            markedAsPaidOrdersCache = markedAsPaidOrdersCache,
+            newOrderNotificationSuppressionCache = newOrderNotificationSuppressionCache,
             paymentOrRefund = param,
             cardReaderType = CardReaderType.EXTERNAL,
             isTTPPaymentInProgress = isTTPinProgressProp,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentControllerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentControllerTest.kt
@@ -38,6 +38,7 @@ import com.woocommerce.android.cardreader.payments.RefundParams
 import com.woocommerce.android.model.Address
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.UiString.UiStringText
+import com.woocommerce.android.notifications.push.MarkedAsPaidOrdersCache
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam.PaymentOrRefund
@@ -98,9 +99,11 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import java.math.BigDecimal
 import kotlin.reflect.KMutableProperty0
@@ -130,6 +133,7 @@ class CardReaderPaymentControllerTest : BaseUnitTest() {
     private val paymentReceiptHelper: PaymentReceiptHelper = mock()
     private val cardReaderOnboardingChecker: CardReaderOnboardingChecker = mock()
     private val paymentReceiptShare: PaymentReceiptShare = mock()
+    private val markedAsPaidOrdersCache: MarkedAsPaidOrdersCache = mock()
 
     private var isTTPinProgress = false
     private val isTTPinProgressProp: KMutableProperty0<Boolean> = ::isTTPinProgress
@@ -222,6 +226,7 @@ class CardReaderPaymentControllerTest : BaseUnitTest() {
             paymentReceiptHelper = paymentReceiptHelper,
             cardReaderOnboardingChecker = cardReaderOnboardingChecker,
             paymentReceiptShare = paymentReceiptShare,
+            markedAsPaidOrdersCache = markedAsPaidOrdersCache,
             paymentOrRefund = cardReaderFlowParam,
             cardReaderType = cardReaderType,
             isTTPPaymentInProgress = isTTPinProgressProp,
@@ -1393,6 +1398,36 @@ class CardReaderPaymentControllerTest : BaseUnitTest() {
             controller.start()
 
             verify(paymentReceiptHelper).storeReceiptUrl(eq(ORDER_ID), eq(receiptUrl))
+        }
+
+    @Test
+    fun `when payment succeeds, then order is recorded as paid`() =
+        testBlocking {
+            whenever(cardReaderManager.collectPayment(any())).thenAnswer {
+                flow { emit(PaymentCompleted("testUrl")) }
+            }
+
+            controller.start()
+
+            verify(markedAsPaidOrdersCache).onOrderMovedToPaidStatus(
+                siteId = eq(siteModel.siteId),
+                orderId = eq(ORDER_ID),
+                newStatusKey = eq(CoreOrderStatus.PROCESSING.value),
+            )
+        }
+
+    @Test
+    fun `when payment fails, then order is not recorded as paid`() =
+        testBlocking {
+            whenever(errorMapper.mapPaymentErrorToUiError(Generic, false))
+                .thenReturn(PaymentFlowError.Generic)
+            whenever(cardReaderManager.collectPayment(any())).thenAnswer {
+                flow { emit(paymentFailedWithEmptyDataForRetry) }
+            }
+
+            controller.start()
+
+            verifyNoInteractions(markedAsPaidOrdersCache)
         }
 
     @Test
@@ -3863,6 +3898,7 @@ class CardReaderPaymentControllerTest : BaseUnitTest() {
             paymentReceiptHelper = paymentReceiptHelper,
             cardReaderOnboardingChecker = cardReaderOnboardingChecker,
             paymentReceiptShare = paymentReceiptShare,
+            markedAsPaidOrdersCache = markedAsPaidOrdersCache,
             paymentOrRefund = param,
             cardReaderType = CardReaderType.EXTERNAL,
             isTTPPaymentInProgress = isTTPinProgressProp,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cashpayment/WooPosCashPaymentRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cashpayment/WooPosCashPaymentRepositoryTest.kt
@@ -2,7 +2,7 @@ package com.woocommerce.android.ui.woopos.cashpayment
 
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.OrderMapper
-import com.woocommerce.android.notifications.push.MarkedAsPaidOrdersCache
+import com.woocommerce.android.notifications.push.NewOrderNotificationSuppressionCache
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.products.models.SiteParameters
 import kotlinx.coroutines.flow.flowOf
@@ -33,7 +33,7 @@ class WooPosCashPaymentRepositoryTest {
     private val orderStore: WCOrderStore = mock()
     private val orderMapper: OrderMapper = mock()
     private val gatewayStore: WCGatewayStore = mock()
-    private val markedAsPaidOrdersCache: MarkedAsPaidOrdersCache = mock()
+    private val newOrderNotificationSuppressionCache: NewOrderNotificationSuppressionCache = mock()
 
     private lateinit var repository: WooPosCashPaymentRepository
 
@@ -45,7 +45,7 @@ class WooPosCashPaymentRepositoryTest {
             orderStore,
             orderMapper,
             gatewayStore,
-            markedAsPaidOrdersCache
+            newOrderNotificationSuppressionCache
         )
     }
 
@@ -161,7 +161,7 @@ class WooPosCashPaymentRepositoryTest {
             newPaymentMethodTitle = gatewayTitle,
             cashPaymentChangeDueAmount = cashPaymentChangeDueAmount
         )
-        verifyNoInteractions(markedAsPaidOrdersCache)
+        verifyNoInteractions(newOrderNotificationSuppressionCache)
     }
 
     @Test
@@ -191,7 +191,7 @@ class WooPosCashPaymentRepositoryTest {
         repository.completeOrder(orderId, cashPaymentChangeDueAmount = "5")
 
         // THEN
-        verify(markedAsPaidOrdersCache).onOrderMovedToPaidStatus(
+        verify(newOrderNotificationSuppressionCache).onOrderMovedToPaidStatus(
             siteId = siteId,
             orderId = orderId,
             newStatusKey = Order.Status.Completed.value,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cashpayment/WooPosCashPaymentRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cashpayment/WooPosCashPaymentRepositoryTest.kt
@@ -4,6 +4,7 @@ import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.OrderMapper
 import com.woocommerce.android.notifications.push.NewOrderNotificationSuppressionCache
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.orders.OrderTestUtils
 import com.woocommerce.android.ui.products.models.SiteParameters
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
@@ -172,7 +173,7 @@ class WooPosCashPaymentRepositoryTest {
         val site: SiteModel = mock { on { this.siteId }.thenReturn(siteId) }
         val statusModel = WCOrderStatusModel(statusKey = Order.Status.Completed.value)
         val updateResult = UpdateOrderResult.RemoteUpdateResult(OnOrderChanged())
-        val storedOrder: OrderEntity = mock { on { status }.thenReturn(Order.Status.Pending.value) }
+        val storedOrder = OrderTestUtils.generateOrder().copy(status = Order.Status.Pending.value)
 
         whenever(selectedSite.get()).thenReturn(site)
         whenever(gatewayStore.getGateway(site, "cod")).thenReturn(null)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cashpayment/WooPosCashPaymentRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cashpayment/WooPosCashPaymentRepositoryTest.kt
@@ -193,7 +193,7 @@ class WooPosCashPaymentRepositoryTest {
         repository.completeOrder(orderId, cashPaymentChangeDueAmount = "5")
 
         // THEN
-        verify(newOrderNotificationSuppressionCache).recordOrderStatusChanged(
+        verify(newOrderNotificationSuppressionCache).onOrderStatusChanged(
             siteId = siteId,
             orderId = orderId,
             previousStatusKey = Order.Status.Pending.value,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cashpayment/WooPosCashPaymentRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cashpayment/WooPosCashPaymentRepositoryTest.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.woopos.cashpayment
 
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.OrderMapper
+import com.woocommerce.android.notifications.push.MarkedAsPaidOrdersCache
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.products.models.SiteParameters
 import kotlinx.coroutines.flow.flowOf
@@ -11,6 +12,7 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.SiteModel
@@ -31,6 +33,7 @@ class WooPosCashPaymentRepositoryTest {
     private val orderStore: WCOrderStore = mock()
     private val orderMapper: OrderMapper = mock()
     private val gatewayStore: WCGatewayStore = mock()
+    private val markedAsPaidOrdersCache: MarkedAsPaidOrdersCache = mock()
 
     private lateinit var repository: WooPosCashPaymentRepository
 
@@ -41,7 +44,8 @@ class WooPosCashPaymentRepositoryTest {
             wooCommerceStore,
             orderStore,
             orderMapper,
-            gatewayStore
+            gatewayStore,
+            markedAsPaidOrdersCache
         )
     }
 
@@ -156,6 +160,41 @@ class WooPosCashPaymentRepositoryTest {
             newPaymentMethodId = "cod",
             newPaymentMethodTitle = gatewayTitle,
             cashPaymentChangeDueAmount = cashPaymentChangeDueAmount
+        )
+        verifyNoInteractions(markedAsPaidOrdersCache)
+    }
+
+    @Test
+    fun `given order completion succeeds, when completeOrder, then order is recorded as paid`() = runTest {
+        // GIVEN
+        val orderId = 123L
+        val siteId = 999L
+        val site: SiteModel = mock { on { this.siteId }.thenReturn(siteId) }
+        val statusModel = WCOrderStatusModel(statusKey = Order.Status.Completed.value)
+        val updateResult = UpdateOrderResult.RemoteUpdateResult(OnOrderChanged())
+
+        whenever(selectedSite.get()).thenReturn(site)
+        whenever(gatewayStore.getGateway(site, "cod")).thenReturn(null)
+        whenever(orderStore.getOrderStatusForSiteAndKey(site, Order.Status.Completed.value)).thenReturn(statusModel)
+        whenever(
+            orderStore.updateOrderStatusAndPaymentDetails(
+                orderId = orderId,
+                site = site,
+                newStatus = statusModel,
+                newPaymentMethodId = "cod",
+                newPaymentMethodTitle = "Pay in Person",
+                cashPaymentChangeDueAmount = "5"
+            )
+        ).thenReturn(flowOf(updateResult))
+
+        // WHEN
+        repository.completeOrder(orderId, cashPaymentChangeDueAmount = "5")
+
+        // THEN
+        verify(markedAsPaidOrdersCache).onOrderMovedToPaidStatus(
+            siteId = siteId,
+            orderId = orderId,
+            newStatusKey = Order.Status.Completed.value,
         )
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cashpayment/WooPosCashPaymentRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cashpayment/WooPosCashPaymentRepositoryTest.kt
@@ -165,16 +165,18 @@ class WooPosCashPaymentRepositoryTest {
     }
 
     @Test
-    fun `given order completion succeeds, when completeOrder, then order is recorded as paid`() = runTest {
+    fun `given order completion succeeds, when completeOrder, then the status change is recorded`() = runTest {
         // GIVEN
         val orderId = 123L
         val siteId = 999L
         val site: SiteModel = mock { on { this.siteId }.thenReturn(siteId) }
         val statusModel = WCOrderStatusModel(statusKey = Order.Status.Completed.value)
         val updateResult = UpdateOrderResult.RemoteUpdateResult(OnOrderChanged())
+        val storedOrder: OrderEntity = mock { on { status }.thenReturn(Order.Status.Pending.value) }
 
         whenever(selectedSite.get()).thenReturn(site)
         whenever(gatewayStore.getGateway(site, "cod")).thenReturn(null)
+        whenever(orderStore.getOrderByIdAndSite(orderId, site)).thenReturn(storedOrder)
         whenever(orderStore.getOrderStatusForSiteAndKey(site, Order.Status.Completed.value)).thenReturn(statusModel)
         whenever(
             orderStore.updateOrderStatusAndPaymentDetails(
@@ -191,9 +193,10 @@ class WooPosCashPaymentRepositoryTest {
         repository.completeOrder(orderId, cashPaymentChangeDueAmount = "5")
 
         // THEN
-        verify(newOrderNotificationSuppressionCache).onOrderMovedToPaidStatus(
+        verify(newOrderNotificationSuppressionCache).recordOrderStatusChanged(
             siteId = siteId,
             orderId = orderId,
+            previousStatusKey = Order.Status.Pending.value,
             newStatusKey = Order.Status.Completed.value,
         )
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
@@ -158,6 +158,7 @@ class WooPosTotalsViewModelTest {
         paymentReceiptHelper = paymentReceiptHelper,
         cardReaderOnboardingChecker = cardReaderOnboardingChecker,
         paymentReceiptShare = paymentReceiptShare,
+        markedAsPaidOrdersCache = mock(),
     )
 
     private fun createMockSavedStateHandle(): SavedStateHandle {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
@@ -158,7 +158,7 @@ class WooPosTotalsViewModelTest {
         paymentReceiptHelper = paymentReceiptHelper,
         cardReaderOnboardingChecker = cardReaderOnboardingChecker,
         paymentReceiptShare = paymentReceiptShare,
-        markedAsPaidOrdersCache = mock(),
+        newOrderNotificationSuppressionCache = mock(),
     )
 
     private fun createMockSavedStateHandle(): SavedStateHandle {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/markorderascomplete/WooPosMarkOrderAsCompleteRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/markorderascomplete/WooPosMarkOrderAsCompleteRepositoryTest.kt
@@ -2,7 +2,7 @@ package com.woocommerce.android.ui.woopos.markorderascomplete
 
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.OrderMapper
-import com.woocommerce.android.notifications.push.MarkedAsPaidOrdersCache
+import com.woocommerce.android.notifications.push.NewOrderNotificationSuppressionCache
 import com.woocommerce.android.tools.SelectedSite
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
@@ -37,7 +37,7 @@ class WooPosMarkOrderAsCompleteRepositoryTest {
     private val orderMapper: OrderMapper = mock()
     private val site: SiteModel = mock()
     private val statusModel = WCOrderStatusModel(statusKey = Order.Status.Completed.value)
-    private val markedAsPaidOrdersCache: MarkedAsPaidOrdersCache = mock()
+    private val newOrderNotificationSuppressionCache: NewOrderNotificationSuppressionCache = mock()
 
     private lateinit var repository: WooPosMarkOrderAsCompleteRepository
 
@@ -48,7 +48,7 @@ class WooPosMarkOrderAsCompleteRepositoryTest {
                 selectedSite,
                 orderStore,
                 orderMapper,
-                markedAsPaidOrdersCache,
+                newOrderNotificationSuppressionCache,
             )
             whenever(selectedSite.get()).thenReturn(site)
             whenever(
@@ -106,7 +106,7 @@ class WooPosMarkOrderAsCompleteRepositoryTest {
             repository.markOrderAsComplete(orderId, customerNote = null)
 
             // THEN
-            verify(markedAsPaidOrdersCache).onOrderMovedToPaidStatus(
+            verify(newOrderNotificationSuppressionCache).onOrderMovedToPaidStatus(
                 siteId = siteId,
                 orderId = orderId,
                 newStatusKey = Order.Status.Completed.value,
@@ -139,7 +139,7 @@ class WooPosMarkOrderAsCompleteRepositoryTest {
 
             // THEN
             assertThat(result).isEqualTo(MarkOrderAsCompleteOutcome.Failure)
-            verifyNoInteractions(markedAsPaidOrdersCache)
+            verifyNoInteractions(newOrderNotificationSuppressionCache)
         }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/markorderascomplete/WooPosMarkOrderAsCompleteRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/markorderascomplete/WooPosMarkOrderAsCompleteRepositoryTest.kt
@@ -25,6 +25,7 @@ import org.wordpress.android.fluxc.model.WCOrderStatusModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+import org.wordpress.android.fluxc.persistence.entity.OrderEntity
 import org.wordpress.android.fluxc.persistence.entity.OrderNoteEntity
 import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderChanged
@@ -95,20 +96,23 @@ class WooPosMarkOrderAsCompleteRepositoryTest {
         }
 
     @Test
-    fun `given remote update succeeds, when markOrderAsComplete, then order is recorded as paid`() =
+    fun `given remote update succeeds, when markOrderAsComplete, then the status change is recorded`() =
         runTest {
             // GIVEN
             val orderId = 123L
             val siteId = 999L
+            val storedOrder: OrderEntity = mock { on { status }.thenReturn(Order.Status.Pending.value) }
             whenever(site.siteId).thenReturn(siteId)
+            whenever(orderStore.getOrderByIdAndSite(orderId, site)).thenReturn(storedOrder)
 
             // WHEN
             repository.markOrderAsComplete(orderId, customerNote = null)
 
             // THEN
-            verify(newOrderNotificationSuppressionCache).onOrderMovedToPaidStatus(
+            verify(newOrderNotificationSuppressionCache).recordOrderStatusChanged(
                 siteId = siteId,
                 orderId = orderId,
+                previousStatusKey = Order.Status.Pending.value,
                 newStatusKey = Order.Status.Completed.value,
             )
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/markorderascomplete/WooPosMarkOrderAsCompleteRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/markorderascomplete/WooPosMarkOrderAsCompleteRepositoryTest.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.woopos.markorderascomplete
 
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.OrderMapper
+import com.woocommerce.android.notifications.push.MarkedAsPaidOrdersCache
 import com.woocommerce.android.tools.SelectedSite
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
@@ -15,6 +16,7 @@ import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
@@ -35,13 +37,19 @@ class WooPosMarkOrderAsCompleteRepositoryTest {
     private val orderMapper: OrderMapper = mock()
     private val site: SiteModel = mock()
     private val statusModel = WCOrderStatusModel(statusKey = Order.Status.Completed.value)
+    private val markedAsPaidOrdersCache: MarkedAsPaidOrdersCache = mock()
 
     private lateinit var repository: WooPosMarkOrderAsCompleteRepository
 
     @Before
     fun setUp() {
         runBlocking {
-            repository = WooPosMarkOrderAsCompleteRepository(selectedSite, orderStore, orderMapper)
+            repository = WooPosMarkOrderAsCompleteRepository(
+                selectedSite,
+                orderStore,
+                orderMapper,
+                markedAsPaidOrdersCache,
+            )
             whenever(selectedSite.get()).thenReturn(site)
             whenever(
                 orderStore.getOrderStatusForSiteAndKey(site, Order.Status.Completed.value)
@@ -84,6 +92,54 @@ class WooPosMarkOrderAsCompleteRepositoryTest {
                 note = any(),
                 isCustomerNote = any(),
             )
+        }
+
+    @Test
+    fun `given remote update succeeds, when markOrderAsComplete, then order is recorded as paid`() =
+        runTest {
+            // GIVEN
+            val orderId = 123L
+            val siteId = 999L
+            whenever(site.siteId).thenReturn(siteId)
+
+            // WHEN
+            repository.markOrderAsComplete(orderId, customerNote = null)
+
+            // THEN
+            verify(markedAsPaidOrdersCache).onOrderMovedToPaidStatus(
+                siteId = siteId,
+                orderId = orderId,
+                newStatusKey = Order.Status.Completed.value,
+            )
+        }
+
+    @Test
+    fun `given remote update fails, when markOrderAsComplete, then order is not recorded as paid`() =
+        runTest {
+            // GIVEN
+            whenever(
+                orderStore.updateOrderStatusAndPaymentDetails(
+                    orderId = any(),
+                    site = eq(site),
+                    newStatus = any(),
+                    newPaymentMethodId = eq("other"),
+                    newPaymentMethodTitle = eq("Other"),
+                    cashPaymentChangeDueAmount = isNull(),
+                )
+            ).thenReturn(
+                flowOf(
+                    UpdateOrderResult.RemoteUpdateResult(
+                        OnOrderChanged(orderError = WCOrderStore.OrderError())
+                    )
+                )
+            )
+
+            // WHEN
+            val result = repository.markOrderAsComplete(123L, customerNote = null)
+
+            // THEN
+            assertThat(result).isEqualTo(MarkOrderAsCompleteOutcome.Failure)
+            verifyNoInteractions(markedAsPaidOrdersCache)
         }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/markorderascomplete/WooPosMarkOrderAsCompleteRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/markorderascomplete/WooPosMarkOrderAsCompleteRepositoryTest.kt
@@ -4,6 +4,7 @@ import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.OrderMapper
 import com.woocommerce.android.notifications.push.NewOrderNotificationSuppressionCache
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.orders.OrderTestUtils
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
@@ -25,7 +26,6 @@ import org.wordpress.android.fluxc.model.WCOrderStatusModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
-import org.wordpress.android.fluxc.persistence.entity.OrderEntity
 import org.wordpress.android.fluxc.persistence.entity.OrderNoteEntity
 import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderChanged
@@ -101,7 +101,7 @@ class WooPosMarkOrderAsCompleteRepositoryTest {
             // GIVEN
             val orderId = 123L
             val siteId = 999L
-            val storedOrder: OrderEntity = mock { on { status }.thenReturn(Order.Status.Pending.value) }
+            val storedOrder = OrderTestUtils.generateOrder().copy(status = Order.Status.Pending.value)
             whenever(site.siteId).thenReturn(siteId)
             whenever(orderStore.getOrderByIdAndSite(orderId, site)).thenReturn(storedOrder)
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/markorderascomplete/WooPosMarkOrderAsCompleteRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/markorderascomplete/WooPosMarkOrderAsCompleteRepositoryTest.kt
@@ -109,7 +109,7 @@ class WooPosMarkOrderAsCompleteRepositoryTest {
             repository.markOrderAsComplete(orderId, customerNote = null)
 
             // THEN
-            verify(newOrderNotificationSuppressionCache).recordOrderStatusChanged(
+            verify(newOrderNotificationSuppressionCache).onOrderStatusChanged(
                 siteId = siteId,
                 orderId = orderId,
                 previousStatusKey = Order.Status.Pending.value,


### PR DESCRIPTION
### Description

Fixes WOOMOB-3636

Stacked on #16326, which adds the suppression and covers cash payments and status changes in store management.

This PR adds the same recording for card reader payments and for the POS cash and mark as paid flows. `CardReaderPaymentController` is the single path for card payments, in POS and in store management, so both are covered here and both are in the test steps.

Release notes are in #16326, the user facing behaviour is the same one.

### Test Steps

Use a new order for every scenario, WooCommerce sends at most one new order notification per order.

**POS cash payment**
1. Open POS.
2. Add a product to the cart.
3. Tap Checkout.
4. Tap Cash.
5. Confirm the payment.
6. Wait 30 seconds and verify no notification arrives.

**POS mark as paid**
1. Open POS.
2. Add a product to the cart.
3. Tap Checkout.
4. Tap the mark as paid option.
5. Confirm.
6. Wait 30 seconds and verify no notification arrives.

**POS card reader payment**
1. Open POS.
2. Add a product to the cart.
3. Tap Checkout.
4. Collect the payment with a card reader.
5. Wait 30 seconds and verify no notification arrives.

**Store card reader payment**
1. Open the Orders tab.
2. Open an unpaid order.
3. Tap Collect Payment.
4. Pick the card reader.
5. Complete the payment.
6. Wait 30 seconds and verify no notification arrives.

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
