### PR TITLE
[WOOMOB-3754] Block subscription products from reaching an order via bundles and scanning

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 25.4
 -----
 - [*] Fixed bundled variable products not asking for a variation when configuring a bundle during order creation
+- [*] Bundles containing a subscription product can no longer be added to an order, and scanning a subscription product now explains why it can't be added
 - [Internal] Attach a Mobile Status Report (device, OS, connectivity, notifications, feature flags) to support tickets
 - [*] Fixed fully refunded orders remaining visible in the Completed orders filter [https://github.com/woocommerce/woocommerce-android/pull/16313]
 - [*] Fixed coupon expiry dates drifting when unrelated coupon changes were saved for stores outside UTC [https://github.com/woocommerce/woocommerce-android/pull/16279]

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/BundledProduct.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/BundledProduct.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.model
 
 import android.os.Parcelable
 import com.woocommerce.android.ui.products.ProductStockStatus
+import com.woocommerce.android.ui.products.ProductType
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
@@ -12,10 +13,13 @@ data class BundledProduct(
     val title: String,
     val stockStatus: ProductStockStatus,
     val rules: BundleProductRules,
+    val productType: ProductType,
     val imageUrl: String? = null,
     val sku: String? = null,
+) : Parcelable {
     val isVariable: Boolean
-) : Parcelable
+        get() = productType == ProductType.VARIABLE
+}
 
 @Parcelize
 data class BundleProductRules(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -1058,7 +1058,7 @@ class OrderCreateEditViewModel @Inject constructor(
         source: ScanningSource,
         barcodeFormat: BarcodeFormat
     ) {
-        val nonSelectableReason = productRestrictions.getNonSelectableRestriction(product)?.nonSelectableReason
+        val unsupportedReason = productRestrictions.getUnsupportedRestriction(product)?.reason
         when {
             product.isNotPublished() -> {
                 sendAddingProductsViaScanningFailedEvent(
@@ -1086,9 +1086,9 @@ class OrderCreateEditViewModel @Inject constructor(
                 )
             }
 
-            nonSelectableReason != null -> {
+            unsupportedReason != null -> {
                 sendAddingProductsViaScanningFailedEvent(
-                    message = resourceProvider.getString(nonSelectableReason)
+                    message = resourceProvider.getString(unsupportedReason)
                 )
                 trackProductSearchViaSKUFailureEvent(
                     source,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -1058,6 +1058,7 @@ class OrderCreateEditViewModel @Inject constructor(
         source: ScanningSource,
         barcodeFormat: BarcodeFormat
     ) {
+        val nonSelectableReason = productRestrictions.getNonSelectableRestriction(product)?.nonSelectableReason
         when {
             product.isNotPublished() -> {
                 sendAddingProductsViaScanningFailedEvent(
@@ -1082,6 +1083,17 @@ class OrderCreateEditViewModel @Inject constructor(
                     source,
                     barcodeFormat,
                     "Failed to add a product whose price is not specified"
+                )
+            }
+
+            nonSelectableReason != null -> {
+                sendAddingProductsViaScanningFailedEvent(
+                    message = resourceProvider.getString(nonSelectableReason)
+                )
+                trackProductSearchViaSKUFailureEvent(
+                    source,
+                    barcodeFormat,
+                    "Failed to add a product which is not supported for order creation"
                 )
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -1000,7 +1000,7 @@ class OrderCreateEditViewModel @Inject constructor(
         source: ScanningSource,
         barcodeFormat: BarcodeFormat
     ) {
-        if (productRestrictions.isProductRestricted(product)) {
+        if (productRestrictions.isProductBlocked(product)) {
             handleProductRestrictions(product, source, barcodeFormat)
         } else if (product.isVariable()) {
             handleVariableProduct(product, source, barcodeFormat, selectedItems)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GetBundledProducts.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GetBundledProducts.kt
@@ -10,7 +10,6 @@ import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCProductModel
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductType
 import org.wordpress.android.fluxc.store.WCProductStore
 import javax.inject.Inject
 
@@ -45,7 +44,7 @@ class GetBundledProducts @Inject constructor(
                             attributesDefault = entity.attributesDefault?.map { VariantOption(it) },
                             variationIds = entity.variationIds
                         ),
-                        isVariable = product?.type == CoreProductType.VARIABLE.value
+                        productType = ProductType.fromString(product?.type.orEmpty())
                     )
                 }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/HasUnsupportedBundledProducts.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/HasUnsupportedBundledProducts.kt
@@ -9,9 +9,9 @@ import javax.inject.Inject
  * product list asks. The bundled products are not part of the cached product list, so this resolves them and is only
  * worth calling once the merchant picks the bundle.
  *
- * Only the restrictions carrying a reason apply: they are the ones saying a product can never be sold from the app.
- * The rest merely keep a product out of the list — a bundled product being unpublished or having no price of its own
- * says nothing about whether the bundle can be sold.
+ * Only the [ProductRestriction.Unsupported] restrictions apply: a [ProductRestriction.Hidden] one merely keeps a
+ * product out of the list — a bundled product being unpublished or having no price of its own says nothing about
+ * whether the bundle can be sold.
  */
 class HasUnsupportedBundledProducts @Inject constructor(
     private val getBundledProducts: GetBundledProducts,
@@ -21,7 +21,7 @@ class HasUnsupportedBundledProducts @Inject constructor(
     suspend operator fun invoke(productId: Long): Boolean {
         return getBundledProducts(productId).first().any { bundledProduct ->
             val product = productDetailRepository.getProduct(bundledProduct.bundledProductId)
-            product != null && productRestrictions.getNonSelectableRestriction(product) != null
+            product != null && productRestrictions.getUnsupportedRestriction(product) != null
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/HasUnsupportedBundledProducts.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/HasUnsupportedBundledProducts.kt
@@ -1,0 +1,27 @@
+package com.woocommerce.android.ui.products
+
+import com.woocommerce.android.ui.products.details.ProductDetailRepository
+import kotlinx.coroutines.flow.first
+import javax.inject.Inject
+
+/**
+ * Tells whether a bundle holds a product which can't be added to an order, by asking the same restrictions the
+ * product list asks. The bundled products are not part of the cached product list, so this resolves them and is only
+ * worth calling once the merchant picks the bundle.
+ *
+ * Only the restrictions carrying a reason apply: they are the ones saying a product can never be sold from the app.
+ * The rest merely keep a product out of the list — a bundled product being unpublished or having no price of its own
+ * says nothing about whether the bundle can be sold.
+ */
+class HasUnsupportedBundledProducts @Inject constructor(
+    private val getBundledProducts: GetBundledProducts,
+    private val productDetailRepository: ProductDetailRepository,
+    private val productRestrictions: OrderCreationProductRestrictions
+) {
+    suspend operator fun invoke(productId: Long): Boolean {
+        return getBundledProducts(productId).first().any { bundledProduct ->
+            val product = productDetailRepository.getProduct(bundledProduct.bundledProductId)
+            product != null && productRestrictions.getNonSelectableRestriction(product) != null
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductRestrictions.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductRestrictions.kt
@@ -9,7 +9,7 @@ import javax.inject.Inject
 
 interface ProductRestrictions {
     val restrictions: List<ProductRestriction>
-    fun isProductRestricted(product: Product): Boolean {
+    fun isProductBlocked(product: Product): Boolean {
         return restrictions.map { restriction -> restriction(product) }
             .fold(false) { acc, result -> acc || result }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductRestrictions.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductRestrictions.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.products
 
 import android.os.Parcelable
 import androidx.annotation.StringRes
+import com.woocommerce.android.R
 import com.woocommerce.android.model.Product
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
@@ -37,6 +38,7 @@ class OrderCreationProductRestrictions @Inject constructor() : ProductRestrictio
             ProductRestriction.NonPurchasableProducts,
             ProductRestriction.VariableProductsWithNoVariations,
             ProductRestriction.ProductWithPriceNotSpecified,
+            ProductRestriction.SubscriptionProducts,
         )
 }
 
@@ -83,6 +85,16 @@ sealed class ProductRestriction : (Product) -> Boolean, Parcelable {
     object ProductWithPriceNotSpecified : ProductRestriction() {
         override fun invoke(product: Product): Boolean {
             return product.price == null
+        }
+    }
+
+    @Parcelize
+    object SubscriptionProducts : ProductRestriction() {
+        override val nonSelectableReason: Int
+            get() = R.string.product_selector_subscription_not_supported
+
+        override fun invoke(product: Product): Boolean {
+            return product.productType.isSubscriptionProduct()
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductRestrictions.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductRestrictions.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.products
 
 import android.os.Parcelable
+import androidx.annotation.StringRes
 import com.woocommerce.android.model.Product
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
@@ -10,6 +11,24 @@ interface ProductRestrictions {
     fun isProductRestricted(product: Product): Boolean {
         return restrictions.map { restriction -> restriction(product) }
             .fold(false) { acc, result -> acc || result }
+    }
+
+    /**
+     * Restricted products which stay in the product list, so that the reason can be shown to the user.
+     */
+    fun getNonSelectableRestriction(product: Product): ProductRestriction? {
+        return restrictions.firstOrNull { restriction ->
+            restriction.nonSelectableReason != null && restriction(product)
+        }
+    }
+
+    /**
+     * Restricted products which are removed from the product list altogether.
+     */
+    fun isProductHidden(product: Product): Boolean {
+        return restrictions.any { restriction ->
+            restriction.nonSelectableReason == null && restriction(product)
+        }
     }
 }
 class OrderCreationProductRestrictions @Inject constructor() : ProductRestrictions {
@@ -31,6 +50,14 @@ class ProductFilterProductRestrictions @Inject constructor() : ProductRestrictio
 
 @Parcelize
 sealed class ProductRestriction : (Product) -> Boolean, Parcelable {
+    /**
+     * When set, the product stays visible in the product selector and this is shown as the reason why it can't be
+     * selected. Restrictions without a reason remove the product from the list instead.
+     */
+    @get:StringRes
+    open val nonSelectableReason: Int?
+        get() = null
+
     @Parcelize
     object NonPublishedProducts : ProductRestriction() {
         override fun invoke(product: Product): Boolean {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductRestrictions.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductRestrictions.kt
@@ -9,27 +9,18 @@ import javax.inject.Inject
 
 interface ProductRestrictions {
     val restrictions: List<ProductRestriction>
+
     fun isProductBlocked(product: Product): Boolean {
-        return restrictions.map { restriction -> restriction(product) }
-            .fold(false) { acc, result -> acc || result }
+        return restrictions.any { restriction -> restriction(product) }
     }
 
-    /**
-     * Restricted products which stay in the product list, so that the reason can be shown to the user.
-     */
-    fun getNonSelectableRestriction(product: Product): ProductRestriction? {
-        return restrictions.firstOrNull { restriction ->
-            restriction.nonSelectableReason != null && restriction(product)
-        }
+    fun getUnsupportedRestriction(product: Product): ProductRestriction.Unsupported? {
+        return restrictions.filterIsInstance<ProductRestriction.Unsupported>()
+            .firstOrNull { restriction -> restriction(product) }
     }
 
-    /**
-     * Restricted products which are removed from the product list altogether.
-     */
     fun isProductHidden(product: Product): Boolean {
-        return restrictions.any { restriction ->
-            restriction.nonSelectableReason == null && restriction(product)
-        }
+        return restrictions.any { restriction -> restriction is ProductRestriction.Hidden && restriction(product) }
     }
 }
 class OrderCreationProductRestrictions @Inject constructor() : ProductRestrictions {
@@ -53,46 +44,46 @@ class ProductFilterProductRestrictions @Inject constructor() : ProductRestrictio
 @Parcelize
 sealed class ProductRestriction : (Product) -> Boolean, Parcelable {
     /**
-     * When set, the product stays visible in the product selector and this is shown as the reason why it can't be
-     * selected. Restrictions without a reason remove the product from the list instead.
+     * A restriction which removes the product from the product list altogether.
      */
-    @get:StringRes
-    open val nonSelectableReason: Int?
-        get() = null
+    sealed class Hidden : ProductRestriction()
+
+    /**
+     * A restriction on products the app can't sell at all. The product stays visible in the product list and
+     * [reason] is shown as why it can't be selected.
+     */
+    sealed class Unsupported(@StringRes val reason: Int) : ProductRestriction()
 
     @Parcelize
-    object NonPublishedProducts : ProductRestriction() {
+    object NonPublishedProducts : Hidden() {
         override fun invoke(product: Product): Boolean {
             return product.status != ProductStatus.PUBLISH
         }
     }
 
     @Parcelize
-    object NonPurchasableProducts : ProductRestriction() {
+    object NonPurchasableProducts : Hidden() {
         override fun invoke(product: Product): Boolean {
             return product.status != ProductStatus.PUBLISH && product.status != ProductStatus.PRIVATE
         }
     }
 
     @Parcelize
-    object VariableProductsWithNoVariations : ProductRestriction() {
+    object VariableProductsWithNoVariations : Hidden() {
         override fun invoke(product: Product): Boolean {
             return (product.isVariable() && product.numVariations == 0)
         }
     }
 
     @Parcelize
-    object ProductWithPriceNotSpecified : ProductRestriction() {
+    object ProductWithPriceNotSpecified : Hidden() {
         override fun invoke(product: Product): Boolean {
             return product.price == null
         }
     }
 
     @Parcelize
-    object SubscriptionProducts : ProductRestriction() {
-        override val nonSelectableReason: Int
-            get() = R.string.product_selector_subscription_not_supported
-
+    object SubscriptionProducts : Unsupported(R.string.product_selector_subscription_not_supported) {
         override fun invoke(product: Product): Boolean {
             return product.productType.isSubscriptionProduct()
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductType.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductType.kt
@@ -19,6 +19,8 @@ enum class ProductType(@StringRes val stringResource: Int = 0, val value: String
 
     fun isVariableProduct() = this == VARIABLE || this == VARIABLE_SUBSCRIPTION
 
+    fun isSubscriptionProduct() = this == SUBSCRIPTION || this == VARIABLE_SUBSCRIPTION
+
     companion object {
         fun fromString(type: String): ProductType {
             return when (type.lowercase(Locale.US)) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorFragment.kt
@@ -14,6 +14,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.extensions.handleResult
 import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.orders.creation.configuration.EditProductConfigurationResult
@@ -31,6 +32,7 @@ import com.woocommerce.android.ui.products.variations.selector.VariationSelector
 import com.woocommerce.android.ui.products.variations.selector.VariationSelectorViewModel.VariationSelectionResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -42,6 +44,8 @@ class ProductSelectorFragment : BaseFragment() {
     }
 
     @Inject lateinit var navigator: ProductNavigator
+
+    @Inject lateinit var uiMessageResolver: UIMessageResolver
 
     private val viewModel: ProductSelectorViewModel by viewModels()
     private val sharedViewModel: ProductSelectorSharedViewModel by activityViewModels()
@@ -76,6 +80,7 @@ class ProductSelectorFragment : BaseFragment() {
                     )
                 }
                 is ProductNavigationTarget -> navigator.navigate(this, event)
+                is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
                 is Exit -> findNavController().navigateUp()
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
@@ -323,10 +323,11 @@ private fun displayProductsSection(
                 onClickLabel = stringResource(id = string.product_selector_select_product_label, product.title),
                 imageContentDescription = stringResource(string.product_image_content_description),
                 isCogwheelVisible = product is ListItem.ConfigurableListItem,
-                enabled = state.selectionEnabled && product.enabled,
+                enabled = state.isSelectable(product),
                 onEditConfiguration = {
                     (product as? ListItem.ConfigurableListItem)?.let(onEditConfiguration)
-                }
+                },
+                isLoading = state.isLoading(product)
             ) {
                 onProductClick(product, productSectionForTracking)
             }
@@ -445,10 +446,11 @@ private fun ProductList(
                     onClickLabel = stringResource(id = string.product_selector_select_product_label, product.title),
                     imageContentDescription = stringResource(string.product_image_content_description),
                     isCogwheelVisible = product is ListItem.ConfigurableListItem,
-                    enabled = state.selectionEnabled && product.enabled,
+                    enabled = state.isSelectable(product),
                     onEditConfiguration = {
                         (product as? ListItem.ConfigurableListItem)?.let(onEditConfiguration)
-                    }
+                    },
+                    isLoading = state.isLoading(product)
                 ) {
                     onProductClick(product, ProductSourceForTracking.ALPHABETICAL)
                 }
@@ -515,6 +517,11 @@ private fun ListItem.hasVariations() =
 
 private val ListItem.enabled: Boolean
     get() = selectionState !is SelectionState.DISABLED
+
+private fun ViewState.isSelectable(item: ListItem) =
+    selectionEnabled && item.enabled && !isLoading(item)
+
+private fun ViewState.isLoading(item: ListItem) = loadingItemId == item.id
 
 private val ListItem.disabledReason: String?
     get() = (selectionState as? SelectionState.DISABLED)?.reason

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
@@ -323,11 +323,11 @@ private fun displayProductsSection(
                 onClickLabel = stringResource(id = string.product_selector_select_product_label, product.title),
                 imageContentDescription = stringResource(string.product_image_content_description),
                 isCogwheelVisible = product is ListItem.ConfigurableListItem,
-                enabled = state.isSelectable(product),
+                enabled = state.selectionEnabled && product.enabled,
                 onEditConfiguration = {
                     (product as? ListItem.ConfigurableListItem)?.let(onEditConfiguration)
                 },
-                isLoading = state.isLoading(product)
+                isLoading = product.isLoading
             ) {
                 onProductClick(product, productSectionForTracking)
             }
@@ -446,11 +446,11 @@ private fun ProductList(
                     onClickLabel = stringResource(id = string.product_selector_select_product_label, product.title),
                     imageContentDescription = stringResource(string.product_image_content_description),
                     isCogwheelVisible = product is ListItem.ConfigurableListItem,
-                    enabled = state.isSelectable(product),
+                    enabled = state.selectionEnabled && product.enabled,
                     onEditConfiguration = {
                         (product as? ListItem.ConfigurableListItem)?.let(onEditConfiguration)
                     },
-                    isLoading = state.isLoading(product)
+                    isLoading = product.isLoading
                 ) {
                     onProductClick(product, ProductSourceForTracking.ALPHABETICAL)
                 }
@@ -516,12 +516,7 @@ private fun ListItem.hasVariations() =
     this is ListItem.ProductListItem && (type == VARIABLE || type == VARIABLE_SUBSCRIPTION) && numVariations > 0
 
 private val ListItem.enabled: Boolean
-    get() = selectionState !is SelectionState.DISABLED
-
-private fun ViewState.isSelectable(item: ListItem) =
-    selectionEnabled && item.enabled && !isLoading(item)
-
-private fun ViewState.isLoading(item: ListItem) = loadingItemId == item.id
+    get() = selectionState !is SelectionState.DISABLED && !isLoading
 
 private val ListItem.disabledReason: String?
     get() = (selectionState as? SelectionState.DISABLED)?.reason

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
@@ -144,14 +144,13 @@ class ProductSelectorViewModel @Inject constructor(
             loadingState = loadingState,
             products = products.map {
                 mapProductsToUiModel(it, selectedIds)
-            },
-            popularProducts = getPopularProductsToDisplay(popularProducts, selectedIds),
-            recentProducts = getRecentProductsToDisplay(recentProducts, selectedIds),
+            }.markLoading(loadingItemId),
+            popularProducts = getPopularProductsToDisplay(popularProducts, selectedIds).markLoading(loadingItemId),
+            recentProducts = getRecentProductsToDisplay(recentProducts, selectedIds).markLoading(loadingItemId),
             selectedItemsCount = selectedIds.size,
             filterState = filterState,
             searchState = searchState,
             selectionMode = navArgs.selectionMode,
-            loadingItemId = loadingItemId,
             productFlow = navArgs.productSelectorFlow,
             screenTitleOverride = navArgs.screenTitleOverride,
             ctaButtonTextOverride = navArgs.ctaButtonTextOverride,
@@ -187,6 +186,21 @@ class ProductSelectorViewModel @Inject constructor(
     ) = when (selectionHandling) {
         NORMAL -> it.toUiModel(selectedIds)
         SIMPLE -> it.toSimpleUiModel(selectedIds)
+    }
+
+    private fun List<ListItem>.markLoading(loadingItemId: Long?): List<ListItem> {
+        if (loadingItemId == null) return this
+        return map { item ->
+            if (item.id != loadingItemId) {
+                item
+            } else {
+                when (item) {
+                    is ListItem.ProductListItem -> item.copy(isLoading = true)
+                    is ListItem.VariationListItem -> item.copy(isLoading = true)
+                    is ListItem.ConfigurableListItem -> item.copy(isLoading = true)
+                }
+            }
+        }
     }
 
     private fun getPopularProductsToDisplay(
@@ -738,7 +752,6 @@ class ProductSelectorViewModel @Inject constructor(
         val screenTitleOverride: String? = null,
         val ctaButtonTextOverride: String? = null,
         val selectionEnabled: Boolean = true,
-        val loadingItemId: Long? = null
     ) {
         val isDoneButtonEnabled: Boolean =
             selectionMode == SelectionMode.MULTIPLE || selectedItemsCount > 0 || productFlow == OrderListFilter
@@ -764,6 +777,7 @@ class ProductSelectorViewModel @Inject constructor(
         open val stockAndPrice: String? = null,
         open val sku: String? = null,
         open val selectionState: SelectionState = UNSELECTED,
+        open val isLoading: Boolean = false,
     ) {
         data class ProductListItem(
             val productId: Long,
@@ -775,6 +789,7 @@ class ProductSelectorViewModel @Inject constructor(
             override val stockAndPrice: String? = null,
             override val sku: String? = null,
             override val selectionState: SelectionState = UNSELECTED,
+            override val isLoading: Boolean = false,
         ) : ListItem(
             id = productId,
             title = title,
@@ -783,6 +798,7 @@ class ProductSelectorViewModel @Inject constructor(
             stockAndPrice = stockAndPrice,
             sku = sku,
             selectionState = selectionState,
+            isLoading = isLoading,
         )
 
         data class VariationListItem(
@@ -794,6 +810,7 @@ class ProductSelectorViewModel @Inject constructor(
             override val stockAndPrice: String? = null,
             override val sku: String? = null,
             override val selectionState: SelectionState = UNSELECTED,
+            override val isLoading: Boolean = false,
         ) : ListItem(
             id = variationId,
             title = title,
@@ -802,6 +819,7 @@ class ProductSelectorViewModel @Inject constructor(
             stockAndPrice = stockAndPrice,
             sku = sku,
             selectionState = selectionState,
+            isLoading = isLoading,
         )
 
         data class ConfigurableListItem(
@@ -812,6 +830,7 @@ class ProductSelectorViewModel @Inject constructor(
             override val stockAndPrice: String? = null,
             override val sku: String? = null,
             override val selectionState: SelectionState = UNSELECTED,
+            override val isLoading: Boolean = false,
         ) : ListItem(
             id = productId,
             title = title,
@@ -820,6 +839,7 @@ class ProductSelectorViewModel @Inject constructor(
             stockAndPrice = stockAndPrice,
             sku = sku,
             selectionState = selectionState,
+            isLoading = isLoading,
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
@@ -17,7 +17,6 @@ import com.woocommerce.android.ui.products.ProductNavigationTarget
 import com.woocommerce.android.ui.products.ProductNavigationTarget.NavigateToProductFilter
 import com.woocommerce.android.ui.products.ProductNavigationTarget.NavigateToVariationSelector
 import com.woocommerce.android.ui.products.ProductType
-import com.woocommerce.android.ui.products.ProductType.SUBSCRIPTION
 import com.woocommerce.android.ui.products.ProductType.VARIABLE
 import com.woocommerce.android.ui.products.ProductType.VARIABLE_SUBSCRIPTION
 import com.woocommerce.android.ui.products.ProductType.VARIATION
@@ -265,14 +264,10 @@ class ProductSelectorViewModel @Inject constructor(
     }
 
     private fun Product.getProductSelection(selectedItems: Collection<SelectedItem>): SelectionState {
+        productRestrictions.getNonSelectableRestriction(product = this)?.nonSelectableReason?.let { reason ->
+            return SelectionState.DISABLED(resourceProvider.getString(reason))
+        }
         return when {
-            productType == SUBSCRIPTION ||
-                productType == VARIABLE_SUBSCRIPTION -> {
-                SelectionState.DISABLED(
-                    resourceProvider.getString(R.string.product_selector_subscription_not_supported)
-                )
-            }
-
             isVariable() && numVariations > 0 -> {
                 val intersection = variationIds.intersect(selectedItems.variationIds.toSet())
                 when {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
@@ -390,7 +390,9 @@ class ProductSelectorViewModel @Inject constructor(
             return
         }
 
-        unlessBundleIsUnsellable(item) { selectItem(item, productSource) }
+        launch {
+            if (verifyBundleIsSellable(item)) selectItem(item, productSource)
+        }
     }
 
     private fun deselectItem(item: ListItem) {
@@ -407,37 +409,32 @@ class ProductSelectorViewModel @Inject constructor(
     }
 
     /**
-     * Runs [onSellable], unless [item] is a bundle holding a product which can't be added to an order.
-     *
-     * Anything other than a bundle runs straight away. A bundle takes a request to check, so it runs once that comes
-     * back: the item reports itself as loading in the meantime, and taps arriving before it does are dropped, so a
-     * merchant tapping again can't run [onSellable] twice.
+     * Returns whether [item] can be added to an order: true for anything other than a bundle, and for a bundle only
+     * once a request confirms it holds no unsupported product — the item reports itself as loading in the meantime,
+     * and a snackbar explains the rejection. Taps arriving while a check runs return false, so a merchant tapping
+     * again can't act twice.
      */
-    private fun unlessBundleIsUnsellable(item: ListItem, onSellable: () -> Unit) {
-        if (item.type != ProductType.BUNDLE) {
-            onSellable()
-            return
-        }
-        if (loadingItemId.value != null) return
+    private suspend fun verifyBundleIsSellable(item: ListItem): Boolean {
+        if (item.type != ProductType.BUNDLE) return true
+        if (loadingItemId.value != null) return false
 
-        launch {
-            loadingItemId.value = item.id
-            val isUnsellable = try {
-                hasUnsupportedBundledProducts(item.id)
-            } finally {
-                loadingItemId.value = null
-            }
-
-            if (isUnsellable) {
-                triggerEvent(ShowSnackbar(R.string.product_selector_bundle_with_subscription_not_supported))
-            } else {
-                onSellable()
-            }
+        loadingItemId.value = item.id
+        val isUnsellable = try {
+            hasUnsupportedBundledProducts(item.id)
+        } finally {
+            loadingItemId.value = null
         }
+
+        if (isUnsellable) {
+            triggerEvent(ShowSnackbar(R.string.product_selector_bundle_with_subscription_not_supported))
+        }
+        return !isUnsellable
     }
 
     fun onEditConfiguration(item: ListItem.ConfigurableListItem) {
-        unlessBundleIsUnsellable(item) { editConfiguration(item) }
+        launch {
+            if (verifyBundleIsSellable(item)) editConfiguration(item)
+        }
     }
 
     private fun editConfiguration(item: ListItem.ConfigurableListItem) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
@@ -12,6 +12,7 @@ import com.woocommerce.android.extensions.isNotNullOrEmpty
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.creation.configuration.ProductConfiguration
+import com.woocommerce.android.ui.products.HasUnsupportedBundledProducts
 import com.woocommerce.android.ui.products.OrderCreationProductRestrictions
 import com.woocommerce.android.ui.products.ProductNavigationTarget
 import com.woocommerce.android.ui.products.ProductNavigationTarget.NavigateToProductFilter
@@ -77,7 +78,8 @@ class ProductSelectorViewModel @Inject constructor(
     private val resourceProvider: ResourceProvider,
     private val tracker: ProductSelectorTracker,
     private val productsMapper: ProductsMapper,
-    private val productRestrictions: OrderCreationProductRestrictions
+    private val productRestrictions: OrderCreationProductRestrictions,
+    private val hasUnsupportedBundledProducts: HasUnsupportedBundledProducts
 ) : ScopedViewModel(savedState) {
     companion object {
         private const val STATE_UPDATE_DELAY = 100L
@@ -110,6 +112,8 @@ class ProductSelectorViewModel @Inject constructor(
     private val selectionEnabled: MutableStateFlow<Boolean> =
         savedState.getStateFlow(viewModelScope, true, "key_selection_enabled")
 
+    private val loadingItemId = MutableStateFlow<Long?>(null)
+
     private val selectedItemsSource: MutableMap<Long, ProductSourceForTracking> = mutableMapOf()
 
     private var fetchProductsJob: Job? = null
@@ -133,7 +137,9 @@ class ProductSelectorViewModel @Inject constructor(
         flow6 = filterState,
         flow7 = searchState,
         flow8 = selectionEnabled,
-    ) { products, popularProducts, recentProducts, loadingState, selectedIds, filterState, searchState, enabled ->
+        flow9 = loadingItemId,
+    ) { products, popularProducts, recentProducts, loadingState, selectedIds, filterState, searchState, enabled,
+        loadingItemId ->
         ViewState(
             loadingState = loadingState,
             products = products.map {
@@ -145,6 +151,7 @@ class ProductSelectorViewModel @Inject constructor(
             filterState = filterState,
             searchState = searchState,
             selectionMode = navArgs.selectionMode,
+            loadingItemId = loadingItemId,
             productFlow = navArgs.productSelectorFlow,
             screenTitleOverride = navArgs.screenTitleOverride,
             ctaButtonTextOverride = navArgs.ctaButtonTextOverride,
@@ -377,30 +384,63 @@ class ProductSelectorViewModel @Inject constructor(
 
     fun onProductClick(item: ListItem, productSourceForTracking: ProductSourceForTracking) {
         val productSource = updateProductSourceIfSearchIsEnabled(productSourceForTracking)
-        if (
-            navArgs.productSelectorFlow == OrderListFilter &&
-            _selectedItems.value.containsItemWith(item.id)
-        ) {
-            selectedItemsSource.remove(item.id)
-            _selectedItems.update { it.filter { selectedItem -> selectedItem.id != item.id } }
-        } else {
-            when (item) {
-                is ListItem.ProductListItem -> {
-                    handleProductTap(item, productSource)
-                }
 
-                is ListItem.VariationListItem -> {
-                    handleVariationItemTap(item, productSource)
-                }
+        if (navArgs.productSelectorFlow == OrderListFilter && _selectedItems.value.containsItemWith(item.id)) {
+            deselectItem(item)
+            return
+        }
 
-                is ListItem.ConfigurableListItem -> {
-                    handleConfigurableItemTap(item)
-                }
+        unlessBundleIsUnsellable(item) { selectItem(item, productSource) }
+    }
+
+    private fun deselectItem(item: ListItem) {
+        selectedItemsSource.remove(item.id)
+        _selectedItems.update { items -> items.filter { it.id != item.id } }
+    }
+
+    private fun selectItem(item: ListItem, productSource: ProductSourceForTracking) {
+        when (item) {
+            is ListItem.ProductListItem -> handleProductTap(item, productSource)
+            is ListItem.VariationListItem -> handleVariationItemTap(item, productSource)
+            is ListItem.ConfigurableListItem -> handleConfigurableItemTap(item)
+        }
+    }
+
+    /**
+     * Runs [onSellable], unless [item] is a bundle holding a product which can't be added to an order.
+     *
+     * Anything other than a bundle runs straight away. A bundle takes a request to check, so it runs once that comes
+     * back: the item reports itself as loading in the meantime, and taps arriving before it does are dropped, so a
+     * merchant tapping again can't run [onSellable] twice.
+     */
+    private fun unlessBundleIsUnsellable(item: ListItem, onSellable: () -> Unit) {
+        if (item.type != ProductType.BUNDLE) {
+            onSellable()
+            return
+        }
+        if (loadingItemId.value != null) return
+
+        launch {
+            loadingItemId.value = item.id
+            val isUnsellable = try {
+                hasUnsupportedBundledProducts(item.id)
+            } finally {
+                loadingItemId.value = null
+            }
+
+            if (isUnsellable) {
+                triggerEvent(ShowSnackbar(R.string.product_selector_bundle_with_subscription_not_supported))
+            } else {
+                onSellable()
             }
         }
     }
 
     fun onEditConfiguration(item: ListItem.ConfigurableListItem) {
+        unlessBundleIsUnsellable(item) { editConfiguration(item) }
+    }
+
+    private fun editConfiguration(item: ListItem.ConfigurableListItem) {
         val selectedItem = selectedItems.value.firstOrNull { it.id == item.id } as? SelectedItem.ConfigurableProduct
         selectedItem?.configuration?.let {
             triggerEvent(
@@ -700,7 +740,8 @@ class ProductSelectorViewModel @Inject constructor(
         val productFlow: ProductSelectorFlow,
         val screenTitleOverride: String? = null,
         val ctaButtonTextOverride: String? = null,
-        val selectionEnabled: Boolean = true
+        val selectionEnabled: Boolean = true,
+        val loadingItemId: Long? = null
     ) {
         val isDoneButtonEnabled: Boolean =
             selectionMode == SelectionMode.MULTIPLE || selectedItemsCount > 0 || productFlow == OrderListFilter

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
@@ -103,7 +103,7 @@ class ProductSelectorViewModel @Inject constructor(
     val selectedItems: StateFlow<List<SelectedItem>> = _selectedItems
     private val filterState = savedState.getStateFlow(viewModelScope, FilterState())
     private val products = listHandler.productsFlow.map { products ->
-        products.filterNot { product -> productRestrictions.isProductRestricted(product = product) }
+        products.filterNot { product -> productRestrictions.isProductHidden(product = product) }
     }
     private val popularProducts: MutableStateFlow<List<Product>> = MutableStateFlow(emptyList())
     private val recentProducts: MutableStateFlow<List<Product>> = MutableStateFlow(emptyList())
@@ -214,7 +214,7 @@ class ProductSelectorViewModel @Inject constructor(
                 recentlySoldOrders
             ).distinctBy { it }
         ).filterNot { product ->
-            productRestrictions.isProductRestricted(product = product)
+            productRestrictions.isProductHidden(product = product)
         }
     }
 
@@ -231,7 +231,7 @@ class ProductSelectorViewModel @Inject constructor(
         popularProducts.value = productsMapper.mapProductIdsToProduct(
             topPopularProductsSorted.keys.toList()
         ).filterNot { product ->
-            productRestrictions.isProductRestricted(product = product)
+            productRestrictions.isProductHidden(product = product)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
@@ -271,8 +271,8 @@ class ProductSelectorViewModel @Inject constructor(
     }
 
     private fun Product.getProductSelection(selectedItems: Collection<SelectedItem>): SelectionState {
-        productRestrictions.getNonSelectableRestriction(product = this)?.nonSelectableReason?.let { reason ->
-            return SelectionState.DISABLED(resourceProvider.getString(reason))
+        productRestrictions.getUnsupportedRestriction(product = this)?.let { restriction ->
+            return SelectionState.DISABLED(resourceProvider.getString(restriction.reason))
         }
         return when {
             isVariable() && numVariations > 0 -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/components/SelectorListItem.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/components/SelectorListItem.kt
@@ -6,12 +6,14 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
@@ -54,6 +56,7 @@ fun SelectorListItem(
     isCogwheelVisible: Boolean,
     enabled: Boolean,
     onEditConfiguration: () -> Unit,
+    isLoading: Boolean = false,
     onItemClick: () -> Unit,
 ) {
     Row(
@@ -130,41 +133,71 @@ fun SelectorListItem(
             }
         }
 
-        if (isArrowVisible || isCogwheelVisible) {
-            val image = ImageVector.vectorResource(
-                if (isArrowVisible) R.drawable.ic_chevron_right_24dp else R.drawable.ic_tune_24dp
-            )
-
-            val contentDescription = if (isArrowVisible) {
-                stringResource(id = R.string.product_selector_arrow_content_description)
-            } else {
-                stringResource(id = R.string.extension_configure_button)
-            }
-
-            val color = if (isArrowVisible) {
-                MaterialTheme.colors.onSurface
-            } else {
-                MaterialTheme.colors.primary
-            }
-
-            val iconModifier = if (isArrowVisible) {
-                Modifier
-                    .size(dimensionResource(id = R.dimen.major_200))
-            } else {
-                Modifier
-                    .clickable { onEditConfiguration() }
-                    .padding(8.dp)
-                    .size(dimensionResource(id = R.dimen.major_150))
-            }
-
-            Icon(
-                imageVector = image,
-                contentDescription = contentDescription,
-                modifier = iconModifier.align(Alignment.CenterVertically),
-                tint = color
-            )
-        }
+        TrailingIndicator(
+            isArrowVisible = isArrowVisible,
+            isCogwheelVisible = isCogwheelVisible,
+            isLoading = isLoading,
+            onEditConfiguration = onEditConfiguration
+        )
     }
+}
+
+/**
+ * Takes the place of the arrow or the configure cogwheel while the item is busy, so the progress sits where the
+ * action the merchant tapped would be.
+ */
+@Composable
+private fun RowScope.TrailingIndicator(
+    isArrowVisible: Boolean,
+    isCogwheelVisible: Boolean,
+    isLoading: Boolean,
+    onEditConfiguration: () -> Unit
+) {
+    if (isLoading) {
+        CircularProgressIndicator(
+            modifier = Modifier
+                .align(Alignment.CenterVertically)
+                .padding(8.dp)
+                .size(dimensionResource(id = R.dimen.major_150)),
+            strokeWidth = dimensionResource(id = R.dimen.minor_25)
+        )
+        return
+    }
+
+    if (!isArrowVisible && !isCogwheelVisible) return
+
+    val image = ImageVector.vectorResource(
+        if (isArrowVisible) R.drawable.ic_chevron_right_24dp else R.drawable.ic_tune_24dp
+    )
+
+    val contentDescription = if (isArrowVisible) {
+        stringResource(id = R.string.product_selector_arrow_content_description)
+    } else {
+        stringResource(id = R.string.extension_configure_button)
+    }
+
+    val color = if (isArrowVisible) {
+        MaterialTheme.colors.onSurface
+    } else {
+        MaterialTheme.colors.primary
+    }
+
+    val iconModifier = if (isArrowVisible) {
+        Modifier
+            .size(dimensionResource(id = R.dimen.major_200))
+    } else {
+        Modifier
+            .clickable { onEditConfiguration() }
+            .padding(8.dp)
+            .size(dimensionResource(id = R.dimen.major_150))
+    }
+
+    Icon(
+        imageVector = image,
+        contentDescription = contentDescription,
+        modifier = iconModifier.align(Alignment.CenterVertically),
+        tint = color
+    )
 }
 
 @Composable
@@ -221,6 +254,31 @@ private fun SelectorListItemPreviewDisabled() =
                     isCogwheelVisible = true,
                     enabled = false,
                     onEditConfiguration = {}
+                )
+            }
+        }
+    }
+
+@Preview
+@Composable
+private fun SelectorListItemPreviewLoading() =
+    WooThemeWithBackground {
+        LazyColumn {
+            item {
+                SelectorListItem(
+                    title = "Item name",
+                    imageUrl = null,
+                    infoLine1 = "Information 1",
+                    infoLine2 = "Information 2",
+                    selectionState = UNSELECTED,
+                    isArrowVisible = false,
+                    onItemClick = {},
+                    onClickLabel = null,
+                    imageContentDescription = null,
+                    isCogwheelVisible = true,
+                    enabled = false,
+                    onEditConfiguration = {},
+                    isLoading = true
                 )
             }
         }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3045,6 +3045,7 @@
     <string name="product_selector_recent_products_heading">Last Sold</string>
     <string name="product_selector_products_heading">Products</string>
     <string name="product_selector_subscription_not_supported">Subscription products are not supported for order creation</string>
+    <string name="product_selector_bundle_with_subscription_not_supported">This bundle contains a subscription product, which is not supported for order creation</string>
 
     <!-- WC Shipping installation flow -->
     <string name="install_wc_shipping_flow_onboarding_screen_title">Fulfill your orders with WooCommerce Shipping</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
@@ -718,7 +718,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
             whenever(createOrderItemUseCase.invoke(10L)).thenReturn(
                 createOrderItem(10L)
             )
-            whenever(productRestrictions.isProductRestricted(product)).thenReturn(true)
+            whenever(productRestrictions.isProductBlocked(product)).thenReturn(true)
             var newOrder: Order? = null
             sut.orderDraft.observeForever { newOrderData ->
                 newOrder = newOrderData
@@ -774,7 +774,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
             whenever(createOrderItemUseCase.invoke(10L)).thenReturn(
                 createOrderItem(10L)
             )
-            whenever(productRestrictions.isProductRestricted(product)).thenReturn(true)
+            whenever(productRestrictions.isProductBlocked(product)).thenReturn(true)
             var newOrder: Order? = null
             sut.orderDraft.observeForever { newOrderData ->
                 newOrder = newOrderData
@@ -805,7 +805,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
             whenever(fetchProductByIdentifier.invoke("12345", BarcodeFormat.FormatUPCA)).thenReturn(
                 Result.success(product)
             )
-            whenever(productRestrictions.isProductRestricted(product)).thenReturn(true)
+            whenever(productRestrictions.isProductBlocked(product)).thenReturn(true)
 
             sut.handleBarcodeScannedStatus(scannedStatus)
 
@@ -832,7 +832,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
             whenever(fetchProductByIdentifier.invoke("12345", BarcodeFormat.FormatUPCA)).thenReturn(
                 Result.success(product)
             )
-            whenever(productRestrictions.isProductRestricted(product)).thenReturn(true)
+            whenever(productRestrictions.isProductBlocked(product)).thenReturn(true)
 
             sut.handleBarcodeScannedStatus(scannedStatus)
 
@@ -863,7 +863,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
             whenever(fetchProductByIdentifier.invoke("12345", BarcodeFormat.FormatUPCA)).thenReturn(
                 Result.success(product)
             )
-            whenever(productRestrictions.isProductRestricted(product)).thenReturn(true)
+            whenever(productRestrictions.isProductBlocked(product)).thenReturn(true)
 
             sut.handleBarcodeScannedStatus(scannedStatus)
 
@@ -888,7 +888,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
             whenever(fetchProductByIdentifier.invoke("12345", BarcodeFormat.FormatUPCA)).thenReturn(
                 Result.success(product)
             )
-            whenever(productRestrictions.isProductRestricted(product)).thenReturn(true)
+            whenever(productRestrictions.isProductBlocked(product)).thenReturn(true)
 
             sut.handleBarcodeScannedStatus(scannedStatus)
 
@@ -921,7 +921,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
             whenever(fetchProductByIdentifier.invoke("12345", BarcodeFormat.FormatUPCA)).thenReturn(
                 Result.success(product)
             )
-            whenever(productRestrictions.isProductRestricted(product)).thenReturn(true)
+            whenever(productRestrictions.isProductBlocked(product)).thenReturn(true)
 
             sut.handleBarcodeScannedStatus(scannedStatus)
 
@@ -953,7 +953,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
             whenever(fetchProductByIdentifier.invoke("12345", BarcodeFormat.FormatUPCA)).thenReturn(
                 Result.success(product)
             )
-            whenever(productRestrictions.isProductRestricted(product)).thenReturn(true)
+            whenever(productRestrictions.isProductBlocked(product)).thenReturn(true)
 
             sut.handleBarcodeScannedStatus(scannedStatus)
 
@@ -979,7 +979,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
             whenever(fetchProductByIdentifier.invoke("12345", BarcodeFormat.FormatUPCA)).thenReturn(
                 Result.success(product)
             )
-            whenever(productRestrictions.isProductRestricted(product)).thenReturn(true)
+            whenever(productRestrictions.isProductBlocked(product)).thenReturn(true)
 
             sut.handleBarcodeScannedStatus(scannedStatus)
 
@@ -1006,7 +1006,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
             whenever(fetchProductByIdentifier.invoke("12345", BarcodeFormat.FormatUPCA)).thenReturn(
                 Result.success(product)
             )
-            whenever(productRestrictions.isProductRestricted(product)).thenReturn(true)
+            whenever(productRestrictions.isProductBlocked(product)).thenReturn(true)
 
             sut.handleBarcodeScannedStatus(scannedStatus)
 
@@ -1030,7 +1030,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
             whenever(fetchProductByIdentifier.invoke("12345", BarcodeFormat.FormatUPCA)).thenReturn(
                 Result.success(product)
             )
-            whenever(productRestrictions.isProductRestricted(product)).thenReturn(true)
+            whenever(productRestrictions.isProductBlocked(product)).thenReturn(true)
 
             sut.handleBarcodeScannedStatus(scannedStatus)
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/configuration/GetChildrenProductInfoTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/configuration/GetChildrenProductInfoTest.kt
@@ -5,6 +5,7 @@ import com.woocommerce.android.model.BundledProduct
 import com.woocommerce.android.ui.products.GetBundledProducts
 import com.woocommerce.android.ui.products.ProductStockStatus
 import com.woocommerce.android.ui.products.ProductTestUtils
+import com.woocommerce.android.ui.products.ProductType
 import com.woocommerce.android.ui.products.details.ProductDetailRepository
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -49,7 +50,7 @@ class GetChildrenProductInfoTest : BaseUnitTest() {
             stockStatus = ProductStockStatus.InStock,
             rules = BundleProductRules(),
             imageUrl = "image2.jpg",
-            isVariable = false
+            productType = ProductType.SIMPLE
         )
         val childProduct2 = BundledProduct(
             id = 3L,
@@ -58,7 +59,7 @@ class GetChildrenProductInfoTest : BaseUnitTest() {
             title = "Child product 2",
             stockStatus = ProductStockStatus.InStock,
             rules = BundleProductRules(),
-            isVariable = false
+            productType = ProductType.SIMPLE
         )
         val bundledProducts = listOf(childProduct1, childProduct2)
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/GetBundledProductsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/GetBundledProductsTest.kt
@@ -101,7 +101,7 @@ class GetBundledProductsTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given a variable bundled product, when the products are processed, then it is marked as variable`() =
+    fun `given bundled products, when the products are processed, then the product type is resolved`() =
         testBlocking {
             // given
             val remoteProductId = 5L
@@ -109,7 +109,7 @@ class GetBundledProductsTest : BaseUnitTest() {
             whenever(productStore.getProductsByRemoteIds(any(), any())).doReturn(
                 listOf(
                     WCProductModel().copy(remoteId = RemoteId(25), type = "variable"),
-                    WCProductModel().copy(remoteId = RemoteId(26), type = "simple"),
+                    WCProductModel().copy(remoteId = RemoteId(26), type = "variable-subscription"),
                     WCProductModel().copy(remoteId = RemoteId(27), type = "simple")
                 )
             )
@@ -118,6 +118,10 @@ class GetBundledProductsTest : BaseUnitTest() {
             val result = sut.invoke(remoteProductId).first().associateBy { it.id }
 
             // then
+            assertThat(result.getValue(1).productType).isEqualTo(ProductType.VARIABLE)
+            assertThat(result.getValue(2).productType).isEqualTo(ProductType.VARIABLE_SUBSCRIPTION)
+            assertThat(result.getValue(3).productType).isEqualTo(ProductType.SIMPLE)
+
             assertThat(result.getValue(1).isVariable).isTrue
             assertThat(result.getValue(2).isVariable).isFalse
             assertThat(result.getValue(3).isVariable).isFalse

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/HasUnsupportedBundledProductsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/HasUnsupportedBundledProductsTest.kt
@@ -1,0 +1,92 @@
+package com.woocommerce.android.ui.products
+
+import com.woocommerce.android.model.BundleProductRules
+import com.woocommerce.android.model.BundledProduct
+import com.woocommerce.android.ui.products.details.ProductDetailRepository
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class HasUnsupportedBundledProductsTest : BaseUnitTest() {
+    private val getBundledProducts: GetBundledProducts = mock()
+    private val productDetailRepository: ProductDetailRepository = mock()
+
+    private lateinit var sut: HasUnsupportedBundledProducts
+
+    @Before
+    fun setUp() {
+        sut = HasUnsupportedBundledProducts(
+            getBundledProducts,
+            productDetailRepository,
+            OrderCreationProductRestrictions()
+        )
+    }
+
+    @Test
+    fun `given a bundle with a subscription, when it is checked, then it holds unsupported products`() = testBlocking {
+        // given
+        setUpBundle(child(SIMPLE_CHILD_ID, "simple"), child(SUBSCRIPTION_CHILD_ID, "variable-subscription"))
+
+        // when & then
+        assertThat(sut(BUNDLE_ID)).isTrue
+    }
+
+    @Test
+    fun `given a bundle without subscriptions, when it is checked, then it holds no unsupported products`() =
+        testBlocking {
+            // given
+            setUpBundle(child(SIMPLE_CHILD_ID, "simple"))
+
+            // when & then
+            assertThat(sut(BUNDLE_ID)).isFalse
+        }
+
+    /**
+     * A child kept out of the product list for its own sake says nothing about whether the bundle can be sold.
+     */
+    @Test
+    fun `given a bundle holding a draft product, when it is checked, then it holds no unsupported products`() =
+        testBlocking {
+            // given
+            setUpBundle(child(SIMPLE_CHILD_ID, "simple", customStatus = ProductStatus.DRAFT.name))
+
+            // when & then
+            assertThat(sut(BUNDLE_ID)).isFalse
+        }
+
+    private fun setUpBundle(vararg children: BundledProduct) {
+        whenever(getBundledProducts.invoke(eq(BUNDLE_ID))).thenReturn(flowOf(children.toList()))
+    }
+
+    private fun child(productId: Long, type: String, customStatus: String? = null): BundledProduct {
+        val product = ProductTestUtils.generateProduct(
+            productId = productId,
+            productType = type,
+            customStatus = customStatus
+        )
+        whenever(productDetailRepository.getProduct(productId)).thenReturn(product)
+
+        return BundledProduct(
+            id = productId,
+            parentProductId = BUNDLE_ID,
+            bundledProductId = productId,
+            title = "Child product",
+            stockStatus = ProductStockStatus.InStock,
+            rules = BundleProductRules(),
+            productType = ProductType.fromString(type)
+        )
+    }
+
+    private companion object {
+        const val BUNDLE_ID = 5L
+        const val SIMPLE_CHILD_ID = 20L
+        const val SUBSCRIPTION_CHILD_ID = 21L
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductRestrictionsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductRestrictionsTest.kt
@@ -21,7 +21,7 @@ class ProductRestrictionsTest : BaseUnitTest() {
         val sut = OrderCreationProductRestrictions()
 
         assertTrue {
-            sut.isProductRestricted(product)
+            sut.isProductBlocked(product)
         }
     }
 
@@ -34,7 +34,7 @@ class ProductRestrictionsTest : BaseUnitTest() {
         val sut = OrderCreationProductRestrictions()
 
         assertFalse {
-            sut.isProductRestricted(product)
+            sut.isProductBlocked(product)
         }
     }
 
@@ -48,7 +48,7 @@ class ProductRestrictionsTest : BaseUnitTest() {
         val sut = OrderCreationProductRestrictions()
 
         assertTrue {
-            sut.isProductRestricted(product)
+            sut.isProductBlocked(product)
         }
     }
 
@@ -62,7 +62,7 @@ class ProductRestrictionsTest : BaseUnitTest() {
         val sut = OrderCreationProductRestrictions()
 
         assertFalse {
-            sut.isProductRestricted(product)
+            sut.isProductBlocked(product)
         }
     }
 
@@ -75,7 +75,7 @@ class ProductRestrictionsTest : BaseUnitTest() {
         val sut = OrderCreationProductRestrictions()
 
         assertTrue {
-            sut.isProductRestricted(product)
+            sut.isProductBlocked(product)
         }
     }
 
@@ -88,7 +88,7 @@ class ProductRestrictionsTest : BaseUnitTest() {
         val sut = OrderCreationProductRestrictions()
 
         assertFalse {
-            sut.isProductRestricted(product)
+            sut.isProductBlocked(product)
         }
     }
 
@@ -159,7 +159,7 @@ class ProductRestrictionsTest : BaseUnitTest() {
         val sut = ProductFilterProductRestrictions()
 
         assertFalse {
-            sut.isProductRestricted(product)
+            sut.isProductBlocked(product)
         }
     }
 
@@ -173,7 +173,7 @@ class ProductRestrictionsTest : BaseUnitTest() {
         val sut = ProductFilterProductRestrictions()
 
         assertTrue {
-            sut.isProductRestricted(product)
+            sut.isProductBlocked(product)
         }
     }
 
@@ -187,7 +187,7 @@ class ProductRestrictionsTest : BaseUnitTest() {
         val sut = ProductFilterProductRestrictions()
 
         assertFalse {
-            sut.isProductRestricted(product)
+            sut.isProductBlocked(product)
         }
     }
 
@@ -200,7 +200,7 @@ class ProductRestrictionsTest : BaseUnitTest() {
         val sut = ProductFilterProductRestrictions()
 
         assertTrue {
-            sut.isProductRestricted(product)
+            sut.isProductBlocked(product)
         }
     }
 
@@ -213,7 +213,7 @@ class ProductRestrictionsTest : BaseUnitTest() {
         val sut = ProductFilterProductRestrictions()
 
         assertFalse {
-            sut.isProductRestricted(product)
+            sut.isProductBlocked(product)
         }
     }
     //endregion

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductRestrictionsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductRestrictionsTest.kt
@@ -3,7 +3,9 @@ package com.woocommerce.android.ui.products
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @ExperimentalCoroutinesApi
@@ -88,6 +90,61 @@ class ProductRestrictionsTest : BaseUnitTest() {
         assertFalse {
             sut.isProductRestricted(product)
         }
+    }
+
+    @Test
+    fun `given subscription product, when order creation products restriction, then product is not selectable`() {
+        val product = ProductTestUtils.generateProduct(
+            productType = "subscription"
+        )
+
+        val sut = OrderCreationProductRestrictions()
+
+        assertEquals(ProductRestriction.SubscriptionProducts, sut.getNonSelectableRestriction(product))
+    }
+
+    @Test
+    fun `given variable subscription product, when order creation products restriction, then product is not selectable`() {
+        val product = ProductTestUtils.generateProduct(
+            productType = "variable-subscription",
+            isVariable = true,
+            variationIds = "[123]"
+        )
+
+        val sut = OrderCreationProductRestrictions()
+
+        assertEquals(ProductRestriction.SubscriptionProducts, sut.getNonSelectableRestriction(product))
+    }
+
+    @Test
+    fun `given subscription product, when order creation products restriction, then product is not hidden`() {
+        val product = ProductTestUtils.generateProduct(
+            productType = "subscription"
+        )
+
+        val sut = OrderCreationProductRestrictions()
+
+        assertFalse { sut.isProductHidden(product) }
+    }
+
+    @Test
+    fun `given simple product, when order creation products restriction, then product is selectable`() {
+        val product = ProductTestUtils.generateProduct()
+
+        val sut = OrderCreationProductRestrictions()
+
+        assertNull(sut.getNonSelectableRestriction(product))
+    }
+
+    @Test
+    fun `given draft product, when order creation products restriction, then product is hidden`() {
+        val product = ProductTestUtils.generateProduct(
+            customStatus = ProductStatus.DRAFT.name
+        )
+
+        val sut = OrderCreationProductRestrictions()
+
+        assertTrue { sut.isProductHidden(product) }
     }
     //endregion
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductRestrictionsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductRestrictionsTest.kt
@@ -100,7 +100,7 @@ class ProductRestrictionsTest : BaseUnitTest() {
 
         val sut = OrderCreationProductRestrictions()
 
-        assertEquals(ProductRestriction.SubscriptionProducts, sut.getNonSelectableRestriction(product))
+        assertEquals(ProductRestriction.SubscriptionProducts, sut.getUnsupportedRestriction(product))
     }
 
     @Test
@@ -113,7 +113,7 @@ class ProductRestrictionsTest : BaseUnitTest() {
 
         val sut = OrderCreationProductRestrictions()
 
-        assertEquals(ProductRestriction.SubscriptionProducts, sut.getNonSelectableRestriction(product))
+        assertEquals(ProductRestriction.SubscriptionProducts, sut.getUnsupportedRestriction(product))
     }
 
     @Test
@@ -133,7 +133,7 @@ class ProductRestrictionsTest : BaseUnitTest() {
 
         val sut = OrderCreationProductRestrictions()
 
-        assertNull(sut.getNonSelectableRestriction(product))
+        assertNull(sut.getUnsupportedRestriction(product))
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
@@ -1613,7 +1613,7 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
         )
 
         whenever(listHandler.productsFlow).thenReturn(flowOf(listOf(subscriptionProduct)))
-        whenever(productRestriction.getNonSelectableRestriction(subscriptionProduct))
+        whenever(productRestriction.getUnsupportedRestriction(subscriptionProduct))
             .thenReturn(ProductRestriction.SubscriptionProducts)
         whenever(resourceProvider.getString(any()))
             .thenReturn("Not supported")
@@ -1643,7 +1643,7 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
         )
 
         whenever(listHandler.productsFlow).thenReturn(flowOf(listOf(variableSubscriptionProduct)))
-        whenever(productRestriction.getNonSelectableRestriction(variableSubscriptionProduct))
+        whenever(productRestriction.getUnsupportedRestriction(variableSubscriptionProduct))
             .thenReturn(ProductRestriction.SubscriptionProducts)
         whenever(resourceProvider.getString(any()))
             .thenReturn("Not supported")

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
@@ -16,6 +16,7 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.OrderTestUtils
 import com.woocommerce.android.ui.products.OrderCreationProductRestrictions
 import com.woocommerce.android.ui.products.ProductNavigationTarget
+import com.woocommerce.android.ui.products.ProductRestriction
 import com.woocommerce.android.ui.products.ProductTestUtils
 import com.woocommerce.android.ui.products.ProductTestUtils.generateProduct
 import com.woocommerce.android.ui.products.ProductType
@@ -1602,6 +1603,8 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
         )
 
         whenever(listHandler.productsFlow).thenReturn(flowOf(listOf(subscriptionProduct)))
+        whenever(productRestriction.getNonSelectableRestriction(subscriptionProduct))
+            .thenReturn(ProductRestriction.SubscriptionProducts)
         whenever(resourceProvider.getString(any()))
             .thenReturn("Not supported")
 
@@ -1630,6 +1633,8 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
         )
 
         whenever(listHandler.productsFlow).thenReturn(flowOf(listOf(variableSubscriptionProduct)))
+        whenever(productRestriction.getNonSelectableRestriction(variableSubscriptionProduct))
+            .thenReturn(ProductRestriction.SubscriptionProducts)
         whenever(resourceProvider.getString(any()))
             .thenReturn("Not supported")
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.products.selector
 
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.AppConstants.SEARCH_TYPING_DELAY_MS
+import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_CREATION_PRODUCT_SELECTOR_CONFIRM_BUTTON_TAPPED
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -14,8 +15,10 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_SEARCH
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.OrderTestUtils
+import com.woocommerce.android.ui.products.HasUnsupportedBundledProducts
 import com.woocommerce.android.ui.products.OrderCreationProductRestrictions
 import com.woocommerce.android.ui.products.ProductNavigationTarget
+import com.woocommerce.android.ui.products.ProductNavigationTarget.NavigateToProductConfiguration
 import com.woocommerce.android.ui.products.ProductRestriction
 import com.woocommerce.android.ui.products.ProductTestUtils
 import com.woocommerce.android.ui.products.ProductTestUtils.generateProduct
@@ -31,7 +34,9 @@ import com.woocommerce.android.util.getOrAwaitValue
 import com.woocommerce.android.util.runAndCaptureValues
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ResourceProvider
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
@@ -43,7 +48,9 @@ import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doSuspendableAnswer
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -59,6 +66,8 @@ import kotlin.test.assertTrue
 @ExperimentalCoroutinesApi
 internal class ProductSelectorViewModelTest : BaseUnitTest() {
     companion object {
+        private const val BUNDLE_ID = 200L
+        private val BUNDLE_NOT_SUPPORTED = R.string.product_selector_bundle_with_subscription_not_supported
         private val VALID_PRODUCT = generateProduct(productId = 1L)
         private val DRAFT_PRODUCT = generateProduct(productId = 2L, customStatus = "draft")
         private val VARIABLE_PRODUCT_WITH_NO_VARIATIONS = generateProduct(
@@ -102,6 +111,7 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
     private val orderStore: WCOrderStore = mock()
     private val productsMapper: ProductsMapper = mock()
     private val productRestriction: OrderCreationProductRestrictions = mock()
+    private val hasUnsupportedBundledProducts: HasUnsupportedBundledProducts = mock()
 
     @Before
     fun setup() {
@@ -1693,6 +1703,102 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
         assertThat(productItem.selectionState).isEqualTo(SelectionState.UNSELECTED)
     }
 
+    @Test
+    fun `given a bundle holding an unsupported product, when clicked, then explain it can't be added`() = testBlocking {
+        whenever(hasUnsupportedBundledProducts.invoke(BUNDLE_ID)).thenReturn(true)
+        val sut = createOrderCreationViewModel()
+
+        sut.onProductClick(bundleListItem(), ProductSourceForTracking.ALPHABETICAL)
+
+        assertThat(sut.event.value).isEqualTo(ShowSnackbar(BUNDLE_NOT_SUPPORTED))
+        assertThat(sut.selectedItems.value).isEmpty()
+    }
+
+    @Test
+    fun `given a bundle holding an unsupported product, when configured, then explain it can't be added`() =
+        testBlocking {
+            whenever(hasUnsupportedBundledProducts.invoke(BUNDLE_ID)).thenReturn(true)
+            val sut = createOrderCreationViewModel()
+
+            sut.onEditConfiguration(bundleListItem())
+
+            assertThat(sut.event.value).isEqualTo(ShowSnackbar(BUNDLE_NOT_SUPPORTED))
+        }
+
+    @Test
+    fun `given a bundle without unsupported products, when clicked, then open its configuration`() = testBlocking {
+        whenever(hasUnsupportedBundledProducts.invoke(BUNDLE_ID)).thenReturn(false)
+        val sut = createOrderCreationViewModel()
+
+        sut.onProductClick(bundleListItem(), ProductSourceForTracking.ALPHABETICAL)
+
+        assertThat(sut.event.value).isEqualTo(NavigateToProductConfiguration(BUNDLE_ID))
+    }
+
+    @Test
+    fun `given a bundle without unsupported products, when configured, then open its configuration`() = testBlocking {
+        whenever(hasUnsupportedBundledProducts.invoke(BUNDLE_ID)).thenReturn(false)
+        val sut = createOrderCreationViewModel()
+
+        sut.onEditConfiguration(bundleListItem())
+
+        assertThat(sut.event.value).isEqualTo(NavigateToProductConfiguration(BUNDLE_ID))
+    }
+
+    @Test
+    fun `given a bundle being resolved, when it is tapped again, then the second tap is ignored`() = testBlocking {
+        val resolution = CompletableDeferred<Boolean>()
+        whenever(hasUnsupportedBundledProducts.invoke(BUNDLE_ID)).doSuspendableAnswer { resolution.await() }
+        val sut = createOrderCreationViewModel()
+
+        sut.onProductClick(bundleListItem(), ProductSourceForTracking.ALPHABETICAL)
+        sut.onProductClick(bundleListItem(), ProductSourceForTracking.ALPHABETICAL)
+        resolution.complete(false)
+
+        verify(hasUnsupportedBundledProducts).invoke(BUNDLE_ID)
+    }
+
+    @Test
+    fun `given a bundle being resolved, when the state is observed, then the item reports itself as loading`() =
+        testBlocking {
+            val resolution = CompletableDeferred<Boolean>()
+            whenever(hasUnsupportedBundledProducts.invoke(BUNDLE_ID)).doSuspendableAnswer { resolution.await() }
+            whenever(listHandler.productsFlow).thenReturn(flowOf(emptyList()))
+            val sut = createOrderCreationViewModel()
+
+            sut.onProductClick(bundleListItem(), ProductSourceForTracking.ALPHABETICAL)
+            assertThat(sut.viewState.getOrAwaitValue().loadingItemId).isEqualTo(BUNDLE_ID)
+
+            resolution.complete(false)
+            assertThat(sut.viewState.getOrAwaitValue().loadingItemId).isNull()
+        }
+
+    @Test
+    fun `given a product which is not a bundle, when clicked, then the bundled products are not resolved`() =
+        testBlocking {
+            val sut = createOrderCreationViewModel()
+
+            sut.onProductClick(
+                ProductListItem(productId = 126L, title = "Simple", type = ProductType.SIMPLE, numVariations = 0),
+                ProductSourceForTracking.ALPHABETICAL
+            )
+
+            verify(hasUnsupportedBundledProducts, never()).invoke(any())
+        }
+
+    private fun createOrderCreationViewModel() = createViewModel(
+        ProductSelectorFragmentArgs(
+            selectedItems = emptyArray(),
+            productSelectorFlow = ProductSelectorViewModel.ProductSelectorFlow.OrderCreation,
+        ).toSavedStateHandle()
+    )
+
+    private fun bundleListItem() = ProductSelectorViewModel.ListItem.ConfigurableListItem(
+        productId = BUNDLE_ID,
+        title = "Test Bundle",
+        type = ProductType.BUNDLE
+    )
+
     private fun createViewModel(navArgs: SavedStateHandle) =
         ProductSelectorViewModel(
             navArgs,
@@ -1706,6 +1812,7 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
             productSelectorTracker,
             productsMapper,
             productRestriction,
+            hasUnsupportedBundledProducts,
         )
 
     private fun createTestOrderEntity(productId: String, datePaid: String = "2018-02-02T16:11:13Z"): OrderEntity {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
@@ -1763,14 +1763,16 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
         testBlocking {
             val resolution = CompletableDeferred<Boolean>()
             whenever(hasUnsupportedBundledProducts.invoke(BUNDLE_ID)).doSuspendableAnswer { resolution.await() }
-            whenever(listHandler.productsFlow).thenReturn(flowOf(emptyList()))
+            whenever(listHandler.productsFlow).thenReturn(
+                flowOf(listOf(generateProduct(productId = BUNDLE_ID, productType = "bundle")))
+            )
             val sut = createOrderCreationViewModel()
 
             sut.onProductClick(bundleListItem(), ProductSourceForTracking.ALPHABETICAL)
-            assertThat(sut.viewState.getOrAwaitValue().loadingItemId).isEqualTo(BUNDLE_ID)
+            assertThat(sut.viewState.getOrAwaitValue().products.single().isLoading).isTrue
 
             resolution.complete(false)
-            assertThat(sut.viewState.getOrAwaitValue().loadingItemId).isNull()
+            assertThat(sut.viewState.getOrAwaitValue().products.single().isLoading).isFalse
         }
 
     @Test


### PR DESCRIPTION
### Description

Fixes WOOMOB-3754

Order creation doesn't support subscription products, but the rule lived only in `ProductSelectorViewModel.getProductSelection`, so it applied to the product list and nothing else. Two paths went around it: a bundle holding a subscription child could be added with no warning, and scanning a subscription product's barcode or SKU added it straight to the order.

The rule now lives in `ProductRestriction.SubscriptionProducts` alongside the other restrictions, so the product list, the scanner and the bundle check all read the same definition. Restrictions gained an optional `nonSelectableReason`: those that carry one keep the product visible and explain why it can't be picked (what subscriptions already did), those that don't keep removing it from the list, which is what every existing restriction does.

For bundles, whether a child is a subscription can't be answered while building the list — the API's `bundled_items` has no product type and a bundle's children usually aren't cached — so it's resolved when the merchant picks the bundle rather than per row. That costs one resolve per bundle actually tapped and avoids a window where a row renders enabled before flipping to disabled. Since that resolve can take a request, the row shows a spinner and ignores further taps until it finishes, otherwise a second tap during the wait would fire the navigation twice. Both entry points are covered: the row tap and the **Configure** button, which go through different ViewModel methods.

One incidental fix: `ProductSelectorFragment` never handled `ShowSnackbar`, so the refusal had nowhere to appear.



### Test Steps

Needs a store with the Product Bundles and Subscriptions extensions.

1. Create a new order and tap **Add products**.
2. Search for a subscription product. It's greyed out with *"Subscription products are not supported for order creation"* — unchanged behaviour, worth confirming it didn't regress.
3. Find a bundle that contains a subscription product. Tap the row: nothing is selected and a snackbar reads *"This bundle contains a subscription product, which is not supported for order creation"*.
4. Tap that bundle's **Configure** button. Same snackbar, and the configuration screen does not open.
6. Find a bundle with no subscription products. It still selects and configures normally.
7. Tap **Scan products** and scan a subscription product's barcode (or its SKU). It isn't added, and the failure message explains why.
8. Scan a normal product to confirm scanning still works.

P.S. Can be tested on https://site-for-woocommerce12a3fasdf45dfs6789.mystagingwebsite.com/ with AAA Product Bundle 2.

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.