### PR TITLE
[WOOMOB-3708] Add Orders Paging 2 presentation seam

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListPaging2Presenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListPaging2Presenter.kt
@@ -1,0 +1,165 @@
+package com.woocommerce.android.ui.orders.list
+
+import androidx.annotation.MainThread
+import androidx.paging.PagedList
+import com.woocommerce.android.ui.orders.list.OrderListItemUIType.LoadingItem
+import com.woocommerce.android.ui.orders.list.OrderListItemUIType.OrderListItemUI
+import com.woocommerce.android.ui.orders.list.OrderListItemUIType.SectionHeader
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import java.util.Collections
+
+@MainThread
+internal class OrderListPaging2Presenter : AutoCloseable {
+    private val mutableState = MutableStateFlow(State())
+    val state: StateFlow<State> = mutableState.asStateFlow()
+
+    private var currentList: PagedList<OrderListItemUIType>? = null
+    private var currentCallback: PagedList.Callback? = null
+    private var isClosed = false
+
+    fun submit(pagedList: PagedList<OrderListItemUIType>?) {
+        if (isClosed || pagedList === currentList) return
+
+        removeCurrentCallback()
+        currentList = pagedList
+        val previousState = mutableState.value
+        val generation = previousState.generation + 1
+        val contentRevision = previousState.contentRevision + 1
+
+        if (pagedList != null) {
+            val callback = callbackFor(pagedList)
+            currentCallback = callback
+            pagedList.addWeakCallback(null, callback)
+        }
+
+        mutableState.value = pagedList.toState(
+            generation = generation,
+            contentRevision = contentRevision,
+        )
+    }
+
+    fun itemAt(capturedState: State, index: Int): OrderListItemUIType? {
+        if (index !in 0 until capturedState.itemCount) return null
+
+        if (capturedState === mutableState.value) {
+            currentList
+                ?.takeIf { index in it.indices }
+                ?.loadAround(index)
+        }
+        return capturedState.items[index]
+    }
+
+    fun keyAt(capturedState: State, index: Int): String? {
+        if (index !in 0 until capturedState.itemCount) return null
+        return capturedState.items[index].stableKey(capturedState.generation, index)
+    }
+
+    fun indexOfKey(capturedState: State, key: String): Int? {
+        return (0 until capturedState.itemCount).firstOrNull { index ->
+            capturedState.items[index].stableKey(capturedState.generation, index) == key
+        }
+    }
+
+    fun indexOfOrder(capturedState: State, orderId: Long): Int? {
+        return (0 until capturedState.itemCount).firstOrNull { index ->
+            val item = capturedState.items[index]
+            item is OrderListItemUI && item.orderId == orderId
+        }
+    }
+
+    fun loadedOrderIds(capturedState: State): List<Long> {
+        val orderIds = ArrayList<Long>()
+        capturedState.items.forEach { item ->
+            if (item is OrderListItemUI) {
+                orderIds += item.orderId
+            }
+        }
+        return Collections.unmodifiableList(orderIds)
+    }
+
+    fun markContentChanged() {
+        if (isClosed) return
+        val capturedState = mutableState.value
+        mutableState.value = State(
+            generation = capturedState.generation,
+            contentRevision = capturedState.contentRevision + 1,
+            items = capturedState.items,
+        )
+    }
+
+    override fun close() {
+        if (isClosed) return
+        isClosed = true
+        removeCurrentCallback()
+        currentList = null
+        val previousState = mutableState.value
+        mutableState.value = State(
+            generation = previousState.generation + 1,
+            contentRevision = previousState.contentRevision + 1,
+        )
+    }
+
+    private fun callbackFor(pagedList: PagedList<OrderListItemUIType>) = object : PagedList.Callback() {
+        override fun onChanged(position: Int, count: Int) = onListChanged(pagedList)
+
+        override fun onInserted(position: Int, count: Int) = onListChanged(pagedList)
+
+        override fun onRemoved(position: Int, count: Int) = onListChanged(pagedList)
+    }
+
+    private fun onListChanged(pagedList: PagedList<OrderListItemUIType>) {
+        if (isClosed || pagedList !== currentList) return
+        val previousState = mutableState.value
+        mutableState.value = pagedList.toState(
+            generation = previousState.generation,
+            contentRevision = previousState.contentRevision + 1,
+        )
+    }
+
+    private fun removeCurrentCallback() {
+        val callback = currentCallback ?: return
+        currentList?.removeWeakCallback(callback)
+        currentCallback = null
+    }
+
+    private fun PagedList<OrderListItemUIType>?.toState(
+        generation: Long,
+        contentRevision: Long,
+    ): State {
+        if (this == null) {
+            return State(
+                generation = generation,
+                contentRevision = contentRevision,
+            )
+        }
+        return State(
+            generation = generation,
+            contentRevision = contentRevision,
+            items = snapshot(),
+        )
+    }
+
+    private fun OrderListItemUIType?.stableKey(generation: Long, index: Int): String = when (this) {
+        is LoadingItem -> "$ORDER_KEY_PREFIX$orderId"
+        is OrderListItemUI -> "$ORDER_KEY_PREFIX$orderId"
+        is SectionHeader -> "$SECTION_KEY_PREFIX${title.name}"
+        null -> "$PLACEHOLDER_KEY_PREFIX$generation:$index"
+    }
+
+    class State(
+        val generation: Long = 0L,
+        val contentRevision: Long = 0L,
+        internal val items: List<OrderListItemUIType?> = emptyList(),
+    ) {
+        val itemCount: Int
+            get() = items.size
+    }
+
+    private companion object {
+        const val ORDER_KEY_PREFIX = "order-list-order:"
+        const val SECTION_KEY_PREFIX = "order-list-section:"
+        const val PLACEHOLDER_KEY_PREFIX = "order-list-placeholder:"
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListPaging2Presenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListPaging2Presenter.kt
@@ -8,7 +8,6 @@ import com.woocommerce.android.ui.orders.list.OrderListItemUIType.SectionHeader
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import java.util.Collections
 
 @MainThread
 internal class OrderListPaging2Presenter : AutoCloseable {
@@ -64,13 +63,9 @@ internal class OrderListPaging2Presenter : AutoCloseable {
     }
 
     fun loadedOrderIds(capturedState: State): List<Long> {
-        val orderIds = ArrayList<Long>()
-        capturedState.items.forEach { item ->
-            if (item is OrderListItemUI) {
-                orderIds += item.orderId
-            }
-        }
-        return Collections.unmodifiableList(orderIds)
+        return capturedState.items
+            .filterIsInstance<OrderListItemUI>()
+            .map { it.orderId }
     }
 
     fun markContentChanged() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListPaging2Presenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListPaging2Presenter.kt
@@ -28,16 +28,16 @@ internal class OrderListPaging2Presenter : AutoCloseable {
         val generation = previousState.generation + 1
         val contentRevision = previousState.contentRevision + 1
 
+        mutableState.value = pagedList.toState(
+            generation = generation,
+            contentRevision = contentRevision,
+        )
+
         if (pagedList != null) {
             val callback = callbackFor(pagedList)
             currentCallback = callback
             pagedList.addWeakCallback(null, callback)
         }
-
-        mutableState.value = pagedList.toState(
-            generation = generation,
-            contentRevision = contentRevision,
-        )
     }
 
     fun itemAt(capturedState: State, index: Int): OrderListItemUIType? {
@@ -54,12 +54,6 @@ internal class OrderListPaging2Presenter : AutoCloseable {
     fun keyAt(capturedState: State, index: Int): String? {
         if (index !in 0 until capturedState.itemCount) return null
         return capturedState.items[index].stableKey(capturedState.generation, index)
-    }
-
-    fun indexOfKey(capturedState: State, key: String): Int? {
-        return (0 until capturedState.itemCount).firstOrNull { index ->
-            capturedState.items[index].stableKey(capturedState.generation, index) == key
-        }
     }
 
     fun indexOfOrder(capturedState: State, orderId: Long): Int? {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/list/OrderListPaging2PresenterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/list/OrderListPaging2PresenterTest.kt
@@ -1,0 +1,150 @@
+package com.woocommerce.android.ui.orders.list
+
+import androidx.paging.PagedList
+import com.woocommerce.android.ui.orders.list.OrderListItemUIType.OrderListItemUI
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class OrderListPaging2PresenterTest {
+    @Test
+    fun `given a same-instance item mutation, when content changes, then snapshot generation and key stay stable`() {
+        // GIVEN
+        val order = order(1L)
+        val pagedList = pagedList(listOf(order))
+        val presenter = OrderListPaging2Presenter()
+        presenter.submit(pagedList)
+        val initialState = presenter.state.value
+        val initialKey = presenter.keyAt(initialState, 0)
+
+        // WHEN
+        order.status = "completed"
+        presenter.markContentChanged()
+        val updatedState = presenter.state.value
+
+        // THEN
+        assertThat(updatedState.generation).isEqualTo(initialState.generation)
+        assertThat(updatedState.contentRevision).isEqualTo(initialState.contentRevision + 1)
+        assertThat(updatedState.items).isSameAs(initialState.items)
+        assertThat(updatedState.itemCount).isEqualTo(initialState.itemCount)
+        assertThat((updatedState.items.single() as OrderListItemUI).status).isEqualTo("completed")
+        assertThat(presenter.keyAt(updatedState, 0)).isEqualTo(initialKey)
+
+        presenter.close()
+    }
+
+    @Test
+    fun `given a callback shrinks the list, when states are queried, then each keeps its snapshot contract`() {
+        // GIVEN
+        val initialItems = listOf(order(1L), order(2L), order(3L))
+        val updatedItems = listOf(order(1L))
+        val pagedList = pagedList(initialItems)
+        val presenter = OrderListPaging2Presenter()
+        presenter.submit(pagedList)
+        val initialState = presenter.state.value
+        val callback = callbackFor(pagedList)
+
+        // WHEN
+        whenever(pagedList.snapshot()).thenReturn(updatedItems)
+        callback.onRemoved(1, 2)
+        val updatedState = presenter.state.value
+
+        // THEN
+        assertThat(initialState.itemCount).isEqualTo(3)
+        assertThat(presenter.keyAt(initialState, 2)).isEqualTo("order-list-order:3")
+        assertThat(updatedState.generation).isEqualTo(initialState.generation)
+        assertThat(updatedState.contentRevision).isEqualTo(initialState.contentRevision + 1)
+        assertThat(updatedState.itemCount).isEqualTo(1)
+        assertThat(presenter.keyAt(updatedState, 0)).isEqualTo("order-list-order:1")
+        assertThat(presenter.keyAt(updatedState, 2)).isNull()
+
+        presenter.close()
+    }
+
+    @Test
+    fun `given a valid placeholder, when key and type are read, then loading identity is saveable without loading`() {
+        // GIVEN
+        val pagedList = pagedList(listOf(order(1L), null))
+        val presenter = OrderListPaging2Presenter()
+        presenter.submit(pagedList)
+        val state = presenter.state.value
+
+        // WHEN
+        val key = presenter.keyAt(state, 1)
+        val contentType = presenter.contentTypeAt(state, 1)
+
+        // THEN
+        assertThat(state.itemCount).isEqualTo(2)
+        assertThat(state.generation).isEqualTo(1L)
+        assertThat(key).isEqualTo("order-list-placeholder:1:1")
+        assertThat(key).isInstanceOf(String::class.java)
+        assertThat(contentType).isEqualTo(OrderListPaging2Presenter.ItemContentType.Loading)
+        verify(pagedList, never()).loadAround(any())
+
+        presenter.close()
+    }
+
+    @Test
+    fun `given a replacement, when stale access and callback arrive, then replacement state and loads are preserved`() {
+        // GIVEN
+        val initialItems = listOf(order(1L), order(2L), order(3L))
+        val replacementItems = listOf(order(4L))
+        val initialList = pagedList(initialItems)
+        val replacementList = pagedList(replacementItems)
+        val presenter = OrderListPaging2Presenter()
+        presenter.submit(initialList)
+        val initialState = presenter.state.value
+        val initialCallback = callbackFor(initialList)
+        presenter.submit(replacementList)
+        val replacementState = presenter.state.value
+        val replacementCallback = callbackFor(replacementList)
+
+        // WHEN
+        initialCallback.onRemoved(0, initialItems.size)
+        val stateAfterStaleCallback = presenter.state.value
+        val staleItem = presenter.itemAt(initialState, 2)
+        val currentItem = presenter.itemAt(replacementState, 0)
+        presenter.close()
+
+        // THEN
+        assertThat(stateAfterStaleCallback).isSameAs(replacementState)
+        assertThat(replacementState.generation).isEqualTo(initialState.generation + 1)
+        assertThat(presenter.keyAt(initialState, 2)).isEqualTo("order-list-order:3")
+        assertThat(presenter.keyAt(replacementState, 0)).isEqualTo("order-list-order:4")
+        assertThat(staleItem).isSameAs(initialItems[2])
+        assertThat(currentItem).isSameAs(replacementItems[0])
+        verify(initialList).removeWeakCallback(initialCallback)
+        verify(replacementList).removeWeakCallback(replacementCallback)
+        verify(initialList, never()).loadAround(any())
+        verify(replacementList).loadAround(0)
+    }
+
+    private fun callbackFor(pagedList: PagedList<OrderListItemUIType>): PagedList.Callback {
+        val callback = argumentCaptor<PagedList.Callback>()
+        verify(pagedList).addWeakCallback(anyOrNull(), callback.capture())
+        return callback.firstValue
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun pagedList(items: List<OrderListItemUIType?>): PagedList<OrderListItemUIType> = mock {
+        on { snapshot() } doReturn items as List<OrderListItemUIType>
+        on { size } doReturn items.size
+    }
+
+    private fun order(orderId: Long) = OrderListItemUI(
+        orderId = orderId,
+        orderNumber = orderId.toString(),
+        orderName = "Order $orderId",
+        orderTotal = orderId.toString(),
+        status = "processing",
+        dateCreated = null,
+        currencyCode = "USD",
+    )
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/list/OrderListPaging2PresenterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/list/OrderListPaging2PresenterTest.kt
@@ -69,7 +69,7 @@ class OrderListPaging2PresenterTest {
     }
 
     @Test
-    fun `given a valid placeholder, when key and type are read, then loading identity is saveable without loading`() {
+    fun `given a valid placeholder, when its key is read, then identity is saveable without loading`() {
         // GIVEN
         val pagedList = pagedList(listOf(order(1L), null))
         val presenter = OrderListPaging2Presenter()
@@ -78,14 +78,12 @@ class OrderListPaging2PresenterTest {
 
         // WHEN
         val key = presenter.keyAt(state, 1)
-        val contentType = presenter.contentTypeAt(state, 1)
 
         // THEN
         assertThat(state.itemCount).isEqualTo(2)
         assertThat(state.generation).isEqualTo(1L)
         assertThat(key).isEqualTo("order-list-placeholder:1:1")
         assertThat(key).isInstanceOf(String::class.java)
-        assertThat(contentType).isEqualTo(OrderListPaging2Presenter.ItemContentType.Loading)
         verify(pagedList, never()).loadAround(any())
 
         presenter.close()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/list/OrderListPaging2PresenterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/list/OrderListPaging2PresenterTest.kt
@@ -1,7 +1,12 @@
 package com.woocommerce.android.ui.orders.list
 
 import androidx.paging.PagedList
+import com.woocommerce.android.ui.orders.list.OrderListItemUIType.LoadingItem
 import com.woocommerce.android.ui.orders.list.OrderListItemUIType.OrderListItemUI
+import com.woocommerce.android.util.runAndCaptureValues
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.any
@@ -13,6 +18,7 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class OrderListPaging2PresenterTest {
     @Test
     fun `given a same-instance item mutation, when content changes, then snapshot generation and key stay stable`() {
@@ -38,6 +44,25 @@ class OrderListPaging2PresenterTest {
         assertThat(presenter.keyAt(updatedState, 0)).isEqualTo(initialKey)
 
         presenter.close()
+    }
+
+    @Test
+    fun `given an active list, when the same instance is submitted, then state and callback stay unchanged`() {
+        // GIVEN
+        val pagedList = pagedList(listOf(order(1L)))
+        val presenter = OrderListPaging2Presenter()
+        presenter.submit(pagedList)
+        val initialState = presenter.state.value
+
+        // WHEN
+        presenter.submit(pagedList)
+        val callback = callbackFor(pagedList)
+
+        // THEN
+        assertThat(presenter.state.value).isSameAs(initialState)
+
+        presenter.close()
+        verify(pagedList).removeWeakCallback(callback)
     }
 
     @Test
@@ -69,6 +94,30 @@ class OrderListPaging2PresenterTest {
     }
 
     @Test
+    fun `given an active list, when null is submitted, then the callback is removed and empty state is published`() {
+        // GIVEN
+        val pagedList = pagedList(listOf(order(1L)))
+        val presenter = OrderListPaging2Presenter()
+        presenter.submit(pagedList)
+        val populatedState = presenter.state.value
+        val callback = callbackFor(pagedList)
+
+        // WHEN
+        presenter.submit(null)
+        val emptyState = presenter.state.value
+        presenter.submit(null)
+
+        // THEN
+        assertThat(emptyState.generation).isEqualTo(populatedState.generation + 1)
+        assertThat(emptyState.contentRevision).isEqualTo(populatedState.contentRevision + 1)
+        assertThat(emptyState.itemCount).isZero()
+        assertThat(presenter.state.value).isSameAs(emptyState)
+        verify(pagedList).removeWeakCallback(callback)
+
+        presenter.close()
+    }
+
+    @Test
     fun `given a valid placeholder, when its key is read, then identity is saveable without loading`() {
         // GIVEN
         val pagedList = pagedList(listOf(order(1L), null))
@@ -83,8 +132,37 @@ class OrderListPaging2PresenterTest {
         assertThat(state.itemCount).isEqualTo(2)
         assertThat(state.generation).isEqualTo(1L)
         assertThat(key).isEqualTo("order-list-placeholder:1:1")
-        assertThat(key).isInstanceOf(String::class.java)
         verify(pagedList, never()).loadAround(any())
+
+        presenter.close()
+    }
+
+    @Test
+    fun `given loaded and unresolved items, when order helpers run, then only loaded orders are returned`() {
+        // GIVEN
+        val pagedList = pagedList(
+            listOf(
+                LoadingItem(1L),
+                order(2L),
+                null,
+                order(3L),
+            ),
+        )
+        val presenter = OrderListPaging2Presenter()
+        presenter.submit(pagedList)
+        val state = presenter.state.value
+
+        // WHEN
+        val firstLoadedIndex = presenter.indexOfOrder(state, 2L)
+        val loadingIndex = presenter.indexOfOrder(state, 1L)
+        val missingIndex = presenter.indexOfOrder(state, 4L)
+        val loadedOrderIds = presenter.loadedOrderIds(state)
+
+        // THEN
+        assertThat(firstLoadedIndex).isEqualTo(1)
+        assertThat(loadingIndex).isNull()
+        assertThat(missingIndex).isNull()
+        assertThat(loadedOrderIds).containsExactly(2L, 3L)
 
         presenter.close()
     }
@@ -122,6 +200,52 @@ class OrderListPaging2PresenterTest {
         verify(replacementList).removeWeakCallback(replacementCallback)
         verify(initialList, never()).loadAround(any())
         verify(replacementList).loadAround(0)
+    }
+
+    @Test
+    fun `given an active presenter, when closed, then its terminal state rejects later changes`() {
+        // GIVEN
+        val initialList = pagedList(listOf(order(1L)))
+        val replacementList = pagedList(listOf(order(2L)))
+        val presenter = OrderListPaging2Presenter()
+        presenter.submit(initialList)
+        val activeState = presenter.state.value
+        val callback = callbackFor(initialList)
+
+        // WHEN
+        presenter.close()
+        val closedState = presenter.state.value
+        presenter.close()
+        presenter.submit(replacementList)
+        presenter.markContentChanged()
+        callback.onChanged(0, 1)
+
+        // THEN
+        assertThat(closedState.generation).isEqualTo(activeState.generation + 1)
+        assertThat(closedState.contentRevision).isEqualTo(activeState.contentRevision + 1)
+        assertThat(closedState.itemCount).isZero()
+        assertThat(presenter.state.value).isSameAs(closedState)
+        verify(initialList).removeWeakCallback(callback)
+        verify(replacementList, never()).addWeakCallback(anyOrNull(), any())
+    }
+
+    @Test
+    fun `when content changes, then state flow emits a new revision`() = runTest(UnconfinedTestDispatcher()) {
+        // GIVEN
+        val presenter = OrderListPaging2Presenter()
+
+        // WHEN
+        val states = presenter.state.runAndCaptureValues {
+            presenter.markContentChanged()
+        }
+
+        // THEN
+        assertThat(states).hasSize(2)
+        assertThat(states[1]).isNotSameAs(states[0])
+        assertThat(states[1].generation).isEqualTo(states[0].generation)
+        assertThat(states[1].contentRevision).isEqualTo(states[0].contentRevision + 1)
+
+        presenter.close()
     }
 
     private fun callbackFor(pagedList: PagedList<OrderListItemUIType>): PagedList.Callback {


### PR DESCRIPTION
### Description
Part of WOOMOB-3708

This stacked PR builds on [PR #16324 — Orders Compose UI foundation](https://github.com/woocommerce/woocommerce-android/pull/16324) and introduces the isolated Paging 2 presentation seam needed by the later production cutover.

The existing Orders list still uses Paging 2. Compose needs an immutable, indexed snapshot for rendering while preserving `PagedList.loadAround()` hints, stable row identity, and callback-driven updates. `OrderListPaging2Presenter` provides that bridge without changing the current production route; PR3 will connect it to the screen.

#### Changes

- Adds `OrderListPaging2Presenter`, exposing immutable `StateFlow` snapshots of the active `PagedList`.
- Keeps item count, indexed reads, stable keys, and loaded order IDs tied to one captured presenter state.
- Triggers `loadAround(index)` only when reading through the currently published state, so stale snapshots remain side-effect free.
- Separates list `generation` from `contentRevision`:
  - Replacing the `PagedList` advances both.
  - Paging callbacks and same-instance item mutations advance only content revision.
- Uses stable, saveable keys for orders, loading rows, date sections, and unresolved placeholders.
- Owns `PagedList.Callback` attachment and removal across replacement and close.
- Publishes each matching snapshot before attaching its callback, keeping list and state authority coherent even if callback behavior changes later.
- Adds JVM coverage for same-instance mutation and resubmission, list shrink and clearing, placeholder identity, loaded-order helpers, stale callbacks, prefetch gating, StateFlow revisions, and terminal cleanup.

#### Scope

- The presenter is intentionally not called by production code at this boundary.
- `OrderListFragment`, `OrderListViewModel`, the RecyclerView renderer, navigation, analytics, and visible behavior remain unchanged.
- Migrating Orders to Paging 3 is out of scope; this seam preserves the current Paging 2 behavior for the Compose cutover.
- No release-notes entry is needed because this PR is internal infrastructure with no user-facing change.

#### Verification

- All nine `OrderListPaging2PresenterTest` cases pass.
- Wasabi debug production and unit-test Kotlin compilation pass as part of the focused test run.
- `detektAll --no-auto-correct` passes.
- `git diff --check` passes at the PR1 → PR2 boundary.

### Test Steps

1. Check out this PR on top of PR #16324, launch the app, and open Orders.
2. Confirm the existing Orders list still loads, scrolls, and paginates as before. No visual or behavioral change is expected because the presenter is not wired until PR3.

### Images/gif
N/A — this PR adds an internal, intentionally unwired presentation seam.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
