### PR TITLE
[WOOMOB-3747] Fix card reader payment crash when the payment screen is recreated

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,7 @@
 - [*] Fixed coupon expiry dates drifting when unrelated coupon changes were saved for stores outside UTC [https://github.com/woocommerce/woocommerce-android/pull/16279]
 - [*] Card payments no longer show an error when the payment was actually captured but the backend reported a network/server issue — the app now verifies the payment status and shows success, preventing double charges [https://github.com/woocommerce/woocommerce-android/pull/16295]
 - [*] Leaving the order note or address editor via the toolbar back button now asks to discard unsaved changes instead of silently dropping them [https://github.com/woocommerce/woocommerce-android/pull/16318]
+- [*] Fixed a crash when the payment screen was recreated, such as rotating the device, while an in-person card payment was being processed — the payment now keeps running instead of freezing [https://github.com/woocommerce/woocommerce-android/pull/16359]
 
 25.3
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.map
+import com.automattic.android.tracks.crashlogging.CrashLogging
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.cardreader.payments.PaymentData
@@ -56,6 +57,7 @@ class CardReaderPaymentViewModel @Inject constructor(
     cardReaderOnboardingChecker: CardReaderOnboardingChecker,
     paymentReceiptShare: PaymentReceiptShare,
     paymentStateMapper: CardReaderPaymentStateToViewStateMapper,
+    crashLogging: CrashLogging,
 ) : ScopedViewModel(savedState) {
     private val arguments: CardReaderPaymentDialogFragmentArgs by savedState.navArgs()
 
@@ -88,6 +90,7 @@ class CardReaderPaymentViewModel @Inject constructor(
         paymentOrRefund = arguments.paymentOrRefund,
         cardReaderType = arguments.cardReaderType,
         isTTPPaymentInProgress = ::isTTPPaymentInProgress,
+        crashLogging = crashLogging,
     )
 
     private val derivedPaymentState: LiveData<ViewState> =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentController.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentController.kt
@@ -136,6 +136,11 @@ class CardReaderPaymentController(
     }
 
     fun start() {
+        // The view can be recreated while a payment is in flight (rotation, dialog recreation). Cancelling the
+        // scope here would kill the running flow without restarting it, and cancelling an in-flight Stripe
+        // operation throws from its cancellation handler.
+        if (paymentFlowJob?.isActive == true || refundFlowJob?.isActive == true) return
+
         scope.cancel()
         scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
         if (cardReaderManager.readerStatus.value is CardReaderStatus.Connected) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentController.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentController.kt
@@ -71,6 +71,7 @@ import com.woocommerce.android.util.PrintHtmlHelper.PrintJobResult.FAILED
 import com.woocommerce.android.util.PrintHtmlHelper.PrintJobResult.STARTED
 import com.woocommerce.android.util.WooLog
 import kotlinx.coroutines.CompletionHandlerException
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.InternalCoroutinesApi
@@ -115,7 +116,17 @@ class CardReaderPaymentController(
     private val isTTPPaymentInProgress: KMutableProperty0<Boolean>,
     private val allowCancelledStatus: Boolean = false,
 ) {
-    private var scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    @OptIn(InternalCoroutinesApi::class)
+    private val scopeExceptionHandler = CoroutineExceptionHandler { _, throwable ->
+        // Stripe Terminal throws from its coroutine cancellation handler when the operation is still waiting for
+        // a network response. Coroutines report that as CompletionHandlerException through this handler instead
+        // of throwing it to the caller, so it cannot be caught around scope.cancel(). Anything else reaching
+        // here is a real failure and has to keep crashing.
+        if (throwable !is CompletionHandlerException) throw throwable
+        WooLog.e(WooLog.T.CARD_READER, "Failed to cancel the card reader payment scope", throwable)
+    }
+
+    private var scope: CoroutineScope = createScope()
     private val terminalPaymentPreparationResolver = TerminalPaymentPreparationResolver(wooStore, appPrefs)
 
     private val _paymentState: MutableStateFlow<CardReaderPaymentOrRefundState> =
@@ -135,6 +146,8 @@ class CardReaderPaymentController(
         _event.emit(event)
     }
 
+    private fun createScope() = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate + scopeExceptionHandler)
+
     fun start() {
         // The view can be recreated while a payment is in flight (rotation, dialog recreation). Cancelling the
         // scope here would kill the running flow without restarting it, and cancelling an in-flight Stripe
@@ -142,7 +155,7 @@ class CardReaderPaymentController(
         if (paymentFlowJob?.isActive == true || refundFlowJob?.isActive == true) return
 
         scope.cancel()
-        scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+        scope = createScope()
         if (cardReaderManager.readerStatus.value is CardReaderStatus.Connected) {
             startFlowWhenReaderConnected()
         } else {
@@ -795,7 +808,6 @@ class CardReaderPaymentController(
         }
     }
 
-    @OptIn(InternalCoroutinesApi::class)
     fun stop() {
         try {
             paymentDataForRetry?.let {
@@ -804,13 +816,7 @@ class CardReaderPaymentController(
         } catch (e: IllegalStateException) {
             WooLog.e(WooLog.T.CARD_READER, "Failed to cancel card reader payment", e)
         } finally {
-            try {
-                // Stripe Terminal can throw from a coroutine cancellation handler while it is waiting for
-                // a network response; coroutines wrap that in CompletionHandlerException.
-                scope.cancel()
-            } catch (e: CompletionHandlerException) {
-                WooLog.e(WooLog.T.CARD_READER, "Failed to stop card reader payment controller", e)
-            }
+            scope.cancel()
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentController.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentController.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.payments.cardreader.payment.controller
 
 import androidx.annotation.StringRes
 import androidx.annotation.VisibleForTesting
+import com.automattic.android.tracks.crashlogging.CrashLogging
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.AppUrls
 import com.woocommerce.android.R
@@ -89,6 +90,7 @@ import org.wordpress.android.fluxc.store.WooCommerceStore
 import kotlin.reflect.KMutableProperty0
 
 private const val ARTIFICIAL_RETRY_DELAY = 500L
+private const val SCOPE_CANCELLATION_FAILURE_MESSAGE = "Failed to cancel the card reader payment scope"
 
 @Suppress("LongParameterList", "LargeClass")
 class CardReaderPaymentController(
@@ -114,6 +116,7 @@ class CardReaderPaymentController(
     private val paymentOrRefund: CardReaderFlowParam.PaymentOrRefund,
     private val cardReaderType: CardReaderType,
     private val isTTPPaymentInProgress: KMutableProperty0<Boolean>,
+    private val crashLogging: CrashLogging,
     private val allowCancelledStatus: Boolean = false,
 ) {
     @OptIn(InternalCoroutinesApi::class)
@@ -123,7 +126,10 @@ class CardReaderPaymentController(
         // of throwing it to the caller, so it cannot be caught around scope.cancel(). Anything else reaching
         // here is a real failure and has to keep crashing.
         if (throwable !is CompletionHandlerException) throw throwable
-        WooLog.e(WooLog.T.CARD_READER, "Failed to cancel the card reader payment scope", throwable)
+        WooLog.e(WooLog.T.CARD_READER, SCOPE_CANCELLATION_FAILURE_MESSAGE, throwable)
+        // CompletionHandlerException is not a Stripe type, so it can also come from a handler we do not know
+        // about. Report it as a non-fatal to keep those visible instead of silently swallowing them.
+        crashLogging.sendReport(exception = throwable, message = SCOPE_CANCELLATION_FAILURE_MESSAGE)
     }
 
     private var scope: CoroutineScope = createScope()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentController.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentController.kt
@@ -121,14 +121,10 @@ class CardReaderPaymentController(
 ) {
     @OptIn(InternalCoroutinesApi::class)
     private val scopeExceptionHandler = CoroutineExceptionHandler { _, throwable ->
-        // Stripe Terminal throws from its coroutine cancellation handler when the operation is still waiting for
-        // a network response. Coroutines report that as CompletionHandlerException through this handler instead
-        // of throwing it to the caller, so it cannot be caught around scope.cancel(). Anything else reaching
-        // here is a real failure and has to keep crashing.
+        // Stripe throws from its cancellation handler while an operation awaits the network. Coroutines route
+        // that here rather than to the caller, so it cannot be caught around scope.cancel().
         if (throwable !is CompletionHandlerException) throw throwable
         WooLog.e(WooLog.T.CARD_READER, SCOPE_CANCELLATION_FAILURE_MESSAGE, throwable)
-        // CompletionHandlerException is not a Stripe type, so it can also come from a handler we do not know
-        // about. Report it as a non-fatal to keep those visible instead of silently swallowing them.
         crashLogging.sendReport(exception = throwable, message = SCOPE_CANCELLATION_FAILURE_MESSAGE)
     }
 
@@ -155,9 +151,7 @@ class CardReaderPaymentController(
     private fun createScope() = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate + scopeExceptionHandler)
 
     fun start() {
-        // The view can be recreated while a payment is in flight (rotation, dialog recreation). Cancelling the
-        // scope here would kill the running flow without restarting it, and cancelling an in-flight Stripe
-        // operation throws from its cancellation handler.
+        // The view can be recreated mid-payment (rotation), and the cancel below would kill the flow for good.
         if (paymentFlowJob?.isActive == true || refundFlowJob?.isActive == true) return
 
         scope.cancel()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosCardReaderPaymentControllerFactory.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosCardReaderPaymentControllerFactory.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.woopos.home.totals
 
+import com.automattic.android.tracks.crashlogging.CrashLogging
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.di.PointOfSaleMode
@@ -48,6 +49,7 @@ class WooPosCardReaderPaymentControllerFactory @Inject constructor(
     private val paymentReceiptHelper: PaymentReceiptHelper,
     private val cardReaderOnboardingChecker: CardReaderOnboardingChecker,
     private val paymentReceiptShare: PaymentReceiptShare,
+    private val crashLogging: CrashLogging,
 ) {
     fun create(
         orderId: Long,
@@ -80,6 +82,7 @@ class WooPosCardReaderPaymentControllerFactory @Inject constructor(
         ),
         cardReaderType = cardReaderType,
         isTTPPaymentInProgress = isTTPPaymentInProgress,
+        crashLogging = crashLogging,
     )
 
     fun createRefund(
@@ -112,6 +115,7 @@ class WooPosCardReaderPaymentControllerFactory @Inject constructor(
         ),
         cardReaderType = CardReaderType.EXTERNAL,
         isTTPPaymentInProgress = isTTPPaymentInProgress,
+        crashLogging = crashLogging,
         allowCancelledStatus = false,
     )
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderPaymentViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.payments.cardreader
 
 import androidx.lifecycle.SavedStateHandle
+import com.automattic.android.tracks.crashlogging.CrashLogging
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R
 import com.woocommerce.android.cardreader.CardReaderManager
@@ -175,6 +176,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     private val paymentReceiptHelper: PaymentReceiptHelper = mock()
     private val cardReaderOnboardingChecker: CardReaderOnboardingChecker = mock()
     private val paymentReceiptShare: PaymentReceiptShare = mock()
+    private val crashLogging: CrashLogging = mock()
     private val paymentStateMapper = CardReaderPaymentStateToViewStateMapper(
         cardReaderPaymentReaderTypeStateProvider
     )
@@ -204,6 +206,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
             paymentReceiptShare = paymentReceiptShare,
             paymentStateProvider = paymentStateProvider,
             paymentStateMapper = paymentStateMapper,
+            crashLogging = crashLogging,
         )
 
         whenever(orderRepository.getOrderById(any())).thenReturn(mockedOrder)
@@ -2699,6 +2702,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
             paymentReceiptShare = paymentReceiptShare,
             paymentStateProvider = paymentStateProvider,
             paymentStateMapper = paymentStateMapper,
+            crashLogging = crashLogging,
         )
         viewModel.event.observeForever {}
         viewModel.viewStateData.observeForever {}
@@ -2737,6 +2741,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
             paymentReceiptShare = paymentReceiptShare,
             paymentStateProvider = paymentStateProvider,
             paymentStateMapper = paymentStateMapper,
+            crashLogging = crashLogging,
         )
         viewModel.event.observeForever {}
         viewModel.viewStateData.observeForever {}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentControllerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentControllerTest.kt
@@ -2511,18 +2511,15 @@ class CardReaderPaymentControllerTest : BaseUnitTest() {
     @Test
     fun `given user leaves the screen, when scope cancellation handler throws, then stop does not crash`() =
         testBlocking {
-            whenever(cardReaderManager.collectPayment(any())).thenAnswer {
-                flow<CardPaymentStatus> {
-                    suspendCancellableCoroutine<Unit> { continuation ->
-                        continuation.invokeOnCancellation {
-                            throw IllegalStateException("Cancellation race")
-                        }
-                    }
-                }
-            }
+            // GIVEN
+            stubPaymentThatThrowsOnCancellation()
             controller.start()
 
-            controller.stop()
+            // WHEN
+            val uncaught = captureUncaughtExceptions { controller.stop() }
+
+            // THEN
+            assertThat(uncaught).isEmpty()
         }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentControllerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentControllerTest.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.payments.cardreader.payment.controller
 
+import com.automattic.android.tracks.crashlogging.CrashLogging
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R
 import com.woocommerce.android.cardreader.CardReaderManager
@@ -130,6 +131,7 @@ class CardReaderPaymentControllerTest : BaseUnitTest() {
     private val paymentReceiptHelper: PaymentReceiptHelper = mock()
     private val cardReaderOnboardingChecker: CardReaderOnboardingChecker = mock()
     private val paymentReceiptShare: PaymentReceiptShare = mock()
+    private val crashLogging: CrashLogging = mock()
 
     private var isTTPinProgress = false
     private val isTTPinProgressProp: KMutableProperty0<Boolean> = ::isTTPinProgress
@@ -225,6 +227,7 @@ class CardReaderPaymentControllerTest : BaseUnitTest() {
             paymentOrRefund = cardReaderFlowParam,
             cardReaderType = cardReaderType,
             isTTPPaymentInProgress = isTTPinProgressProp,
+            crashLogging = crashLogging,
         )
     }
 
@@ -3920,6 +3923,7 @@ class CardReaderPaymentControllerTest : BaseUnitTest() {
             paymentOrRefund = param,
             cardReaderType = CardReaderType.EXTERNAL,
             isTTPPaymentInProgress = isTTPinProgressProp,
+            crashLogging = crashLogging,
         )
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentControllerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentControllerTest.kt
@@ -2526,6 +2526,63 @@ class CardReaderPaymentControllerTest : BaseUnitTest() {
         }
 
     @Test
+    fun `given payment in flight, when the flow is restarted, then cancellation handler does not crash`() =
+        testBlocking {
+            // GIVEN
+            stubPaymentThatThrowsOnCancellation()
+            controller.start()
+
+            // WHEN
+            val uncaught = captureUncaughtExceptions { controller.start() }
+
+            // THEN
+            assertThat(uncaught).isEmpty()
+        }
+
+    @Test
+    fun `given payment in flight, when the flow is restarted, then payment updates are still delivered`() =
+        testBlocking {
+            // GIVEN
+            val paymentStatus = MutableStateFlow<CardPaymentStatus>(InitializingPayment)
+            whenever(cardReaderManager.collectPayment(any())).thenReturn(paymentStatus)
+            controller.start()
+
+            // WHEN
+            controller.start()
+            paymentStatus.value = ProcessingPayment
+
+            // THEN
+            assertThat(controller.paymentState.value)
+                .isInstanceOf(CardReaderPaymentState.ProcessingPayment::class.java)
+        }
+
+    private suspend fun stubPaymentThatThrowsOnCancellation() {
+        whenever(cardReaderManager.collectPayment(any())).thenAnswer {
+            flow<CardPaymentStatus> {
+                suspendCancellableCoroutine<Unit> { continuation ->
+                    continuation.invokeOnCancellation {
+                        throw IllegalStateException(
+                            "Cannot cancel this operation while it is waiting for a network response"
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    private fun captureUncaughtExceptions(block: () -> Unit): List<Throwable> {
+        val captured = mutableListOf<Throwable>()
+        val originalHandler = Thread.getDefaultUncaughtExceptionHandler()
+        Thread.setDefaultUncaughtExceptionHandler { _, throwable -> captured.add(throwable) }
+        try {
+            block()
+        } finally {
+            Thread.setDefaultUncaughtExceptionHandler(originalHandler)
+        }
+        return captured
+    }
+
+    @Test
     fun `given user leaves the screen, when payment succeeded on retry, then payment NOT canceled`() =
         testBlocking {
             whenever(errorMapper.mapPaymentErrorToUiError(Generic, false))

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentControllerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentControllerTest.kt
@@ -2553,32 +2553,6 @@ class CardReaderPaymentControllerTest : BaseUnitTest() {
                 .isInstanceOf(CardReaderPaymentState.ProcessingPayment::class.java)
         }
 
-    private suspend fun stubPaymentThatThrowsOnCancellation() {
-        whenever(cardReaderManager.collectPayment(any())).thenAnswer {
-            flow<CardPaymentStatus> {
-                suspendCancellableCoroutine<Unit> { continuation ->
-                    continuation.invokeOnCancellation {
-                        throw IllegalStateException(
-                            "Cannot cancel this operation while it is waiting for a network response"
-                        )
-                    }
-                }
-            }
-        }
-    }
-
-    private fun captureUncaughtExceptions(block: () -> Unit): List<Throwable> {
-        val captured = mutableListOf<Throwable>()
-        val originalHandler = Thread.getDefaultUncaughtExceptionHandler()
-        Thread.setDefaultUncaughtExceptionHandler { _, throwable -> captured.add(throwable) }
-        try {
-            block()
-        } finally {
-            Thread.setDefaultUncaughtExceptionHandler(originalHandler)
-        }
-        return captured
-    }
-
     @Test
     fun `given user leaves the screen, when payment succeeded on retry, then payment NOT canceled`() =
         testBlocking {
@@ -3882,6 +3856,32 @@ class CardReaderPaymentControllerTest : BaseUnitTest() {
 
             verify(cardReaderManager, never()).collectPayment(any())
         }
+
+    private suspend fun stubPaymentThatThrowsOnCancellation() {
+        whenever(cardReaderManager.collectPayment(any())).thenAnswer {
+            flow<CardPaymentStatus> {
+                suspendCancellableCoroutine<Unit> { continuation ->
+                    continuation.invokeOnCancellation {
+                        throw IllegalStateException(
+                            "Cannot cancel this operation while it is waiting for a network response"
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    private fun captureUncaughtExceptions(block: () -> Unit): List<Throwable> {
+        val captured = mutableListOf<Throwable>()
+        val originalHandler = Thread.getDefaultUncaughtExceptionHandler()
+        Thread.setDefaultUncaughtExceptionHandler { _, throwable -> captured.add(throwable) }
+        try {
+            block()
+        } finally {
+            Thread.setDefaultUncaughtExceptionHandler(originalHandler)
+        }
+        return captured
+    }
 
     private suspend fun simulateFetchOrderJobState(inProgress: Boolean) {
         if (inProgress) {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.woopos.home.totals
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
+import com.automattic.android.tracks.crashlogging.CrashLogging
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R
 import com.woocommerce.android.WooException
@@ -138,6 +139,7 @@ class WooPosTotalsViewModelTest {
     private val paymentReceiptShare: PaymentReceiptShare = mock()
     private val uiStringParser: UiStringParser = mock()
     private val wooPosLogWrapper: WooPosLogWrapper = mock()
+    private val crashLogging: CrashLogging = mock()
     private val paymentControllerFactory = WooPosCardReaderPaymentControllerFactory(
         cardReaderManager = cardReaderManager,
         orderRepository = orderRepository,
@@ -158,6 +160,7 @@ class WooPosTotalsViewModelTest {
         paymentReceiptHelper = paymentReceiptHelper,
         cardReaderOnboardingChecker = cardReaderOnboardingChecker,
         paymentReceiptShare = paymentReceiptShare,
+        crashLogging = crashLogging,
     )
 
     private fun createMockSavedStateHandle(): SavedStateHandle {


### PR DESCRIPTION
### Description

Fixes WOOMOB-3747

`start()` runs again when the payment dialog's view is recreated, for example on rotation, while the controller survives. It always called `scope.cancel()`, which caused two bugs during a payment:

- Cancelling an in-flight Stripe operation makes Stripe throw from its cancellation handler. Coroutines pass that to the uncaught exception handler, so the app crashes. 23 users in Sentry.
- The cancelled payment job was never restarted, so the screen froze while the charge could still go through.

`start()` now returns early while a payment or refund is still running, which fixes both. `stop()` still has to cancel, so the scope now has a `CoroutineExceptionHandler`. The old `try/catch` in `stop()` never worked and is removed, because coroutines never throw that exception to the caller.

The added unit tests reproduce both bugs. All three fail on trunk and pass with this change.

Notes for review:

- The handler catches any `CompletionHandlerException`, not only Stripe's. Narrowing it would need Stripe types in the app module or matching on the message.
- The exception no longer crashes the app, so it is logged to `WooLog` and sent to Sentry as a non-fatal.
- POS is not affected. It creates a new controller before every `start()`.

### Test Steps

1. Open an order and start a card payment.
2. Rotate the device while the payment is being processed.
3. The app does not crash, the screen keeps updating, and the payment completes.
4. Start another payment and press back while it is being processed. The app does not crash.
5. Check a normal payment still works, and cancelling one before tapping a card.

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
