### PR TITLE
[WOOMOB-3704] Send a Mobile Status Report to Zendesk - Part 4

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/zendesk/MobileStatusProvider.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/zendesk/MobileStatusProvider.kt
@@ -8,6 +8,7 @@ import com.woocommerce.android.background.GetBackgroundRestrictions
 import com.woocommerce.android.extensions.logInformation
 import com.woocommerce.android.notifications.NotificationChannelsHandler
 import com.woocommerce.android.notifications.NotificationChannelsHandler.NewOrderNotificationSoundStatus
+import com.woocommerce.android.notifications.push.PushNotificationRegistrationStatus
 import com.woocommerce.android.tools.connectionTypeOrNull
 import com.woocommerce.android.ui.payments.cardreader.onboarding.PluginType
 import com.woocommerce.android.ui.troubleshooting.useCases.NotificationSystemStatusProvider
@@ -27,6 +28,8 @@ import kotlinx.coroutines.flow.first
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.plugin.SitePluginModel
+import org.wordpress.android.fluxc.model.pushnotifications.WooPushNotificationPreferences
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.pushnotifications.WooPushNotificationsStore
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.WooCommerceStore
@@ -51,6 +54,7 @@ class MobileStatusProvider @Inject constructor(
     private val featureFlagRepository: FeatureFlagRepository,
     private val notificationSystemStatusProvider: NotificationSystemStatusProvider,
     private val notificationChannelsHandler: NotificationChannelsHandler,
+    private val pushNotificationRegistrationStatus: PushNotificationRegistrationStatus,
     private val getBackgroundRestrictions: GetBackgroundRestrictions,
     private val deviceFeatures: DeviceFeatures,
     private val getWooCorePluginCachedVersion: GetWooCorePluginCachedVersion,
@@ -61,7 +65,8 @@ class MobileStatusProvider @Inject constructor(
     private val posLocalCatalogStore: WooPosLocalCatalogStore,
     private val syncTimestampManager: WooPosSyncTimestampManager,
     private val posPreferencesRepository: WooPosPreferencesRepository,
-    private val isLocalCatalogSupported: WooPosIsLocalCatalogSupported
+    private val isLocalCatalogSupported: WooPosIsLocalCatalogSupported,
+    private val wooPushNotificationsStore: WooPushNotificationsStore
 ) {
     /**
      * @param siteAddress the address the merchant typed into the support form, which can differ from the selected
@@ -87,6 +92,7 @@ class MobileStatusProvider @Inject constructor(
         if (selectedSite == null) return@buildString
 
         appendSection(HEADING_STORE) { storeSection(selectedSite) }
+        appendSection(HEADING_STORE_NOTIFICATIONS) { storeNotificationsSection(selectedSite) }
         appendSection(HEADING_PAYMENTS) { paymentsSection(selectedSite) }
         appendSection(HEADING_POS) { posSection(selectedSite) }
     }
@@ -167,6 +173,37 @@ class MobileStatusProvider @Inject constructor(
             entry("Woo core version", getWooCorePluginCachedVersion() ?: UNKNOWN)
         )
     }
+
+    private suspend fun storeNotificationsSection(selectedSite: SiteModel) = listOf(
+        entry("Push registration", pushNotificationRegistrationStatus(selectedSite.siteId).name)
+    ) + alertSettings(selectedSite)
+
+    private suspend fun alertSettings(selectedSite: SiteModel): List<String> {
+        val preferences = wooPushNotificationsStore.observeNotificationPreferences(selectedSite).first()
+            ?: return listOf(entry("Alert settings", "$NOT_FETCHED ($REASON_NO_ALERT_SETTINGS)"))
+
+        return listOf(
+            entry("New order alerts", preferences.storeOrder.describeOrders()),
+            entry("Review alerts", preferences.storeReview.describeReviews()),
+            entry("Stock alerts", preferences.storeStock.describeStock())
+        )
+    }
+
+    private fun WooPushNotificationPreferences.StoreOrderPreferences?.describeOrders() =
+        if (this == null) NOT_SET else "enabled=${enabled.orNotSet()}, min amount=${minAmount.orNotSet()}"
+
+    private fun WooPushNotificationPreferences.StoreReviewPreferences?.describeReviews() =
+        if (this == null) NOT_SET else "enabled=${enabled.orNotSet()}, max rating=${maxRating.orNotSet()}"
+
+    private fun WooPushNotificationPreferences.StoreStockPreferences?.describeStock() =
+        if (this == null) {
+            NOT_SET
+        } else {
+            "enabled=${enabled.orNotSet()}, low stock=${lowStock.orNotSet()}, " +
+                "out of stock=${outOfStock.orNotSet()}, on backorder=${onBackorder.orNotSet()}"
+        }
+
+    private fun Any?.orNotSet() = this?.toString() ?: NOT_SET
 
     // Non-Woo sites are excluded here and from the count: the site store holds every site on the WPCom account.
     private fun wooSites() = siteStore.sites.filter { it.hasWooCommerce }
@@ -325,6 +362,10 @@ class MobileStatusProvider @Inject constructor(
     companion object {
         private const val REPORT_HEADING = "### Mobile Status Report generated via the WooCommerce Android app ###"
 
+        // What every field means, and what an absent value means, lives in the doc rather than in the report.
+        private const val FIELD_REFERENCE = "Field reference: " +
+            "https://github.com/woocommerce/woocommerce-android/blob/trunk/docs/mobile-status-report.md"
+
         private const val HEADING_NO_STORE = "# No store selected"
         private const val HEADING_APP = "## App"
         private const val HEADING_DEVICE = "## Device"
@@ -332,6 +373,7 @@ class MobileStatusProvider @Inject constructor(
         private const val HEADING_NOTIFICATIONS = "## Notifications"
         private const val HEADING_ACCOUNT = "## Account & Stores"
         private const val HEADING_STORE = "## Store Details"
+        private const val HEADING_STORE_NOTIFICATIONS = "## Store Notifications"
         private const val HEADING_PAYMENTS = "## Payments"
         private const val HEADING_POS = "## Point of Sale"
         private const val HEADING_FEATURE_FLAGS = "## Feature Flags"
@@ -343,16 +385,14 @@ class MobileStatusProvider @Inject constructor(
         private const val NONE = "none"
         private const val MISSING = "missing"
         private const val NOT_SET = "not set"
+        private const val NOT_FETCHED = "not fetched"
         private const val NOT_LOGGED_IN = "not logged in"
         private const val NEVER = "never"
         private const val REDACTED_TOKEN_LENGTH = 6
 
-        // What every field means, and what an absent value means, lives in the doc rather than in the report.
-        private const val FIELD_REFERENCE = "Field reference: " +
-            "https://github.com/woocommerce/woocommerce-android/blob/trunk/docs/mobile-status-report.md"
-
         // Why a value is absent, said in the report itself rather than left to the reader. A bare "not set" reads
         // as a fault in every one of these cases, when each is the expected state for some kind of store or setup.
+        private const val REASON_NO_ALERT_SETTINGS = "the merchant has not opened notification settings yet"
         private const val REASON_NO_BLOG_ID = "stores connected with application passwords do not have one"
         private const val REASON_NO_STORE_ID = "no store system status has been fetched yet"
         private const val REASON_NOT_CACHED = "none cached for this site"

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/support/MobileStatusProviderTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/support/MobileStatusProviderTest.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.background.GetBackgroundRestrictions.BackgroundRe
 import com.woocommerce.android.notifications.NotificationChannelType
 import com.woocommerce.android.notifications.NotificationChannelsHandler
 import com.woocommerce.android.notifications.NotificationChannelsHandler.NewOrderNotificationSoundStatus
+import com.woocommerce.android.notifications.push.PushNotificationRegistrationStatus
 import com.woocommerce.android.support.zendesk.MobileStatusProvider
 import com.woocommerce.android.support.zendesk.ZendeskEnvironmentDataSource
 import com.woocommerce.android.ui.payments.cardreader.onboarding.PluginType
@@ -28,6 +29,7 @@ import kotlinx.coroutines.flow.flowOf
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doThrow
@@ -37,10 +39,13 @@ import org.wordpress.android.fluxc.model.AccountModel
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.plugin.SitePluginModel
+import org.wordpress.android.fluxc.model.pushnotifications.WooPushNotificationPreferences
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.pushnotifications.WooPushNotificationsStore
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import org.wordpress.android.fluxc.store.pos.localcatalog.WooPosLocalCatalogStore
+import java.math.BigDecimal
 import java.util.Locale
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -85,6 +90,10 @@ class MobileStatusProviderTest : BaseUnitTest() {
 
     private val notificationChannelsHandler: NotificationChannelsHandler = mock {
         on { checkNewOrderNotificationSound() } doReturn NewOrderNotificationSoundStatus.SOUND_MODIFIED
+    }
+
+    private val pushNotificationRegistrationStatus: PushNotificationRegistrationStatus = mock {
+        on { invoke(anyOrNull()) } doReturn PushNotificationRegistrationStatus.Status.REGISTERED_BOTH
     }
 
     private val getBackgroundRestrictions: GetBackgroundRestrictions = mock {
@@ -157,6 +166,27 @@ class MobileStatusProviderTest : BaseUnitTest() {
         )
     }
 
+    private val wooPushNotificationsStore: WooPushNotificationsStore = mock {
+        on { observeNotificationPreferences(any()) } doReturn flowOf(
+            WooPushNotificationPreferences(
+                storeOrder = WooPushNotificationPreferences.StoreOrderPreferences(
+                    enabled = true,
+                    minAmount = BigDecimal("100.50")
+                ),
+                storeReview = WooPushNotificationPreferences.StoreReviewPreferences(
+                    enabled = false,
+                    maxRating = 3
+                ),
+                storeStock = WooPushNotificationPreferences.StoreStockPreferences(
+                    enabled = true,
+                    lowStock = true,
+                    outOfStock = false,
+                    onBackorder = null
+                )
+            )
+        )
+    }
+
     private val sut = MobileStatusProvider(
         context = mock(),
         envDataSource = envDataSource,
@@ -165,6 +195,7 @@ class MobileStatusProviderTest : BaseUnitTest() {
         featureFlagRepository = featureFlagRepository,
         notificationSystemStatusProvider = notificationSystemStatusProvider,
         notificationChannelsHandler = notificationChannelsHandler,
+        pushNotificationRegistrationStatus = pushNotificationRegistrationStatus,
         getBackgroundRestrictions = getBackgroundRestrictions,
         deviceFeatures = deviceFeatures,
         getWooCorePluginCachedVersion = getWooCorePluginCachedVersion,
@@ -175,7 +206,8 @@ class MobileStatusProviderTest : BaseUnitTest() {
         posLocalCatalogStore = posLocalCatalogStore,
         syncTimestampManager = syncTimestampManager,
         posPreferencesRepository = posPreferencesRepository,
-        isLocalCatalogSupported = isLocalCatalogSupported
+        isLocalCatalogSupported = isLocalCatalogSupported,
+        wooPushNotificationsStore = wooPushNotificationsStore
     )
 
     /**
@@ -312,6 +344,18 @@ class MobileStatusProviderTest : BaseUnitTest() {
 
             assertThat(report).contains("Auth method: unknown")
         }
+
+    @Test
+    fun `given alert settings were never fetched, when the report is generated, then it says so`() = testBlocking {
+        wooPushNotificationsStore.stub { on { observeNotificationPreferences(any()) } doReturn flowOf(null) }
+
+        val report = sut(SiteModel().apply { url = "https://example.com" })
+
+        assertThat(report).contains(
+            "Alert settings: not fetched (the merchant has not opened notification settings yet)"
+        )
+        assertThat(report).doesNotContain("New order alerts")
+    }
 
     @Test
     fun `given no remote flag values, when the report is generated, then they are reported as not loaded`() =
@@ -485,6 +529,7 @@ class MobileStatusProviderTest : BaseUnitTest() {
         featureFlagRepository = featureFlagRepository,
         notificationSystemStatusProvider = notificationSystemStatusProvider,
         notificationChannelsHandler = notificationChannelsHandler,
+        pushNotificationRegistrationStatus = pushNotificationRegistrationStatus,
         getBackgroundRestrictions = getBackgroundRestrictions,
         deviceFeatures = deviceFeatures,
         getWooCorePluginCachedVersion = getWooCorePluginCachedVersion,
@@ -495,7 +540,8 @@ class MobileStatusProviderTest : BaseUnitTest() {
         posLocalCatalogStore = posLocalCatalogStore,
         syncTimestampManager = syncTimestampManager,
         posPreferencesRepository = posPreferencesRepository,
-        isLocalCatalogSupported = isLocalCatalogSupported
+        isLocalCatalogSupported = isLocalCatalogSupported,
+        wooPushNotificationsStore = wooPushNotificationsStore
     )
 
     private fun sitePlugin(name: String, isActive: Boolean, version: String) = SitePluginModel(
@@ -613,6 +659,12 @@ class MobileStatusProviderTest : BaseUnitTest() {
             Jetpack: installed=false connected=false CP=false
             Plan: unknown (0)
             Woo core version: 10.9.2
+
+            ## Store Notifications
+            Push registration: REGISTERED_BOTH
+            New order alerts: enabled=true, min amount=100.50
+            Review alerts: enabled=false, max rating=3
+            Stock alerts: enabled=true, low stock=true, out of stock=false, on backorder=not set
 
             ## Payments
             WooPayments: active 8.1.0

--- a/docs/mobile-status-report.md
+++ b/docs/mobile-status-report.md
@@ -163,7 +163,7 @@ Woo token is registered per store, and the alert settings live on the store.
 
 | Field | Meaning | Values |
 | --- | --- | --- |
-| `Push registration` | Which push system holds a token for this store. `REGISTERED_WOO_ONLY` is Woo-driven, `REGISTERED_WPCOM_ONLY` is the legacy Jetpack-driven system, `REGISTERED_BOTH` means both hold one — a known duplicate-notification cause. See below for diagnosing an absent Woo registration. | `REGISTERED_BOTH`, `REGISTERED_WOO_ONLY`, `REGISTERED_WPCOM_ONLY`, `UNREGISTERED` |
+| `Push registration` | Which push system holds a token for this store. `REGISTERED_WOO_ONLY` is Woo-driven, `REGISTERED_WPCOM_ONLY` is the legacy Jetpack-driven system, `REGISTERED_BOTH` means the device holds a WPCom registration while this store also holds a Woo token. See below for diagnosing an absent Woo registration. | `REGISTERED_BOTH`, `REGISTERED_WOO_ONLY`, `REGISTERED_WPCOM_ONLY`, `UNREGISTERED` |
 | `New order alerts` | The stored `store_order` settings. | `enabled=<bool>, min amount=<amount>`; `not set` |
 | `Review alerts` | The stored `store_review` settings. | `enabled=<bool>, max rating=<n>`; `not set` |
 | `Stock alerts` | The stored `store_stock` settings. | `enabled=<bool>, low stock=<bool>, out of stock=<bool>, on backorder=<bool>`; `not set` |
@@ -201,7 +201,10 @@ Worked combinations:
   Updating Woo moves the store onto Woo-driven push.
 - **`UNREGISTERED`, Woo 10.9.2 or later, flag `true`, `Push token: present`** — the store is not the constraint.
   Registration was attempted and did not succeed; check the app log for the registration call.
-- **`REGISTERED_BOTH`** — both systems hold a token, the usual explanation for duplicate new-order notifications.
+- **`REGISTERED_BOTH`** — the ordinary state for a Jetpack store on a Woo new enough for Woo-driven push, not a
+  fault. The WPCom half is a device-wide registration that outlives the move to Woo-driven push, so it stays
+  while this store also holds a Woo token. It does not mean the merchant gets a notification twice:
+  `NotificationMessageHandler` drops any WPCom notification for a store already registered with Woo Core.
 
 Don't reach for "install Jetpack" on a store above the version gate — Woo-driven push needs only a site connection.
 

--- a/docs/mobile-status-report.md
+++ b/docs/mobile-status-report.md
@@ -17,7 +17,7 @@ The report is split in two by a single band:
 ## Account & Stores … ## Feature Flags … ## Experimental Features
 
 # Selected store: https://merchants-store.com
-## Store Details … ## Payments … ## Point of Sale
+## Store Details … ## Store Notifications … ## Payments … ## Point of Sale
 ```
 
 Everything **above** the band describes the whole app on this device, whichever store is selected. Everything
@@ -95,6 +95,9 @@ Duplicated on purpose — the report has to stand on its own when a merchant rea
 | `Power save mode` | Battery saver is on device-wide. | `true`, `false` |
 | `Data saver` | Data saver is on, which blocks background network use. | `true`, `false` |
 
+Push registration is **not** here — it is keyed on a single store, so it is reported under Store Notifications
+along with that store's alert settings.
+
 ## Account & Stores
 
 | Field | Meaning | Values |
@@ -152,6 +155,59 @@ Jetpack flags. These values are shared with the iOS app, so a ticket from either
 One case the report cannot show: after an application-password request fails, the app flags that site as
 unsupported for a period and silently falls back to the Jetpack tunnel. That flag is not reported, because
 reading it clears it once it has expired, and a status report must not change what it reports.
+
+## Store Notifications
+
+Which of the two push systems serves this store, and the store's own alert settings. Both are store-scoped — the
+Woo token is registered per store, and the alert settings live on the store.
+
+| Field | Meaning | Values |
+| --- | --- | --- |
+| `Push registration` | Which push system holds a token for this store. `REGISTERED_WOO_ONLY` is Woo-driven, `REGISTERED_WPCOM_ONLY` is the legacy Jetpack-driven system, `REGISTERED_BOTH` means both hold one — a known duplicate-notification cause. See below for diagnosing an absent Woo registration. | `REGISTERED_BOTH`, `REGISTERED_WOO_ONLY`, `REGISTERED_WPCOM_ONLY`, `UNREGISTERED` |
+| `New order alerts` | The stored `store_order` settings. | `enabled=<bool>, min amount=<amount>`; `not set` |
+| `Review alerts` | The stored `store_review` settings. | `enabled=<bool>, max rating=<n>`; `not set` |
+| `Stock alerts` | The stored `store_stock` settings. | `enabled=<bool>, low stock=<bool>, out of stock=<bool>, on backorder=<bool>`; `not set` |
+
+The fields are printed as stored, without interpreting them. What they mean, in the settings screen's own words:
+
+| Field | Meaning |
+| --- | --- |
+| `min amount` | The "Only high-value orders" filter — the screen describes it as **orders over** this value. `not set` means every order qualifies. |
+| `max rating` | The "Only low-rated reviews" filter — a rating ceiling. `not set` means every review qualifies. |
+| `low stock` | A product variant reaching its low stock threshold, which can be per-product or store-wide. |
+| `out of stock` | A product variant hitting zero. |
+| `on backorder` | A customer ordering an item that is currently out of stock. |
+
+An individual field reading `not set` means the API did not return it, which is not the same as `false`.
+| `Alert settings` | Replaces the three rows above when no settings have been fetched. | `not fetched (the merchant has not opened notification settings yet)` |
+
+### Diagnosing a missing Woo registration
+
+The report states the registration status and nothing more — it does not try to work out *why*. The inputs that
+decide it are all reported elsewhere as their own fields, and reading them together is the diagnosis:
+
+| Check | Where it is in the report | What it means |
+| --- | --- | --- |
+| Is there a push token at all? | `Push token` (Notifications) | `missing` blocks both systems — nothing can register. Start here. |
+| Is Woo-driven push switched on? | `woo_self_driven_push_notifications_m1` (Feature Flags) | `false` means the Woo-driven path is never attempted, whatever the store supports. |
+| Is the plugin new enough? | `Woo core version` (Store Details) | Woo-driven push needs **10.9.2 or later**. Below that, only the legacy WPCom system can serve the store. |
+| Can the legacy system serve it? | `Auth method` (Store Details) | The legacy system needs a WPCom account and a full Jetpack connection. `ApplicationPasswords` has neither, so a store below the version gate on an application-password login receives nothing at all. |
+
+Worked combinations:
+
+- **`UNREGISTERED`, Woo below 10.9.2, `Auth method: ApplicationPasswords`** — nothing will arrive. Woo-driven is
+  unavailable and there is no legacy fallback for this merchant. Updating Woo is the only fix.
+- **`REGISTERED_WPCOM_ONLY`, Woo below 10.9.2, `Auth method: Jetpack`** — working as designed on the legacy system.
+  Updating Woo moves the store onto Woo-driven push.
+- **`UNREGISTERED`, Woo 10.9.2 or later, flag `true`, `Push token: present`** — the store is not the constraint.
+  Registration was attempted and did not succeed; check the app log for the registration call.
+- **`REGISTERED_BOTH`** — both systems hold a token, the usual explanation for duplicate new-order notifications.
+
+Don't reach for "install Jetpack" on a store above the version gate — Woo-driven push needs only a site connection.
+
+`not fetched` is not the same as disabled: the settings are persisted by the last successful fetch, so they are
+absent until the merchant has opened notification settings at least once. A merchant reporting a missing alert
+with `not fetched` here has never changed these settings, so the store defaults apply.
 
 ## Payments
 


### PR DESCRIPTION
### Description

Fixes WOOMOB-3704

Stacked on #16331. Support asked whether the report could show a store's notification settings and which of the two push systems serves it, so this adds a `Store Notifications` section for the selected store: the push registration status, and the store's new-order, review and stock alert settings read from the local cache with no network call on the ticket path. `Push registration` moves here from `Store Details`, since it belongs with the rest of that store's notification state.

The fields are printed as stored rather than interpreted. The report doesn't work out *why* a store is unregistered — the inputs are already separate fields (`FCM token`, `woo_self_driven_push_notifications_m1`, `Woo core version`, `Auth method`), and deriving a cause here would be a second copy of the decisions `RegisterDevice` makes. `docs/mobile-status-report.md` gains the field rows plus a table for reading those fields together, including what the alert thresholds mean in the settings screen's own wording.

### Test Steps

Test on the last PR in the chain

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.