### PR TITLE
[WOOMOB-3738] Migrate the More menu to the store design system

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/moremenu/MoreMenuScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/moremenu/MoreMenuScreen.kt
@@ -3,7 +3,7 @@ package com.woocommerce.android.e2e.screens.moremenu
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.ComposeTestRule
-import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
@@ -11,6 +11,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.e2e.helpers.util.Screen
 import com.woocommerce.android.e2e.screens.mystore.settings.SettingsScreen
 import com.woocommerce.android.e2e.screens.reviews.ReviewsListScreen
+import com.woocommerce.android.ui.moremenu.MoreMenuTestTags
 
 class MoreMenuScreen : Screen(R.id.more_menu_compose_view) {
     fun openReviewsListScreen(composeTestRule: ComposeTestRule): ReviewsListScreen {
@@ -31,7 +32,8 @@ class MoreMenuScreen : Screen(R.id.more_menu_compose_view) {
 
         while (currentAttempt < maxAttempts) {
             try {
-                composeTestRule.onNodeWithContentDescription(getTranslatedString(R.string.more_menu_button_settings))
+                composeTestRule.onNodeWithTag(MoreMenuTestTags.SETTINGS_ITEM)
+                    .performScrollTo()
                     .assertIsDisplayed()
                     .assertHasClickAction()
                 break // Exit loop if node is displayed and clickable
@@ -46,9 +48,11 @@ class MoreMenuScreen : Screen(R.id.more_menu_compose_view) {
             throw IllegalStateException("Failed to open settings due to: ${lastError.message}", lastError)
         }
 
-        composeTestRule.onNodeWithContentDescription(
-            getTranslatedString(R.string.more_menu_button_settings)
-        ).assertHasClickAction().performClick()
+        composeTestRule.onNodeWithTag(MoreMenuTestTags.SETTINGS_ITEM)
+            .performScrollTo()
+            .assertIsDisplayed()
+            .assertHasClickAction()
+            .performClick()
 
         return SettingsScreen()
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/animations/SkeletonAnimation.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/animations/SkeletonAnimation.kt
@@ -12,19 +12,19 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import com.woocommerce.android.R
 
-private const val SKELETON_ANIMATION_ALPHA = 0.2F
+private const val SKELETON_BASE_ALPHA = 0.12f
+private const val SKELETON_HIGHLIGHT_ALPHA = 0.20f
 
 @Composable
 fun SkeletonView(
@@ -62,10 +62,11 @@ private fun skeletonAnimationBrush(): Brush {
         label = "shimmer_animation"
     )
 
+    val skeletonColor = MaterialTheme.colorScheme.onSurface
     val shimmerColorShades = listOf(
-        colorResource(id = R.color.skeleton_color),
-        colorResource(id = R.color.skeleton_color).copy(SKELETON_ANIMATION_ALPHA),
-        colorResource(id = R.color.skeleton_color)
+        skeletonColor.copy(alpha = SKELETON_BASE_ALPHA),
+        skeletonColor.copy(alpha = SKELETON_HIGHLIGHT_ALPHA),
+        skeletonColor.copy(alpha = SKELETON_BASE_ALPHA)
     )
 
     return Brush.linearGradient(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuFragment.kt
@@ -4,8 +4,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.compose.ui.platform.ComposeView
-import androidx.compose.ui.platform.ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
@@ -18,7 +16,7 @@ import com.woocommerce.android.ui.base.TopLevelFragment
 import com.woocommerce.android.ui.blaze.BlazeUrlsHelper.BlazeFlowSource
 import com.woocommerce.android.ui.blaze.creation.BlazeCampaignCreationDispatcher
 import com.woocommerce.android.ui.common.webview.AuthenticatedWebViewLauncher
-import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.compose.designSystemComposeView
 import com.woocommerce.android.ui.google.webview.GoogleAdsWebViewFragment
 import com.woocommerce.android.ui.google.webview.GoogleAdsWebViewViewModel
 import com.woocommerce.android.ui.main.AppBarStatus
@@ -73,15 +71,10 @@ class MoreMenuFragment : TopLevelFragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        return ComposeView(requireContext()).apply {
+        return designSystemComposeView {
+            MoreMenuScreen(viewModel, scrollToTopTrigger)
+        }.apply {
             id = R.id.more_menu_compose_view
-            // Dispose of the Composition when the view's LifecycleOwner is destroyed
-            setViewCompositionStrategy(DisposeOnViewTreeLifecycleDestroyed)
-            setContent {
-                WooThemeWithBackground {
-                    MoreMenuScreen(viewModel, scrollToTopTrigger)
-                }
-            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuScreen.kt
@@ -2,70 +2,90 @@ package com.woocommerce.android.ui.moremenu
 
 import android.content.res.Configuration.UI_MODE_NIGHT_NO
 import android.content.res.Configuration.UI_MODE_NIGHT_YES
-import android.graphics.Bitmap
-import android.graphics.drawable.Drawable
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.core.MutableTransitionState
 import androidx.compose.animation.core.TweenSpec
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.scaleIn
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.Button
-import androidx.compose.material.ButtonDefaults
-import androidx.compose.material.Icon
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
-import androidx.compose.material.contentColorFor
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.key
 import androidx.compose.runtime.livedata.observeAsState
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.drawBehind
-import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.colorResource
-import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.semantics.CollectionInfo
+import androidx.compose.ui.semantics.CollectionItemInfo
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.collectionInfo
+import androidx.compose.ui.semantics.collectionItemInfo
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.isTraversalGroup
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
+import androidx.compose.ui.semantics.traversalIndex
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
-import com.bumptech.glide.Glide
-import com.bumptech.glide.request.target.CustomTarget
-import com.bumptech.glide.request.transition.Transition
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.animations.SkeletonView
-import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.compose.designsystem.WooTheme
+import com.woocommerce.android.ui.compose.designsystem.component.WooBadge
+import com.woocommerce.android.ui.compose.designsystem.component.WooBadgeDefaults
+import com.woocommerce.android.ui.compose.designsystem.component.WooCell
+import com.woocommerce.android.ui.compose.designsystem.component.WooDivider
+import com.woocommerce.android.ui.compose.designsystem.component.WooIconContainer
+import com.woocommerce.android.ui.compose.designsystem.component.WooIconContainerTone
+import com.woocommerce.android.ui.compose.designsystem.foundation.WooDesignSystemThemeWithBackground
+import com.woocommerce.android.ui.compose.designsystem.icons.ArrowUpRight
+import com.woocommerce.android.ui.compose.designsystem.icons.BadgePercent
+import com.woocommerce.android.ui.compose.designsystem.icons.Bolt
+import com.woocommerce.android.ui.compose.designsystem.icons.CaretDown
+import com.woocommerce.android.ui.compose.designsystem.icons.CreditCard
+import com.woocommerce.android.ui.compose.designsystem.icons.Gauge
+import com.woocommerce.android.ui.compose.designsystem.icons.Gear
+import com.woocommerce.android.ui.compose.designsystem.icons.Inbox
+import com.woocommerce.android.ui.compose.designsystem.icons.Star
+import com.woocommerce.android.ui.compose.designsystem.icons.Store
+import com.woocommerce.android.ui.compose.designsystem.icons.UserGroup
+import com.woocommerce.android.ui.compose.designsystem.icons.WooIcons
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 
@@ -73,9 +93,9 @@ import kotlinx.coroutines.flow.emptyFlow
 fun MoreMenuScreen(viewModel: MoreMenuViewModel, scrollToTopTrigger: Flow<Unit>) {
     viewModel.moreMenuViewState.observeAsState().value?.let { moreMenuState ->
         MoreMenuScreen(
-            moreMenuState,
-            viewModel::onSwitchStoreClick,
-            scrollToTopTrigger
+            state = moreMenuState,
+            onSwitchStore = viewModel::onSwitchStoreClick,
+            scrollToTopTrigger = scrollToTopTrigger,
         )
     }
 }
@@ -84,468 +104,710 @@ fun MoreMenuScreen(viewModel: MoreMenuViewModel, scrollToTopTrigger: Flow<Unit>)
 fun MoreMenuScreen(
     state: MoreMenuViewState,
     onSwitchStore: () -> Unit,
-    scrollToTopTrigger: Flow<Unit> = emptyFlow()
+    scrollToTopTrigger: Flow<Unit> = emptyFlow(),
 ) {
     val scrollState = rememberScrollState()
 
-    LaunchedEffect(Unit) {
+    LaunchedEffect(scrollToTopTrigger) {
         scrollToTopTrigger.collect {
             scrollState.animateScrollTo(0)
         }
     }
 
-    Column(
+    Box(
         modifier = Modifier
-            .verticalScroll(scrollState)
             .fillMaxSize()
+            .background(WooTheme.colors.surface.default),
     ) {
-        Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
+        Column(
+            modifier = Modifier
+                .align(Alignment.TopCenter)
+                .widthIn(max = MAX_OUTER_CONTENT_WIDTH)
+                .fillMaxWidth()
+                .verticalScroll(scrollState)
+                .padding(
+                    horizontal = WooTheme.padding.padding7,
+                    vertical = WooTheme.padding.padding7,
+                )
+                .testTag(MoreMenuTestTags.CONTENT),
+            verticalArrangement = Arrangement.spacedBy(WooTheme.spacing.space7),
+        ) {
+            MoreMenuHeader(
+                state = state,
+                onSwitchStore = onSwitchStore,
+            )
 
-        MoreMenuHeader(onSwitchStore, state)
-
-        Spacer(modifier = Modifier.height(8.dp))
-
-        state.menuSections.forEach { section -> MoreMenuSection(section) }
-
-        Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
+            state.menuSections.forEach { section ->
+                key(section.title) {
+                    MoreMenuSection(section)
+                }
+            }
+        }
     }
 }
 
 @Composable
 private fun MoreMenuHeader(
+    state: MoreMenuViewState,
     onSwitchStore: () -> Unit,
-    state: MoreMenuViewState
+    modifier: Modifier = Modifier,
 ) {
-    HeaderButton(
-        onClick = onSwitchStore,
-        enabled = state.isStoreSwitcherEnabled
+    val switchStoreLabel = stringResource(R.string.more_menu_switch_store)
+    val headerModifier = if (state.isStoreSwitcherEnabled) {
+        Modifier.clickable(
+            role = Role.Button,
+            onClickLabel = switchStoreLabel,
+            onClick = onSwitchStore,
+        )
+    } else {
+        Modifier
+    }
+
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(WooTheme.radius.extraLarge),
+        color = WooTheme.colors.surface.bright,
+        contentColor = WooTheme.colors.surface.onDefault,
     ) {
         Row(
-            modifier = Modifier.fillMaxSize(),
-            horizontalArrangement = Arrangement.SpaceBetween
+            modifier = headerModifier
+                .fillMaxWidth()
+                .padding(WooTheme.padding.padding7)
+                .semantics(mergeDescendants = true) {}
+                .testTag(MoreMenuTestTags.STORE_HEADER),
+            verticalAlignment = Alignment.CenterVertically,
         ) {
+            HeaderAvatar(avatarUrl = state.userAvatarUrl)
+            Spacer(modifier = Modifier.width(WooTheme.spacing.space4))
             HeaderContent(
-                userAvatarUrl = state.userAvatarUrl,
                 siteName = state.siteName,
                 planName = state.sitePlan,
                 siteUrl = state.siteUrl,
-                modifier = Modifier.weight(1f, false)
+                modifier = Modifier.weight(1f),
             )
-
             if (state.isStoreSwitcherEnabled) {
+                Spacer(modifier = Modifier.width(WooTheme.spacing.space3))
                 Icon(
-                    painter = painterResource(id = R.drawable.ic_arrow_drop_down),
+                    imageVector = WooIcons.Regular.CaretDown,
                     contentDescription = null,
-                    tint = colorResource(id = R.color.color_on_surface),
                     modifier = Modifier
-                        .align(Alignment.CenterVertically)
-                        .size(dimensionResource(id = R.dimen.major_150))
+                        .size(WooTheme.iconSize.size24)
+                        .clearAndSetSemantics {}
+                        .testTag(MoreMenuTestTags.HEADER_SWITCH_AFFORDANCE),
                 )
             }
         }
     }
 }
 
-/**
- * Since the header is also a button that opens the store switch, it can be disabled
- * through the [MoreMenuViewState.isStoreSwitcherEnabled] flag.
- *
- * But since it's also a header with store information,
- * we want to just hide the drop down arrow to reflect the disabled appearance.
- *
- * This custom color scheme ensures that.
- */
 @Composable
-private fun HeaderButton(
-    onClick: () -> Unit,
-    enabled: Boolean,
-    content: @Composable RowScope.() -> Unit
-) {
-    val headerBackgroundColors = colorResource(
-        id = R.color.more_menu_button_background
-    ).let { backgroundColor ->
-        ButtonDefaults.buttonColors(
-            backgroundColor = backgroundColor,
-            disabledBackgroundColor = backgroundColor,
-            disabledContentColor = contentColorFor(backgroundColor)
-        )
-    }
-
-    Button(
-        onClick = onClick,
-        enabled = enabled,
-        contentPadding = PaddingValues(dimensionResource(id = R.dimen.major_75)),
-        colors = headerBackgroundColors,
-        shape = RoundedCornerShape(dimensionResource(id = R.dimen.major_75)),
-        modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.major_100)),
-        content = content
-    )
-}
-
-@Composable
+@OptIn(ExperimentalLayoutApi::class)
 private fun HeaderContent(
-    modifier: Modifier,
-    userAvatarUrl: String,
     siteName: String,
     planName: String,
-    siteUrl: String
+    siteUrl: String,
+    modifier: Modifier = Modifier,
 ) {
-    Row(modifier) {
-        HeaderAvatar(
-            modifier = Modifier.align(Alignment.CenterVertically),
-            avatarUrl = userAvatarUrl
-        )
-        Spacer(modifier = Modifier.width(dimensionResource(id = R.dimen.major_100)))
-        Column {
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.minor_50))
-            ) {
-                Text(
-                    text = siteName,
-                    fontWeight = FontWeight.Bold,
-                    style = MaterialTheme.typography.body1,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier
-                        .align(Alignment.CenterVertically)
-                        .weight(1f, false)
-                )
-                if (planName.isNotEmpty()) {
-                    StorePlanBadge(planName)
-                }
-            }
-            Text(
-                text = siteUrl,
-                style = MaterialTheme.typography.caption,
-                modifier = Modifier.padding(vertical = dimensionResource(id = R.dimen.minor_50))
-            )
-        }
-    }
-}
-
-@Composable
-private fun StorePlanBadge(planName: String) {
-    Box(
-        modifier = Modifier
-            .clip(CircleShape)
-            .background(colorResource(id = R.color.free_trial_component_background))
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(WooTheme.spacing.space1),
     ) {
-        Text(
-            text = planName.uppercase(),
-            color = colorResource(id = R.color.free_trial_component_text),
-            style = MaterialTheme.typography.caption,
-            fontWeight = FontWeight.Bold,
-            modifier = Modifier.padding(
-                vertical = dimensionResource(id = R.dimen.minor_25),
-                horizontal = dimensionResource(id = R.dimen.minor_100)
+        FlowRow(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(WooTheme.spacing.space2),
+            verticalArrangement = Arrangement.spacedBy(WooTheme.spacing.space1),
+        ) {
+            Text(
+                text = siteName,
+                color = WooTheme.colors.surface.onDefault,
+                style = WooTheme.text.titleLarge.strong,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
             )
+            if (planName.isNotEmpty()) {
+                WooBadge(
+                    text = planName.uppercase(),
+                    colors = WooBadgeDefaults.colors(
+                        containerColor = WooTheme.colors.container.primaryContainer,
+                        contentColor = WooTheme.colors.container.onPrimaryContainer,
+                    ),
+                )
+            }
+        }
+        Text(
+            text = siteUrl,
+            color = WooTheme.colors.surface.onVariant,
+            style = WooTheme.text.bodySmall.regular,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
         )
     }
 }
 
 @Composable
 private fun HeaderAvatar(
-    modifier: Modifier,
-    avatarUrl: String
+    avatarUrl: String,
+    modifier: Modifier = Modifier,
 ) {
-    val bitmapState = remember { mutableStateOf<Bitmap?>(null) }
+    val contentDescription = stringResource(R.string.more_menu_avatar)
+    val avatarModifier = modifier
+        .size(AVATAR_SIZE)
+        .clip(RoundedCornerShape(WooTheme.radius.medium))
 
-    if (avatarUrl.isNotEmpty()) {
-        Glide.with(LocalContext.current)
-            .asBitmap()
-            .load(avatarUrl)
-            .into(
-                object : CustomTarget<Bitmap>() {
-                    override fun onResourceReady(resource: Bitmap, transition: Transition<in Bitmap>?) {
-                        bitmapState.value = resource
-                    }
-
-                    override fun onLoadCleared(placeholder: Drawable?) {
-                        // Nothing to do here.
-                    }
-                }
-            )
+    if (avatarUrl.isBlank()) {
+        Image(
+            painter = painterResource(R.drawable.img_gravatar_placeholder),
+            contentDescription = contentDescription,
+            contentScale = ContentScale.Crop,
+            modifier = avatarModifier,
+        )
+        return
     }
 
-    val circledModifier = modifier
-        .size(dimensionResource(id = R.dimen.major_250))
-        .clip(CircleShape)
-        .background(color = colorResource(id = R.color.more_menu_button_icon_background))
+    val context = LocalContext.current
+    val imageRequest = remember(context, avatarUrl) {
+        ImageRequest.Builder(context)
+            .data(avatarUrl)
+            .crossfade(true)
+            .placeholder(R.drawable.img_gravatar_placeholder)
+            .fallback(R.drawable.img_gravatar_placeholder)
+            .error(R.drawable.img_gravatar_placeholder)
+            .build()
+    }
 
-    bitmapState.value?.let {
-        Image(
-            bitmap = it.asImageBitmap(),
+    key(avatarUrl) {
+        AsyncImage(
+            model = imageRequest,
+            contentDescription = contentDescription,
             contentScale = ContentScale.Crop,
-            contentDescription = stringResource(id = R.string.more_menu_avatar),
-            modifier = circledModifier
+            modifier = avatarModifier,
         )
-    } ?: Image(
-        painter = painterResource(id = R.drawable.img_gravatar_placeholder),
-        contentDescription = stringResource(id = R.string.more_menu_avatar),
-        modifier = circledModifier
-    )
+    }
 }
 
 @Composable
 private fun MoreMenuSection(section: MoreMenuItemSection) {
+    val renderedItems = section.items.filter { it.state != MoreMenuItemButton.State.Hidden }
+    if (!section.isVisible || renderedItems.isEmpty()) return
+
     Column(
-        modifier = Modifier
-            .padding(horizontal = 16.dp)
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(WooTheme.spacing.space3),
     ) {
-        Spacer(modifier = Modifier.height(8.dp))
         section.title?.let { title ->
             Text(
-                text = stringResource(id = title),
-                style = MaterialTheme.typography.subtitle1,
-                color = colorResource(id = R.color.color_surface_variant),
+                text = stringResource(title),
+                color = WooTheme.colors.surface.onVariant,
+                style = WooTheme.text.bodyLarge.emphasized,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .semantics { heading() }
+                    .testTag(MoreMenuTestTags.section(title)),
             )
-
-            Spacer(modifier = Modifier.height(8.dp))
         }
 
-        Column {
-            section.items.forEach { item ->
-                when (item.state) {
-                    MoreMenuItemButton.State.Loading -> MoreMenuLoading()
-                    MoreMenuItemButton.State.Visible -> MoreMenuButton(item)
-                    MoreMenuItemButton.State.Hidden -> Unit
+        Surface(
+            modifier = Modifier
+                .fillMaxWidth()
+                .semantics {
+                    collectionInfo = CollectionInfo(rowCount = renderedItems.size, columnCount = 1)
+                    isTraversalGroup = true
                 }
-                Spacer(modifier = Modifier.height(8.dp))
+                .testTag(MoreMenuTestTags.collection(section.title)),
+            shape = RoundedCornerShape(WooTheme.radius.extraLarge),
+            color = WooTheme.colors.surface.bright,
+            contentColor = WooTheme.colors.surface.onDefault,
+        ) {
+            Column {
+                renderedItems.forEachIndexed { index, item ->
+                    key(item.title) {
+                        when (item.state) {
+                            MoreMenuItemButton.State.Loading -> MoreMenuLoadingCell(
+                                item = item,
+                                modifier = Modifier.collectionItem(index),
+                            )
+                            MoreMenuItemButton.State.Visible -> MoreMenuCell(
+                                item = item,
+                                modifier = Modifier.collectionItem(index),
+                            )
+                            MoreMenuItemButton.State.Hidden -> Unit
+                        }
+                        if (index < renderedItems.lastIndex) {
+                            WooDivider(
+                                modifier = Modifier
+                                    .padding(horizontal = WooTheme.padding.padding7)
+                                    .testTag(MoreMenuTestTags.divider(section.title, index)),
+                            )
+                        }
+                    }
+                }
             }
         }
     }
 }
 
+private fun Modifier.collectionItem(index: Int) = semantics {
+    collectionItemInfo = CollectionItemInfo(index, 1, 0, 1)
+    traversalIndex = index.toFloat()
+}
+
 @Composable
-fun MoreMenuLoading() {
+private fun MoreMenuCell(
+    item: MoreMenuItemButton,
+    modifier: Modifier = Modifier,
+) {
+    val badgeStateDescription = item.badgeStateDescription()
+    WooCell(
+        title = stringResource(item.title),
+        description = stringResource(item.description),
+        onClick = item.onClick,
+        modifier = modifier
+            .testTag(MoreMenuTestTags.item(item.title))
+            .semantics {
+                badgeStateDescription?.let { stateDescription = it }
+            },
+        leadingContent = { MoreMenuIcon(item.icon) },
+        trailingContent = if (item.badgeState != null || item.extraIcon != null) {
+            { MoreMenuTrailingContent(item) }
+        } else {
+            null
+        },
+    )
+}
+
+@Composable
+private fun MoreMenuTrailingContent(item: MoreMenuItemButton) {
     Row(
+        horizontalArrangement = Arrangement.spacedBy(WooTheme.spacing.space3),
         verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier
-            .fillMaxSize()
-            .background(
-                color = colorResource(id = R.color.more_menu_button_background),
-                shape = RoundedCornerShape(dimensionResource(id = R.dimen.major_75)),
+    ) {
+        MoreMenuBadge(item.badgeState)
+        if (item.extraIcon == R.drawable.ic_external) {
+            Icon(
+                imageVector = WooIcons.Regular.ArrowUpRight,
+                contentDescription = null,
+                modifier = Modifier
+                    .size(WooTheme.iconSize.size18)
+                    .clearAndSetSemantics {},
             )
-            .padding(all = 12.dp)
+        }
+    }
+}
+
+@Composable
+private fun MoreMenuLoadingCell(
+    item: MoreMenuItemButton,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .testTag(MoreMenuTestTags.loadingItem(item.title))
+            .fillMaxWidth()
+            .heightIn(min = MINIMUM_TOUCH_TARGET_SIZE)
+            .background(WooTheme.colors.surface.bright)
+            .padding(WooTheme.padding.padding7),
+        verticalAlignment = Alignment.CenterVertically,
     ) {
         SkeletonView(
             modifier = Modifier
-                .clip(CircleShape),
-            height = 40.dp,
-            width = 40.dp
+                .testTag(MoreMenuTestTags.loadingIcon(item.title))
+                .size(ICON_CONTAINER_SIZE)
+                .clip(RoundedCornerShape(WooTheme.radius.medium)),
         )
-
-        Spacer(modifier = Modifier.width(16.dp))
-
-        Column {
-            SkeletonView(
-                modifier = Modifier
-                    .height(16.dp)
-                    .width(120.dp)
-            )
-            Spacer(modifier = Modifier.height(4.dp))
-            SkeletonView(
-                modifier = Modifier
-                    .height(14.dp)
-                    .width(200.dp)
-            )
-        }
-    }
-}
-
-@Composable
-private fun MoreMenuButton(button: MoreMenuItemButton) {
-    Button(
-        onClick = button.onClick,
-        contentPadding = PaddingValues(dimensionResource(id = R.dimen.major_75)),
-        colors = ButtonDefaults.buttonColors(
-            backgroundColor = colorResource(id = R.color.more_menu_button_background),
-        ),
-        shape = RoundedCornerShape(dimensionResource(id = R.dimen.major_75)),
-    ) {
-        Box(Modifier.fillMaxSize()) {
-            MoreMenuBadge(badgeState = button.badgeState)
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier
-                    .fillMaxSize()
-            ) {
-                Box(
-                    modifier = Modifier
-                        .size(dimensionResource(id = R.dimen.major_250))
-                        .clip(CircleShape)
-                        .background(colorResource(id = R.color.more_menu_button_icon_background))
-                ) {
-                    Image(
-                        painter = painterResource(id = button.icon),
-                        contentDescription = stringResource(id = button.title),
-                        modifier = Modifier
-                            .size(dimensionResource(id = R.dimen.major_125))
-                            .align(Alignment.Center)
-                    )
-                }
-                Column(
-                    horizontalAlignment = Alignment.Start,
-                    modifier = Modifier.padding(start = dimensionResource(id = R.dimen.major_100))
-                ) {
-                    Text(
-                        text = stringResource(id = button.title),
-                        textAlign = TextAlign.Start,
-                    )
-                    Text(
-                        text = stringResource(id = button.description),
-                        style = MaterialTheme.typography.caption,
-                        textAlign = TextAlign.Start,
-                        color = colorResource(id = R.color.color_surface_variant),
-                    )
-                }
-            }
-
-            button.extraIcon?.let {
-                Icon(
-                    painter = painterResource(id = it),
-                    contentDescription = null,
-                    tint = colorResource(id = R.color.color_icon),
-                    modifier = Modifier
-                        .align(Alignment.CenterEnd)
-                        .padding(end = 8.dp)
-                        .size(20.dp)
-                )
-            }
-        }
-    }
-}
-
-@Composable
-fun MoreMenuBadge(badgeState: BadgeState?) {
-    if (badgeState != null) {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically
+        Spacer(modifier = Modifier.width(WooTheme.spacing.space5))
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .testTag(MoreMenuTestTags.loadingContent(item.title)),
+            verticalArrangement = Arrangement.spacedBy(WooTheme.spacing.space2),
         ) {
-            Spacer(modifier = Modifier.weight(1f))
-
-            @Suppress("RememberReturnType")
-            val visible = remember {
-                MutableTransitionState(badgeState.animateAppearance.not()).apply { targetState = true }
-            }
-            AnimatedVisibility(
-                visibleState = visible,
-                enter = createBadgeEnterAnimation()
-            ) {
-                val backgroundColor = colorResource(id = badgeState.backgroundColor)
-                Text(
-                    text = badgeState.textState.text,
-                    fontSize = dimensionResource(id = badgeState.textState.fontSize).value.sp,
-                    color = colorResource(id = badgeState.textColor),
-                    textAlign = TextAlign.Center,
-                    modifier = Modifier
-                        .size(dimensionResource(id = badgeState.badgeSize))
-                        .drawBehind { drawCircle(color = backgroundColor) }
-                        .wrapContentHeight()
-                )
-            }
+            SkeletonView(
+                modifier = Modifier
+                    .fillMaxWidth(LOADING_TITLE_PLACEHOLDER_FRACTION)
+                    .height(WooTheme.spacing.space5)
+                    .clip(RoundedCornerShape(WooTheme.radius.small)),
+            )
+            SkeletonView(
+                modifier = Modifier
+                    .fillMaxWidth(LOADING_DESCRIPTION_PLACEHOLDER_FRACTION)
+                    .height(WooTheme.spacing.space4)
+                    .clip(RoundedCornerShape(WooTheme.radius.small)),
+            )
         }
     }
+}
+
+@Composable
+private fun MoreMenuIcon(
+    icon: Int,
+    modifier: Modifier = Modifier,
+) {
+    when (icon) {
+        R.drawable.ic_more_screen_settings -> DesignSystemIcon(
+            icon = WooIcons.Regular.Gear,
+            tone = WooIconContainerTone.Green,
+            modifier = modifier,
+        )
+        R.drawable.ic_more_menu_upgrades -> DesignSystemIcon(WooIcons.Regular.Bolt, modifier = modifier)
+        R.drawable.ic_more_menu_payments -> DesignSystemIcon(WooIcons.Regular.CreditCard, modifier = modifier)
+        R.drawable.ic_more_menu_wp_admin -> DesignSystemIcon(
+            icon = WooIcons.Regular.Gauge,
+            tone = WooIconContainerTone.Sandstone,
+            modifier = modifier,
+        )
+        R.drawable.ic_more_menu_store -> DesignSystemIcon(
+            icon = WooIcons.Regular.Store,
+            tone = WooIconContainerTone.Sandstone,
+            modifier = modifier,
+        )
+        R.drawable.ic_more_menu_coupons -> DesignSystemIcon(WooIcons.Regular.BadgePercent, modifier = modifier)
+        R.drawable.ic_more_menu_reviews -> DesignSystemIcon(WooIcons.Regular.Star, modifier = modifier)
+        R.drawable.icon_multiple_users -> DesignSystemIcon(WooIcons.Regular.UserGroup, modifier = modifier)
+        R.drawable.ic_more_menu_inbox -> DesignSystemIcon(WooIcons.Regular.Inbox, modifier = modifier)
+        R.drawable.google_logo,
+        R.drawable.ic_blaze -> BrandIconContainer(drawable = icon, modifier = modifier)
+        else -> BrandIconContainer(drawable = icon, modifier = modifier)
+    }
+}
+
+@Composable
+private fun DesignSystemIcon(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    modifier: Modifier = Modifier,
+    tone: WooIconContainerTone = WooIconContainerTone.Purple,
+) {
+    WooIconContainer(
+        imageVector = icon,
+        tone = tone,
+        contentDescription = null,
+        modifier = modifier.clearAndSetSemantics {},
+    )
+}
+
+@Composable
+private fun BrandIconContainer(
+    drawable: Int,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        modifier = modifier
+            .size(ICON_CONTAINER_SIZE)
+            .clearAndSetSemantics {},
+        shape = RoundedCornerShape(WooTheme.radius.medium),
+        color = WooTheme.colors.background.sectionVariant,
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            Image(
+                painter = painterResource(drawable),
+                contentDescription = null,
+                modifier = Modifier.size(WooTheme.iconSize.size24),
+            )
+        }
+    }
+}
+
+@Composable
+private fun MoreMenuBadge(badgeState: BadgeState?) {
+    when {
+        badgeState == null -> Unit
+        badgeState.animateAppearance -> PaymentNewFeatureDot()
+        badgeState.textState.text.isNotEmpty() -> WooBadge(
+            text = badgeState.textState.text,
+            colors = WooBadgeDefaults.colors(
+                containerColor = WooTheme.colors.primary,
+                contentColor = WooTheme.colors.onPrimary,
+            ),
+            modifier = Modifier.clearAndSetSemantics {},
+        )
+    }
+}
+
+@Composable
+private fun PaymentNewFeatureDot() {
+    Box(
+        modifier = Modifier
+            .size(WooTheme.iconSize.size24)
+            .clearAndSetSemantics {},
+        contentAlignment = Alignment.Center,
+    ) {
+        val visible = remember {
+            MutableTransitionState(false).apply { targetState = true }
+        }
+        AnimatedVisibility(
+            visibleState = visible,
+            enter = createBadgeEnterAnimation(),
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(WooTheme.spacing.space3)
+                    .background(WooTheme.colors.secondary, CircleShape),
+            )
+        }
+    }
+}
+
+@Composable
+private fun MoreMenuItemButton.badgeStateDescription(): String? = when {
+    badgeState == null -> null
+    badgeState.animateAppearance -> stringResource(R.string.more_menu_payments_new_feature_state_description)
+    badgeState.textState.text.toIntOrNull() != null -> {
+        val count = badgeState.textState.text.toInt()
+        pluralStringResource(
+            R.plurals.more_menu_unseen_reviews_state_description,
+            count,
+            count,
+        )
+    }
+    else -> null
 }
 
 private fun createBadgeEnterAnimation(): EnterTransition {
-    val animationSpec = TweenSpec<Float>(durationMillis = 400, delay = 200)
+    val animationSpec = TweenSpec<Float>(
+        durationMillis = BADGE_ANIMATION_DURATION_MILLIS,
+        delay = BADGE_ANIMATION_DELAY,
+    )
     return scaleIn(animationSpec = animationSpec) + fadeIn(animationSpec = animationSpec)
 }
 
-@ExperimentalFoundationApi
-@Preview(name = "dark", uiMode = UI_MODE_NIGHT_YES)
-@Preview(name = "light", uiMode = UI_MODE_NIGHT_NO)
-@Preview(name = "small screen", device = Devices.PIXEL)
-@Preview(name = "mid screen", device = Devices.PIXEL_4)
-@Preview(name = "large screen", device = Devices.NEXUS_10)
-@Composable
-private fun MoreMenuPreview() {
-    WooThemeWithBackground {
-        val state = MoreMenuViewState(
-            menuSections = listOf(
-                MoreMenuItemSection(
-                    title = R.string.more_menu_settings_section_title,
-                    items = listOf(
-                        MoreMenuItemButton(
-                            title = R.string.more_menu_button_settings,
-                            description = R.string.more_menu_button_settings_description,
-                            icon = R.drawable.ic_more_screen_settings,
-                        ),
-                        MoreMenuItemButton(
-                            title = R.string.more_menu_button_subscriptions,
-                            description = R.string.more_menu_button_subscriptions_description,
-                            icon = R.drawable.ic_more_menu_upgrades,
-                        ),
-                    ),
-                ),
+object MoreMenuTestTags {
+    const val CONTENT = "more_menu_content"
+    const val STORE_HEADER = "more_menu_store_header"
+    const val HEADER_SWITCH_AFFORDANCE = "more_menu_header_switch_affordance"
+    const val SETTINGS_SECTION = "more_menu_section_settings"
+    const val GENERAL_SECTION = "more_menu_section_general"
+    const val SETTINGS_COLLECTION = "more_menu_collection_settings"
+    const val GENERAL_COLLECTION = "more_menu_collection_general"
 
-                MoreMenuItemSection(
-                    title = R.string.more_menu_general_section_title,
-                    items = listOf(
-                        MoreMenuItemButton(
-                            title = R.string.more_menu_button_payments,
-                            description = R.string.more_menu_button_payments_description,
-                            icon = R.drawable.ic_more_menu_payments,
-                            badgeState = BadgeState(
-                                badgeSize = R.dimen.major_110,
-                                backgroundColor = R.color.color_secondary,
-                                textColor = R.color.color_on_primary,
-                                textState = TextState("", R.dimen.text_minor_80),
-                                animateAppearance = true
-                            )
-                        ),
-                        MoreMenuItemButton(
-                            title = R.string.more_menu_button_wс_admin,
-                            description = R.string.more_menu_button_wc_admin_description,
-                            icon = R.drawable.ic_more_menu_wp_admin,
-                            extraIcon = R.drawable.ic_external
-                        ),
-                        MoreMenuItemButton(
-                            title = R.string.more_menu_button_store,
-                            description = R.string.more_menu_button_store_description,
-                            icon = R.drawable.ic_more_menu_store
-                        ),
-                        MoreMenuItemButton(
-                            title = R.string.more_menu_button_reviews,
-                            description = R.string.more_menu_button_reviews_description,
-                            icon = R.drawable.ic_more_menu_reviews,
-                            badgeState = BadgeState(
-                                badgeSize = R.dimen.major_150,
-                                backgroundColor = R.color.color_primary,
-                                textColor = R.color.color_on_primary,
-                                textState = TextState("3", R.dimen.text_minor_80),
-                                animateAppearance = false
-                            )
-                        ),
-                        MoreMenuItemButton(
-                            title = R.string.more_menu_button_coupons,
-                            description = R.string.more_menu_button_coupons_description,
-                            icon = R.drawable.ic_more_menu_coupons,
-                        ),
-                        MoreMenuItemButton(
-                            title = R.string.more_menu_button_reviews,
-                            description = R.string.more_menu_button_reviews_description,
-                            icon = R.drawable.ic_more_menu_reviews,
-                            badgeState = BadgeState(
-                                badgeSize = R.dimen.major_150,
-                                backgroundColor = R.color.color_primary,
-                                textColor = R.color.color_on_primary,
-                                textState = TextState("3", R.dimen.text_minor_80),
-                                animateAppearance = false
-                            ),
-                            state = MoreMenuItemButton.State.Loading
-                        ),
-                    ),
+    const val PAYMENTS_ITEM = "more_menu_item_payments"
+    const val COUPONS_ITEM = "more_menu_item_coupons"
+    const val REVIEWS_ITEM = "more_menu_item_reviews"
+    const val CUSTOMERS_ITEM = "more_menu_item_customers"
+    const val SETTINGS_ITEM = "more_menu_item_settings"
+    const val WC_ADMIN_ITEM = "more_menu_item_wc_admin"
+    const val VIEW_STORE_ITEM = "more_menu_item_view_store"
+    const val SUBSCRIPTIONS_ITEM = "more_menu_item_subscriptions"
+    const val GOOGLE_ITEM = "more_menu_item_google"
+    const val BLAZE_ITEM = "more_menu_item_blaze"
+    const val INBOX_ITEM = "more_menu_item_inbox"
+
+    fun section(title: Int) = when (title) {
+        R.string.more_menu_settings_section_title -> SETTINGS_SECTION
+        R.string.more_menu_general_section_title -> GENERAL_SECTION
+        else -> "more_menu_section_$title"
+    }
+
+    fun collection(title: Int?) = when (title) {
+        R.string.more_menu_settings_section_title -> SETTINGS_COLLECTION
+        R.string.more_menu_general_section_title -> GENERAL_COLLECTION
+        else -> "more_menu_collection_$title"
+    }
+
+    fun divider(sectionTitle: Int?, itemIndex: Int) = "${collection(sectionTitle)}_divider_$itemIndex"
+
+    fun item(title: Int) = when (title) {
+        R.string.more_menu_button_payments -> PAYMENTS_ITEM
+        R.string.more_menu_button_coupons -> COUPONS_ITEM
+        R.string.more_menu_button_reviews -> REVIEWS_ITEM
+        R.string.more_menu_button_customers -> CUSTOMERS_ITEM
+        R.string.more_menu_button_settings -> SETTINGS_ITEM
+        R.string.more_menu_button_wс_admin -> WC_ADMIN_ITEM
+        R.string.more_menu_button_store -> VIEW_STORE_ITEM
+        R.string.more_menu_button_subscriptions -> SUBSCRIPTIONS_ITEM
+        R.string.more_menu_button_google -> GOOGLE_ITEM
+        R.string.more_menu_button_blaze -> BLAZE_ITEM
+        R.string.more_menu_button_inbox -> INBOX_ITEM
+        else -> "more_menu_item_$title"
+    }
+
+    fun loadingItem(title: Int) = "${item(title)}_loading"
+
+    fun loadingIcon(title: Int) = "${loadingItem(title)}_icon"
+
+    fun loadingContent(title: Int) = "${loadingItem(title)}_content"
+}
+
+@Preview(name = "430dp light", widthDp = 430, heightDp = 932, uiMode = UI_MODE_NIGHT_NO)
+@Preview(name = "430dp dark", widthDp = 430, heightDp = 932, uiMode = UI_MODE_NIGHT_YES)
+@Composable
+private fun MoreMenuCompactPreview() {
+    MoreMenuPreviewRoot(previewMoreMenuState())
+}
+
+@Preview(name = "320dp 2x font", widthDp = 320, heightDp = 932, fontScale = 2f)
+@Composable
+private fun MoreMenuNarrowLargeFontPreview() {
+    MoreMenuPreviewRoot(previewMoreMenuState())
+}
+
+@Preview(name = "Arabic RTL", widthDp = 430, heightDp = 932, locale = "ar")
+@Composable
+private fun MoreMenuRtlPreview() {
+    MoreMenuPreviewRoot(
+        previewMoreMenuState(
+            siteName = "متجر القهوة والكتب",
+            siteUrl = "example.com",
+        ),
+    )
+}
+
+@Preview(name = "Expanded tablet", widthDp = 840, heightDp = 900)
+@Composable
+private fun MoreMenuExpandedPreview() {
+    MoreMenuPreviewRoot(previewMoreMenuState())
+}
+
+@Preview(name = "Loading hidden disabled", widthDp = 430, heightDp = 932)
+@Composable
+private fun MoreMenuLoadingAndHiddenPreview() {
+    val state = previewMoreMenuState(isStoreSwitcherEnabled = false)
+    MoreMenuPreviewRoot(
+        state.copy(
+            menuSections = state.menuSections.map { section ->
+                section.copy(
+                    items = section.items.map { item ->
+                        when (item.title) {
+                            R.string.more_menu_button_subscriptions,
+                            R.string.more_menu_button_google -> item.copy(state = MoreMenuItemButton.State.Loading)
+                            R.string.more_menu_button_blaze,
+                            R.string.more_menu_button_inbox -> item.copy(state = MoreMenuItemButton.State.Hidden)
+                            else -> item
+                        }
+                    },
                 )
-            ),
-            siteName = "Example Site",
-            siteUrl = "woocommerce.com",
-            sitePlan = "free trial",
-            userAvatarUrl = "", // To force displaying placeholder image
-            isStoreSwitcherEnabled = true
-        )
-        MoreMenuScreen(state, {})
+            },
+        ),
+    )
+}
+
+@Composable
+private fun MoreMenuPreviewRoot(state: MoreMenuViewState) {
+    WooDesignSystemThemeWithBackground {
+        MoreMenuScreen(state = state, onSwitchStore = {})
     }
 }
+
+private fun previewMoreMenuState(
+    siteName: String = "Mug & Hug",
+    siteUrl: String = "mugandhugstore.com",
+    sitePlan: String = "Free Trial",
+    isStoreSwitcherEnabled: Boolean = true,
+) = MoreMenuViewState(
+    menuSections = previewMenuSections(),
+    siteName = siteName,
+    siteUrl = siteUrl,
+    sitePlan = sitePlan,
+    userAvatarUrl = "",
+    isStoreSwitcherEnabled = isStoreSwitcherEnabled,
+)
+
+@Suppress("LongMethod")
+private fun previewMenuSections() = listOf(
+    MoreMenuItemSection(
+        title = R.string.more_menu_settings_section_title,
+        items = listOf(
+            previewItem(
+                title = R.string.more_menu_button_settings,
+                description = R.string.more_menu_button_settings_description,
+                icon = R.drawable.ic_more_screen_settings,
+            ),
+            previewItem(
+                title = R.string.more_menu_button_subscriptions,
+                description = R.string.more_menu_button_subscriptions_description,
+                icon = R.drawable.ic_more_menu_upgrades,
+            ),
+        ),
+    ),
+    MoreMenuItemSection(
+        title = R.string.more_menu_general_section_title,
+        items = listOf(
+            previewItem(
+                title = R.string.more_menu_button_payments,
+                description = R.string.more_menu_button_payments_description,
+                icon = R.drawable.ic_more_menu_payments,
+                badgeState = previewPaymentBadge(),
+            ),
+            previewItem(
+                title = R.string.more_menu_button_google,
+                description = R.string.more_menu_button_google_description,
+                icon = R.drawable.google_logo,
+            ),
+            previewItem(
+                title = R.string.more_menu_button_blaze,
+                description = R.string.more_menu_button_blaze_description,
+                icon = R.drawable.ic_blaze,
+            ),
+            previewItem(
+                title = R.string.more_menu_button_wс_admin,
+                description = R.string.more_menu_button_wc_admin_description,
+                icon = R.drawable.ic_more_menu_wp_admin,
+                extraIcon = R.drawable.ic_external,
+            ),
+            previewItem(
+                title = R.string.more_menu_button_store,
+                description = R.string.more_menu_button_store_description,
+                icon = R.drawable.ic_more_menu_store,
+                extraIcon = R.drawable.ic_external,
+            ),
+            previewItem(
+                title = R.string.more_menu_button_coupons,
+                description = R.string.more_menu_button_coupons_description,
+                icon = R.drawable.ic_more_menu_coupons,
+            ),
+            previewItem(
+                title = R.string.more_menu_button_reviews,
+                description = R.string.more_menu_button_reviews_description,
+                icon = R.drawable.ic_more_menu_reviews,
+                badgeState = previewReviewBadge(PREVIEW_REVIEW_COUNT),
+            ),
+            previewItem(
+                title = R.string.more_menu_button_customers,
+                description = R.string.more_menu_button_customers_description,
+                icon = R.drawable.icon_multiple_users,
+            ),
+            previewItem(
+                title = R.string.more_menu_button_inbox,
+                description = R.string.more_menu_button_inbox_description,
+                icon = R.drawable.ic_more_menu_inbox,
+            ),
+        ),
+    ),
+)
+
+private fun previewItem(
+    title: Int,
+    description: Int,
+    icon: Int,
+    extraIcon: Int? = null,
+    badgeState: BadgeState? = null,
+) = MoreMenuItemButton(
+    title = title,
+    description = description,
+    icon = icon,
+    extraIcon = extraIcon,
+    badgeState = badgeState,
+)
+
+private fun previewPaymentBadge() = BadgeState(
+    badgeSize = R.dimen.major_110,
+    backgroundColor = R.color.color_secondary,
+    textColor = R.color.color_on_surface,
+    textState = TextState("", R.dimen.text_minor_80),
+    animateAppearance = true,
+)
+
+private fun previewReviewBadge(count: Int) = BadgeState(
+    badgeSize = R.dimen.major_150,
+    backgroundColor = R.color.color_primary,
+    textColor = R.color.color_on_primary,
+    textState = TextState(count.toString(), R.dimen.text_minor_80),
+)
+
+private val MAX_OUTER_CONTENT_WIDTH = 648.dp
+private val AVATAR_SIZE = 44.dp
+private val ICON_CONTAINER_SIZE = 44.dp
+private val MINIMUM_TOUCH_TARGET_SIZE = 48.dp
+private const val LOADING_TITLE_PLACEHOLDER_FRACTION = 0.4f
+private const val LOADING_DESCRIPTION_PLACEHOLDER_FRACTION = 0.7f
+private const val BADGE_ANIMATION_DURATION_MILLIS = 400
+private const val BADGE_ANIMATION_DELAY = 200
+private const val PREVIEW_REVIEW_COUNT = 128

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuScreen.kt
@@ -193,8 +193,7 @@ private fun MoreMenuHeader(
                     contentDescription = null,
                     modifier = Modifier
                         .size(WooTheme.iconSize.size24)
-                        .clearAndSetSemantics {}
-                        .testTag(MoreMenuTestTags.HEADER_SWITCH_AFFORDANCE),
+                        .clearAndSetSemantics {},
                 )
             }
         }
@@ -571,7 +570,6 @@ private fun createBadgeEnterAnimation(): EnterTransition {
 object MoreMenuTestTags {
     const val CONTENT = "more_menu_content"
     const val STORE_HEADER = "more_menu_store_header"
-    const val HEADER_SWITCH_AFFORDANCE = "more_menu_header_switch_affordance"
     const val SETTINGS_SECTION = "more_menu_section_settings"
     const val GENERAL_SECTION = "more_menu_section_general"
     const val SETTINGS_COLLECTION = "more_menu_collection_settings"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuScreen.kt
@@ -464,8 +464,6 @@ private fun MoreMenuIcon(
         R.drawable.ic_more_menu_reviews -> DesignSystemIcon(WooIcons.Regular.Star, modifier = modifier)
         R.drawable.icon_multiple_users -> DesignSystemIcon(WooIcons.Regular.UserGroup, modifier = modifier)
         R.drawable.ic_more_menu_inbox -> DesignSystemIcon(WooIcons.Regular.Inbox, modifier = modifier)
-        R.drawable.google_logo,
-        R.drawable.ic_blaze -> BrandIconContainer(drawable = icon, modifier = modifier)
         else -> BrandIconContainer(drawable = icon, modifier = modifier)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuScreen.kt
@@ -41,6 +41,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
@@ -470,7 +471,7 @@ private fun MoreMenuIcon(
 
 @Composable
 private fun DesignSystemIcon(
-    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    icon: ImageVector,
     modifier: Modifier = Modifier,
     tone: WooIconContainerTone = WooIconContainerTone.Purple,
 ) {

--- a/WooCommerce/src/main/res/values-night/colors_base.xml
+++ b/WooCommerce/src/main/res/values-night/colors_base.xml
@@ -137,13 +137,6 @@
     -->
     <color name="jetpack_install_progressbar">@color/woo_white</color>
 
-    <!--
-    More menu button
-    -->
-    <color name="more_menu_button_background">#232323</color>
-    <color name="more_menu_button_icon_background">#383838</color>
-
-
     <!-- Text colors -->
     <color name="link_text">@color/woo_blue_30</color>
 

--- a/WooCommerce/src/main/res/values/colors_base.xml
+++ b/WooCommerce/src/main/res/values/colors_base.xml
@@ -204,14 +204,6 @@
     -->
     <color name="woo_push_notifications_connection_steps_progressbar">#70B954</color>
 
-    <!--
-    More menu button
-    -->
-    <color name="more_menu_button_background">@color/color_surface</color>
-    <color name="more_menu_button_icon_background">@color/woo_gray_0</color>
-
-
-
     <!-- Text colors -->
     <color name="link_text">@color/woo_blue_40</color>
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3392,6 +3392,12 @@
     -->
     <string name="more_menu">Menu</string>
     <string name="more_menu_avatar">User profile picture</string>
+    <string name="more_menu_switch_store">Switch store</string>
+    <string name="more_menu_payments_new_feature_state_description">New payment feature available</string>
+    <plurals name="more_menu_unseen_reviews_state_description">
+        <item quantity="one">%d unseen review</item>
+        <item quantity="other">%d unseen reviews</item>
+    </plurals>
 
     <string name="more_menu_settings_section_title">Settings</string>
     <string name="more_menu_general_section_title">General</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModelTests.kt
@@ -357,7 +357,11 @@ class MoreMenuViewModelTests : BaseUnitTest() {
         prefsChanges.emit(true)
 
         // THEN
-        assertThat(states.last().menuSections.flatMap { it.items }.first().badgeState).isNull()
+        assertThat(
+            states.last().menuSections.flatMap { it.items }.first {
+                it.title == R.string.more_menu_button_payments
+            }.badgeState
+        ).isNull()
     }
 
     @Test
@@ -440,12 +444,95 @@ class MoreMenuViewModelTests : BaseUnitTest() {
 
         // THEN
         val items = states.first().menuSections.flatMap { it.items }
-        assertThat(items.first { it.title == R.string.more_menu_button_blaze }.state)
+        assertThat(items.first { it.title == R.string.more_menu_button_subscriptions }.state)
             .isEqualTo(MoreMenuItemButton.State.Loading)
         assertThat(items.first { it.title == R.string.more_menu_button_google }.state)
             .isEqualTo(MoreMenuItemButton.State.Loading)
+        assertThat(items.first { it.title == R.string.more_menu_button_blaze }.state)
+            .isEqualTo(MoreMenuItemButton.State.Loading)
         assertThat(items.first { it.title == R.string.more_menu_button_inbox }.state)
             .isEqualTo(MoreMenuItemButton.State.Loading)
+    }
+
+    @Test
+    fun `when building state, then sections and items use the original hierarchy and order`() = testBlocking {
+        // GIVEN
+        setup {
+            whenever(moreMenuRepository.isUpgradesEnabled()).thenReturn(true)
+        }
+
+        // WHEN
+        val state = viewModel.moreMenuViewState.captureValues().last()
+
+        // THEN
+        assertThat(state.menuSections.map { it.title }).containsExactly(
+            R.string.more_menu_settings_section_title,
+            R.string.more_menu_general_section_title,
+        )
+        assertThat(state.menuSections[0].items.map { it.title }).containsExactly(
+            R.string.more_menu_button_settings,
+            R.string.more_menu_button_subscriptions,
+        )
+        assertThat(state.menuSections[1].items.map { it.title }).containsExactly(
+            R.string.more_menu_button_payments,
+            R.string.more_menu_button_google,
+            R.string.more_menu_button_blaze,
+            R.string.more_menu_button_wс_admin,
+            R.string.more_menu_button_store,
+            R.string.more_menu_button_coupons,
+            R.string.more_menu_button_reviews,
+            R.string.more_menu_button_customers,
+            R.string.more_menu_button_inbox,
+        )
+    }
+
+    @Test
+    fun `given optional actions are unavailable, when state resolves, then hidden rows are removed in place`() =
+        testBlocking {
+            // GIVEN
+            setup {
+                whenever(isBlazeEnabled.invoke()).thenReturn(false)
+                whenever(isGoogleForWooEnabled.invoke()).thenReturn(false)
+                whenever(moreMenuRepository.isUpgradesEnabled()).thenReturn(false)
+                whenever(moreMenuRepository.isInboxEnabled()).thenReturn(false)
+            }
+
+            // WHEN
+            val state = viewModel.moreMenuViewState.captureValues().last()
+
+            // THEN
+            assertThat(state.menuSections.map { it.title }).containsExactly(
+                R.string.more_menu_settings_section_title,
+                R.string.more_menu_general_section_title,
+            )
+            assertThat(state.menuSections[0].items.map { it.title }).containsExactly(
+                R.string.more_menu_button_settings,
+            )
+            assertThat(state.menuSections[1].items.map { it.title }).containsExactly(
+                R.string.more_menu_button_payments,
+                R.string.more_menu_button_wс_admin,
+                R.string.more_menu_button_store,
+                R.string.more_menu_button_coupons,
+                R.string.more_menu_button_reviews,
+                R.string.more_menu_button_customers,
+            )
+        }
+
+    @Test
+    fun `given a large unseen review count, when building state, then semantic count is not capped`() = testBlocking {
+        // GIVEN
+        setup {
+            whenever(unseenReviewsCountHandler.observeUnseenCount()).thenReturn(flowOf(1234))
+        }
+
+        // WHEN
+        val state = viewModel.moreMenuViewState.captureValues().last()
+
+        // THEN
+        val reviewBadge = state.menuSections.flatMap { it.items }
+            .first { it.title == R.string.more_menu_button_reviews }
+            .badgeState
+        assertThat(reviewBadge?.textState?.text).isEqualTo("1234")
     }
 
     @Test

--- a/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooCell.kt
+++ b/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooCell.kt
@@ -46,12 +46,14 @@ internal fun WooCellContent(
             text = title,
             color = if (enabled) colors.surface.onDefault else colors.surface.onVariantLowest,
             style = WooTheme.text.bodyLarge.emphasized,
+            modifier = Modifier.fillMaxWidth(),
         )
         if (description != null) {
             Text(
                 text = description,
                 color = if (enabled) colors.surface.onVariant else colors.surface.onVariantLowest,
                 style = WooTheme.text.bodyMedium.regular,
+                modifier = Modifier.fillMaxWidth(),
             )
         }
     }
@@ -117,7 +119,7 @@ internal fun WooCellLayout(
             .fillMaxWidth()
             .heightIn(min = MIN_TOUCH_TARGET_SIZE)
             .background(style.containerColor)
-            .padding(horizontal = WooTheme.padding.padding7, vertical = WooTheme.padding.padding4),
+            .padding(WooTheme.padding.padding7),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         if (leadingContent != null) {

--- a/libs/store-design-system/src/test/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooCellTest.kt
+++ b/libs/store-design-system/src/test/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooCellTest.kt
@@ -1,14 +1,39 @@
 package com.woocommerce.android.ui.compose.designsystem.component
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.requiredWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
 import androidx.test.core.app.ApplicationProvider
+import com.woocommerce.android.ui.compose.designsystem.WooTheme
+import com.woocommerce.android.ui.compose.designsystem.foundation.WooDesignSystemTheme
 import com.woocommerce.android.ui.compose.designsystem.foundation.loadWooColors
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.within
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import kotlin.math.roundToInt
 
 @RunWith(RobolectricTestRunner::class)
 class WooCellTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
     private val colors = loadWooColors(
         context = ApplicationProvider.getApplicationContext(),
         useDarkTheme = false,
@@ -28,5 +53,143 @@ class WooCellTest {
 
         assertThat(style.containerColor).isEqualTo(colors.surface.bright)
         assertThat(style.slotContentColor).isEqualTo(colors.surface.onVariantLowest)
+    }
+
+    @Test
+    fun `when cell is rendered, then shell has 24dp padding on every side`() {
+        // GIVEN
+        var expectedPaddingPx = 0f
+        composeTestRule.setContent {
+            WooDesignSystemTheme {
+                expectedPaddingPx = with(LocalDensity.current) { EXPECTED_CELL_PADDING.toPx() }
+                WooCell(
+                    title = CELL_TITLE,
+                    modifier = Modifier
+                        .requiredWidth(CONSTRAINED_CELL_WIDTH)
+                        .testTag(CELL_TAG),
+                    leadingContent = {
+                        Box(
+                            modifier = Modifier
+                                .size(LEADING_CONTENT_SIZE)
+                                .testTag(LEADING_CONTENT_TAG),
+                        )
+                    },
+                    trailingContent = {
+                        Box(
+                            modifier = Modifier
+                                .size(TRAILING_CONTENT_SIZE)
+                                .testTag(TRAILING_CONTENT_TAG),
+                        )
+                    },
+                )
+            }
+        }
+
+        // THEN
+        val cellBounds = boundsForTag(CELL_TAG)
+        val leadingBounds = boundsForTag(LEADING_CONTENT_TAG, useUnmergedTree = true)
+        val trailingBounds = boundsForTag(TRAILING_CONTENT_TAG, useUnmergedTree = true)
+
+        assertThat(leadingBounds.left - cellBounds.left)
+            .isCloseTo(expectedPaddingPx, within(POSITION_TOLERANCE))
+        assertThat(cellBounds.right - trailingBounds.right)
+            .isCloseTo(expectedPaddingPx, within(POSITION_TOLERANCE))
+        assertThat(leadingBounds.top - cellBounds.top)
+            .isCloseTo(expectedPaddingPx, within(POSITION_TOLERANCE))
+        assertThat(cellBounds.bottom - leadingBounds.bottom)
+            .isCloseTo(expectedPaddingPx, within(POSITION_TOLERANCE))
+    }
+
+    @Test
+    fun `given constrained RTL cell, when rendered, then text fills its space and remains on one line`() {
+        // GIVEN
+        var slotSpacingPx = 0f
+        composeTestRule.setContent {
+            CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Rtl) {
+                WooDesignSystemTheme {
+                    slotSpacingPx = with(LocalDensity.current) { WooTheme.spacing.space5.toPx() }
+                    WooCell(
+                        title = ARABIC_TITLE,
+                        description = ARABIC_DESCRIPTION,
+                        onClick = {},
+                        modifier = Modifier.requiredWidth(CONSTRAINED_CELL_WIDTH),
+                        leadingContent = {
+                            Box(
+                                modifier = Modifier
+                                    .size(LEADING_CONTENT_SIZE)
+                                    .testTag(LEADING_CONTENT_TAG),
+                            )
+                        },
+                        trailingContent = {
+                            Box(
+                                modifier = Modifier
+                                    .size(TRAILING_CONTENT_SIZE)
+                                    .testTag(TRAILING_CONTENT_TAG),
+                            )
+                        },
+                    )
+                }
+            }
+        }
+
+        // THEN
+        val titleBounds = textBounds(ARABIC_TITLE)
+        val descriptionBounds = textBounds(ARABIC_DESCRIPTION)
+        val leadingBounds = composeTestRule
+            .onNodeWithTag(LEADING_CONTENT_TAG, useUnmergedTree = true)
+            .fetchSemanticsNode()
+            .boundsInRoot
+        val trailingBounds = composeTestRule
+            .onNodeWithTag(TRAILING_CONTENT_TAG, useUnmergedTree = true)
+            .fetchSemanticsNode()
+            .boundsInRoot
+        val expectedTextLeft = trailingBounds.right + slotSpacingPx
+        val expectedTextRight = leadingBounds.left - slotSpacingPx
+
+        assertThat(titleBounds.left.roundToInt()).isEqualTo(expectedTextLeft.roundToInt())
+        assertThat(titleBounds.right.roundToInt()).isEqualTo(expectedTextRight.roundToInt())
+        assertThat(descriptionBounds.left.roundToInt()).isEqualTo(expectedTextLeft.roundToInt())
+        assertThat(descriptionBounds.right.roundToInt()).isEqualTo(expectedTextRight.roundToInt())
+        assertThat(textLayoutResult(ARABIC_TITLE).lineCount).isEqualTo(1)
+        assertThat(textLayoutResult(ARABIC_DESCRIPTION).lineCount).isEqualTo(1)
+    }
+
+    private fun boundsForTag(tag: String, useUnmergedTree: Boolean = false): Rect = composeTestRule
+        .onNodeWithTag(tag, useUnmergedTree = useUnmergedTree)
+        .fetchSemanticsNode()
+        .boundsInRoot
+
+    private fun textBounds(text: String): Rect = composeTestRule
+        .onNodeWithText(text, useUnmergedTree = true)
+        .fetchSemanticsNode()
+        .boundsInRoot
+
+    private fun textLayoutResult(text: String): TextLayoutResult {
+        val results = mutableListOf<TextLayoutResult>()
+        val action = composeTestRule
+            .onNodeWithText(text, useUnmergedTree = true)
+            .fetchSemanticsNode()
+            .config
+            .getOrNull(SemanticsActions.GetTextLayoutResult)
+            ?.action
+
+        composeTestRule.runOnIdle {
+            assertThat(action?.invoke(results)).isTrue()
+        }
+        return results.single()
+    }
+
+    private companion object {
+        const val ARABIC_TITLE = "الاشتراكات"
+        const val ARABIC_DESCRIPTION = "إدارة اشتراكك"
+        const val CELL_TITLE = "Cell title"
+        const val CELL_TAG = "cell"
+        const val LEADING_CONTENT_TAG = "leading-content"
+        const val TRAILING_CONTENT_TAG = "trailing-content"
+        const val POSITION_TOLERANCE = 1f
+        val CONSTRAINED_CELL_WIDTH = 320.dp
+        val EXPECTED_CELL_PADDING = 24.dp
+        val LEADING_CONTENT_SIZE = 44.dp
+        val TRAILING_CONTENT_SIZE = 18.dp
     }
 }


### PR DESCRIPTION
### Description

Fixes WOOMOB-3738

Migrates the Android Menu tab from the legacy Compose theme and resources to the Store Design System.

The screen retains the existing Android information architecture and ordering: the store header is followed by Settings and General sections, with every action rendered as a full-width Design System cell. The layout remains a single column at all screen sizes, centered within a capped content width on larger displays.

The migration preserves the Fragment shell, Activity-owned bottom navigation, navigation and authenticated web flows, feature gating and loading positions, store switching, review/payment badges, analytics timing, and tab-reselection scroll-to-top behavior. It also makes the shared skeleton use Material 3 theme colors, aligns WooCell with the Design System's 24dp padding contract, strengthens RTL text constraints, adds focused unit coverage, and removes obsolete More color resources.

The status-bar inset color remains owned by the app-wide XML/window theme and is intentionally unchanged here; it will be aligned once the full app design-system migration can update window chrome consistently.

Figma: 50XIH5MmOf4xUYEkM6fAm6-fi-670_13821

### Test Steps

1. Log in to a store and open the Menu tab.
2. Verify the store header, followed by the Settings and General sections with full-width cells in their existing order.
3. Open Settings and return to Menu; also verify WC Admin and View Store still open their authenticated browser destinations.
4. Scroll down, reselect the Menu bottom-tab item, and verify the screen scrolls back to the top.
5. Check a store where optional actions resolve visible or hidden and verify loading placeholders disappear without gaps or reordering.
6. At a narrow width or 2× font size, verify cells remain readable and the store name/plan badge reflow without overlap.
7. In dark mode, RTL, landscape, and a tablet-sized window, verify the single-column content remains readable, correctly ordered, scrollable, and centered.

### Images/gif

#### Themes

| Light | Dark |
| --- | --- |
| <img width="1129" height="2447" alt="image" src="https://github.com/user-attachments/assets/f74573cd-4610-4da9-83ab-01ffba32d11a" /> | <img width="1129" height="2447" alt="image" src="https://github.com/user-attachments/assets/338ccd70-3735-4692-af59-7da6b0558456" /> |


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.