### PR TITLE
[POS] Harden the server-calculated refund flow

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 
 25.4
 -----
+- [Internal] POS refunds: server-refund availability is now tracked per WooCommerce version, so a store that changes version mid-session is re-probed instead of reusing a stale verdict [https://github.com/woocommerce/woocommerce-android/pull/16365]
 - [*] Fixed fully refunded orders remaining visible in the Completed orders filter [https://github.com/woocommerce/woocommerce-android/pull/16313]
 - [*] Fixed coupon expiry dates drifting when unrelated coupon changes were saved for stores outside UTC [https://github.com/woocommerce/woocommerce-android/pull/16279]
 - [*] Card payments no longer show an error when the payment was actually captured but the backend reported a network/server issue — the app now verifies the payment status and shows success, preventing double charges [https://github.com/woocommerce/woocommerce-android/pull/16295]

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundPreview.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundPreview.kt
@@ -29,7 +29,8 @@ class WooPosRefundPreview @Inject constructor(
         val site = selectedSite.get()
         val localSiteId = site.localId().value
 
-        if (resolveRefundFlow() is WooPosRefundFlow.LocalComputed) {
+        val flow = resolveRefundFlow()
+        if (flow !is WooPosRefundFlow.ServerComputed) {
             return Result.FallbackToLocal
         }
 
@@ -43,7 +44,7 @@ class WooPosRefundPreview @Inject constructor(
             response.isError -> {
                 if (response.error.type == WooErrorType.API_NOT_FOUND) {
                     WooLog.i(WooLog.T.POS, "WooPosRefund: preview route not available; falling back to local")
-                    availabilityCache.markUnavailable(localSiteId)
+                    availabilityCache.markUnavailable(localSiteId, flow.wooVersion)
                     Result.FallbackToLocal
                 } else {
                     WooLog.e(
@@ -57,7 +58,7 @@ class WooPosRefundPreview @Inject constructor(
             }
 
             preview != null -> {
-                availabilityCache.markAvailable(localSiteId)
+                availabilityCache.markAvailable(localSiteId, flow.wooVersion)
                 Result.ServerCalculated(preview)
             }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundState.kt
@@ -35,7 +35,6 @@ sealed class WooPosRefundState {
         // Refund-specific message for a failed preview (see [WooPosRefundApiError]); null when
         // the failure has no mapped code, in which case the UI shows the generic preview error.
         val previewErrorMessage: String? = null,
-        val maxRefundable: BigDecimal? = null,
     ) : WooPosRefundState() {
 
         @Immutable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundViewModel.kt
@@ -215,7 +215,7 @@ class WooPosRefundViewModel @AssistedInject constructor(
 
     /**
      * Fetches the store settings required for local refund calculation (currency decimals and tax
-     * rounding mode) unless already cached. Only the v3 fallback path needs these.
+     * rounding mode) unless already cached. Only the local-calculation flow needs these.
      */
     private suspend fun ensureLocalCalculationSettings(): Boolean {
         if (cachedNumberOfDecimalPoints == null && fetchSiteSettings().isFailure) return false
@@ -410,28 +410,16 @@ class WooPosRefundViewModel @AssistedInject constructor(
     /**
      * Triggered when the user commits their selection by tapping "Continue". On a server-eligible
      * store this fetches the server-calculated totals and, on success, advances to the review step
-     * showing those authoritative totals. On a local-flow store (flag off, WooCommerce too old, or
-     * server refunds known unavailable) the totals are calculated locally instead. On a preview
-     * error the user stays on the selection step with a retry affordance.
+     * showing those authoritative totals. [WooPosRefundPreview] owns the eligibility decision and
+     * reports `FallbackToLocal` for a local-flow store (flag off, WooCommerce too old, or server
+     * refunds known unavailable), which resolves the totals on-device instead. On a preview error
+     * the user stays on the selection step with a retry affordance.
      */
     private fun continueToReview(currentState: WooPosRefundState.Content) {
         if (currentState.selectedItemIds.isEmpty()) return
         previewJob?.cancel()
 
         val selectedItems = currentState.refundableItems.filter { it.uniqueId in currentState.selectedItemIds }
-
-        if (resolveRefundFlow() is WooPosRefundFlow.LocalComputed) {
-            // The legacy local flow: skip the probe and resolve totals on-device.
-            _state.value = currentState.copy(
-                isPreviewLoading = true,
-                previewFailed = false,
-                previewErrorMessage = null,
-            )
-            previewJob = viewModelScope.launch {
-                advanceToReviewWithLocalTotals(currentState, selectedItems)
-            }
-            return
-        }
 
         _state.value = currentState.copy(
             isPreviewLoading = true,
@@ -513,7 +501,6 @@ class WooPosRefundViewModel @AssistedInject constructor(
             subtotal = preview.subtotal,
             taxes = preview.tax,
             total = preview.total,
-            maxRefundable = preview.maxRefundable,
             formattedSubtotal = PriceUtils.formatCurrency(preview.subtotal, currency, currencyFormatter),
             formattedTaxes = PriceUtils.formatCurrency(preview.tax, currency, currencyFormatter),
             formattedTotal = PriceUtils.formatCurrency(preview.total, currency, currencyFormatter),
@@ -577,9 +564,13 @@ class WooPosRefundViewModel @AssistedInject constructor(
         contentState: WooPosRefundState.Content,
         selectedItems: List<WooPosRefundableItem>,
     ): WooPosRefundSubmissionRequest? {
-        val serverRefundsConfirmedAvailable =
-            serverRefundAvailabilityCache.isAvailable(selectedSite.get().localId().value) == true
-        if (resolveRefundFlow() is WooPosRefundFlow.ServerComputed && serverRefundsConfirmedAvailable) {
+        val flow = resolveRefundFlow()
+        val serverRefundsConfirmedAvailable = flow is WooPosRefundFlow.ServerComputed &&
+            serverRefundAvailabilityCache.isAvailable(
+                localSiteId = selectedSite.get().localId().value,
+                wooVersion = flow.wooVersion,
+            ) == true
+        if (serverRefundsConfirmedAvailable) {
             return WooPosRefundSubmissionRequest(
                 order = order,
                 refundAmount = contentState.total,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosResolveRefundFlow.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosResolveRefundFlow.kt
@@ -5,6 +5,7 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.FeatureFlagRepository
 import com.woocommerce.android.util.GetWooCorePluginCachedVersion
+import com.woocommerce.android.util.WooLog
 import javax.inject.Inject
 
 /**
@@ -13,12 +14,18 @@ import javax.inject.Inject
  * [ServerComputed] means the store is eligible for server-calculated refunds: the preview endpoint
  * (`POST /wc/v3/orders/<order_id>/refunds/preview`) resolves the totals and the refund is created
  * with `compute_totals=true`. [LocalComputed] is the legacy flow where totals are calculated
- * on-device and the classic v3 item refund is sent; it exists only for stores below
- * [WooPosResolveRefundFlow.MIN_WC_VERSION_FOR_SERVER_REFUNDS] and is meant to be deleted once
- * those stores are no longer supported.
+ * on-device and the classic v3 item refund is sent. It is the flow for stores below
+ * [WooPosResolveRefundFlow.MIN_WC_VERSION_FOR_SERVER_REFUNDS], and also for a disabled feature
+ * flag, an unknown store version, or a store already probed as lacking the server endpoints. It is
+ * meant to be deleted once every supported store ships the server endpoints.
  */
 sealed interface WooPosRefundFlow {
-    data object ServerComputed : WooPosRefundFlow
+    /**
+     * [wooVersion] is the store's WooCommerce version this decision was made against. Callers pass
+     * it back when reading or writing [WooPosServerRefundAvailabilityCache], so a probe result is
+     * never applied to a store running a different version than the one probed.
+     */
+    data class ServerComputed(val wooVersion: String) : WooPosRefundFlow
     data object LocalComputed : WooPosRefundFlow
 }
 
@@ -48,23 +55,34 @@ class WooPosResolveRefundFlow @Inject constructor(
     private val featureFlagRepository: FeatureFlagRepository,
 ) {
     operator fun invoke(): WooPosRefundFlow {
-        if (!featureFlagRepository.isEnabled(FeatureFlag.WOO_POS_REFUND_V4)) {
-            return WooPosRefundFlow.LocalComputed
+        val wooVersion = getWooCoreVersion()
+        val eligibleVersion = when {
+            !featureFlagRepository.isEnabled(FeatureFlag.WOO_POS_REFUND_V4) ->
+                fallBackToLocal("feature flag disabled")
+            // Unknown version fails closed: eligibility must never rest on the preview probe alone,
+            // because the preview route does not prove `compute_totals` create support.
+            wooVersion == null -> fallBackToLocal("WooCommerce version unknown")
+            wooVersion.semverCompareTo(MIN_WC_VERSION_FOR_SERVER_REFUNDS) < 0 ->
+                fallBackToLocal("WooCommerce $wooVersion is below $MIN_WC_VERSION_FOR_SERVER_REFUNDS")
+            availabilityCache.isAvailable(selectedSite.get().localId().value, wooVersion) == false ->
+                fallBackToLocal("a preview probe found no server refund support on WooCommerce $wooVersion")
+            else -> wooVersion
         }
-        if (isWooVersionBelowServerRefundSupport()) {
-            return WooPosRefundFlow.LocalComputed
-        }
-        if (availabilityCache.isAvailable(selectedSite.get().localId().value) == false) {
-            return WooPosRefundFlow.LocalComputed
-        }
-        return WooPosRefundFlow.ServerComputed
+
+        return eligibleVersion?.let {
+            WooLog.i(WooLog.T.POS, "WooPosRefund: server calculation eligible on WooCommerce $it")
+            WooPosRefundFlow.ServerComputed(it)
+        } ?: WooPosRefundFlow.LocalComputed
     }
 
-    private fun isWooVersionBelowServerRefundSupport(): Boolean {
-        // Unknown version fails closed: eligibility must never rest on the preview probe alone,
-        // because the preview route does not prove `compute_totals` create support.
-        val version = getWooCoreVersion() ?: return true
-        return version.semverCompareTo(MIN_WC_VERSION_FOR_SERVER_REFUNDS) < 0
+    /**
+     * Logs why the store falls back, then reports "no eligible version" to the caller. Without this
+     * a store on local calculation leaves no trace of the reason, which makes "why are this store's
+     * totals local?" reports hard to answer — especially since an unknown version fails closed.
+     */
+    private fun fallBackToLocal(reason: String): String? {
+        WooLog.i(WooLog.T.POS, "WooPosRefund: using local calculation, $reason")
+        return null
     }
 
     companion object {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosServerRefundAvailabilityCache.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosServerRefundAvailabilityCache.kt
@@ -12,20 +12,33 @@ import javax.inject.Singleton
  * the computed create: on stores that do not support `compute_totals`, the unknown param would be
  * silently dropped and a quantity-only body would create a ghost zero-amount refund with restock.
  *
+ * Each verdict records the WooCommerce version it was probed against and only answers for that
+ * version, so a store that upgrades or downgrades mid-session is re-probed instead of being judged
+ * by a verdict that no longer describes it. Both directions matter: a `true` carried across a
+ * downgrade would reopen the ghost-refund window, and a `false` carried across an upgrade would
+ * keep a now-capable store on local calculation until the process restarts.
+ *
  * Keyed by the *local* site id (unique per stored site), not the remote WP.com site id, which is
  * `0` for self-hosted/WPAPI stores and would collide across them.
  */
 @Singleton
 class WooPosServerRefundAvailabilityCache @Inject constructor() {
-    private val availabilityByLocalSiteId = ConcurrentHashMap<Int, Boolean>()
+    private val verdictByLocalSiteId = ConcurrentHashMap<Int, Verdict>()
 
-    fun isAvailable(localSiteId: Int): Boolean? = availabilityByLocalSiteId[localSiteId]
+    /**
+     * The verdict recorded for this store while it was running [wooVersion], or null when nothing
+     * has been probed for that version yet.
+     */
+    fun isAvailable(localSiteId: Int, wooVersion: String): Boolean? =
+        verdictByLocalSiteId[localSiteId]?.takeIf { it.wooVersion == wooVersion }?.isAvailable
 
-    fun markAvailable(localSiteId: Int) {
-        availabilityByLocalSiteId[localSiteId] = true
+    fun markAvailable(localSiteId: Int, wooVersion: String) {
+        verdictByLocalSiteId[localSiteId] = Verdict(isAvailable = true, wooVersion = wooVersion)
     }
 
-    fun markUnavailable(localSiteId: Int) {
-        availabilityByLocalSiteId[localSiteId] = false
+    fun markUnavailable(localSiteId: Int, wooVersion: String) {
+        verdictByLocalSiteId[localSiteId] = Verdict(isAvailable = false, wooVersion = wooVersion)
     }
+
+    private data class Verdict(val isAvailable: Boolean, val wooVersion: String)
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundPreviewTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundPreviewTest.kt
@@ -69,7 +69,7 @@ class WooPosRefundPreviewTest {
 
         // THEN
         assertThat(result).isEqualTo(WooPosRefundPreview.Result.FallbackToLocal)
-        assertThat(availabilityCache.isAvailable(LOCAL_SITE_ID)).isNull()
+        assertThat(availabilityCache.isAvailable(LOCAL_SITE_ID, MIN_VERSION)).isNull()
         verify(refundStore, never()).previewRefund(any(), any(), any())
     }
 
@@ -84,7 +84,7 @@ class WooPosRefundPreviewTest {
 
         // THEN
         assertThat(result).isInstanceOf(WooPosRefundPreview.Result.ServerCalculated::class.java)
-        assertThat(availabilityCache.isAvailable(LOCAL_SITE_ID)).isTrue()
+        assertThat(availabilityCache.isAvailable(LOCAL_SITE_ID, MIN_VERSION)).isTrue()
     }
 
     @Test
@@ -98,7 +98,7 @@ class WooPosRefundPreviewTest {
 
         // THEN
         assertThat(result).isEqualTo(WooPosRefundPreview.Result.FallbackToLocal)
-        assertThat(availabilityCache.isAvailable(LOCAL_SITE_ID)).isFalse()
+        assertThat(availabilityCache.isAvailable(LOCAL_SITE_ID, MIN_VERSION)).isFalse()
     }
 
     @Test
@@ -135,7 +135,7 @@ class WooPosRefundPreviewTest {
         assertThat(result).isEqualTo(
             WooPosRefundPreview.Result.Error(apiError = WooPosRefundApiError.AmountExceedsOrderRemaining)
         )
-        assertThat(availabilityCache.isAvailable(LOCAL_SITE_ID)).isNull()
+        assertThat(availabilityCache.isAvailable(LOCAL_SITE_ID, MIN_VERSION)).isNull()
     }
 
     @Test
@@ -157,7 +157,7 @@ class WooPosRefundPreviewTest {
 
         // THEN
         assertThat(result).isInstanceOf(WooPosRefundPreview.Result.Error::class.java)
-        assertThat(availabilityCache.isAvailable(LOCAL_SITE_ID)).isNull()
+        assertThat(availabilityCache.isAvailable(LOCAL_SITE_ID, MIN_VERSION)).isNull()
     }
 
     @Test
@@ -204,7 +204,7 @@ class WooPosRefundPreviewTest {
     @Test
     fun `given server refunds known unavailable, when invoked, then falls back without probing`() = runTest {
         // GIVEN
-        availabilityCache.markUnavailable(LOCAL_SITE_ID)
+        availabilityCache.markUnavailable(LOCAL_SITE_ID, MIN_VERSION)
 
         // WHEN
         val result = sut(ORDER_ID, lineItems)
@@ -236,7 +236,7 @@ class WooPosRefundPreviewTest {
                 id = 102
                 siteId = 0L
             }
-            availabilityCache.markUnavailable(siteA.localId().value)
+            availabilityCache.markUnavailable(siteA.localId().value, MIN_VERSION)
 
             val selectedSiteB: SelectedSite = mock()
             whenever(selectedSiteB.get()).thenReturn(siteB)
@@ -254,7 +254,7 @@ class WooPosRefundPreviewTest {
 
             // THEN siteA's verdict does not poison siteB — it probes the route and is marked available.
             assertThat(result).isInstanceOf(WooPosRefundPreview.Result.ServerCalculated::class.java)
-            assertThat(availabilityCache.isAvailable(siteB.localId().value)).isTrue()
+            assertThat(availabilityCache.isAvailable(siteB.localId().value, MIN_VERSION)).isTrue()
             verify(refundStore).previewRefund(eq(siteB), eq(ORDER_ID), eq(lineItems))
         }
 
@@ -281,5 +281,6 @@ class WooPosRefundPreviewTest {
         private const val LOCAL_SITE_ID = 11
         private const val SITE_ID = 7L
         private const val ORDER_ID = 123L
+        private const val MIN_VERSION = WooPosResolveRefundFlow.MIN_WC_VERSION_FOR_SERVER_REFUNDS
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSubmissionProcessorTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSubmissionProcessorTest.kt
@@ -387,6 +387,113 @@ class WooPosRefundSubmissionProcessorTest {
     }
 
     @Test
+    fun `given interac refund with server line items, when reader succeeds, then computed refund is created`() =
+        runTest {
+            // GIVEN — an Interac order refunded through the reader on a store that supports
+            // server-computed totals. The reader reverses the money, then the backend records it.
+            val paymentState = MutableStateFlow<CardReaderPaymentOrRefundState>(
+                CardReaderInteracRefundState.LoadingData {}
+            )
+            val controller = mockController(paymentState)
+            whenever(paymentChargeRepository.fetchCardDataUsedForOrderPayment("ch_123")).thenReturn(
+                PaymentChargeRepository.CardDataUsedForOrderPaymentResult.Success(
+                    cardBrand = "interac",
+                    cardLast4 = "1234",
+                    paymentMethodType = INTERAC_PRESENT
+                )
+            )
+            whenever(cardReaderPaymentControllerFactory.createRefund(any(), any(), any()))
+                .thenReturn(controller)
+            val serverLineItems = listOf(ComputedRefundLineItem.quantityBased(lineItemId = 1L, quantity = 1))
+            whenever(
+                refundStore.createComputedItemsRefund(
+                    site = eq(site),
+                    orderId = eq(order.id),
+                    reason = eq("Customer request"),
+                    autoRefund = eq(false),
+                    restockItems = eq(true),
+                    amount = anyOrNull(),
+                    items = eq(serverLineItems),
+                )
+            ).thenReturn(WooResult(refundModel))
+
+            // WHEN
+            processor.submit(request.copy(serverLineItems = serverLineItems)).test {
+                assertThat(awaitItem()).isEqualTo(WooPosRefundSubmissionState.PreparingReader)
+
+                paymentState.value = CardReaderInteracRefundState.InteracRefundSuccessful("$22.00")
+                assertThat(awaitItem()).isEqualTo(WooPosRefundSubmissionState.NotifyingStore)
+                assertThat(awaitItem()).isEqualTo(WooPosRefundSubmissionState.Success)
+                awaitComplete()
+            }
+
+            // THEN — the computed create is used, and the gateway is not asked to refund again
+            // because the reader already did (autoRefund false).
+            verify(refundStore).createComputedItemsRefund(
+                site = eq(site),
+                orderId = eq(order.id),
+                reason = eq("Customer request"),
+                autoRefund = eq(false),
+                restockItems = eq(true),
+                amount = isNull(),
+                items = eq(serverLineItems),
+            )
+            verify(refundStore, never()).createItemsRefund(
+                site = any(),
+                orderId = any(),
+                amount = any(),
+                reason = any(),
+                restockItems = any(),
+                autoRefund = any(),
+                items = any()
+            )
+        }
+
+    @Test
+    fun `given server line items, when the computed create fails, then the failure is surfaced`() = runTest {
+        // GIVEN
+        whenever(paymentChargeRepository.fetchCardDataUsedForOrderPayment("ch_123")).thenReturn(
+            PaymentChargeRepository.CardDataUsedForOrderPaymentResult.Success(
+                cardBrand = "visa",
+                cardLast4 = "1234",
+                paymentMethodType = CARD_PRESENT
+            )
+        )
+        val serverLineItems = listOf(ComputedRefundLineItem.quantityBased(lineItemId = 1L, quantity = 1))
+        whenever(
+            refundStore.createComputedItemsRefund(
+                site = any(),
+                orderId = any(),
+                reason = any(),
+                autoRefund = any(),
+                restockItems = any(),
+                amount = anyOrNull(),
+                items = any(),
+            )
+        ).thenReturn(
+            WooResult(
+                error = WooError(
+                    type = WooErrorType.GENERIC_ERROR,
+                    original = GenericErrorType.UNKNOWN,
+                    message = "Something went wrong.",
+                    apiErrorCode = "some_unmapped_code"
+                )
+            )
+        )
+
+        // WHEN
+        processor.submit(request.copy(serverLineItems = serverLineItems)).test {
+            assertThat(awaitItem()).isEqualTo(WooPosRefundSubmissionState.Processing)
+
+            // THEN — the error from the computed create reaches the cashier rather than being
+            // swallowed into a success state.
+            val failure = awaitItem() as WooPosRefundSubmissionState.Failure
+            assertThat(failure.message).isEqualTo("Something went wrong.")
+            awaitComplete()
+        }
+    }
+
+    @Test
     fun `given interac refund controller starts with payment loading state, when submitted, then state is ignored`() =
         runTest {
             val paymentState = MutableStateFlow<CardReaderPaymentOrRefundState>(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundViewModelTest.kt
@@ -52,6 +52,9 @@ import org.wordpress.android.fluxc.store.WooCommerceStore
 import java.math.BigDecimal
 import java.util.Date
 
+/** The store version these tests report; availability verdicts are recorded against it. */
+private const val MIN_VERSION = WooPosResolveRefundFlow.MIN_WC_VERSION_FOR_SERVER_REFUNDS
+
 @OptIn(ExperimentalCoroutinesApi::class)
 class WooPosRefundViewModelTest {
 
@@ -152,7 +155,7 @@ class WooPosRefundViewModelTest {
         whenever(cardReaderFacade.readerStatus).thenReturn(readerStatus)
 
         whenever(loadPaymentMethod.invoke(any())).thenReturn(Result.success("Manual refund"))
-        // Default to the v3 fallback so existing assertions exercise the local-calculation path;
+        // Default to the local flow so existing assertions exercise the local-calculation path;
         // server-flow tests override this.
         whenever(refundPreview.invoke(any(), any())).thenReturn(WooPosRefundPreview.Result.FallbackToLocal)
         whenever(refundSubmissionProcessor.submit(any())).thenReturn(
@@ -324,7 +327,7 @@ class WooPosRefundViewModelTest {
     fun `given server refunds unavailable, when continue clicked, then settings fetched and totals calculated locally`() =
         runTest {
             // GIVEN — server refunds are known unavailable for the site, so the local path is used.
-            serverRefundAvailabilityCache.markUnavailable(testSite.localId().value)
+            serverRefundAvailabilityCache.markUnavailable(testSite.localId().value, MIN_VERSION)
             val refundableItems = listOf(
                 testRefundableItem.copy(rowIndex = 0),
                 testRefundableItem.copy(rowIndex = 1)
@@ -340,9 +343,12 @@ class WooPosRefundViewModelTest {
             viewModel.onUIEvent(WooPosRefundUIEvent.ContinueToReviewClicked)
             advanceUntilIdle()
 
-            // THEN — settings were fetched lazily and the totals computed locally.
+            // THEN — settings were fetched lazily and the totals computed locally. The eligibility
+            // decision lives only in WooPosRefundPreview now, so it is consulted and reports the
+            // fallback; that it does not reach the network for an unavailable store is asserted in
+            // WooPosRefundPreviewTest rather than duplicated here.
             verify(wooCommerceStore).fetchSiteSettingsTaxRoundAtSubtotal(testSite)
-            verify(refundPreview, never()).invoke(any(), any())
+            verify(refundPreview).invoke(any(), any())
             val content = viewModel.state.value as WooPosRefundState.Content
             assertThat(content.step).isEqualTo(WooPosRefundState.Content.RefundStep.ReviewRefund)
             assertThat(content.subtotal).isEqualByComparingTo(BigDecimal("40.00"))
@@ -356,7 +362,7 @@ class WooPosRefundViewModelTest {
         // that verdict must not bleed into testSite (local id 1) — important for self-hosted/WPAPI
         // stores that all share remote siteId 0.
         val otherLocalSiteId = testSite.localId().value + 1
-        serverRefundAvailabilityCache.markUnavailable(otherLocalSiteId)
+        serverRefundAvailabilityCache.markUnavailable(otherLocalSiteId, MIN_VERSION)
         whenever(ordersDataSource.refreshOrderById(testOrderId)).thenReturn(Result.success(testOrder))
         whenever(retrieveOrderRefunds.invoke(eq(testOrder), any())).thenReturn(Result.success(emptyList()))
         whenever(getRefundableItems.invoke(any(), any())).thenReturn(listOf(testRefundableItem))
@@ -427,7 +433,6 @@ class WooPosRefundViewModelTest {
         assertThat(content.subtotal).isEqualByComparingTo(BigDecimal("55.00"))
         assertThat(content.taxes).isEqualByComparingTo(BigDecimal("5.00"))
         assertThat(content.total).isEqualByComparingTo(BigDecimal("60.00"))
-        assertThat(content.maxRefundable).isEqualByComparingTo(BigDecimal("60.00"))
         assertThat(content.isPreviewLoading).isFalse()
         assertThat(content.previewFailed).isFalse()
     }
@@ -539,7 +544,7 @@ class WooPosRefundViewModelTest {
     fun `given preview succeeded, when refund confirmed, then processor receives server line items`() =
         runTest {
             // GIVEN — server refunds are available, so the preview returns server-calculated totals.
-            serverRefundAvailabilityCache.markAvailable(testSite.localId().value)
+            serverRefundAvailabilityCache.markAvailable(testSite.localId().value, MIN_VERSION)
             val refundableItems = listOf(testRefundableItem)
             whenever(ordersDataSource.refreshOrderById(testOrderId)).thenReturn(Result.success(testOrder))
             whenever(retrieveOrderRefunds.invoke(eq(testOrder), any())).thenReturn(Result.success(emptyList()))
@@ -575,10 +580,39 @@ class WooPosRefundViewModelTest {
         }
 
     @Test
+    fun `given store eligible but no successful preview, when refund confirmed, then the classic request is sent`() =
+        runTest {
+            // GIVEN — an eligible store (flag on, supported version) whose preview reported the
+            // local fallback, so nothing ever confirmed `compute_totals` support. This is the deny
+            // side of the create gate: sending a computed create here would silently drop the
+            // parameter on a store that does not understand it and book a zero-amount refund.
+            val refundableItems = listOf(testRefundableItem)
+            whenever(ordersDataSource.refreshOrderById(testOrderId)).thenReturn(Result.success(testOrder))
+            whenever(retrieveOrderRefunds.invoke(eq(testOrder), any())).thenReturn(Result.success(emptyList()))
+            whenever(getRefundableItems.invoke(any(), any())).thenReturn(refundableItems)
+            whenever(refundPreview.invoke(any(), any())).thenReturn(WooPosRefundPreview.Result.FallbackToLocal)
+            viewModel = createViewModel()
+            viewModel.onUIEvent(WooPosRefundUIEvent.RefundFlowOpened)
+            advanceUntilIdle()
+
+            // WHEN
+            viewModel.onUIEvent(WooPosRefundUIEvent.ContinueToReviewClicked)
+            advanceUntilIdle()
+            viewModel.onUIEvent(WooPosRefundUIEvent.OnRefundConfirmed)
+            advanceUntilIdle()
+
+            // THEN — no server line items, and the items come from local grouping instead.
+            verify(refundSubmissionProcessor).submit(
+                argThat { orderId == testOrderId && serverLineItems == null }
+            )
+            verify(groupRefundItems).invoke(any(), any(), any())
+        }
+
+    @Test
     fun `given preview loading, when selection toggled, then loading is cleared and stale preview dropped`() =
         runTest {
             // GIVEN — server refunds are available; the preview is held open to simulate a request in flight.
-            serverRefundAvailabilityCache.markAvailable(testSite.localId().value)
+            serverRefundAvailabilityCache.markAvailable(testSite.localId().value, MIN_VERSION)
             val refundableItems = listOf(testRefundableItem.copy(rowIndex = 0), testRefundableItem.copy(rowIndex = 1))
             whenever(ordersDataSource.refreshOrderById(testOrderId)).thenReturn(Result.success(testOrder))
             whenever(retrieveOrderRefunds.invoke(eq(testOrder), any())).thenReturn(Result.success(emptyList()))
@@ -782,7 +816,7 @@ class WooPosRefundViewModelTest {
             )
 
             // Server refunds unavailable so totals are calculated locally on Continue.
-            serverRefundAvailabilityCache.markUnavailable(testSite.localId().value)
+            serverRefundAvailabilityCache.markUnavailable(testSite.localId().value, MIN_VERSION)
             whenever(ordersDataSource.refreshOrderById(testOrderId)).thenReturn(Result.success(orderWithMultipleItems))
             whenever(
                 retrieveOrderRefunds.invoke(eq(orderWithMultipleItems), any())
@@ -1272,7 +1306,7 @@ class WooPosRefundViewModelTest {
             viewModel.onUIEvent(WooPosRefundUIEvent.RefundFlowOpened)
             advanceUntilIdle()
 
-            // WHEN — Continue resolves the totals (locally, via the v3 fallback) before confirming.
+            // WHEN — Continue resolves the totals (locally, via the legacy flow) before confirming.
             viewModel.onUIEvent(WooPosRefundUIEvent.ContinueToReviewClicked)
             advanceUntilIdle()
             viewModel.onUIEvent(WooPosRefundUIEvent.OnRefundConfirmed)
@@ -1909,7 +1943,7 @@ class WooPosRefundViewModelTest {
             val stateBeforeConfirm = viewModel.state.value as WooPosRefundState.Content
             assertThat(stateBeforeConfirm.selectedItemIds).containsExactlyInAnyOrder(item1.uniqueId, item3.uniqueId)
 
-            // WHEN — Continue resolves the totals (locally, via the v3 fallback) before confirming.
+            // WHEN — Continue resolves the totals (locally, via the legacy flow) before confirming.
             viewModel.onUIEvent(WooPosRefundUIEvent.ContinueToReviewClicked)
             advanceUntilIdle()
             viewModel.onUIEvent(WooPosRefundUIEvent.OnRefundConfirmed)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosResolveRefundFlowTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosResolveRefundFlowTest.kt
@@ -56,7 +56,7 @@ class WooPosResolveRefundFlowTest {
         whenever(getWooCoreVersion.invoke()).thenReturn("11.1.0")
 
         // THEN
-        assertThat(sut()).isEqualTo(WooPosRefundFlow.ServerComputed)
+        assertThat(sut()).isEqualTo(WooPosRefundFlow.ServerComputed("11.1.0"))
     }
 
     @Test
@@ -65,7 +65,7 @@ class WooPosResolveRefundFlowTest {
         whenever(getWooCoreVersion.invoke()).thenReturn("11.2.0")
 
         // THEN
-        assertThat(sut()).isEqualTo(WooPosRefundFlow.ServerComputed)
+        assertThat(sut()).isEqualTo(WooPosRefundFlow.ServerComputed("11.2.0"))
     }
 
     @Test
@@ -81,7 +81,7 @@ class WooPosResolveRefundFlowTest {
     fun `given WC version unknown and availability cached true, when resolved, then flow is still local`() {
         // GIVEN
         whenever(getWooCoreVersion.invoke()).thenReturn(null)
-        availabilityCache.markAvailable(LOCAL_SITE_ID)
+        availabilityCache.markAvailable(LOCAL_SITE_ID, MIN_VERSION)
 
         // THEN
         assertThat(sut()).isEqualTo(WooPosRefundFlow.LocalComputed)
@@ -90,7 +90,7 @@ class WooPosResolveRefundFlowTest {
     @Test
     fun `given server refunds known unavailable, when resolved, then flow is local`() {
         // GIVEN
-        availabilityCache.markUnavailable(LOCAL_SITE_ID)
+        availabilityCache.markUnavailable(LOCAL_SITE_ID, MIN_VERSION)
 
         // THEN
         assertThat(sut()).isEqualTo(WooPosRefundFlow.LocalComputed)
@@ -99,22 +99,45 @@ class WooPosResolveRefundFlowTest {
     @Test
     fun `given server refunds confirmed available, when resolved, then flow is server`() {
         // GIVEN
-        availabilityCache.markAvailable(LOCAL_SITE_ID)
+        availabilityCache.markAvailable(LOCAL_SITE_ID, MIN_VERSION)
 
         // THEN
-        assertThat(sut()).isEqualTo(WooPosRefundFlow.ServerComputed)
+        assertThat(sut()).isEqualTo(WooPosRefundFlow.ServerComputed(MIN_VERSION))
+    }
+
+    @Test
+    fun `given a prerelease of the minimum version, when resolved, then flow is server`() {
+        // GIVEN — trunk builds report `11.1.0-dev`, and betas `11.1.0-beta1`. Neither may read as
+        // below 11.1.0, otherwise testers silently get the local flow.
+        whenever(getWooCoreVersion.invoke()).thenReturn("11.1.0-dev")
+
+        // THEN
+        assertThat(sut()).isEqualTo(WooPosRefundFlow.ServerComputed("11.1.0-dev"))
+    }
+
+    @Test
+    fun `given a verdict probed on an older version, when the store upgrades, then flow is server again`() {
+        // GIVEN a store probed as unavailable while it ran an older WooCommerce
+        availabilityCache.markUnavailable(LOCAL_SITE_ID, "11.0.5")
+
+        // WHEN it now reports a supported version
+        whenever(getWooCoreVersion.invoke()).thenReturn(MIN_VERSION)
+
+        // THEN the stale verdict does not pin it to local calculation for the rest of the process
+        assertThat(sut()).isEqualTo(WooPosRefundFlow.ServerComputed(MIN_VERSION))
     }
 
     @Test
     fun `given another site is unavailable, when resolved, then this site is still eligible`() {
         // GIVEN — the cache is keyed by local site id; another store's verdict must not bleed over.
-        availabilityCache.markUnavailable(LOCAL_SITE_ID + 1)
+        availabilityCache.markUnavailable(LOCAL_SITE_ID + 1, MIN_VERSION)
 
         // THEN
-        assertThat(sut()).isEqualTo(WooPosRefundFlow.ServerComputed)
+        assertThat(sut()).isEqualTo(WooPosRefundFlow.ServerComputed(MIN_VERSION))
     }
 
     private companion object {
         private const val LOCAL_SITE_ID = 11
+        private const val MIN_VERSION = WooPosResolveRefundFlow.MIN_WC_VERSION_FOR_SERVER_REFUNDS
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosServerRefundAvailabilityCacheTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosServerRefundAvailabilityCacheTest.kt
@@ -9,38 +9,72 @@ class WooPosServerRefundAvailabilityCacheTest {
 
     @Test
     fun `given site not probed, when isAvailable, then returns null`() {
-        assertThat(cache.isAvailable(SITE_ID)).isNull()
+        assertThat(cache.isAvailable(SITE_ID, WOO_VERSION)).isNull()
     }
 
     @Test
-    fun `given site marked available, when isAvailable, then returns true`() {
+    fun `given site marked available, when isAvailable for the same version, then returns true`() {
         // WHEN
-        cache.markAvailable(SITE_ID)
+        cache.markAvailable(SITE_ID, WOO_VERSION)
 
         // THEN
-        assertThat(cache.isAvailable(SITE_ID)).isTrue()
+        assertThat(cache.isAvailable(SITE_ID, WOO_VERSION)).isTrue()
     }
 
     @Test
-    fun `given site marked unavailable, when isAvailable, then returns false`() {
+    fun `given site marked unavailable, when isAvailable for the same version, then returns false`() {
         // WHEN
-        cache.markUnavailable(SITE_ID)
+        cache.markUnavailable(SITE_ID, WOO_VERSION)
 
         // THEN
-        assertThat(cache.isAvailable(SITE_ID)).isFalse()
+        assertThat(cache.isAvailable(SITE_ID, WOO_VERSION)).isFalse()
     }
 
     @Test
     fun `given one site unavailable, when querying another site, then it is independent`() {
         // GIVEN
-        cache.markUnavailable(SITE_ID)
+        cache.markUnavailable(SITE_ID, WOO_VERSION)
 
         // THEN
-        assertThat(cache.isAvailable(OTHER_SITE_ID)).isNull()
+        assertThat(cache.isAvailable(OTHER_SITE_ID, WOO_VERSION)).isNull()
+    }
+
+    @Test
+    fun `given unavailable on an older version, when the store upgrades, then the verdict no longer applies`() {
+        // GIVEN a store probed as lacking the endpoints while it ran an older WooCommerce
+        cache.markUnavailable(SITE_ID, OLDER_WOO_VERSION)
+
+        // THEN the upgraded store is re-probed rather than kept on local calculation
+        assertThat(cache.isAvailable(SITE_ID, WOO_VERSION)).isNull()
+    }
+
+    @Test
+    fun `given available on a newer version, when the store downgrades, then the verdict no longer applies`() {
+        // GIVEN a successful probe against a version that supports the endpoints
+        cache.markAvailable(SITE_ID, WOO_VERSION)
+
+        // THEN a downgraded store must not inherit it: a stale `true` would allow a computed
+        // create against a store that silently drops `compute_totals`.
+        assertThat(cache.isAvailable(SITE_ID, OLDER_WOO_VERSION)).isNull()
+    }
+
+    @Test
+    fun `given a verdict, when the store is re-probed on a new version, then the latest verdict wins`() {
+        // GIVEN
+        cache.markUnavailable(SITE_ID, OLDER_WOO_VERSION)
+
+        // WHEN the upgraded store probes successfully
+        cache.markAvailable(SITE_ID, WOO_VERSION)
+
+        // THEN
+        assertThat(cache.isAvailable(SITE_ID, WOO_VERSION)).isTrue()
+        assertThat(cache.isAvailable(SITE_ID, OLDER_WOO_VERSION)).isNull()
     }
 
     private companion object {
         private const val SITE_ID = 1
         private const val OTHER_SITE_ID = 2
+        private const val WOO_VERSION = "11.1.0"
+        private const val OLDER_WOO_VERSION = "11.0.5"
     }
 }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WCRefundStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WCRefundStore.kt
@@ -135,7 +135,8 @@ class WCRefundStore @Inject internal constructor(
                 reason = reason,
                 apiRefund = autoRefund,
                 apiRestock = restockItems,
-                amount = amount?.toString(),
+                // toPlainString: toString() can emit scientific notation for extreme scales.
+                amount = amount?.toPlainString(),
                 lineItems = items,
             )
             return@withDefaultContext when {


### PR DESCRIPTION
WOOMOB-3749

Follow-ups from the review of #16335. None of these block the WC 11.1.0 rollout; they were deliberately kept out of that PR to keep it focused. Stacked on #16338, which this branch's base points at.

### Description

**Correctness — the availability cache outlived the store it described.** A verdict was recorded per store with no record of the WooCommerce version it was probed against. A `false` from a pre-11.1 probe survived the store upgrading and kept a now-capable store on local math until the process restarted. Worse, a `true` survived a *downgrade*, which would allow a `compute_totals` create against a store that silently drops the parameter — the ghost zero-amount refund the whole preview-before-create design exists to prevent.

Each verdict now carries the version it was probed against and only answers for that version, so a store that changes version mid-session is re-probed. To make that impossible to get wrong at the call sites, `WooPosRefundFlow.ServerComputed` became a data class carrying `wooVersion`, and every cache read and write goes through it.

**Diagnosability — the resolver was silent.** A store on local calculation left no trace of why, and since an unknown version fails closed, that path was invisible. It now logs the resolved flow and the reason (flag / version / cache).

**Simplification.** Eligibility was evaluated in the ViewModel and again inside `WooPosRefundPreview`, which routed both outcomes to the same place. The redundant ViewModel pre-check is gone, leaving one decision point per phase and shrinking the window in which the decision can change mid-flow.

**Smaller items.** Dropped the write-only `maxRefundable` state — the server enforces the cap and reports `preview_exceeds_max_refundable`, so a client-side copy was dead weight and was never cleared on local fallback. Used `toPlainString()` for the money string. Corrected KDoc that described both flows as "v3" and that claimed `LocalComputed` was only for old stores.

**Tests added** for the gaps the review found: prerelease version resolution (`11.1.0-dev`, which trunk builds report), verdicts across a version change in both directions, the deny side of the create gate, Interac followed by a computed create, and error propagation from a failed computed create.

One test assertion changed meaning: it previously verified the ViewModel short-circuits *before* consulting the preview. That pre-check is the redundancy removed here, so it now verifies the preview is consulted; that no network call happens for an unavailable store is asserted in `WooPosRefundPreviewTest` rather than duplicated.

### Test Steps

1. On a store running WooCommerce 11.1.0+ with the `woo_pos_refund_v4` flag on, issue a POS refund by item selection. Totals come from the server preview and the created refund shows server-computed amounts in wp-admin.
2. Check the Application log (Settings → Help & Support) filtered to `POS`: the resolved flow and its reason are now logged on every refund.
3. On a store below 11.1.0, or with the flag off, the flow falls back to local calculation with no user-visible difference.
4. Version-change behaviour: refund on a pre-11.1 store (verdict recorded as unavailable), upgrade the store, then refund again without restarting the app — it should re-probe and use the server flow rather than staying local.

Unit coverage: 186 tests green across the `woopos.orders.details.refund` package, `detektAll` clean.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.