### PR TITLE
[WOOMOB-3735] Upload Zendesk ticket attachments concurrently

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/zendesk/ZendeskTicketRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/zendesk/ZendeskTicketRepository.kt
@@ -20,7 +20,10 @@ import com.woocommerce.android.util.WCSSRModelCachingFetcher
 import com.woocommerce.android.util.WooLog
 import com.zendesk.service.ErrorResponse
 import com.zendesk.service.ZendeskCallback
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.flowOn
@@ -78,11 +81,15 @@ class ZendeskTicketRepository @Inject constructor(
 
         val deviceLogs = envDataSource.getFullDeviceLogs()
 
-        val attachmentTokens = listOfNotNull(
-            diagnosticLog?.let { uploadTextAttachment(DIAGNOSTIC_LOG_FILENAME, it) },
-            uploadTextAttachment(APPLICATION_LOG_FILENAME, deviceLogs),
-            uploadTextAttachment(MSR_FILENAME, msr)
-        )
+        // The uploads are independent, so we run them concurrently to wait for the slowest one instead of
+        // the sum of all of them. Failed uploads yield null and are dropped, without affecting the others.
+        val attachmentTokens = coroutineScope {
+            listOfNotNull(
+                diagnosticLog?.let { async { uploadTextAttachment(DIAGNOSTIC_LOG_FILENAME, it) } },
+                async { uploadTextAttachment(APPLICATION_LOG_FILENAME, deviceLogs) },
+                async { uploadTextAttachment(MSR_FILENAME, msr) }
+            ).awaitAll().filterNotNull()
+        }
 
         val requestCallback = object : ZendeskCallback<Request>() {
             override fun onSuccess(result: Request?) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/zendesk/ZendeskTicketRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/zendesk/ZendeskTicketRepository.kt
@@ -81,8 +81,6 @@ class ZendeskTicketRepository @Inject constructor(
 
         val deviceLogs = envDataSource.getFullDeviceLogs()
 
-        // The uploads are independent, so we run them concurrently to wait for the slowest one instead of
-        // the sum of all of them. Failed uploads yield null and are dropped, without affecting the others.
         val attachmentTokens = coroutineScope {
             listOfNotNull(
                 diagnosticLog?.let { async { uploadTextAttachment(DIAGNOSTIC_LOG_FILENAME, it) } },

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/support/ZendeskTicketRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/support/ZendeskTicketRepositoryTest.kt
@@ -854,7 +854,12 @@ internal class ZendeskTicketRepositoryTest : BaseUnitTest() {
             }
 
             // then
-            verify(uploadProvider).uploadAttachment(any(), any(), any(), uploadCaptor.capture())
+            verify(uploadProvider).uploadAttachment(
+                eq("application_log.txt"),
+                any(),
+                any(),
+                uploadCaptor.capture()
+            )
             uploadCaptor.firstValue.onError(mock())
             advanceUntilIdle()
             verify(requestProvider).createRequest(requestCaptor.capture(), any())
@@ -987,6 +992,94 @@ internal class ZendeskTicketRepositoryTest : BaseUnitTest() {
             job.cancel()
 
             assertThat(requestCaptor.firstValue.attachments).containsExactly("app-log-token", "status-token")
+        }
+
+    @Test
+    fun `when createRequest is called, then all the attachments are uploaded before any of them completes`() =
+        testBlocking {
+            // given
+            val uploadProvider = mock<UploadProvider>()
+            given(zendeskSettings.uploadProvider).willReturn(uploadProvider)
+
+            // when
+            val job = launch {
+                sut.createRequest(
+                    context = mock(),
+                    origin = HelpOrigin.LOGIN_HELP_NOTIFICATION,
+                    ticketType = TicketType.MobileApp,
+                    selectedSite = null,
+                    subject = "subject",
+                    description = "description",
+                    extraTags = emptyList(),
+                    siteAddress = "siteAddress",
+                    diagnosticLog = "diagnostic logs"
+                ).first()
+            }
+
+            // then all three uploads are in flight even though none of them has invoked its callback yet
+            verify(uploadProvider).uploadAttachment(eq("connectivitytest_log.txt"), any(), any(), any())
+            verify(uploadProvider).uploadAttachment(eq("application_log.txt"), any(), any(), any())
+            verify(uploadProvider).uploadAttachment(eq("mobile_status_report.txt"), any(), any(), any())
+            advanceUntilIdle()
+            job.cancel()
+        }
+
+    @Test
+    fun `given one attachment upload fails, when createRequest is called, then the others are still attached`() =
+        testBlocking {
+            // given
+            val diagnosticResponse = mock<UploadResponse> { on { token } doReturn "diagnostic-token" }
+            val statusResponse = mock<UploadResponse> { on { token } doReturn "status-token" }
+            val uploadProvider = mock<UploadProvider>()
+            given(zendeskSettings.uploadProvider).willReturn(uploadProvider)
+            val diagnosticCaptor = argumentCaptor<ZendeskCallback<UploadResponse>>()
+            val appLogCaptor = argumentCaptor<ZendeskCallback<UploadResponse>>()
+            val statusCaptor = argumentCaptor<ZendeskCallback<UploadResponse>>()
+            val requestCaptor = argumentCaptor<CreateRequest>()
+
+            // when
+            val job = launch {
+                sut.createRequest(
+                    context = mock(),
+                    origin = HelpOrigin.LOGIN_HELP_NOTIFICATION,
+                    ticketType = TicketType.MobileApp,
+                    selectedSite = null,
+                    subject = "subject",
+                    description = "description",
+                    extraTags = emptyList(),
+                    siteAddress = "siteAddress",
+                    diagnosticLog = "diagnostic logs"
+                ).first()
+            }
+
+            verify(uploadProvider).uploadAttachment(
+                eq("connectivitytest_log.txt"),
+                any(),
+                any(),
+                diagnosticCaptor.capture()
+            )
+            verify(uploadProvider).uploadAttachment(
+                eq("application_log.txt"),
+                any(),
+                any(),
+                appLogCaptor.capture()
+            )
+            verify(uploadProvider).uploadAttachment(
+                eq("mobile_status_report.txt"),
+                any(),
+                any(),
+                statusCaptor.capture()
+            )
+            appLogCaptor.firstValue.onError(mock())
+            diagnosticCaptor.firstValue.onSuccess(diagnosticResponse)
+            statusCaptor.firstValue.onSuccess(statusResponse)
+            advanceUntilIdle()
+
+            // then
+            verify(requestProvider).createRequest(requestCaptor.capture(), any())
+            job.cancel()
+
+            assertThat(requestCaptor.firstValue.attachments).containsExactly("diagnostic-token", "status-token")
         }
 
     private fun createSUT() {


### PR DESCRIPTION
### Description

Fixes WOOMOB-3735

`ZendeskTicketRepository.createRequest()` uploaded the ticket attachments one after another, so submitting a support request waited for the sum of all three round trips instead of the slowest one — and in the worst case burned 3× `attachmentUploadTimeout`. This runs them in a `coroutineScope` with `async`/`awaitAll` instead.

`uploadTextAttachment()` already returns `null` on failure or timeout rather than throwing, so the best-effort semantics survive unchanged: one failing upload can't cancel its siblings or block ticket creation. Attachment order is preserved too, since `awaitAll` keeps the list order.

One existing test needed its `verify` narrowed from `any()` to `eq("application_log.txt")` — with concurrent uploads two calls are recorded by the time it runs, so the unfiltered matcher hit `TooManyActualInvocations`.

### Test Steps

1. Open **Settings → Help & Support → Contact Support**, fill in a subject and description, and submit.
2. Confirm the ticket is created successfully and that submission feels faster than before.
3. Turn off networking mid-submission (or use a flaky connection) and submit again — the ticket should still be created, just without the attachments that failed.

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.