### PR TITLE
[WOOMOB-3275] Prevent stale navigation results replaying after process death

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -14,6 +14,7 @@
 - [*] Fixed bundled variable products not asking for a variation when configuring a bundle during order creation [https://github.com/woocommerce/woocommerce-android/pull/16360]
 - [*] Scanning a subscription product's barcode or SKU during order creation now explains why it can't be added [https://github.com/woocommerce/woocommerce-android/pull/16380]
 - [*] Custom amounts now use the same decimal entry as shipping and the rest of the app — enter 2.50 instead of 250 to get $2.50 [https://github.com/woocommerce/woocommerce-android/pull/16358]
+- [*] Fixed an order status sometimes reverting on tablets after reopening the app following a long period of inactivity [https://github.com/woocommerce/woocommerce-android/pull/16392]
 - [*] Fixed bundled variable products not asking for a variation when configuring a bundle during order creation
 - [Internal] Improved recovery when the selected store is no longer available through WordPress.com, including when its Jetpack connection has been removed. [https://github.com/woocommerce/woocommerce-android/pull/16327]
 - [Internal] Attach a Mobile Status Report (device, OS, connectivity, notifications, feature flags) to support tickets [https://github.com/woocommerce/woocommerce-android/pull/16325]

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
@@ -1,8 +1,10 @@
 package com.woocommerce.android.extensions
 
+import android.os.Parcelable
 import android.view.View
 import androidx.annotation.IdRes
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.NavController
 import androidx.navigation.fragment.NavHostFragment
@@ -18,10 +20,37 @@ import com.woocommerce.android.support.help.HelpOrigin
 import com.woocommerce.android.ui.analytics.hub.AnalyticsHubFragment
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.parcelize.Parcelize
+import kotlinx.parcelize.RawValue
 import java.time.Instant
 import java.time.ZoneId
 import java.time.ZonedDateTime
+import java.util.UUID
 import kotlin.math.abs
+
+/**
+ * A process-lifetime token used to tell nav results produced in the current process apart from ones restored from a
+ * [SavedStateHandle] after the process was killed (e.g. a tablet woken after a long idle). It is stable across
+ * configuration changes and regenerated on process death. See WOOMOB-3275.
+ */
+private val navResultSessionId: String = UUID.randomUUID().toString()
+
+/**
+ * Wraps a nav result together with the [session] that produced it. Only the observed value key is restored across
+ * process death (its sibling keys are not), so the discriminator must live *inside* the persisted value. On restore
+ * the envelope comes back with its original [session]; if that differs from [navResultSessionId] the result is a
+ * leftover from a dead process and is dropped instead of replayed. See WOOMOB-3275.
+ */
+@Parcelize
+private data class NavResultEnvelope(val session: String, val value: @RawValue Any?) : Parcelable
+
+/** True when a restored nav result was produced by a different (already dead) process — see [NavResultEnvelope]. */
+private fun Any.isStaleNavResult(): Boolean =
+    this is NavResultEnvelope && session != navResultSessionId
+
+/** Unwraps a [NavResultEnvelope]; a value written without the envelope is returned as-is (legacy behaviour). */
+private fun Any.unwrapNavResult(): Any? =
+    if (this is NavResultEnvelope) value else this
 
 /**
  * A helper function that sets the submitted key-value pair in the Fragment's SavedStateHandle. The value can be
@@ -47,14 +76,14 @@ fun <T> Fragment.navigateBackWithResult(
 
     if (popDestination && destinationId != null) {
         navController.popBackStack(destinationId, true)
-        navController.currentBackStackEntry?.savedStateHandle?.set(key, result)
+        navController.currentBackStackEntry?.savedStateHandle?.set(key, NavResultEnvelope(navResultSessionId, result))
     } else {
         val entry = if (destinationId != null) {
             navController.getBackStackEntry(destinationId)
         } else {
             navController.previousBackStackEntry
         }
-        entry?.savedStateHandle?.set(key, result)
+        entry?.savedStateHandle?.set(key, NavResultEnvelope(navResultSessionId, result))
 
         if (destinationId != null) {
             navController.popBackStack(destinationId, false)
@@ -110,9 +139,9 @@ fun Fragment.navigateBackWithNotice(
  * @param [navHostId] An optional ID of the NavHostFragment, it's useful when the fragment is used in two-pane layouts
  * @param [handler] A result handler
  *
- * Note: The handler is called only if the value wasn't handled before (i.e. the data is fresh). Once the observer is
- * called, the boolean value is updated. This puts a limit on the number of observers for a particular key-result pair
- * to 1.
+ * Note: The value is consumed once — after the handler runs, the value is nulled so it won't be delivered again.
+ * A result restored from a previous process (i.e. the app was killed and recreated, e.g. a tablet woken after a
+ * long idle period) is discarded without invoking the handler, so a stale result cannot be replayed. See WOOMOB-3275.
  */
 fun <T> Fragment.handleResult(
     key: String,
@@ -129,9 +158,18 @@ fun <T> Fragment.handleResult(
     }
 
     entry?.savedStateHandle?.let { saveState ->
-        saveState.getLiveData<T?>(key).observe(this.viewLifecycleOwner) {
-            it?.let {
-                handler(it)
+        saveState.getLiveData<Any?>(key).observe(this.viewLifecycleOwner) { raw ->
+            raw?.let { rawValue ->
+                if (rawValue.isStaleNavResult()) {
+                    // Restored from a dead process (e.g. a tablet woken after a long idle) — drop, don't replay.
+                    saveState.set(key, null)
+                    return@let
+                }
+                // A null payload keeps the legacy behaviour of not invoking the handler.
+                rawValue.unwrapNavResult()?.let { payload ->
+                    @Suppress("UNCHECKED_CAST")
+                    handler(payload as T)
+                }
                 saveState.set(key, null)
             }
         }
@@ -149,9 +187,9 @@ fun <T> Fragment.handleResult(
  * @param [navHostId] An optional ID of the NavHostFragment, it's useful when the fragment is used in two-pane layouts
  * @param [handler] A result handler
  *
- * Note: The handler is called only if the value wasn't handled before (i.e. the data is fresh). Once the observer is
- * called, the value is nulled and the handler won't be called. This puts a limit on the number of observers for
- * a particular key-result pair to 1.
+ * Note: The value is consumed once — after the handler runs, the value is nulled so it won't be delivered again.
+ * A result restored from a previous process (i.e. the app was killed and recreated, e.g. a tablet woken after a
+ * long idle period) is discarded without invoking the handler, so a stale result cannot be replayed. See WOOMOB-3275.
  */
 fun <T> Fragment.handleDialogResult(
     key: String,
@@ -173,9 +211,9 @@ fun <T> Fragment.handleDialogResult(
  * @param [navHostId] An optional ID of the NavHostFragment, it's useful when the fragment is used in two-pane layouts
  * @param [handler] A result handler
  *
- * Note: The handler is called only if the value wasn't handled before (i.e. the data is fresh). Once the observer is
- * called, the value is nulled and the handler won't be called. This puts a limit on the number of observers for
- * a particular key-result pair to 1.
+ * Note: The value is consumed once — after the handler runs, the value is nulled so it won't be delivered again.
+ * A result restored from a previous process (i.e. the app was killed and recreated, e.g. a tablet woken after a
+ * long idle period) is discarded without invoking the handler, so a stale result cannot be replayed. See WOOMOB-3275.
  */
 fun Fragment.handleDialogNotice(
     key: String,
@@ -196,9 +234,9 @@ fun Fragment.handleDialogNotice(
  * @param [navHostId] An optional ID of the NavHostFragment, it's useful when the fragment is used in two-pane layouts
  * @param [handler] A result handler
  *
- * Note: The handler is called only if the value wasn't handled before (i.e. the data is fresh). Once the observer is
- * called, the value is nulled and the handler won't be called. This puts a limit on the number of observers for
- * a particular key-result pair to 1.
+ * Note: The value is consumed once — after the handler runs, the value is nulled so it won't be delivered again.
+ * A notice restored from a previous process (i.e. the app was killed and recreated) is discarded without invoking
+ * the handler, so a stale notice cannot be replayed. See WOOMOB-3275.
  */
 fun Fragment.handleNotice(
     key: String,
@@ -215,8 +253,13 @@ fun Fragment.handleNotice(
     }
 
     entry?.savedStateHandle?.let { saveState ->
-        saveState.getLiveData<String>(key).observe(this.viewLifecycleOwner) {
-            it?.let {
+        saveState.getLiveData<Any?>(key).observe(this.viewLifecycleOwner) { raw ->
+            raw?.let { rawValue ->
+                if (rawValue.isStaleNavResult()) {
+                    // Restored from a dead process (e.g. a tablet woken after a long idle) — drop, don't replay.
+                    saveState.set(key, null)
+                    return@let
+                }
                 handler()
                 saveState.set(key, null)
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
@@ -33,7 +33,8 @@ import kotlin.math.abs
  * [SavedStateHandle] after the process was killed (e.g. a tablet woken after a long idle). It is stable across
  * configuration changes and regenerated on process death. See WOOMOB-3275.
  */
-private val navResultSessionId: String = UUID.randomUUID().toString()
+// internal (not private) so the pure envelope/staleness logic can be unit-tested — see FragmentExtTest.
+internal val navResultSessionId: String = UUID.randomUUID().toString()
 
 /**
  * Wraps a nav result together with the [session] that produced it. Only the observed value key is restored across
@@ -42,14 +43,14 @@ private val navResultSessionId: String = UUID.randomUUID().toString()
  * leftover from a dead process and is dropped instead of replayed. See WOOMOB-3275.
  */
 @Parcelize
-private data class NavResultEnvelope(val session: String, val value: @RawValue Any?) : Parcelable
+internal data class NavResultEnvelope(val session: String, val value: @RawValue Any?) : Parcelable
 
 /** True when a restored nav result was produced by a different (already dead) process — see [NavResultEnvelope]. */
-private fun Any.isStaleNavResult(): Boolean =
+internal fun Any.isStaleNavResult(): Boolean =
     this is NavResultEnvelope && session != navResultSessionId
 
 /** Unwraps a [NavResultEnvelope]; a value written without the envelope is returned as-is (legacy behaviour). */
-private fun Any.unwrapNavResult(): Any? =
+internal fun Any.unwrapNavResult(): Any? =
     if (this is NavResultEnvelope) value else this
 
 /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
@@ -33,7 +33,7 @@ import kotlin.math.abs
  * [SavedStateHandle] after the process was killed (e.g. a tablet woken after a long idle). It is stable across
  * configuration changes and regenerated on process death. See WOOMOB-3275.
  */
-// internal (not private) so the pure envelope/staleness logic can be unit-tested — see FragmentExtTest.
+// internal so the pure envelope/staleness logic can be unit-tested — see FragmentExtTest.
 internal val navResultSessionId: String = UUID.randomUUID().toString()
 
 /**

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/extensions/FragmentExtTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/extensions/FragmentExtTest.kt
@@ -1,0 +1,54 @@
+package com.woocommerce.android.extensions
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+/**
+ * Unit tests for the nav-result staleness logic that guards against a consumed result being replayed after
+ * process death (WOOMOB-3275). The full observer/restore behaviour needs an Android runtime; these cover the
+ * pure envelope + token-comparison logic.
+ */
+class FragmentExtTest {
+    @Test
+    fun `given an envelope from the current process, when checked, then it is not stale`() {
+        val result: Any = NavResultEnvelope(session = navResultSessionId, value = "payload")
+
+        assertThat(result.isStaleNavResult()).isFalse()
+    }
+
+    @Test
+    fun `given an envelope from a different process, when checked, then it is stale`() {
+        val result: Any = NavResultEnvelope(session = "a-previous-process-token", value = "payload")
+
+        assertThat(result.isStaleNavResult()).isTrue()
+    }
+
+    @Test
+    fun `given a non-envelope legacy value, when checked, then it is not stale`() {
+        val result: Any = "raw-legacy-value"
+
+        assertThat(result.isStaleNavResult()).isFalse()
+    }
+
+    @Test
+    fun `given an envelope, when unwrapped, then the inner value is returned`() {
+        val payload = "payload"
+        val result: Any = NavResultEnvelope(session = navResultSessionId, value = payload)
+
+        assertThat(result.unwrapNavResult()).isEqualTo(payload)
+    }
+
+    @Test
+    fun `given an envelope wrapping null, when unwrapped, then null is returned`() {
+        val result: Any = NavResultEnvelope(session = navResultSessionId, value = null)
+
+        assertThat(result.unwrapNavResult()).isNull()
+    }
+
+    @Test
+    fun `given a non-envelope legacy value, when unwrapped, then it is returned as-is`() {
+        val result: Any = "raw-legacy-value"
+
+        assertThat(result.unwrapNavResult()).isEqualTo("raw-legacy-value")
+    }
+}


### PR DESCRIPTION
### Description

Fixes WOOMOB-3275

> **Note:** This is filed as an order-status bug, but the root cause is in shared navigation-result handling, so it **also affects product details** (and every other two-pane detail screen), not just orders — reproduced and fixed on both.

On tablets the order (and product) detail screen is hosted in a nested `NavHostFragment`. After the OS kills the app — e.g. a tablet woken after a long idle — Jetpack Navigation restores the child back stack and **re-delivers a one-shot `SavedStateHandle` result that was already consumed** in the previous process, replaying the action before any app code runs. For an order this re-sends a stale status to the server (a `completed` order reverting to `processing`); it reproduces the same way for any two-pane detail (verified on orders and products).

This wraps every result written through `navigateBackWithResult`/`navigateBackWithNotice` in a small envelope carrying a process-lifetime token. `handleResult`/`handleNotice` drop any result whose token is from a previous (dead) process instead of invoking the handler; fresh results and configuration-change survivors (same process, same token) are delivered exactly as before.

Simpler fixes were tried and don't work:
- **Clearing the consumed value** (`set(key, null)` / `remove(key)`): the value restored after process death is re-hydrated from the framework's persisted `SavedStateHandle` (via its `getLiveData`), independent of the live value, so clearing it has no effect on the restore.
- **A sibling "session" key stored next to the value**: only the observed value key is restored across process death — sibling keys are not — so the marker disappears and the stale value looks fresh.
- **Navigation-level changes** (dropping `launchSingleTop`, `popUpTo` on the detail entry, resetting the nested host): the replay fires while the framework restores the nested back stack, before any app navigation runs, so nothing at the `navigate()` layer can prevent it.
- **An `Event`/`hasBeenHandled` wrapper**: the flag deserializes back to `false` after process death, so it re-delivers anyway.

That's why the token has to live *inside* the persisted value — it's the only thing restored alongside it, so the consumer can tell a dead-process leftover from a fresh result. (Results written via a direct `savedStateHandle.set`, e.g. `VariationSelectorFragment`, or via `setFragmentResult` are not enveloped; the former is a full-screen selector in the Activity host, not a two-pane nested pane, so it isn't exposed to this bug.)

### Test Steps

On a **tablet** (two-pane orders):

I highly recommend reproducing the bug on trunk first, to make sure you can verify the fix. 

1. Open an order that is `Pending`/`On hold` in the detail pane - or create a new one.
2. Change its status (e.g. to **Processing**) and wait for the undo snackbar to dismiss (the change is applied).
3. Send the app to the background, then kill the process: `adb shell am kill com.woocommerce.android.dev` (or Android Studio → Terminate).
4. From wp-admin (or another device) change that order to **Completed**.
5. Reopen the app and open the same order.
6. **Expected:** the order stays **Completed**. (Before this change it reverted to **Processing** and re-sent that status to the server.)
7. Optional sanity check that normal delivery still works: change a status without killing the app — the change applies once, as usual.

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

