### PR TITLE
[WOOMOB-3712] Fix POS Scan to Pay false success and non-fullscreen success screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeChildToParentCommunication.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeChildToParentCommunication.kt
@@ -39,6 +39,7 @@ sealed class ChildToParentEvent {
     data object GoBackToCheckoutAfterFailedPayment : ChildToParentEvent()
     data object OrderSuccessfullyPaidByCard : ChildToParentEvent()
     data object OrderSuccessfullyPaidExternally : ChildToParentEvent()
+    data object OrderSuccessfullyPaidViaScanToPay : ChildToParentEvent()
     data object ExitPosClicked : ChildToParentEvent()
     data object SetupBarcodeScannerClicked : ChildToParentEvent()
     data object CouponsValidationFailed : ChildToParentEvent()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeChildToParentCommunication.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeChildToParentCommunication.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.woopos.home
 
+import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent.OrderSuccessfullyPaid.PaymentMethod
 import com.woocommerce.android.ui.woopos.home.cart.WooPosCartItemViewState
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent
@@ -37,9 +38,7 @@ sealed class ChildToParentEvent {
     data object PaymentFailed : ChildToParentEvent()
     data object ReturnedFromCardReaderPaymentToCheckout : ChildToParentEvent()
     data object GoBackToCheckoutAfterFailedPayment : ChildToParentEvent()
-    data object OrderSuccessfullyPaidByCard : ChildToParentEvent()
-    data object OrderSuccessfullyPaidExternally : ChildToParentEvent()
-    data object OrderSuccessfullyPaidViaScanToPay : ChildToParentEvent()
+    data class OrderSuccessfullyPaid(val paymentMethod: PaymentMethod) : ChildToParentEvent()
     data object ExitPosClicked : ChildToParentEvent()
     data object SetupBarcodeScannerClicked : ChildToParentEvent()
     data object CouponsValidationFailed : ChildToParentEvent()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModel.kt
@@ -188,17 +188,7 @@ class WooPosHomeViewModel @Inject constructor(
                         }
                     }
 
-                    is ChildToParentEvent.OrderSuccessfullyPaidByCard -> onOrderSuccessfullyPaid(
-                        PaymentMethod.CARD
-                    )
-
-                    is ChildToParentEvent.OrderSuccessfullyPaidExternally -> onOrderSuccessfullyPaid(
-                        PaymentMethod.EXTERNAL
-                    )
-
-                    is ChildToParentEvent.OrderSuccessfullyPaidViaScanToPay -> onOrderSuccessfullyPaid(
-                        PaymentMethod.SCAN_TO_PAY
-                    )
+                    is ChildToParentEvent.OrderSuccessfullyPaid -> onOrderSuccessfullyPaid(event.paymentMethod)
 
                     is ChildToParentEvent.PaymentCollecting -> {
                         _state.value = _state.value.copy(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModel.kt
@@ -196,6 +196,10 @@ class WooPosHomeViewModel @Inject constructor(
                         PaymentMethod.EXTERNAL
                     )
 
+                    is ChildToParentEvent.OrderSuccessfullyPaidViaScanToPay -> onOrderSuccessfullyPaid(
+                        PaymentMethod.SCAN_TO_PAY
+                    )
+
                     is ChildToParentEvent.PaymentCollecting -> {
                         _state.value = _state.value.copy(
                             screenPositionState = ScreenPositionState.Checkout.CartWithTotals

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
@@ -35,7 +35,6 @@ import com.woocommerce.android.ui.woopos.home.ChildToParentEvent.NavigationEvent
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent.NavigationEvent.ToMarkOrderAsPaid
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent.NavigationEvent.ToScanToPay
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent.OnNewTransactionStarted
-import com.woocommerce.android.ui.woopos.home.ChildToParentEvent.OrderSuccessfullyPaidByCard
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent.ToastMessageDisplayed
 import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent
 import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent.OrderSuccessfullyPaid.PaymentMethod
@@ -651,7 +650,7 @@ class WooPosTotalsViewModel @Inject constructor(
             )
             when (result) {
                 WooPosRemoteReaderPaymentFlow.Result.Completed -> {
-                    childrenToParentEventSender.sendToParent(OrderSuccessfullyPaidByCard)
+                    notifyOrderPaidByCard()
                 }
                 is WooPosRemoteReaderPaymentFlow.Result.Failed -> {
                     uiState.value = PaymentFailed(
@@ -752,6 +751,10 @@ class WooPosTotalsViewModel @Inject constructor(
         viewModelScope.launch { totalsAnalyticsTracker.trackPaymentStates(cardReaderPaymentController?.paymentState) }
     }
 
+    private suspend fun notifyOrderPaidByCard() {
+        childrenToParentEventSender.sendToParent(ChildToParentEvent.OrderSuccessfullyPaid(PaymentMethod.CARD))
+    }
+
     private suspend fun handleTapToPayPaymentState(paymentState: CardReaderPaymentOrRefundState) {
         when (paymentState) {
             is CardReaderPaymentState.LoadingData ->
@@ -763,7 +766,7 @@ class WooPosTotalsViewModel @Inject constructor(
                 isTTPPaymentInProgress = false
                 resetTapToPayProgress()
                 viewModelScope.launch { builtInReaderConnector.disconnectIfConnected() }
-                childrenToParentEventSender.sendToParent(OrderSuccessfullyPaidByCard)
+                notifyOrderPaidByCard()
             }
 
             is CardReaderPaymentState.PaymentFailed.BuiltInReaderFailedPayment -> {
@@ -799,7 +802,7 @@ class WooPosTotalsViewModel @Inject constructor(
             is CardReaderPaymentState.PaymentCapturing -> handleCapturingPaymentState()
 
             is CardReaderPaymentState.PaymentSuccessful ->
-                childrenToParentEventSender.sendToParent(OrderSuccessfullyPaidByCard)
+                notifyOrderPaidByCard()
 
             is CardReaderPaymentState.PaymentFailed.ExternalReaderFailedPayment -> {
                 uiState.value = buildPaymentFailedState(paymentState)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/markorderascomplete/WooPosMarkOrderAsCompleteViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/markorderascomplete/WooPosMarkOrderAsCompleteViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
+import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent.OrderSuccessfullyPaid.PaymentMethod
 import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
 import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BackToCheckoutFromMarkAsPaid
@@ -140,7 +141,7 @@ class WooPosMarkOrderAsCompleteViewModel @Inject constructor(
 
     private suspend fun onMarkAsPaidSucceeded() {
         analyticsTracker.track(MarkAsPaidSuccess)
-        childrenToParentEventSender.sendToParent(ChildToParentEvent.OrderSuccessfullyPaidExternally)
+        childrenToParentEventSender.sendToParent(ChildToParentEvent.OrderSuccessfullyPaid(PaymentMethod.EXTERNAL))
         _navigationEvent.emit(WooPosNavigationEvent.GoBack)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/scantopay/WooPosScanToPayScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/scantopay/WooPosScanToPayScreen.kt
@@ -58,6 +58,7 @@ fun WooPosScanToPayScreen(onNavigationEvent: (WooPosNavigationEvent) -> Unit) {
         state = state,
         onCancelClicked = { viewModel.onUIEvent(WooPosScanToPayUIEvent.CancelClicked) },
         onRetryClicked = { viewModel.onUIEvent(WooPosScanToPayUIEvent.RetryClicked) },
+        onCollectOnRegisterClicked = { viewModel.onUIEvent(WooPosScanToPayUIEvent.CollectOnRegisterClicked) },
     )
     BackHandler(enabled = state !is WooPosScanToPayState.PaymentDetected) { viewModel.onBackClicked() }
 }
@@ -67,6 +68,7 @@ private fun WooPosScanToPayScreen(
     state: WooPosScanToPayState,
     onCancelClicked: () -> Unit,
     onRetryClicked: () -> Unit,
+    onCollectOnRegisterClicked: () -> Unit,
 ) {
     Column(modifier = Modifier.fillMaxSize()) {
         WooPosToolbar(
@@ -86,7 +88,7 @@ private fun WooPosScanToPayScreen(
                 is WooPosScanToPayState.ShowingQR -> ShowingQR(state = state, onCancelClicked = onCancelClicked)
 
                 WooPosScanToPayState.PayInPersonSelected -> PayInPersonSelected(
-                    onCollectOnRegisterClicked = onCancelClicked,
+                    onCollectOnRegisterClicked = onCollectOnRegisterClicked,
                     onShowQrAgainClicked = onRetryClicked,
                 )
 
@@ -243,6 +245,7 @@ private fun WooPosScanToPayLoadingPreview() {
             state = WooPosScanToPayState.Loading,
             onCancelClicked = {},
             onRetryClicked = {},
+            onCollectOnRegisterClicked = {},
         )
     }
 }
@@ -258,6 +261,7 @@ private fun WooPosScanToPayShowingQrPreview() {
             ),
             onCancelClicked = {},
             onRetryClicked = {},
+            onCollectOnRegisterClicked = {},
         )
     }
 }
@@ -270,6 +274,7 @@ private fun WooPosScanToPayPayInPersonPreview() {
             state = WooPosScanToPayState.PayInPersonSelected,
             onCancelClicked = {},
             onRetryClicked = {},
+            onCollectOnRegisterClicked = {},
         )
     }
 }
@@ -284,6 +289,7 @@ private fun WooPosScanToPayFailedPreview() {
             ),
             onCancelClicked = {},
             onRetryClicked = {},
+            onCollectOnRegisterClicked = {},
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/scantopay/WooPosScanToPayScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/scantopay/WooPosScanToPayScreen.kt
@@ -85,6 +85,11 @@ private fun WooPosScanToPayScreen(
 
                 is WooPosScanToPayState.ShowingQR -> ShowingQR(state = state, onCancelClicked = onCancelClicked)
 
+                WooPosScanToPayState.PayInPersonSelected -> PayInPersonSelected(
+                    onCollectOnRegisterClicked = onCancelClicked,
+                    onShowQrAgainClicked = onRetryClicked,
+                )
+
                 is WooPosScanToPayState.Failed -> Failed(
                     state = state,
                     onRetryClicked = onRetryClicked,
@@ -134,6 +139,45 @@ private fun ShowingQR(
                 .testTag(WooPosTestTags.SCAN_TO_PAY_CANCEL_BUTTON),
             text = stringResource(R.string.woopos_scan_to_pay_cancel),
             onClick = onCancelClicked,
+        )
+    }
+}
+
+@Composable
+private fun PayInPersonSelected(
+    onCollectOnRegisterClicked: () -> Unit,
+    onShowQrAgainClicked: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(WooPosSpacing.Large.value),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        WooPosText(
+            text = stringResource(R.string.woopos_scan_to_pay_pay_in_person_title),
+            style = WooPosTypography.Heading,
+            fontWeight = FontWeight.Bold,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
+        WooPosText(
+            text = stringResource(R.string.woopos_scan_to_pay_pay_in_person_message),
+            style = WooPosTypography.BodyLarge,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(modifier = Modifier.height(WooPosSpacing.XLarge.value))
+        WooPosButton(
+            modifier = Modifier.fillMaxWidth(),
+            text = stringResource(R.string.woopos_scan_to_pay_pay_in_person_collect),
+            onClick = onCollectOnRegisterClicked,
+        )
+        Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
+        WooPosOutlinedButton(
+            modifier = Modifier.fillMaxWidth(),
+            text = stringResource(R.string.woopos_scan_to_pay_pay_in_person_show_qr),
+            onClick = onShowQrAgainClicked,
         )
     }
 }
@@ -212,6 +256,18 @@ private fun WooPosScanToPayShowingQrPreview() {
                 paymentUrl = "https://example.com/checkout/pay/abc123",
                 totalText = "Order total: $42.00",
             ),
+            onCancelClicked = {},
+            onRetryClicked = {},
+        )
+    }
+}
+
+@WooPosPreview
+@Composable
+private fun WooPosScanToPayPayInPersonPreview() {
+    WooPosTheme {
+        WooPosScanToPayScreen(
+            state = WooPosScanToPayState.PayInPersonSelected,
             onCancelClicked = {},
             onRetryClicked = {},
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/scantopay/WooPosScanToPayState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/scantopay/WooPosScanToPayState.kt
@@ -19,6 +19,9 @@ sealed class WooPosScanToPayState : Parcelable {
     data object PaymentDetected : WooPosScanToPayState()
 
     @Parcelize
+    data object PayInPersonSelected : WooPosScanToPayState()
+
+    @Parcelize
     data class Failed(
         val message: String,
     ) : WooPosScanToPayState()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/scantopay/WooPosScanToPayUIEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/scantopay/WooPosScanToPayUIEvent.kt
@@ -3,4 +3,5 @@ package com.woocommerce.android.ui.woopos.scantopay
 sealed class WooPosScanToPayUIEvent {
     data object RetryClicked : WooPosScanToPayUIEvent()
     data object CancelClicked : WooPosScanToPayUIEvent()
+    data object CollectOnRegisterClicked : WooPosScanToPayUIEvent()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/scantopay/WooPosScanToPayViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/scantopay/WooPosScanToPayViewModel.kt
@@ -4,9 +4,8 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R
-import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent
-import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent.OrderSuccessfullyPaid.PaymentMethod
-import com.woocommerce.android.ui.woopos.home.WooPosParentToChildrenEventSender
+import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
+import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
 import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BackToCheckoutFromScanToPay
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.ScanToPayCollectPaymentSuccess
@@ -29,7 +28,7 @@ import javax.inject.Inject
 @HiltViewModel
 class WooPosScanToPayViewModel @Inject constructor(
     private val repository: WooPosScanToPayRepository,
-    private val parentToChildrenEventSender: WooPosParentToChildrenEventSender,
+    private val childrenToParentEventSender: WooPosChildrenToParentEventSender,
     private val analyticsTracker: WooPosAnalyticsTracker,
     private val resourceProvider: ResourceProvider,
     private val priceFormat: WooPosFormatPrice,
@@ -138,9 +137,7 @@ class WooPosScanToPayViewModel @Inject constructor(
         _state.value = WooPosScanToPayState.PaymentDetected
         analyticsTracker.track(ScanToPayPaymentDetectedViaPolling)
         analyticsTracker.track(ScanToPayCollectPaymentSuccess)
-        parentToChildrenEventSender.sendToChildren(
-            ParentToChildrenEvent.OrderSuccessfullyPaid(PaymentMethod.SCAN_TO_PAY),
-        )
+        childrenToParentEventSender.sendToParent(ChildToParentEvent.OrderSuccessfullyPaidViaScanToPay)
         _navigationEvent.emit(WooPosNavigationEvent.GoBack)
         viewModelScope.launch {
             repository.addOrderNote(orderId, resourceProvider.getString(R.string.woopos_scan_to_pay_order_note))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/scantopay/WooPosScanToPayViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/scantopay/WooPosScanToPayViewModel.kt
@@ -73,6 +73,13 @@ class WooPosScanToPayViewModel @Inject constructor(
                 prepareAndShowQr()
             }
             WooPosScanToPayUIEvent.CancelClicked -> onBackClicked()
+            // The customer already placed the order through the QR page, so the cart is sent back to
+            // the register rather than to checkout: the merchant starts a fresh order to collect on.
+            WooPosScanToPayUIEvent.CollectOnRegisterClicked -> viewModelScope.launch {
+                pollingJob?.cancel()
+                childrenToParentEventSender.sendToParent(ChildToParentEvent.BackFromCheckoutToCartClicked)
+                _navigationEvent.emit(WooPosNavigationEvent.GoBack)
+            }
         }
     }
 
@@ -127,11 +134,14 @@ class WooPosScanToPayViewModel @Inject constructor(
                 delay(intervalMs)
 
                 val snapshot = repository.fetchOrderSnapshot(orderId) ?: continue
-                if (snapshot.isPaidOnline()) {
+                if (snapshot.isOrderPaid) {
                     onPaymentDetected()
                     return@launch
                 }
-                if (snapshot.isPaidInPerson()) {
+                // Online gateways stamp `datePaid` when the money arrives. Offline ones such as
+                // "Pay in Person" only advance the status, so a paid status without `datePaid`
+                // means the customer picked an offline method instead of paying through the QR.
+                if (snapshot.status in OFFLINE_PAYMENT_STATUSES) {
                     _state.value = WooPosScanToPayState.PayInPersonSelected
                     return@launch
                 }
@@ -139,13 +149,6 @@ class WooPosScanToPayViewModel @Inject constructor(
             failAndTrack()
         }
     }
-
-    // Offline gateways such as "Pay in Person" (cod) still move the order to processing, which makes
-    // WooCommerce stamp `datePaid` even though no money has been collected. Only an online gateway
-    // means the customer actually paid through the QR code.
-    private fun Order.isPaidOnline(): Boolean = isOrderPaid && !isCashPayment
-
-    private fun Order.isPaidInPerson(): Boolean = isOrderPaid && isCashPayment
 
     private suspend fun onPaymentDetected() {
         _state.value = WooPosScanToPayState.PaymentDetected
@@ -177,5 +180,10 @@ class WooPosScanToPayViewModel @Inject constructor(
         const val SLOW_POLL_INTERVAL_MS = 5_000L
         const val FAST_POLL_ATTEMPTS = 15
         const val MAX_POLL_ATTEMPTS = 75
+
+        val OFFLINE_PAYMENT_STATUSES: Set<Order.Status> = setOf(
+            Order.Status.Processing,
+            Order.Status.Completed,
+        )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/scantopay/WooPosScanToPayViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/scantopay/WooPosScanToPayViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
+import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent.OrderSuccessfullyPaid.PaymentMethod
 import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
 import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BackToCheckoutFromScanToPay
@@ -137,7 +138,9 @@ class WooPosScanToPayViewModel @Inject constructor(
         _state.value = WooPosScanToPayState.PaymentDetected
         analyticsTracker.track(ScanToPayPaymentDetectedViaPolling)
         analyticsTracker.track(ScanToPayCollectPaymentSuccess)
-        childrenToParentEventSender.sendToParent(ChildToParentEvent.OrderSuccessfullyPaidViaScanToPay)
+        childrenToParentEventSender.sendToParent(
+            ChildToParentEvent.OrderSuccessfullyPaid(PaymentMethod.SCAN_TO_PAY)
+        )
         _navigationEvent.emit(WooPosNavigationEvent.GoBack)
         viewModelScope.launch {
             repository.addOrderNote(orderId, resourceProvider.getString(R.string.woopos_scan_to_pay_order_note))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/scantopay/WooPosScanToPayViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/scantopay/WooPosScanToPayViewModel.kt
@@ -60,6 +60,7 @@ class WooPosScanToPayViewModel @Inject constructor(
                 WooPosScanToPayState.Loading -> prepareAndShowQr()
                 is WooPosScanToPayState.ShowingQR -> startPolling()
                 WooPosScanToPayState.PaymentDetected -> _navigationEvent.emit(WooPosNavigationEvent.GoBack)
+                WooPosScanToPayState.PayInPersonSelected,
                 is WooPosScanToPayState.Failed -> Unit
             }
         }
@@ -130,6 +131,10 @@ class WooPosScanToPayViewModel @Inject constructor(
                     onPaymentDetected()
                     return@launch
                 }
+                if (snapshot.isPaidInPerson()) {
+                    _state.value = WooPosScanToPayState.PayInPersonSelected
+                    return@launch
+                }
             }
             failAndTrack()
         }
@@ -139,6 +144,8 @@ class WooPosScanToPayViewModel @Inject constructor(
     // WooCommerce stamp `datePaid` even though no money has been collected. Only an online gateway
     // means the customer actually paid through the QR code.
     private fun Order.isPaidOnline(): Boolean = isOrderPaid && !isCashPayment
+
+    private fun Order.isPaidInPerson(): Boolean = isOrderPaid && isCashPayment
 
     private suspend fun onPaymentDetected() {
         _state.value = WooPosScanToPayState.PaymentDetected

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/scantopay/WooPosScanToPayViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/scantopay/WooPosScanToPayViewModel.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R
-import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent
 import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent.OrderSuccessfullyPaid.PaymentMethod
 import com.woocommerce.android.ui.woopos.home.WooPosParentToChildrenEventSender
@@ -126,7 +125,7 @@ class WooPosScanToPayViewModel @Inject constructor(
                 delay(intervalMs)
 
                 val snapshot = repository.fetchOrderSnapshot(orderId) ?: continue
-                if (snapshot.isPaid()) {
+                if (snapshot.isOrderPaid) {
                     onPaymentDetected()
                     return@launch
                 }
@@ -152,11 +151,6 @@ class WooPosScanToPayViewModel @Inject constructor(
         message = resourceProvider.getString(R.string.woopos_scan_to_pay_error_message),
     )
 
-    // `isOrderPaid` only checks `datePaid`; treat Processing/Completed as paid even when the
-    // backend hasn't populated `datePaid` yet, so polling can detect payment as soon as the
-    // status transitions.
-    private fun Order.isPaid(): Boolean = isOrderPaid || status in PAID_STATUSES
-
     override fun onCleared() {
         pollingJob?.cancel()
         super.onCleared()
@@ -170,10 +164,5 @@ class WooPosScanToPayViewModel @Inject constructor(
         const val SLOW_POLL_INTERVAL_MS = 5_000L
         const val FAST_POLL_ATTEMPTS = 15
         const val MAX_POLL_ATTEMPTS = 75
-
-        val PAID_STATUSES: Set<Order.Status> = setOf(
-            Order.Status.Processing,
-            Order.Status.Completed,
-        )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/scantopay/WooPosScanToPayViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/scantopay/WooPosScanToPayViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R
+import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
 import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent.OrderSuccessfullyPaid.PaymentMethod
 import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
@@ -125,7 +126,7 @@ class WooPosScanToPayViewModel @Inject constructor(
                 delay(intervalMs)
 
                 val snapshot = repository.fetchOrderSnapshot(orderId) ?: continue
-                if (snapshot.isOrderPaid) {
+                if (snapshot.isPaidOnline()) {
                     onPaymentDetected()
                     return@launch
                 }
@@ -133,6 +134,11 @@ class WooPosScanToPayViewModel @Inject constructor(
             failAndTrack()
         }
     }
+
+    // Offline gateways such as "Pay in Person" (cod) still move the order to processing, which makes
+    // WooCommerce stamp `datePaid` even though no money has been collected. Only an online gateway
+    // means the customer actually paid through the QR code.
+    private fun Order.isPaidOnline(): Boolean = isOrderPaid && !isCashPayment
 
     private suspend fun onPaymentDetected() {
         _state.value = WooPosScanToPayState.PaymentDetected

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4027,6 +4027,10 @@
     <string name="woopos_scan_to_pay_retry">Try again</string>
     <string name="woopos_scan_to_pay_cancel">Cancel</string>
     <string name="woopos_scan_to_pay_order_note">Customer paid via Scan to Pay</string>
+    <string name="woopos_scan_to_pay_pay_in_person_title">Customer chose to pay in person</string>
+    <string name="woopos_scan_to_pay_pay_in_person_message">No payment was taken online. Collect it on the register, or show the code again.</string>
+    <string name="woopos_scan_to_pay_pay_in_person_collect">Collect on the register</string>
+    <string name="woopos_scan_to_pay_pay_in_person_show_qr">Show the code again</string>
     <string name="woopos_payment_method_picker_bottom_sheet_title">Choose payment method</string>
     <string name="woopos_payment_method_picker_bottom_sheet_scrim_content_description">Dimmed background. Tap to dismiss the payment method picker.</string>
     <string name="woopos_tap_to_pay_promoted_title">Tap to pay</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModelTest.kt
@@ -146,6 +146,26 @@ class WooPosHomeViewModelTest {
         }
 
     @Test
+    fun `when OrderSuccessfullyPaidViaScanToPay received, then totals go fullscreen and sound played`() =
+        runTest {
+            // GIVEN
+            whenever(childrenToParentEventReceiver.events).thenReturn(
+                flowOf(ChildToParentEvent.OrderSuccessfullyPaidViaScanToPay)
+            )
+
+            // WHEN
+            val viewModel = createViewModel()
+
+            // THEN
+            verify(parentToChildrenEventSender).sendToChildren(
+                ParentToChildrenEvent.OrderSuccessfullyPaid(PaymentMethod.SCAN_TO_PAY)
+            )
+            verify(soundHelper).playChaChing()
+            assertThat(viewModel.state.value.screenPositionState)
+                .isEqualTo(WooPosHomeState.ScreenPositionState.Checkout.FullScreenTotals)
+        }
+
+    @Test
     fun `given state is Checkout NotPaid, when ExitConfirmationDialogDismissed passed, then exit confirmation dialog should be dismissed`() =
         runTest {
             // GIVEN

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModelTest.kt
@@ -108,7 +108,7 @@ class WooPosHomeViewModelTest {
         runTest {
             // GIVEN
             whenever(childrenToParentEventReceiver.events).thenReturn(
-                flowOf(ChildToParentEvent.OrderSuccessfullyPaidByCard)
+                flowOf(ChildToParentEvent.OrderSuccessfullyPaid(PaymentMethod.CARD))
             )
             val viewModel = createViewModel()
 
@@ -126,11 +126,11 @@ class WooPosHomeViewModelTest {
         }
 
     @Test
-    fun `when OrderSuccessfullyPaidExternally received, then OrderSuccessfullyPaid with EXTERNAL is sent and sound played`() =
+    fun `when OrderSuccessfullyPaid with EXTERNAL received, then event forwarded and sound played`() =
         runTest {
             // GIVEN
             whenever(childrenToParentEventReceiver.events).thenReturn(
-                flowOf(ChildToParentEvent.OrderSuccessfullyPaidExternally)
+                flowOf(ChildToParentEvent.OrderSuccessfullyPaid(PaymentMethod.EXTERNAL))
             )
 
             // WHEN
@@ -146,11 +146,11 @@ class WooPosHomeViewModelTest {
         }
 
     @Test
-    fun `when OrderSuccessfullyPaidViaScanToPay received, then totals go fullscreen and sound played`() =
+    fun `when OrderSuccessfullyPaid with SCAN_TO_PAY received, then totals go fullscreen and sound played`() =
         runTest {
             // GIVEN
             whenever(childrenToParentEventReceiver.events).thenReturn(
-                flowOf(ChildToParentEvent.OrderSuccessfullyPaidViaScanToPay)
+                flowOf(ChildToParentEvent.OrderSuccessfullyPaid(PaymentMethod.SCAN_TO_PAY))
             )
 
             // WHEN

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/markorderascomplete/WooPosMarkOrderAsCompleteViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/markorderascomplete/WooPosMarkOrderAsCompleteViewModelTest.kt
@@ -6,6 +6,7 @@ import app.cash.turbine.test
 import com.woocommerce.android.R
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
+import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent.OrderSuccessfullyPaid.PaymentMethod
 import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
 import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent
 import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
@@ -134,7 +135,7 @@ class WooPosMarkOrderAsCompleteViewModelTest {
             verify(tracker).track(MarkAsPaidConfirmed)
             verify(tracker).track(MarkAsPaidSuccess)
             verify(childrenToParentEventSender).sendToParent(
-                eq(ChildToParentEvent.OrderSuccessfullyPaidExternally),
+                eq(ChildToParentEvent.OrderSuccessfullyPaid(PaymentMethod.EXTERNAL)),
             )
         }
 
@@ -198,7 +199,7 @@ class WooPosMarkOrderAsCompleteViewModelTest {
         }
         verify(tracker).track(MarkAsPaidSuccess)
         verify(childrenToParentEventSender).sendToParent(
-            eq(ChildToParentEvent.OrderSuccessfullyPaidExternally),
+            eq(ChildToParentEvent.OrderSuccessfullyPaid(PaymentMethod.EXTERNAL)),
         )
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/scantopay/WooPosScanToPayViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/scantopay/WooPosScanToPayViewModelTest.kt
@@ -184,6 +184,21 @@ class WooPosScanToPayViewModelTest {
     }
 
     @Test
+    fun `when collect on register clicked, then cart is restored and GoBack emitted`() = runTest {
+        // GIVEN
+        whenever(repository.promoteOrderToPending(orderId)).thenReturn(Result.failure(Exception("boom")))
+        val viewModel = createViewModel()
+        runCurrent()
+
+        // WHEN / THEN
+        viewModel.navigationEvent.test {
+            viewModel.onUIEvent(WooPosScanToPayUIEvent.CollectOnRegisterClicked)
+            assertThat(awaitItem()).isEqualTo(WooPosNavigationEvent.GoBack)
+        }
+        verify(childrenToParentEventSender).sendToParent(ChildToParentEvent.BackFromCheckoutToCartClicked)
+    }
+
+    @Test
     fun `given QR shown, when customer picks Pay in Person, then PayInPersonSelected shown`() = runTest {
         // GIVEN
         val pendingOrder = Order.getEmptyOrder(Date(), Date()).copy(
@@ -193,10 +208,9 @@ class WooPosScanToPayViewModelTest {
         )
         val codOrder = Order.getEmptyOrder(Date(), Date()).copy(
             id = orderId,
-            datePaid = Date(),
+            datePaid = null,
             status = Order.Status.Processing,
             paymentMethod = "cod",
-            isCashPayment = true,
         )
         whenever(repository.promoteOrderToPending(orderId)).thenReturn(Result.success(Unit))
         whenever(repository.fetchOrderSnapshot(orderId)).thenReturn(pendingOrder, codOrder)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/scantopay/WooPosScanToPayViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/scantopay/WooPosScanToPayViewModelTest.kt
@@ -6,6 +6,7 @@ import app.cash.turbine.test
 import com.woocommerce.android.R
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
+import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent.OrderSuccessfullyPaid.PaymentMethod
 import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
 import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent
 import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
@@ -161,7 +162,9 @@ class WooPosScanToPayViewModelTest {
             // THEN
             verify(tracker).track(ScanToPayPaymentDetectedViaPolling)
             verify(tracker).track(ScanToPayCollectPaymentSuccess)
-            verify(childrenToParentEventSender).sendToParent(ChildToParentEvent.OrderSuccessfullyPaidViaScanToPay)
+            verify(childrenToParentEventSender).sendToParent(
+                ChildToParentEvent.OrderSuccessfullyPaid(PaymentMethod.SCAN_TO_PAY)
+            )
             verify(repository).addOrderNote(orderId, "Customer paid via Scan to Pay")
         }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/scantopay/WooPosScanToPayViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/scantopay/WooPosScanToPayViewModelTest.kt
@@ -184,20 +184,22 @@ class WooPosScanToPayViewModelTest {
     }
 
     @Test
-    fun `given QR shown, when polling sees Processing status without datePaid, then payment not detected`() = runTest {
+    fun `given QR shown, when customer picks Pay in Person, then payment not detected`() = runTest {
         // GIVEN
         val pendingOrder = Order.getEmptyOrder(Date(), Date()).copy(
             id = orderId,
             paymentUrl = "https://example.com/pay/abc",
             status = Order.Status.Pending,
         )
-        val processingOrder = Order.getEmptyOrder(Date(), Date()).copy(
+        val codOrder = Order.getEmptyOrder(Date(), Date()).copy(
             id = orderId,
-            datePaid = null,
+            datePaid = Date(),
             status = Order.Status.Processing,
+            paymentMethod = "cod",
+            isCashPayment = true,
         )
         whenever(repository.promoteOrderToPending(orderId)).thenReturn(Result.success(Unit))
-        whenever(repository.fetchOrderSnapshot(orderId)).thenReturn(pendingOrder, processingOrder)
+        whenever(repository.fetchOrderSnapshot(orderId)).thenReturn(pendingOrder, codOrder)
         whenever(repository.getCachedOrder(orderId)).thenReturn(pendingOrder)
 
         // WHEN

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/scantopay/WooPosScanToPayViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/scantopay/WooPosScanToPayViewModelTest.kt
@@ -5,9 +5,8 @@ import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
 import com.woocommerce.android.R
 import com.woocommerce.android.model.Order
-import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent
-import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent.OrderSuccessfullyPaid.PaymentMethod
-import com.woocommerce.android.ui.woopos.home.WooPosParentToChildrenEventSender
+import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
+import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
 import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent
 import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BackToCheckoutFromScanToPay
@@ -46,7 +45,7 @@ class WooPosScanToPayViewModelTest {
     val instantTaskRule = InstantTaskExecutorRule()
 
     private val repository: WooPosScanToPayRepository = mock()
-    private val parentToChildrenEventSender: WooPosParentToChildrenEventSender = mock()
+    private val childrenToParentEventSender: WooPosChildrenToParentEventSender = mock()
     private val tracker: WooPosAnalyticsTracker = mock()
     private val resourceProvider: ResourceProvider = mock()
     private val priceFormat: WooPosFormatPrice = mock()
@@ -66,7 +65,7 @@ class WooPosScanToPayViewModelTest {
 
     private fun createViewModel() = WooPosScanToPayViewModel(
         repository = repository,
-        parentToChildrenEventSender = parentToChildrenEventSender,
+        childrenToParentEventSender = childrenToParentEventSender,
         analyticsTracker = tracker,
         resourceProvider = resourceProvider,
         priceFormat = priceFormat,
@@ -162,9 +161,7 @@ class WooPosScanToPayViewModelTest {
             // THEN
             verify(tracker).track(ScanToPayPaymentDetectedViaPolling)
             verify(tracker).track(ScanToPayCollectPaymentSuccess)
-            verify(parentToChildrenEventSender).sendToChildren(
-                eq(ParentToChildrenEvent.OrderSuccessfullyPaid(PaymentMethod.SCAN_TO_PAY)),
-            )
+            verify(childrenToParentEventSender).sendToParent(ChildToParentEvent.OrderSuccessfullyPaidViaScanToPay)
             verify(repository).addOrderNote(orderId, "Customer paid via Scan to Pay")
         }
 
@@ -307,7 +304,7 @@ class WooPosScanToPayViewModelTest {
         // WHEN
         val viewModel = WooPosScanToPayViewModel(
             repository = repository,
-            parentToChildrenEventSender = parentToChildrenEventSender,
+            childrenToParentEventSender = childrenToParentEventSender,
             analyticsTracker = tracker,
             resourceProvider = resourceProvider,
             priceFormat = priceFormat,
@@ -333,7 +330,7 @@ class WooPosScanToPayViewModelTest {
             // GIVEN
             val viewModel = WooPosScanToPayViewModel(
                 repository = repository,
-                parentToChildrenEventSender = parentToChildrenEventSender,
+                childrenToParentEventSender = childrenToParentEventSender,
                 analyticsTracker = tracker,
                 resourceProvider = resourceProvider,
                 priceFormat = priceFormat,
@@ -358,7 +355,7 @@ class WooPosScanToPayViewModelTest {
         // GIVEN
         val viewModel = WooPosScanToPayViewModel(
             repository = repository,
-            parentToChildrenEventSender = parentToChildrenEventSender,
+            childrenToParentEventSender = childrenToParentEventSender,
             analyticsTracker = tracker,
             resourceProvider = resourceProvider,
             priceFormat = priceFormat,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/scantopay/WooPosScanToPayViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/scantopay/WooPosScanToPayViewModelTest.kt
@@ -184,7 +184,7 @@ class WooPosScanToPayViewModelTest {
     }
 
     @Test
-    fun `given QR shown, when polling sees Processing status, then payment detected`() = runTest {
+    fun `given QR shown, when polling sees Processing status without datePaid, then payment not detected`() = runTest {
         // GIVEN
         val pendingOrder = Order.getEmptyOrder(Date(), Date()).copy(
             id = orderId,
@@ -199,17 +199,16 @@ class WooPosScanToPayViewModelTest {
         whenever(repository.promoteOrderToPending(orderId)).thenReturn(Result.success(Unit))
         whenever(repository.fetchOrderSnapshot(orderId)).thenReturn(pendingOrder, processingOrder)
         whenever(repository.getCachedOrder(orderId)).thenReturn(pendingOrder)
-        whenever(repository.addOrderNote(eq(orderId), any())).thenReturn(Result.success(Unit))
 
         // WHEN
         val viewModel = createViewModel()
         runCurrent()
+        advanceTimeBy(2_500)
+        runCurrent()
 
         // THEN
-        viewModel.navigationEvent.test {
-            assertThat(awaitItem()).isEqualTo(WooPosNavigationEvent.GoBack)
-        }
-        verify(tracker).track(ScanToPayPaymentDetectedViaPolling)
+        verify(tracker, never()).track(ScanToPayPaymentDetectedViaPolling)
+        assertThat(viewModel.state.value).isInstanceOf(WooPosScanToPayState.ShowingQR::class.java)
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/scantopay/WooPosScanToPayViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/scantopay/WooPosScanToPayViewModelTest.kt
@@ -184,7 +184,7 @@ class WooPosScanToPayViewModelTest {
     }
 
     @Test
-    fun `given QR shown, when customer picks Pay in Person, then payment not detected`() = runTest {
+    fun `given QR shown, when customer picks Pay in Person, then PayInPersonSelected shown`() = runTest {
         // GIVEN
         val pendingOrder = Order.getEmptyOrder(Date(), Date()).copy(
             id = orderId,
@@ -210,7 +210,8 @@ class WooPosScanToPayViewModelTest {
 
         // THEN
         verify(tracker, never()).track(ScanToPayPaymentDetectedViaPolling)
-        assertThat(viewModel.state.value).isInstanceOf(WooPosScanToPayState.ShowingQR::class.java)
+        verify(tracker, never()).track(ScanToPayPaymentFailed)
+        assertThat(viewModel.state.value).isEqualTo(WooPosScanToPayState.PayInPersonSelected)
     }
 
     @Test


### PR DESCRIPTION
### Description

@samiuelson I could not validate that the success path works as on the web it doesn't collect the money and shows an error "canot read properties of null". Both here and on trunk. Did it work before?

Fixes WOOMOB-3712

Two fixes for POS Scan to Pay:

1. Picking "Pay in Person" in the QR webview showed `Order Successfully Paid`. Polling treated `processing`/`completed` as paid, but that order looks like this:

   ```
   status=processing datePaid=null isOrderPaid=false paymentMethod='cod'
   paymentMethodTitle='Pay in Person' isCashPayment=true
   ```

   Online gateways stamp `datePaid` when the money arrives; offline ones only advance the status. So success now requires `datePaid`, and a paid status *without* it is treated as "customer picked an offline method" — keyed on status rather than the gateway id, so it holds for any offline gateway. That state stops polling and explains what happened, offering *Collect on the register* or *Show the code again*. Without it the merchant would sit on the QR for the full 5.5 min polling window and then get a generic error.

   *Collect on the register* sends `BackFromCheckoutToCartClicked`, returning to the cart so the next checkout builds a fresh order — the customer already placed the offline one, so collecting against it would conflate two sales.

2. The success screen kept the cart visible and played no cha-ching. Scan to Pay sent `OrderSuccessfullyPaid` straight down to children, skipping `WooPosHomeViewModel.onOrderSuccessfullyPaid()` which sets fullscreen totals and plays the sound. It now reports upward like the card and external flows.

While wiring that up, the three child-to-parent success events (`OrderSuccessfullyPaidByCard`, `...Externally`, plus the new Scan to Pay one) collapsed into a single `ChildToParentEvent.OrderSuccessfullyPaid(paymentMethod)`.

Offline gateways that land on `on-hold` (bacs, cheque) aren't detected and still fall through to the polling timeout — only `processing`/`completed` are treated as an offline checkout.

### Test Steps

Requires a debug build (`WOO_POS_SCAN_TO_PAY` is off in production).

1. Enable Cash on delivery / Pay in Person in the store's payment settings.
2. In POS, add an item, go to checkout, tap Scan to Pay.
3. Scan the QR, choose "Pay in Person" and place the order.
4. POS shows "Customer chose to pay in person" — no success screen

Note: the store's new-order push notification uses the same cha-ching audio file, so the sound alone doesn't tell you which fired — watch the screen.

### Images/gif

The UI of this error is just for testing - should be redone when ready

<img width="1011" height="659" alt="image" src="https://github.com/user-attachments/assets/b1810fe2-a635-4b5a-b371-2af8eb2e6529" />


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.