### PR TITLE
[WOOMOB-3739] Prepare Product Detail for the Compose cutover (1/3)

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailUiMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailUiMapper.kt
@@ -1,0 +1,215 @@
+package com.woocommerce.android.ui.products.details
+
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.products.details.ProductDetailViewModel.ProductDetailViewState.AuxiliaryState
+import com.woocommerce.android.ui.products.details.ProductDetailViewModel.ProductDetailViewState.AuxiliaryState.Error
+import com.woocommerce.android.ui.products.details.ProductDetailViewModel.ProductDetailViewState.AuxiliaryState.Loading
+import com.woocommerce.android.ui.products.details.ProductDetailViewModel.ProductDetailViewState.AuxiliaryState.None
+import com.woocommerce.android.ui.products.models.ProductProperty
+import com.woocommerce.android.ui.products.models.ProductPropertyCard
+
+class ProductDetailUiMapper {
+    fun mapScreenState(
+        auxiliaryState: AuxiliaryState,
+        hasProduct: Boolean,
+        cards: List<ProductDetailCardUiModel>,
+        showAddMore: Boolean,
+        showLinkedProductPromo: Boolean,
+    ): ProductDetailScreenState = when (auxiliaryState) {
+        Loading -> ProductDetailScreenState.Loading
+        is Error -> if (auxiliaryState.message == R.string.product_detail_product_not_selected) {
+            ProductDetailScreenState.Empty(auxiliaryState.message)
+        } else {
+            ProductDetailScreenState.Error(auxiliaryState.message)
+        }
+        None -> if (hasProduct) {
+            ProductDetailScreenState.Content(
+                cards = cards,
+                showAddMore = showAddMore,
+                showLinkedProductPromo = showLinkedProductPromo,
+            )
+        } else {
+            ProductDetailScreenState.Empty()
+        }
+    }
+
+    fun map(cards: List<ProductPropertyCard>): List<ProductDetailCardUiModel> {
+        val cardKeyOccurrences = mutableMapOf<String, Int>()
+        return cards.map { card ->
+            val rows = mapRows(card.properties)
+            val cardBaseKey = when (card.type) {
+                ProductPropertyCard.Type.PRIMARY -> PRIMARY_CARD_KEY
+                ProductPropertyCard.Type.SECONDARY -> if (card.properties.any { it.isBlazeProperty() }) {
+                    BLAZE_CARD_KEY
+                } else {
+                    SECONDARY_CARD_KEY
+                }
+            }
+            val cardKey = cardBaseKey.withOccurrence(cardKeyOccurrences)
+
+            ProductDetailCardUiModel(
+                key = cardKey,
+                style = when (card.type) {
+                    ProductPropertyCard.Type.PRIMARY -> ProductDetailCardStyle.PRIMARY
+                    ProductPropertyCard.Type.SECONDARY -> ProductDetailCardStyle.SECONDARY
+                },
+                caption = card.caption,
+                rows = rows,
+            )
+        }
+    }
+
+    private fun mapRows(properties: List<ProductProperty>): List<ProductDetailRowUiModel> {
+        val keyOccurrences = mutableMapOf<String, Int>()
+        return properties.mapIndexed { index, property ->
+            val key = property.semanticKey().withOccurrence(keyOccurrences)
+            property.toUiModel(key).let { row ->
+                if (row is ProductDetailRowUiModel.Rating) {
+                    row.copy(showDivider = index != properties.lastIndex)
+                } else {
+                    row
+                }
+            }
+        }
+    }
+
+    private fun ProductProperty.toUiModel(key: String): ProductDetailRowUiModel = when (this) {
+        ProductProperty.Divider -> ProductDetailRowUiModel.Divider(key)
+        is ProductProperty.Property -> toPropertyUiModel(key)
+        is ProductProperty.ComplexProperty -> toComplexPropertyUiModel(key)
+        is ProductProperty.RatingBar -> toRatingUiModel(key)
+        is ProductProperty.Editable -> toEditableUiModel(key)
+        is ProductProperty.PropertyGroup -> toPropertyGroupUiModel(key)
+        is ProductProperty.Link -> toLinkUiModel(key)
+        is ProductProperty.Button -> toButtonUiModel(key)
+        is ProductProperty.Switch -> toSwitchUiModel(key)
+        is ProductProperty.Warning -> ProductDetailRowUiModel.Warning(key, content)
+    }
+
+    private fun ProductProperty.Property.toPropertyUiModel(key: String) =
+        ProductDetailRowUiModel.Property(
+            key = key,
+            title = title,
+            value = value,
+            showDivider = isDividerVisible,
+        )
+
+    private fun ProductProperty.ComplexProperty.toComplexPropertyUiModel(key: String) =
+        ProductDetailRowUiModel.ComplexProperty(
+            key = key,
+            title = title,
+            value = value,
+            icon = icon,
+            showTitle = showTitle,
+            maxLines = maxLines,
+            showDivider = isDividerVisible,
+            onClick = onClick,
+        )
+
+    private fun ProductProperty.RatingBar.toRatingUiModel(key: String) =
+        ProductDetailRowUiModel.Rating(
+            key = key,
+            title = title,
+            value = value,
+            rating = rating,
+            icon = icon,
+            showDivider = false,
+            onClick = onClick,
+        )
+
+    private fun ProductProperty.Editable.toEditableUiModel(key: String) =
+        ProductDetailRowUiModel.Editable(
+            key = key,
+            hint = hint,
+            text = text,
+            shouldFocus = shouldFocus,
+            isReadOnly = isReadOnly,
+            badgeText = badgeText,
+            badgeTone = badgeColor?.let {
+                if (it == R.color.product_status_badge_pending) {
+                    ProductDetailBadgeTone.WARNING
+                } else {
+                    ProductDetailBadgeTone.NEUTRAL
+                }
+            },
+            onTextChanged = onTextChanged,
+        )
+
+    private fun ProductProperty.PropertyGroup.toPropertyGroupUiModel(key: String) =
+        ProductDetailRowUiModel.PropertyGroup(
+            key = key,
+            title = title,
+            properties = properties.entries.map { ProductDetailPropertyValueUiModel(it.key, it.value) },
+            icon = icon,
+            showTitle = showTitle,
+            showDivider = isDividerVisible,
+            isHighlighted = isHighlighted,
+            propertyFormat = propertyFormat,
+            onClick = onClick,
+        )
+
+    private fun ProductProperty.Link.toLinkUiModel(key: String) =
+        ProductDetailRowUiModel.Link(
+            key = key,
+            title = title,
+            icon = icon,
+            showDivider = isDividerVisible,
+            onClick = onClick,
+        )
+
+    private fun ProductProperty.Button.toButtonUiModel(key: String) =
+        ProductDetailRowUiModel.Button(
+            key = key,
+            text = text,
+            icon = icon,
+            showDivider = isDividerVisible,
+            tooltip = tooltip?.let {
+                ProductDetailTooltipUiModel(
+                    title = it.title,
+                    text = it.text,
+                    dismissButtonText = it.dismissButtonText,
+                    onDismiss = it.onDismiss,
+                )
+            },
+            link = link?.let { ProductDetailButtonLinkUiModel(it.text, it.onClick) },
+            onClick = onClick,
+        )
+
+    private fun ProductProperty.Switch.toSwitchUiModel(key: String) =
+        ProductDetailRowUiModel.Switch(
+            key = key,
+            title = title,
+            isOn = isOn,
+            icon = icon,
+            onStateChanged = onStateChanged,
+        )
+
+    private fun ProductProperty.semanticKey(): String = when (this) {
+        ProductProperty.Divider -> "divider"
+        is ProductProperty.Property -> "property_$title"
+        is ProductProperty.ComplexProperty -> "complex_${title ?: NO_RESOURCE}_${icon ?: NO_RESOURCE}"
+        is ProductProperty.RatingBar -> "rating_$title"
+        is ProductProperty.Editable -> "editable_$hint"
+        is ProductProperty.PropertyGroup -> "group_$title"
+        is ProductProperty.Link -> "link_$title"
+        is ProductProperty.Button -> "button_$text"
+        is ProductProperty.Switch -> "switch_$title"
+        is ProductProperty.Warning -> "warning"
+    }
+
+    private fun ProductProperty.isBlazeProperty() =
+        this is ProductProperty.Link && title == R.string.product_details_blaze_card
+
+    private fun String.withOccurrence(occurrences: MutableMap<String, Int>): String {
+        val occurrence = occurrences.getOrDefault(this, 0)
+        occurrences[this] = occurrence + 1
+        return if (occurrence == 0) this else "${this}_$occurrence"
+    }
+
+    private companion object {
+        const val PRIMARY_CARD_KEY = "primary"
+        const val SECONDARY_CARD_KEY = "secondary"
+        const val BLAZE_CARD_KEY = "blaze"
+        const val NO_RESOURCE = 0
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailUiModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailUiModel.kt
@@ -1,0 +1,158 @@
+package com.woocommerce.android.ui.products.details
+
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
+import androidx.compose.runtime.Immutable
+
+@Immutable
+sealed interface ProductDetailScreenState {
+    data object Loading : ProductDetailScreenState
+
+    data class Empty(@StringRes val message: Int? = null) : ProductDetailScreenState
+
+    data class Error(@StringRes val message: Int) : ProductDetailScreenState
+
+    data class Content(
+        val cards: List<ProductDetailCardUiModel>,
+        val showAddMore: Boolean,
+        val showLinkedProductPromo: Boolean,
+    ) : ProductDetailScreenState
+}
+
+@Immutable
+sealed interface ProductDetailImageUiState {
+    data object Loading : ProductDetailImageUiState
+    data object Gallery : ProductDetailImageUiState
+    data object AddImage : ProductDetailImageUiState
+    data object Unavailable : ProductDetailImageUiState
+    data object Hidden : ProductDetailImageUiState
+}
+
+@Immutable
+data class ProductDetailCardUiModel(
+    val key: String,
+    val style: ProductDetailCardStyle,
+    val caption: String,
+    val rows: List<ProductDetailRowUiModel>,
+)
+
+enum class ProductDetailCardStyle {
+    PRIMARY,
+    SECONDARY,
+}
+
+enum class ProductDetailBadgeTone {
+    NEUTRAL,
+    WARNING,
+}
+
+@Immutable
+sealed interface ProductDetailRowUiModel {
+    val key: String
+
+    data class Divider(
+        override val key: String,
+    ) : ProductDetailRowUiModel
+
+    data class Property(
+        override val key: String,
+        @StringRes val title: Int,
+        val value: String,
+        val showDivider: Boolean,
+    ) : ProductDetailRowUiModel
+
+    data class ComplexProperty(
+        override val key: String,
+        @StringRes val title: Int?,
+        val value: String,
+        @DrawableRes val icon: Int?,
+        val showTitle: Boolean,
+        val maxLines: Int,
+        val showDivider: Boolean,
+        val onClick: (() -> Unit)?,
+    ) : ProductDetailRowUiModel
+
+    data class Rating(
+        override val key: String,
+        @StringRes val title: Int,
+        val value: String,
+        val rating: Float,
+        @DrawableRes val icon: Int,
+        val showDivider: Boolean,
+        val onClick: (() -> Unit)?,
+    ) : ProductDetailRowUiModel
+
+    data class Editable(
+        override val key: String,
+        @StringRes val hint: Int,
+        val text: String,
+        val shouldFocus: Boolean,
+        val isReadOnly: Boolean,
+        @StringRes val badgeText: Int?,
+        val badgeTone: ProductDetailBadgeTone?,
+        val onTextChanged: ((String) -> Unit)?,
+    ) : ProductDetailRowUiModel
+
+    data class PropertyGroup(
+        override val key: String,
+        @StringRes val title: Int,
+        val properties: List<ProductDetailPropertyValueUiModel>,
+        @DrawableRes val icon: Int?,
+        val showTitle: Boolean,
+        val showDivider: Boolean,
+        val isHighlighted: Boolean,
+        @StringRes val propertyFormat: Int,
+        val onClick: (() -> Unit)?,
+    ) : ProductDetailRowUiModel
+
+    data class Link(
+        override val key: String,
+        @StringRes val title: Int,
+        @DrawableRes val icon: Int?,
+        val showDivider: Boolean,
+        val onClick: (() -> Unit)?,
+    ) : ProductDetailRowUiModel
+
+    data class Button(
+        override val key: String,
+        @StringRes val text: Int,
+        @DrawableRes val icon: Int?,
+        val showDivider: Boolean,
+        val tooltip: ProductDetailTooltipUiModel?,
+        val link: ProductDetailButtonLinkUiModel?,
+        val onClick: () -> Unit,
+    ) : ProductDetailRowUiModel
+
+    data class Switch(
+        override val key: String,
+        @StringRes val title: Int,
+        val isOn: Boolean,
+        @DrawableRes val icon: Int?,
+        val onStateChanged: ((Boolean) -> Unit)?,
+    ) : ProductDetailRowUiModel
+
+    data class Warning(
+        override val key: String,
+        val content: String,
+    ) : ProductDetailRowUiModel
+}
+
+@Immutable
+data class ProductDetailPropertyValueUiModel(
+    val label: String,
+    val value: String,
+)
+
+@Immutable
+data class ProductDetailTooltipUiModel(
+    @StringRes val title: Int,
+    @StringRes val text: Int,
+    @StringRes val dismissButtonText: Int,
+    val onDismiss: () -> Unit,
+)
+
+@Immutable
+data class ProductDetailButtonLinkUiModel(
+    @StringRes val text: Int,
+    val onClick: () -> Unit,
+)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel.kt
@@ -473,11 +473,7 @@ class ProductDetailViewModel @Inject constructor(
             } else {
                 when (val mode = navArgs.mode) {
                     is ProductDetailFragment.Mode.ShowProduct -> {
-                        productRepository.getProductAggregate(
-                            viewState.productDraft?.remoteId ?: mode.remoteProductId
-                        )?.let {
-                            storedProductAggregate.value = it
-                        }
+                        restoreStoredProduct(viewState.productDraft?.remoteId ?: mode.remoteProductId)
                     }
 
                     ProductDetailFragment.Mode.Loading -> {
@@ -491,9 +487,19 @@ class ProductDetailViewModel @Inject constructor(
                             )
                         )
 
-                    is ProductDetailFragment.Mode.AddNewProduct -> Unit
+                    is ProductDetailFragment.Mode.AddNewProduct -> {
+                        viewState.productDraft?.remoteId
+                            ?.takeIf { it != DEFAULT_ADD_NEW_PRODUCT_ID }
+                            ?.let { restoreStoredProduct(it) }
+                    }
                 }
             }
+        }
+    }
+
+    private suspend fun restoreStoredProduct(remoteProductId: Long) {
+        productRepository.getProductAggregate(remoteProductId)?.let {
+            storedProductAggregate.value = it
         }
     }
 
@@ -1468,8 +1474,14 @@ class ProductDetailViewModel @Inject constructor(
 
     fun refreshProduct() {
         launch {
-            val mode = navArgs.mode as ProductDetailFragment.Mode.ShowProduct
-            fetchProduct(viewState.productDraft?.remoteId ?: mode.remoteProductId)
+            val remoteProductId = when (val mode = navArgs.mode) {
+                is ProductDetailFragment.Mode.ShowProduct -> viewState.productDraft?.remoteId ?: mode.remoteProductId
+                ProductDetailFragment.Mode.AddNewProduct ->
+                    viewState.productDraft?.remoteId?.takeIf { it != DEFAULT_ADD_NEW_PRODUCT_ID }
+                ProductDetailFragment.Mode.Empty,
+                ProductDetailFragment.Mode.Loading -> null
+            }
+            remoteProductId?.let { fetchProduct(it) }
         }
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailCardBuilderTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailCardBuilderTest.kt
@@ -31,6 +31,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 @ExperimentalCoroutinesApi
 class ProductDetailCardBuilderTest : BaseUnitTest() {
     private lateinit var sut: ProductDetailCardBuilder
+    private lateinit var viewModel: ProductDetailViewModel
     private lateinit var productStub: Product
     private val isBlazeEnabled: IsBlazeEnabled = mock {
         on { invoke() } doReturn false
@@ -45,7 +46,7 @@ class ProductDetailCardBuilderTest : BaseUnitTest() {
 
     @Before
     fun setUp() {
-        val viewModel: ProductDetailViewModel = mock {
+        viewModel = mock {
             on { getShippingClassByRemoteShippingClassId(any()) } doReturn ""
         }
 
@@ -311,5 +312,46 @@ class ProductDetailCardBuilderTest : BaseUnitTest() {
         Assertions.assertThat(propertyKeys).doesNotContain(
             resourceProvider.getString(R.string.subscription_one_time_shipping)
         )
+    }
+
+    @Test
+    fun `given every product detail type, when mapping builder output, then card and row order is preserved`() = testBlocking {
+        doReturn(0).whenever(viewModel).getBundledProductsSize(any())
+        doReturn(emptyList<com.woocommerce.android.model.Component>()).whenever(viewModel).getComponents(any())
+        val productTypes = listOf(
+            ProductType.SIMPLE,
+            ProductType.VARIABLE,
+            ProductType.GROUPED,
+            ProductType.EXTERNAL,
+            ProductType.SUBSCRIPTION,
+            ProductType.VARIABLE_SUBSCRIPTION,
+            ProductType.BUNDLE,
+            ProductType.COMPOSITE,
+            ProductType.OTHER,
+        )
+        val mapper = ProductDetailUiMapper()
+
+        productTypes.forEach { productType ->
+            val type = productType.value.ifEmpty { "unsupported" }
+            val aggregate = ProductAggregate(
+                product = ProductTestUtils.generateProduct().copy(type = type),
+                subscription = ProductHelper.getDefaultSubscriptionDetails(),
+            )
+
+            val cards = sut.buildPropertyCards(aggregate, "")
+            val mappedCards = mapper.map(cards)
+
+            Assertions.assertThat(mappedCards.map { it.style }).containsExactlyElementsOf(
+                cards.map {
+                    when (it.type) {
+                        ProductPropertyCard.Type.PRIMARY -> ProductDetailCardStyle.PRIMARY
+                        ProductPropertyCard.Type.SECONDARY -> ProductDetailCardStyle.SECONDARY
+                    }
+                }
+            )
+            Assertions.assertThat(mappedCards.map { it.rows.size }).containsExactlyElementsOf(
+                cards.map { it.properties.size }
+            )
+        }
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailUiMapperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailUiMapperTest.kt
@@ -1,0 +1,268 @@
+package com.woocommerce.android.ui.products.details
+
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.products.details.ProductDetailViewModel.ProductDetailViewState.AuxiliaryState
+import com.woocommerce.android.ui.products.models.ProductProperty
+import com.woocommerce.android.ui.products.models.ProductPropertyCard
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class ProductDetailUiMapperTest {
+    private val mapper = ProductDetailUiMapper()
+
+    @Test
+    fun `given offline cache miss, when None is mapped without a product, then terminal empty state is returned`() {
+        val result = mapper.mapScreenState(
+            auxiliaryState = AuxiliaryState.None,
+            hasProduct = false,
+            cards = emptyList(),
+            showAddMore = false,
+            showLinkedProductPromo = false,
+        )
+
+        assertThat(result).isEqualTo(ProductDetailScreenState.Empty())
+    }
+
+    @Test
+    fun `when cards are mapped, then card and property order is preserved`() {
+        val cards = listOf(
+            ProductPropertyCard(
+                type = ProductPropertyCard.Type.PRIMARY,
+                properties = listOf(
+                    ProductProperty.Editable(R.string.product_detail_title_hint, "Title"),
+                    ProductProperty.ComplexProperty(value = "Description"),
+                ),
+            ),
+            ProductPropertyCard(
+                type = ProductPropertyCard.Type.SECONDARY,
+                caption = "Details",
+                properties = allPropertyVariants(),
+            ),
+        )
+
+        val result = mapper.map(cards)
+
+        assertThat(result.map { it.style }).containsExactly(
+            ProductDetailCardStyle.PRIMARY,
+            ProductDetailCardStyle.SECONDARY,
+        )
+        assertThat(result[1].caption).isEqualTo("Details")
+        assertThat(result[1].rows.map { it::class.java }).containsExactly(
+            ProductDetailRowUiModel.Divider::class.java,
+            ProductDetailRowUiModel.Property::class.java,
+            ProductDetailRowUiModel.ComplexProperty::class.java,
+            ProductDetailRowUiModel.Rating::class.java,
+            ProductDetailRowUiModel.Editable::class.java,
+            ProductDetailRowUiModel.PropertyGroup::class.java,
+            ProductDetailRowUiModel.Link::class.java,
+            ProductDetailRowUiModel.Button::class.java,
+            ProductDetailRowUiModel.Switch::class.java,
+            ProductDetailRowUiModel.Warning::class.java,
+        )
+    }
+
+    @Test
+    fun `when properties are mapped, then values callbacks and ordered groups are preserved`() {
+        val callbackResults = mutableListOf<String>()
+        val properties = allPropertyVariants(onCallback = callbackResults::add)
+
+        val rows = mapper.map(
+            listOf(ProductPropertyCard(ProductPropertyCard.Type.SECONDARY, properties = properties))
+        ).single().rows
+
+        val group = rows.filterIsInstance<ProductDetailRowUiModel.PropertyGroup>().single()
+        assertThat(group.properties).containsExactly(
+            ProductDetailPropertyValueUiModel("First", "1"),
+            ProductDetailPropertyValueUiModel("Second", "2"),
+        )
+        val editable = rows.filterIsInstance<ProductDetailRowUiModel.Editable>().single()
+        assertThat(editable.shouldFocus).isTrue()
+        assertThat(editable.isReadOnly).isTrue()
+        editable.onTextChanged?.invoke("updated")
+        rows.filterIsInstance<ProductDetailRowUiModel.ComplexProperty>().single().onClick?.invoke()
+        rows.filterIsInstance<ProductDetailRowUiModel.Rating>().single().onClick?.invoke()
+        group.onClick?.invoke()
+        rows.filterIsInstance<ProductDetailRowUiModel.Link>().single().onClick?.invoke()
+        val button = rows.filterIsInstance<ProductDetailRowUiModel.Button>().single()
+        button.tooltip?.onDismiss?.invoke()
+        button.link?.onClick?.invoke()
+        rows.filterIsInstance<ProductDetailRowUiModel.Switch>().single().onStateChanged?.invoke(false)
+        button.onClick()
+
+        assertThat(callbackResults).containsExactly(
+            "updated",
+            "complex",
+            "rating",
+            "group",
+            "link",
+            "tooltip",
+            "buttonLink",
+            "switch",
+            "button",
+        )
+    }
+
+    @Test
+    fun `when mutable editable flags change after mapping, then mapped values remain a snapshot`() {
+        val editable = ProductProperty.Editable(
+            hint = R.string.product_detail_title_hint,
+            shouldFocus = true,
+            isReadOnly = true,
+        )
+
+        val mapped = mapper.map(
+            listOf(
+                ProductPropertyCard(
+                    ProductPropertyCard.Type.PRIMARY,
+                    properties = listOf(editable),
+                )
+            )
+        ).single().rows.single() as ProductDetailRowUiModel.Editable
+        editable.shouldFocus = false
+        editable.isReadOnly = false
+
+        assertThat(mapped.shouldFocus).isTrue()
+        assertThat(mapped.isReadOnly).isTrue()
+    }
+
+    @Test
+    fun `when rating position is mapped, then its legacy divider is hidden only at the end of a card`() {
+        val rating = ProductProperty.RatingBar(
+            title = R.string.product_reviews,
+            value = "4 reviews",
+            rating = 4.5f,
+            icon = R.drawable.ic_reviews,
+        )
+        val followedRating = mapper.map(
+            listOf(
+                ProductPropertyCard(
+                    ProductPropertyCard.Type.SECONDARY,
+                    properties = listOf(rating, ProductProperty.Warning("Warning")),
+                )
+            )
+        ).single().rows.first() as ProductDetailRowUiModel.Rating
+        val finalRating = mapper.map(
+            listOf(ProductPropertyCard(ProductPropertyCard.Type.SECONDARY, properties = listOf(rating)))
+        ).single().rows.single() as ProductDetailRowUiModel.Rating
+
+        assertThat(followedRating.showDivider).isTrue()
+        assertThat(finalRating.showDivider).isFalse()
+    }
+
+    @Test
+    fun `when semantic rows repeat, then keys are stable and unique without list indexes`() {
+        val properties = listOf(
+            ProductProperty.Property(R.string.product_price, "10"),
+            ProductProperty.Property(R.string.product_price, "20"),
+        )
+
+        val first = mapper.map(
+            listOf(ProductPropertyCard(ProductPropertyCard.Type.SECONDARY, properties = properties))
+        )
+        val second = mapper.map(
+            listOf(ProductPropertyCard(ProductPropertyCard.Type.SECONDARY, properties = properties))
+        )
+
+        assertThat(first.single().rows.map { it.key }).containsExactly(
+            "property_${R.string.product_price}",
+            "property_${R.string.product_price}_1",
+        )
+        assertThat(second.single().rows.map { it.key }).isEqualTo(first.single().rows.map { it.key })
+    }
+
+    @Test
+    fun `given Add is persisted, when cards are remapped, then semantic keys stay stable and callbacks are current`() {
+        var callback = ""
+        val initialCards = listOf(
+            ProductPropertyCard(
+                ProductPropertyCard.Type.PRIMARY,
+                properties = listOf(
+                    ProductProperty.Editable(
+                        hint = R.string.product_detail_title_hint,
+                        onTextChanged = { callback = "initial:$it" },
+                    )
+                ),
+            )
+        )
+        val persistedCards = listOf(
+            ProductPropertyCard(
+                ProductPropertyCard.Type.PRIMARY,
+                properties = listOf(
+                    ProductProperty.Editable(
+                        hint = R.string.product_detail_title_hint,
+                        onTextChanged = { callback = "persisted:$it" },
+                    )
+                ),
+            )
+        )
+
+        val initial = mapper.map(initialCards)
+        val persisted = mapper.map(persistedCards)
+        val editable = persisted.single().rows.single() as ProductDetailRowUiModel.Editable
+        editable.onTextChanged?.invoke("Title")
+
+        assertThat(persisted.map { it.key }).isEqualTo(initial.map { it.key })
+        assertThat(persisted.single().rows.map { it.key }).isEqualTo(initial.single().rows.map { it.key })
+        assertThat(callback).isEqualTo("persisted:Title")
+    }
+
+    private fun allPropertyVariants(
+        onCallback: (String) -> Unit = {},
+    ) = listOf(
+        ProductProperty.Divider,
+        ProductProperty.Property(R.string.product_price, "10"),
+        ProductProperty.ComplexProperty(
+            title = R.string.product_description,
+            value = "Description",
+            icon = R.drawable.ic_gridicons_product,
+            onClick = { onCallback("complex") },
+        ),
+        ProductProperty.RatingBar(
+            title = R.string.product_reviews,
+            value = "4 reviews",
+            rating = 4.5f,
+            icon = R.drawable.ic_reviews,
+            onClick = { onCallback("rating") },
+        ),
+        ProductProperty.Editable(
+            hint = R.string.product_detail_title_hint,
+            text = "Title",
+            shouldFocus = true,
+            isReadOnly = true,
+            badgeText = R.string.product_status_private,
+            badgeColor = R.color.product_status_badge_pending,
+            onTextChanged = onCallback,
+        ),
+        ProductProperty.PropertyGroup(
+            title = R.string.product_inventory,
+            properties = linkedMapOf("First" to "1", "Second" to "2"),
+            icon = R.drawable.ic_gridicons_list_checkmark,
+            isHighlighted = true,
+            onClick = { onCallback("group") },
+        ),
+        ProductProperty.Link(
+            title = R.string.product_detail_add_more,
+            icon = R.drawable.ic_add,
+            onClick = { onCallback("link") },
+        ),
+        ProductProperty.Button(
+            text = R.string.set_up_now,
+            icon = R.drawable.ic_add,
+            tooltip = ProductProperty.Button.Tooltip(
+                title = R.string.tip,
+                text = R.string.promo_linked_products_banner_message,
+                dismissButtonText = R.string.dismiss,
+                onDismiss = { onCallback("tooltip") },
+            ),
+            link = ProductProperty.Button.Link(R.string.learn_more) { onCallback("buttonLink") },
+            onClick = { onCallback("button") },
+        ),
+        ProductProperty.Switch(
+            title = R.string.product_reviews,
+            isOn = true,
+            icon = R.drawable.ic_reviews,
+            onStateChanged = { onCallback("switch") },
+        ),
+        ProductProperty.Warning("Warning"),
+    )
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModelTest.kt
@@ -397,6 +397,20 @@ class ProductDetailViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `given offline cache miss, when product loads, then None is emitted without a product`() = testBlocking {
+        doReturn(null).whenever(productRepository).getProductAggregate(PRODUCT_REMOTE_ID)
+        doReturn(false).whenever(networkStatus).isConnected()
+
+        viewModel.start()
+
+        verify(productRepository, times(1)).getProductAggregate(PRODUCT_REMOTE_ID)
+        verify(productRepository, never()).fetchAndGetProductAggregate(any())
+        Assertions.assertThat(viewModel.getProduct().productDraft).isNull()
+        Assertions.assertThat(viewModel.getProduct().auxiliaryState)
+            .isEqualTo(ProductDetailViewModel.ProductDetailViewState.AuxiliaryState.None)
+    }
+
+    @Test
     fun `Shows and hides product detail skeleton correctly`() = testBlocking {
         doReturn(null).whenever(productRepository).getProductAggregate(any())
         doReturn(productAggregate).whenever(productRepository).fetchAndGetProductAggregate(any())

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel_AddFlowTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel_AddFlowTest.kt
@@ -12,6 +12,7 @@ import com.woocommerce.android.model.ProductAggregate
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.blaze.IsBlazeEnabled
+import com.woocommerce.android.ui.customfields.CustomFieldsRepository
 import com.woocommerce.android.ui.media.MediaFileUploadHandler
 import com.woocommerce.android.ui.products.DuplicateProduct
 import com.woocommerce.android.ui.products.ParameterRepository
@@ -63,7 +64,9 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
 
     private val wooCommerceStore: WooCommerceStore = mock()
     private val networkStatus: NetworkStatus = mock()
-    private val productRepository: ProductDetailRepository = mock()
+    private val productRepository: ProductDetailRepository = mock {
+        on { getCachedVariationCount(any()) } doReturn 0
+    }
     private val productCategoriesRepository: ProductCategoriesRepository = mock()
     private val productTagsRepository: ProductTagsRepository = mock()
     private val mediaFilesRepository: MediaFilesRepository = mock()
@@ -87,6 +90,9 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
     }
     private val isBlazeEnabled: IsBlazeEnabled = mock {
         on { invoke() } doReturn false
+    }
+    private val customFieldsRepository: CustomFieldsRepository = mock {
+        on { hasDisplayableCustomFields(any()) } doReturn false
     }
     private var savedState: SavedStateHandle =
         ProductDetailFragmentArgs(
@@ -198,7 +204,7 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
                 isProductCurrentlyPromoted = mock(),
                 isWindowClassLargeThanCompact = mock(),
                 determineProductPasswordApi = mock(),
-                customFieldsRepository = mock(),
+                customFieldsRepository = customFieldsRepository,
                 canAutoAuthenticateInWebView = mock(),
             )
         )
@@ -420,6 +426,50 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
 
         verify(mediaFileUploadHandler).assignUploadsToCreatedProduct(PRODUCT_REMOTE_ID)
     }
+
+    @Test
+    fun `given an added product has a remote id, when reviews return, then refresh the persisted product`() = testBlocking {
+        doReturn(Pair(true, PRODUCT_REMOTE_ID)).whenever(productRepository).addProduct(any<ProductAggregate>())
+        doReturn(ProductAggregate(product)).whenever(productRepository).getProductAggregate(PRODUCT_REMOTE_ID)
+        doReturn(ProductAggregate(product)).whenever(productRepository).fetchAndGetProductAggregate(PRODUCT_REMOTE_ID)
+        viewModel.productDetailViewStateData.observeForever { _, _ -> }
+
+        viewModel.onSaveAsDraftButtonClicked()
+        clearInvocations(productRepository)
+        viewModel.refreshProduct()
+
+        verify(productRepository).fetchAndGetProductAggregate(PRODUCT_REMOTE_ID)
+    }
+
+    @Test
+    fun `given edited persisted Add state is process-restored, when backed out, then discard is protected`() =
+        testBlocking {
+            val storedAggregate = ProductAggregate(product)
+            val restoredDraft = storedAggregate.copy(product = product.copy(name = "Restored edit"))
+            savedState = ProductDetailFragmentArgs(
+                mode = ProductDetailFragment.Mode.AddNewProduct
+            ).toSavedStateHandle().apply {
+                set(
+                    ProductDetailViewModel.ProductDetailViewState::class.java.name,
+                    ProductDetailViewModel.ProductDetailViewState(
+                        productAggregateDraft = restoredDraft,
+                        auxiliaryState = ProductDetailViewModel.ProductDetailViewState.AuxiliaryState.None,
+                        areImagesAvailable = true,
+                    )
+                )
+            }
+            doReturn(storedAggregate).whenever(productRepository).getProductAggregate(PRODUCT_REMOTE_ID)
+            setup()
+
+            var hasChanges: Boolean? = null
+            viewModel.productDetailViewStateData.observeForever { _, _ -> }
+            viewModel.hasChanges.observeForever { hasChanges = it }
+
+            viewModel.onBackButtonClickedProductDetail()
+
+            Assertions.assertThat(hasChanges).isTrue()
+            Assertions.assertThat(viewModel.event.value).isInstanceOf(MultiLiveEvent.Event.ShowDialog::class.java)
+        }
 
     @Test
     fun `given a product is under creation, when displaying discard changes dialog, then stop observing uploads`() =

--- a/libs/store-design-system/src/debug/res/menu/woo_design_system_toolbar_test_menu.xml
+++ b/libs/store-design-system/src/debug/res/menu/woo_design_system_toolbar_test_menu.xml
@@ -8,4 +8,9 @@
         android:title="Open"
         tools:ignore="HardcodedText"
         app:showAsAction="always" />
+    <item
+        android:id="@+id/woo_ds_toolbar_test_overflow"
+        android:title="Settings"
+        tools:ignore="HardcodedText"
+        app:showAsAction="never" />
 </menu>

--- a/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooDesignSystemToolbar.kt
+++ b/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooDesignSystemToolbar.kt
@@ -25,6 +25,8 @@ import androidx.core.content.ContextCompat
 import androidx.core.view.children
 import com.google.android.material.appbar.MaterialToolbar
 import com.woocommerce.android.ui.compose.designsystem.R
+import kotlin.math.ceil
+import kotlin.math.roundToInt
 
 class WooDesignSystemToolbar @JvmOverloads constructor(
     context: Context,
@@ -50,7 +52,7 @@ class WooDesignSystemToolbar @JvmOverloads constructor(
         decorateNavigationButton()
         decorateRenderedMenuActions()
         super.onMeasure(widthMeasureSpec, heightMeasureSpec)
-        if (decorateNavigationButton() || decorateRenderedMenuActions()) {
+        if (decorateTitle() || decorateNavigationButton() || decorateRenderedMenuActions()) {
             super.onMeasure(widthMeasureSpec, heightMeasureSpec)
         }
     }
@@ -78,6 +80,14 @@ class WooDesignSystemToolbar @JvmOverloads constructor(
     private fun decorateNavigationButton(): Boolean {
         val navigationButton = children.filterIsInstance<AppCompatImageButton>().firstOrNull() ?: return false
         return navigationButton.applyOutlinedToolbarImageButtonStyle()
+    }
+
+    private fun decorateTitle(): Boolean {
+        val titleView = children.filterIsInstance<TextView>().firstOrNull { it.text == title } ?: return false
+        if (!titleView.includeFontPadding) return false
+
+        titleView.includeFontPadding = false
+        return true
     }
 
     private fun decorateRenderedMenuActions(): Boolean {
@@ -166,50 +176,72 @@ class WooDesignSystemToolbar @JvmOverloads constructor(
         this !is TextView || text.isNullOrEmpty()
 
     private fun applyToolbarControlEdgeInsets() {
-        val edgeInset = context.dimensionPixelSize(R.dimen.woo_ds_toolbar_edge_padding)
+        val controlEdgeInset = (
+            resources.getDimension(R.dimen.woo_ds_toolbar_edge_padding) -
+                resources.getDimension(R.dimen.woo_ds_toolbar_icon_border_inset)
+        ).roundToInt()
         val isRtl = layoutDirection == View.LAYOUT_DIRECTION_RTL
         val toolbarWidth = width
+        val toolbarHeight = height
 
         children.filterIsInstance<AppCompatImageButton>().firstOrNull()?.layoutWithStartInset(
-            edgeInset = edgeInset,
+            edgeInset = controlEdgeInset,
             toolbarWidth = toolbarWidth,
+            toolbarHeight = toolbarHeight,
             isRtl = isRtl,
         )
 
-        children.filterIsInstance<ActionMenuView>().firstOrNull()?.layoutWithEndInset(
-            edgeInset = edgeInset,
-            toolbarWidth = toolbarWidth,
-            isRtl = isRtl,
-        )
+        children.filterIsInstance<ActionMenuView>().firstOrNull()?.let { actionMenuView ->
+            actionMenuView.layoutWithEndInset(
+                edgeInset = controlEdgeInset,
+                toolbarWidth = toolbarWidth,
+                toolbarHeight = toolbarHeight,
+                isRtl = isRtl,
+            )
+            actionMenuView.centerOutlinedActionsVertically(toolbarHeight)
+        }
     }
 }
 
 private fun View.layoutWithStartInset(
     edgeInset: Int,
     toolbarWidth: Int,
+    toolbarHeight: Int,
     isRtl: Boolean,
 ) {
     val childWidth = measuredWidth
+    val childTop = ((toolbarHeight - measuredHeight) / 2f).roundToInt()
     val childLeft = if (isRtl) {
         toolbarWidth - edgeInset - childWidth
     } else {
         edgeInset
     }
-    layout(childLeft, top, childLeft + childWidth, bottom)
+    layout(childLeft, childTop, childLeft + childWidth, childTop + measuredHeight)
 }
 
 private fun View.layoutWithEndInset(
     edgeInset: Int,
     toolbarWidth: Int,
+    toolbarHeight: Int,
     isRtl: Boolean,
 ) {
     val childWidth = measuredWidth
+    val childTop = ((toolbarHeight - measuredHeight) / 2f).roundToInt()
     val childLeft = if (isRtl) {
         edgeInset
     } else {
         toolbarWidth - edgeInset - childWidth
     }
-    layout(childLeft, top, childLeft + childWidth, bottom)
+    layout(childLeft, childTop, childLeft + childWidth, childTop + measuredHeight)
+}
+
+private fun ActionMenuView.centerOutlinedActionsVertically(toolbarHeight: Int) {
+    children
+        .filter { child -> child.getTag(R.id.woo_ds_toolbar_action_view) == true }
+        .forEach { child ->
+            val childTop = ((toolbarHeight - child.measuredHeight) / 2f).roundToInt() - top
+            child.layout(child.left, childTop, child.left + child.measuredWidth, childTop + child.measuredHeight)
+        }
 }
 
 private fun View.applyToolbarIconTouchTarget(): Boolean {
@@ -302,20 +334,22 @@ private class CenteredToolbarIconButtonDrawable(
     icon: Drawable?,
     private val spec: CenteredToolbarIconButtonSpec,
 ) : Drawable() {
+    private val borderStrokeWidth = ceil(spec.strokeWidth)
     private val icon = icon?.newMutableDrawable()?.apply {
         setTintList(spec.iconTint)
     }
     private val paint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
         style = Paint.Style.STROKE
-        strokeWidth = spec.strokeWidth
+        strokeWidth = borderStrokeWidth
         color = spec.color
     }
     private val rect = RectF()
 
     override fun draw(canvas: Canvas) {
         centeredSquareIn(bounds, spec.boxSize, rect)
-        rect.inset(spec.strokeWidth / 2, spec.strokeWidth / 2)
-        canvas.drawRoundRect(rect, spec.cornerRadius, spec.cornerRadius, paint)
+        rect.inset(borderStrokeWidth / 2, borderStrokeWidth / 2)
+        val strokeCornerRadius = spec.cornerRadius - borderStrokeWidth / 2
+        canvas.drawRoundRect(rect, strokeCornerRadius, strokeCornerRadius, paint)
 
         icon?.let { drawable ->
             val iconLeft = bounds.left + (bounds.width() - spec.iconSize) / 2
@@ -390,8 +424,8 @@ private class CenteredToolbarIconButtonMaskDrawable(
 
 private fun centeredSquareIn(bounds: Rect, boxSize: Float, out: RectF) {
     val size = boxSize.coerceAtMost(bounds.width().toFloat()).coerceAtMost(bounds.height().toFloat())
-    val left = bounds.left + (bounds.width() - size) / 2
-    val top = bounds.top + (bounds.height() - size) / 2
+    val left = (bounds.left + (bounds.width() - size) / 2).roundToInt().toFloat()
+    val top = (bounds.top + (bounds.height() - size) / 2).roundToInt().toFloat()
     out.set(left, top, left + size, top + size)
 }
 

--- a/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooDesignSystemToolbar.kt
+++ b/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooDesignSystemToolbar.kt
@@ -179,7 +179,7 @@ class WooDesignSystemToolbar @JvmOverloads constructor(
         val controlEdgeInset = (
             resources.getDimension(R.dimen.woo_ds_toolbar_edge_padding) -
                 resources.getDimension(R.dimen.woo_ds_toolbar_icon_border_inset)
-        ).roundToInt()
+            ).roundToInt()
         val isRtl = layoutDirection == View.LAYOUT_DIRECTION_RTL
         val toolbarWidth = width
         val toolbarHeight = height

--- a/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooDesignSystemToolbar.kt
+++ b/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooDesignSystemToolbar.kt
@@ -77,17 +77,7 @@ class WooDesignSystemToolbar @JvmOverloads constructor(
 
     private fun decorateNavigationButton(): Boolean {
         val navigationButton = children.filterIsInstance<AppCompatImageButton>().firstOrNull() ?: return false
-        var changed = navigationButton.applyToolbarIconTouchTarget()
-        if (navigationButton.scaleType != ImageView.ScaleType.FIT_CENTER) {
-            navigationButton.scaleType = ImageView.ScaleType.FIT_CENTER
-            changed = true
-        }
-        if (navigationButton.getTag(R.id.woo_ds_toolbar_action_view) != true) {
-            navigationButton.background = context.toolbarIconButtonBackground(icon = null)
-            navigationButton.setTag(R.id.woo_ds_toolbar_action_view, true)
-            changed = true
-        }
-        return changed
+        return navigationButton.applyOutlinedToolbarImageButtonStyle()
     }
 
     private fun decorateRenderedMenuActions(): Boolean {
@@ -97,6 +87,12 @@ class WooDesignSystemToolbar @JvmOverloads constructor(
             .filterIsInstance<ActionMenuView>()
             .flatMap { actionMenuView -> actionMenuView.children.asIterable() }
             .forEach { child ->
+                val layoutParams = child.layoutParams as? ActionMenuView.LayoutParams
+                if (layoutParams?.isOverflowButton == true) {
+                    changed = child.applyOutlinedToolbarImageButtonStyle() || changed
+                    return@forEach
+                }
+
                 val item = menu.findItem(child.id) ?: return@forEach
                 if (item.actionView === child) {
                     return@forEach
@@ -108,6 +104,20 @@ class WooDesignSystemToolbar @JvmOverloads constructor(
                     child.clearOutlinedToolbarActionStyle(icon, iconSize) || changed
                 }
             }
+        return changed
+    }
+
+    private fun View.applyOutlinedToolbarImageButtonStyle(): Boolean {
+        var changed = applyToolbarIconTouchTarget()
+        if (this is ImageView && scaleType != ImageView.ScaleType.FIT_CENTER) {
+            scaleType = ImageView.ScaleType.FIT_CENTER
+            changed = true
+        }
+        if (getTag(R.id.woo_ds_toolbar_action_view) != true) {
+            background = context.toolbarIconButtonBackground(icon = null)
+            setTag(R.id.woo_ds_toolbar_action_view, true)
+            changed = true
+        }
         return changed
     }
 
@@ -215,11 +225,14 @@ private fun View.applyToolbarIconTouchTarget(): Boolean {
         minimumHeight = touchTarget
         changed = true
     }
-    if (layoutParams?.width != touchTarget || layoutParams?.height != touchTarget) {
-        layoutParams = (layoutParams ?: ViewGroup.LayoutParams(touchTarget, touchTarget)).apply {
-            width = touchTarget
-            height = touchTarget
-        }
+    val currentLayoutParams = layoutParams
+    if (currentLayoutParams == null) {
+        layoutParams = ViewGroup.LayoutParams(touchTarget, touchTarget)
+        changed = true
+    } else if (currentLayoutParams.width != touchTarget || currentLayoutParams.height != touchTarget) {
+        currentLayoutParams.width = touchTarget
+        currentLayoutParams.height = touchTarget
+        requestLayout()
         changed = true
     }
     if (!hasUniformPadding(iconPadding)) {

--- a/libs/store-design-system/src/main/res/values/dimens.xml
+++ b/libs/store-design-system/src/main/res/values/dimens.xml
@@ -9,6 +9,6 @@
     <dimen name="woo_ds_toolbar_icon_size">18dp</dimen>
     <dimen name="woo_ds_toolbar_icon_padding">15dp</dimen>
     <dimen name="woo_ds_toolbar_icon_border_inset">4dp</dimen>
-    <dimen name="woo_ds_toolbar_icon_border_width">0.5dp</dimen>
+    <dimen name="woo_ds_toolbar_icon_border_width">1dp</dimen>
     <dimen name="woo_ds_toolbar_icon_corner_radius">12dp</dimen>
 </resources>

--- a/libs/store-design-system/src/main/res/values/styles.xml
+++ b/libs/store-design-system/src/main/res/values/styles.xml
@@ -20,6 +20,7 @@
         <item name="toolbarStyle">@style/Widget.Woo.DesignSystem.Toolbar</item>
         <item name="toolbarNavigationButtonStyle">@style/Widget.Woo.DesignSystem.Toolbar.NavigationButton</item>
         <item name="actionButtonStyle">@style/Widget.Woo.DesignSystem.Toolbar.ActionButton</item>
+        <item name="actionOverflowButtonStyle">@style/Widget.Woo.DesignSystem.Toolbar.OverflowButton</item>
         <item name="actionMenuTextAppearance">@style/TextAppearance.Woo.DesignSystem.ToolbarTextAction</item>
         <item name="actionMenuTextColor">@color/woo_ds_toolbar_text_action_tint</item>
         <item name="colorControlNormal">@color/woo_ds_color_surface_on_default</item>
@@ -31,6 +32,12 @@
         <item name="android:minHeight">@dimen/woo_ds_toolbar_icon_touch_target</item>
         <item name="android:padding">@dimen/woo_ds_toolbar_icon_padding</item>
         <item name="android:scaleType">fitCenter</item>
+    </style>
+
+    <style name="Widget.Woo.DesignSystem.Toolbar.OverflowButton" parent="Widget.AppCompat.ActionButton.Overflow">
+        <!-- android:src must take precedence over AppCompat's inherited srcCompat overflow glyph. -->
+        <item name="android:src">@drawable/woo_ds_ic_regular_ellipsis_24dp</item>
+        <item name="tint">@color/woo_ds_toolbar_icon_button_tint</item>
     </style>
 
     <style name="Widget.Woo.DesignSystem.Toolbar.ActionButton" parent="Widget.AppCompat.ActionButton">

--- a/libs/store-design-system/src/test/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooDesignSystemToolbarTest.kt
+++ b/libs/store-design-system/src/test/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooDesignSystemToolbarTest.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.compose.designsystem.component
 
+import android.content.pm.ApplicationInfo
 import android.graphics.Rect
 import android.graphics.drawable.RippleDrawable
 import android.view.ContextThemeWrapper
@@ -16,12 +17,14 @@ import androidx.appcompat.widget.SearchView
 import androidx.core.content.ContextCompat
 import androidx.core.graphics.ColorUtils
 import androidx.core.view.children
+import androidx.core.widget.ImageViewCompat
 import androidx.test.core.app.ApplicationProvider
 import com.woocommerce.android.ui.compose.designsystem.R
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
 import kotlin.math.roundToInt
 
@@ -122,6 +125,91 @@ class WooDesignSystemToolbarTest {
     }
 
     @Test
+    fun `given overflow item, when menu is rendered, then overflow matches outlined icon contract`() {
+        val toolbar = LayoutInflater.from(toolbarContext())
+            .inflate(R.layout.woo_design_system_toolbar_test, null) as WooDesignSystemToolbar
+
+        toolbar.layoutToolbar()
+        val overflowButton = toolbar.overflowButton()
+        val touchTarget = toolbar.resources.getDimensionPixelSize(R.dimen.woo_ds_toolbar_icon_touch_target)
+        val iconPadding = toolbar.resources.getDimensionPixelSize(R.dimen.woo_ds_toolbar_icon_padding)
+        val overflowLayoutParams = overflowButton.layoutParams as ActionMenuView.LayoutParams
+        val expectedTint = checkNotNull(
+            AppCompatResources.getColorStateList(toolbar.context, R.color.woo_ds_toolbar_icon_button_tint),
+        )
+
+        assertThat(overflowLayoutParams.isOverflowButton).isTrue()
+        assertThat(overflowLayoutParams.width).isEqualTo(touchTarget)
+        assertThat(overflowLayoutParams.height).isEqualTo(touchTarget)
+        assertThat(overflowButton.measuredWidth).isEqualTo(touchTarget)
+        assertThat(overflowButton.measuredHeight).isEqualTo(touchTarget)
+        assertThat(overflowButton.minimumWidth).isEqualTo(touchTarget)
+        assertThat(overflowButton.minimumHeight).isEqualTo(touchTarget)
+        assertThat(overflowButton.paddingLeft).isEqualTo(iconPadding)
+        assertThat(overflowButton.paddingTop).isEqualTo(iconPadding)
+        assertThat(overflowButton.paddingRight).isEqualTo(iconPadding)
+        assertThat(overflowButton.paddingBottom).isEqualTo(iconPadding)
+        assertThat(overflowButton.scaleType).isEqualTo(ImageView.ScaleType.FIT_CENTER)
+        assertThat(overflowButton.background).isInstanceOf(RippleDrawable::class.java)
+        assertThat(overflowButton.getTag(R.id.woo_ds_toolbar_action_view)).isEqualTo(true)
+        assertThat(shadowOf(overflowButton.drawable).createdFromResId)
+            .isEqualTo(R.drawable.woo_ds_ic_regular_ellipsis_24dp)
+        assertThat(ImageViewCompat.getImageTintList(overflowButton)).isEqualTo(expectedTint)
+        assertThat(overflowButton.contentDescription)
+            .isEqualTo(toolbar.context.getString(androidx.appcompat.R.string.abc_action_menu_overflow_description))
+        assertThat(overflowButton.isClickable).isTrue()
+        assertThat(overflowButton.isFocusable).isTrue()
+    }
+
+    @Test
+    fun `given decorated overflow, when laid out again, then background and overflow layout params are reused`() {
+        val toolbar = LayoutInflater.from(toolbarContext())
+            .inflate(R.layout.woo_design_system_toolbar_test, null) as WooDesignSystemToolbar
+
+        toolbar.layoutToolbar()
+        val firstOverflowButton = toolbar.overflowButton()
+        val firstBackground = firstOverflowButton.background
+        val firstLayoutParams = firstOverflowButton.layoutParams
+
+        toolbar.layoutToolbar()
+        val secondOverflowButton = toolbar.overflowButton()
+
+        assertThat(secondOverflowButton).isSameAs(firstOverflowButton)
+        assertThat(secondOverflowButton.background).isSameAs(firstBackground)
+        assertThat(secondOverflowButton.layoutParams).isSameAs(firstLayoutParams)
+        assertThat((secondOverflowButton.layoutParams as ActionMenuView.LayoutParams).isOverflowButton).isTrue()
+    }
+
+    @Test
+    fun `given decorated overflow, when menu is cleared and reinflated, then overflow remains styled`() {
+        val toolbar = WooDesignSystemToolbar(toolbarContext())
+        toolbar.inflateMenu(R.menu.woo_design_system_toolbar_test_menu)
+        toolbar.layoutToolbar()
+        val overflowButton = toolbar.overflowButton()
+        val overflowBackground = overflowButton.background
+        val touchTarget = toolbar.resources.getDimensionPixelSize(R.dimen.woo_ds_toolbar_icon_touch_target)
+
+        toolbar.menu.clear()
+        toolbar.inflateMenu(R.menu.woo_design_system_toolbar_test_menu)
+        val overflowLayoutParams = overflowButton.layoutParams as ActionMenuView.LayoutParams
+        overflowLayoutParams.width = ViewGroup.LayoutParams.WRAP_CONTENT
+        overflowLayoutParams.height = ViewGroup.LayoutParams.MATCH_PARENT
+        toolbar.layoutToolbar()
+        val redecoratedOverflowButton = toolbar.overflowButton()
+
+        assertThat(redecoratedOverflowButton).isSameAs(overflowButton)
+        assertThat(redecoratedOverflowButton.layoutParams).isSameAs(overflowLayoutParams)
+        assertThat(overflowLayoutParams.width).isEqualTo(touchTarget)
+        assertThat(overflowLayoutParams.height).isEqualTo(touchTarget)
+        assertThat(overflowButton.background).isInstanceOf(RippleDrawable::class.java)
+        assertThat(overflowButton.background).isSameAs(overflowBackground)
+        assertThat(overflowButton.getTag(R.id.woo_ds_toolbar_action_view)).isEqualTo(true)
+        assertThat(shadowOf(overflowButton.drawable).createdFromResId)
+            .isEqualTo(R.drawable.woo_ds_ic_regular_ellipsis_24dp)
+        assertThat(overflowLayoutParams.isOverflowButton).isTrue()
+    }
+
+    @Test
     @Config(qualifiers = "notnight")
     fun `given light theme, when icon controls are rendered, then ripple matches compose pressed state`() {
         assertToolbarIconRippleColor()
@@ -131,6 +219,33 @@ class WooDesignSystemToolbarTest {
     @Config(qualifiers = "night")
     fun `given dark theme, when icon controls are rendered, then ripple matches compose pressed state`() {
         assertToolbarIconRippleColor()
+    }
+
+    @Test
+    @Config(qualifiers = "ldrtl")
+    fun `given rtl layout with overflow, when laid out, then actions honor the logical end inset`() {
+        val toolbar = WooDesignSystemToolbar(toolbarContext()).apply {
+            addOverflowAction()
+        }
+        val edgeInset = toolbar.resources.getDimensionPixelSize(R.dimen.woo_ds_toolbar_edge_padding)
+        val applicationInfo = toolbar.context.applicationInfo
+        val originalApplicationFlags = applicationInfo.flags
+
+        try {
+            applicationInfo.flags = applicationInfo.flags or ApplicationInfo.FLAG_SUPPORTS_RTL
+            toolbar.measure(
+                exactMeasureSpec(toolbar.dp(360)),
+                exactMeasureSpec(toolbar.resources.getDimensionPixelSize(R.dimen.woo_ds_toolbar_height)),
+            )
+            toolbar.layoutDirection = View.LAYOUT_DIRECTION_RTL
+            toolbar.layout(0, 0, toolbar.measuredWidth, toolbar.measuredHeight)
+
+            assertThat(toolbar.layoutDirection).isEqualTo(View.LAYOUT_DIRECTION_RTL)
+            assertThat(toolbar.actionMenuView().left).isEqualTo(edgeInset)
+            assertThat((toolbar.overflowButton().layoutParams as ActionMenuView.LayoutParams).isOverflowButton).isTrue()
+        } finally {
+            applicationInfo.flags = originalApplicationFlags
+        }
     }
 
     @Test
@@ -315,6 +430,11 @@ class WooDesignSystemToolbarTest {
         setShowAsAction(showAsAction)
     }
 
+    private fun WooDesignSystemToolbar.addOverflowAction(): MenuItem =
+        menu.add(0, OVERFLOW_ACTION_ID, 0, "Settings").apply {
+            setShowAsAction(MenuItem.SHOW_AS_ACTION_NEVER)
+        }
+
     private fun WooDesignSystemToolbar.layoutToolbar(widthDp: Int = 360) {
         measure(
             exactMeasureSpec(dp(widthDp)),
@@ -336,6 +456,13 @@ class WooDesignSystemToolbarTest {
     private fun WooDesignSystemToolbar.actionMenuView(): ActionMenuView =
         children.filterIsInstance<ActionMenuView>().first()
 
+    private fun WooDesignSystemToolbar.overflowButton(): ImageView =
+        actionMenuView()
+            .children
+            .first { child ->
+                (child.layoutParams as? ActionMenuView.LayoutParams)?.isOverflowButton == true
+            } as ImageView
+
     private fun WooDesignSystemToolbar.navigationButton(contentDescription: String): AppCompatImageButton =
         children
             .filterIsInstance<AppCompatImageButton>()
@@ -352,6 +479,7 @@ class WooDesignSystemToolbarTest {
         )
         toolbar.navigationContentDescription = "Back"
         toolbar.addIconAction()
+        toolbar.addOverflowAction()
 
         toolbar.layoutToolbar()
         val expectedColor = ColorUtils.setAlphaComponent(
@@ -369,6 +497,9 @@ class WooDesignSystemToolbarTest {
         assertThat(rippleColor.defaultColor).isEqualTo(expectedColor)
         assertThat(toolbar.navigationButton("Back").background).isInstanceOf(RippleDrawable::class.java)
         assertThat(toolbar.actionChild(ACTION_ID).background).isInstanceOf(RippleDrawable::class.java)
+        assertThat(toolbar.overflowButton().background).isInstanceOf(RippleDrawable::class.java)
+        assertThat(ImageViewCompat.getImageTintList(toolbar.overflowButton())?.defaultColor)
+            .isEqualTo(ContextCompat.getColor(toolbar.context, R.color.woo_ds_color_surface_on_default))
         assertThat(resourceBackground).isInstanceOf(RippleDrawable::class.java)
     }
 
@@ -382,6 +513,7 @@ class WooDesignSystemToolbarTest {
         const val ACTION_ID = 1
         const val TEXT_ACTION_ID = 2
         const val SEARCH_ACTION_ID = 3
+        const val OVERFLOW_ACTION_ID = 4
         const val FULL_COLOR_ALPHA = 255
         const val PRESSED_STATE_ALPHA = 0.1f
     }

--- a/libs/store-design-system/src/test/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooDesignSystemToolbarTest.kt
+++ b/libs/store-design-system/src/test/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooDesignSystemToolbarTest.kt
@@ -58,7 +58,7 @@ class WooDesignSystemToolbarTest {
         val controlEdgeInset = (
             toolbar.resources.getDimension(R.dimen.woo_ds_toolbar_edge_padding) -
                 toolbar.resources.getDimension(R.dimen.woo_ds_toolbar_icon_border_inset)
-        ).roundToInt()
+            ).roundToInt()
         toolbar.navigationIcon = AppCompatResources.getDrawable(
             toolbar.context,
             R.drawable.woo_ds_ic_regular_angle_left_24dp,
@@ -242,7 +242,7 @@ class WooDesignSystemToolbarTest {
         val controlEdgeInset = (
             toolbar.resources.getDimension(R.dimen.woo_ds_toolbar_edge_padding) -
                 toolbar.resources.getDimension(R.dimen.woo_ds_toolbar_icon_border_inset)
-        ).roundToInt()
+            ).roundToInt()
         val applicationInfo = toolbar.context.applicationInfo
         val originalApplicationFlags = applicationInfo.flags
 

--- a/libs/store-design-system/src/test/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooDesignSystemToolbarTest.kt
+++ b/libs/store-design-system/src/test/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooDesignSystemToolbarTest.kt
@@ -52,9 +52,13 @@ class WooDesignSystemToolbarTest {
     }
 
     @Test
+    @Config(qualifiers = "420dpi")
     fun `given navigation and actions, when laid out, then controls honor edge insets`() {
         val toolbar = WooDesignSystemToolbar(toolbarContext())
-        val edgeInset = toolbar.resources.getDimensionPixelSize(R.dimen.woo_ds_toolbar_edge_padding)
+        val controlEdgeInset = (
+            toolbar.resources.getDimension(R.dimen.woo_ds_toolbar_edge_padding) -
+                toolbar.resources.getDimension(R.dimen.woo_ds_toolbar_icon_border_inset)
+        ).roundToInt()
         toolbar.navigationIcon = AppCompatResources.getDrawable(
             toolbar.context,
             R.drawable.woo_ds_ic_regular_angle_left_24dp,
@@ -65,9 +69,16 @@ class WooDesignSystemToolbarTest {
         toolbar.layoutToolbar()
         val navigationButton = toolbar.navigationButton("Back")
         val actionMenuView = toolbar.actionMenuView()
+        val action = toolbar.actionChild(ACTION_ID)
 
-        assertThat(navigationButton.left).isEqualTo(edgeInset)
-        assertThat(actionMenuView.right).isEqualTo(toolbar.width - edgeInset)
+        assertThat(navigationButton.left).isEqualTo(controlEdgeInset)
+        assertThat(actionMenuView.right).isEqualTo(toolbar.width - controlEdgeInset)
+        assertThat(navigationButton.top)
+            .isEqualTo(((toolbar.height - navigationButton.height) / 2f).roundToInt())
+        assertThat(actionMenuView.top)
+            .isEqualTo(((toolbar.height - actionMenuView.height) / 2f).roundToInt())
+        assertThat(actionMenuView.top + action.top)
+            .isEqualTo(((toolbar.height - action.height) / 2f).roundToInt())
     }
 
     @Test
@@ -80,6 +91,7 @@ class WooDesignSystemToolbarTest {
         val titleView = toolbar.titleTextView("Products")
         assertThat(titleView.width).isGreaterThan(0)
         assertThat(titleView.visibility).isEqualTo(View.VISIBLE)
+        assertThat(titleView.includeFontPadding).isFalse()
     }
 
     @Test
@@ -227,7 +239,10 @@ class WooDesignSystemToolbarTest {
         val toolbar = WooDesignSystemToolbar(toolbarContext()).apply {
             addOverflowAction()
         }
-        val edgeInset = toolbar.resources.getDimensionPixelSize(R.dimen.woo_ds_toolbar_edge_padding)
+        val controlEdgeInset = (
+            toolbar.resources.getDimension(R.dimen.woo_ds_toolbar_edge_padding) -
+                toolbar.resources.getDimension(R.dimen.woo_ds_toolbar_icon_border_inset)
+        ).roundToInt()
         val applicationInfo = toolbar.context.applicationInfo
         val originalApplicationFlags = applicationInfo.flags
 
@@ -241,7 +256,7 @@ class WooDesignSystemToolbarTest {
             toolbar.layout(0, 0, toolbar.measuredWidth, toolbar.measuredHeight)
 
             assertThat(toolbar.layoutDirection).isEqualTo(View.LAYOUT_DIRECTION_RTL)
-            assertThat(toolbar.actionMenuView().left).isEqualTo(edgeInset)
+            assertThat(toolbar.actionMenuView().left).isEqualTo(controlEdgeInset)
             assertThat((toolbar.overflowButton().layoutParams as ActionMenuView.LayoutParams).isOverflowButton).isTrue()
         } finally {
             applicationInfo.flags = originalApplicationFlags


### PR DESCRIPTION
### Description

Part 1 of 3. Followed by #16394 and #16395.

Part of WOOMOB-3739 — does not close the ticket.

This is part 1 of 3 in the Product Detail Compose migration stack. It adds the prerequisites without changing the production Product Detail rendering route:

- aligns the shared View-hosted design-system toolbar with the Compose app bar contract, including title metrics, control placement, outlined buttons, and overflow styling;
- preserves persisted Add Product state across restoration and review refreshes; and
- maps legacy Product Detail cards into immutable UI models with stable keys and current callbacks.

The toolbar bridge is reusable by later View-hosted screen migrations. Product-specific Share behavior remains in the final cutover PR.

### Test Steps

1. Compare the Compose and XML toolbars in the light image below; verify their height, centered title, control spacing, outlined button geometry, and overflow icon match.
2. Repeat the comparison in the dark image and verify the colors and contrast match.
3. Create and save a product draft, recreate Product Detail after making another edit, and press Back; confirm the restored edit is retained and the discard-changes dialog appears.

### Images/gif

| Light | Dark |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/ae483d7e-8019-4f74-9448-95507fc20e46" width="400" alt="Light Compose and XML toolbar comparison" /> | <img src="https://github.com/user-attachments/assets/9f59272e-7f3e-4765-9dac-056578dcce99" width="400" alt="Dark Compose and XML toolbar comparison" /> |

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
