### PR TITLE
[WOOMOB-3799] Verify cookie authentication endpoints before sending credentials (1/3)

### DIFF
--- a/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/NonceRestClientTest.kt
+++ b/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/NonceRestClientTest.kt
@@ -381,6 +381,20 @@ class NonceRestClientTest {
     }
 
     @Test
+    fun `given WPS reaches admin base without trailing slash, when requesting a nonce, then reuse it`() = test {
+        val dashboardUrl = "$SITE_ORIGIN/wp-admin"
+        givenGet(DEFAULT_LOGIN_URL, redirect(dashboardUrl))
+        givenGet(dashboardUrl, WPAPIResponse.Success(ADMIN_DASHBOARD, emptyList()))
+        givenNonce(DEFAULT_NONCE_URL)
+
+        val actual = subject.requestNonce(SITE_ORIGIN, USERNAME, PASSWORD)
+
+        assertIs<Nonce.Available>(actual)
+        verifyNoCredentialPost()
+        verify(requestBuilder).syncGetRequest(subject, DEFAULT_NONCE_URL)
+    }
+
+    @Test
     fun `given preflight reaches an unexpected dashboard URL, when requesting a nonce, then reject it`() = test {
         givenGet(DEFAULT_LOGIN_URL, redirect(CUSTOM_ADMIN_URL))
         givenGet(CUSTOM_ADMIN_URL, WPAPIResponse.Success(ADMIN_DASHBOARD, emptyList()))
@@ -720,7 +734,7 @@ class NonceRestClientTest {
             "<html><body class=\"wp-admin wp-core-ui index-php\">" +
                 "<div id=\"dashboard-widgets-wrap\"></div></body></html>"
         val MANUAL_ADMIN_ENDPOINTS = CookieNonceAuthenticationEndpoints(
-            canonicalSiteOrigin = SITE_ORIGIN,
+            siteUrl = SITE_ORIGIN,
             adminBaseUrl = CUSTOM_ADMIN_URL,
             adminBaseVerification = AdminBaseVerification.AUTHENTICATED_DASHBOARD
         )

--- a/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/NonceRestClientTest.kt
+++ b/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/NonceRestClientTest.kt
@@ -1,330 +1,683 @@
 package org.wordpress.android.fluxc.network.rest.wpapi
 
+import com.android.volley.Header
 import com.android.volley.NetworkResponse
 import com.android.volley.NoConnectionError
 import com.android.volley.RequestQueue
 import com.android.volley.VolleyError
-import junit.framework.TestCase
 import org.junit.Before
 import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.Dispatcher
-import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
 import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.rest.wpapi.CookieNonceAuthenticationEndpoints.AdminBaseVerification
 import org.wordpress.android.fluxc.test
 import org.wordpress.android.fluxc.utils.CurrentTimeProvider
 import java.util.Date
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertNull
 
 class NonceRestClientTest {
-    private val wpApiEncodedRequestBuilder: WPAPIEncodedBodyRequestBuilder = mock()
+    private val requestBuilder: WPAPIEncodedBodyRequestBuilder = mock()
     private val currentTimeProvider: CurrentTimeProvider = mock()
-    private val dispatcher: Dispatcher = mock()
-    private val requestQueue: RequestQueue = mock()
-    private val userAgent: UserAgent = mock()
-
     private lateinit var subject: NonceRestClient
-    private val time = 123456L
-
-    private val site = SiteModel().apply {
-        url = "asiteurl.com"
-        username = "a_username"
-        password = "a_password"
-    }
-    private val nonceRequestUrl = "${site.url}/wp-admin/admin-ajax.php?action=rest-nonce"
 
     @Before
     fun setUp() {
-        subject = NonceRestClient(wpApiEncodedRequestBuilder, currentTimeProvider, dispatcher, requestQueue, userAgent)
-        whenever(currentTimeProvider.currentDate()).thenReturn(Date(time))
-    }
-
-    @Test
-    fun `successful nonce request`() = test {
-        val redirectResponse = WPAPIResponse.Error<String>(
-            WPAPINetworkError(
-                BaseNetworkError(
-                    VolleyError(
-                        NetworkResponse(
-                            301,
-                            byteArrayOf(),
-                            false,
-                            System.currentTimeMillis(),
-                            listOf(com.android.volley.Header("Location", nonceRequestUrl))
-                        )
-                    )
-                ),
-                null
-            )
+        subject = NonceRestClient(
+            requestBuilder,
+            currentTimeProvider,
+            mock<Dispatcher>(),
+            mock<RequestQueue>(),
+            mock<UserAgent>()
         )
-        val expectedNonce = "1expectedNONCE"
-        givenLoginResponse(redirectResponse)
-        givenNonceRequestResponse(WPAPIResponse.Success(expectedNonce, emptyList()))
-
-        val actual = subject.requestNonce(site)
-
-        TestCase.assertEquals(Nonce.Available(expectedNonce, site.username), actual)
+        whenever(currentTimeProvider.currentDate()).thenReturn(Date(RESPONSE_TIME))
     }
 
     @Test
-    fun `invalid credentials returns correct error message`() = test {
-        @Suppress("MaxLineLength")
-        val loginResponse = WPAPIResponse.Success(
+    fun `given core login markup, when requesting a nonce, then authenticate and cache`() = test {
+        givenLoginForm(DEFAULT_LOGIN_URL)
+        givenCredentialRedirect(DEFAULT_LOGIN_URL, DEFAULT_NONCE_URL, DEFAULT_NONCE_URL)
+        givenNonce(DEFAULT_NONCE_URL)
+
+        val actual = subject.requestNonce("$SITE_ORIGIN/", USERNAME, PASSWORD)
+
+        assertEquals(Nonce.Available(EXPECTED_NONCE, USERNAME), actual)
+        assertEquals(actual, subject.getNonce(SITE_ORIGIN, USERNAME))
+        listOf(
+            "username" to (SITE_ORIGIN to "other-user"),
+            "subdirectory" to ("$SITE_HOST/other-store" to USERNAME),
+            "scheme" to ("http://site.example/store" to USERNAME),
+            "host" to ("https://other.example/store" to USERNAME),
+            "effective port" to ("https://site.example:8443/store" to USERNAME)
+        ).forEach { (label, identity) ->
+            assertNull(subject.getNonce(identity.first, identity.second), label)
+        }
+        verifyCredentialPost(DEFAULT_LOGIN_URL, DEFAULT_NONCE_URL)
+    }
+
+    @Test
+    fun `given a custom login endpoint, when requesting a nonce, then post only to its verified form`() = test {
+        givenLoginForm(CUSTOM_LOGIN_URL)
+        givenCredentialRedirect(CUSTOM_LOGIN_URL, DEFAULT_NONCE_URL, DEFAULT_NONCE_URL)
+        givenNonce(DEFAULT_NONCE_URL)
+
+        val actual = subject.requestNonce(
+            CookieNonceAuthenticationEndpoints(SITE_ORIGIN, loginEntryUrl = CUSTOM_LOGIN_URL),
+            USERNAME,
+            PASSWORD
+        )
+
+        assertIs<Nonce.Available>(actual)
+        verifyCredentialPost(CUSTOM_LOGIN_URL, DEFAULT_NONCE_URL)
+    }
+
+    @Test
+    fun `given login fields in separate forms, when preflighting, then never post credentials`() = test {
+        givenLoginForm(
+            CUSTOM_LOGIN_URL,
             """
-            <html>
-              <script>${NonceRestClient.INVALID_CREDENTIAL_HTML_PATTERN}</script>
-              <head>
-                    <div id="login_error">
-                        <strong>Error:</strong> The password you entered for the username <strong>demo</strong> is incorrect. <a href="link/">Lost your password?</a><br>
-                    </div>
-              </head>
-            </html>
-        """.trimIndent(), emptyList()
+            <form name="loginform" id="loginform" method="post">
+                <input type="text" name="log" id="user_login">
+            </form>
+            <form name="loginform" id="loginform" method="post">
+                <input type="password" name="pwd" id="user_pass">
+            </form>
+            """.trimIndent()
         )
-        givenLoginResponse(loginResponse)
 
-        val actual = subject.requestNonce(site)
+        val actual = subject.requestNonce(
+            CookieNonceAuthenticationEndpoints(SITE_ORIGIN, loginEntryUrl = CUSTOM_LOGIN_URL),
+            USERNAME,
+            PASSWORD
+        )
 
-        assertIs<Nonce.FailedRequest>(actual)
-        assertEquals(Nonce.CookieNonceErrorType.INVALID_CREDENTIALS, actual.type)
-        assertEquals("Error: The password you entered for the username demo is incorrect.", actual.errorMessage)
+        assertFailed(Nonce.CookieNonceErrorType.INVALID_RESPONSE, actual, "split forms")
+        verifyNoCredentialPost()
     }
 
     @Test
-    fun `when error message mentions captcha, treat error as invalid response`() = test {
-        @Suppress("MaxLineLength")
-        val loginResponse = WPAPIResponse.Success(
+    fun `given a dashboard contains decoy login fields, when preflighting, then never post credentials`() = test {
+        val dashboardWithDecoyForm = ADMIN_DASHBOARD.replace(
+            "</body>",
+            "${loginForm()}</body>"
+        )
+        givenGet(CUSTOM_LOGIN_URL, WPAPIResponse.Success(dashboardWithDecoyForm, emptyList()))
+
+        val actual = subject.requestNonce(
+            CookieNonceAuthenticationEndpoints(SITE_ORIGIN, loginEntryUrl = CUSTOM_LOGIN_URL),
+            USERNAME,
+            PASSWORD
+        )
+
+        assertFailed(Nonce.CookieNonceErrorType.CUSTOM_ADMIN_URL, actual, "dashboard decoy")
+        verifyNoCredentialPost()
+    }
+
+    @Test
+    fun `given an inert template contains decoy login fields, when preflighting, then never post credentials`() = test {
+        givenLoginForm(
+            CUSTOM_LOGIN_URL,
+            "<template>${loginForm("action=\"https://attacker.example/login\"")}</template>"
+        )
+
+        val actual = subject.requestNonce(
+            CookieNonceAuthenticationEndpoints(SITE_ORIGIN, loginEntryUrl = CUSTOM_LOGIN_URL),
+            USERNAME,
+            PASSWORD
+        )
+
+        assertFailed(Nonce.CookieNonceErrorType.INVALID_RESPONSE, actual, "template decoy")
+        verifyNoCredentialPost()
+    }
+
+    @Test
+    fun `given comment and script decoys, when preflighting, then only a rendered login form is used`() = test {
+        val decoys = "<!-- ${loginForm()} --><script>const decoy = `${loginForm()}`;</script>"
+        givenLoginForm(CUSTOM_LOGIN_URL, decoys)
+
+        val decoyOnly = subject.requestNonce(
+            CookieNonceAuthenticationEndpoints(SITE_ORIGIN, loginEntryUrl = CUSTOM_LOGIN_URL),
+            USERNAME,
+            PASSWORD
+        )
+
+        assertFailed(Nonce.CookieNonceErrorType.INVALID_RESPONSE, decoyOnly, "decoy only")
+        verifyNoCredentialPost()
+
+        val submissionUrl = "$SITE_ORIGIN/authenticate"
+        givenLoginForm(CUSTOM_LOGIN_URL, decoys + loginForm("action=\"$submissionUrl\""))
+        givenCredentialRedirect(submissionUrl, DEFAULT_NONCE_URL, DEFAULT_NONCE_URL)
+        givenNonce(DEFAULT_NONCE_URL)
+
+        assertIs<Nonce.Available>(subject.requestNonce(
+            CookieNonceAuthenticationEndpoints(SITE_ORIGIN, loginEntryUrl = CUSTOM_LOGIN_URL),
+            USERNAME,
+            PASSWORD
+        ))
+        verifyCredentialPost(submissionUrl, DEFAULT_NONCE_URL)
+    }
+
+    @Test
+    fun `given two credential forms, when preflighting, then never post credentials`() = test {
+        givenLoginForm(CUSTOM_LOGIN_URL, loginForm() + loginForm("action=\"$SITE_ORIGIN/authenticate\""))
+
+        val actual = subject.requestNonce(
+            CookieNonceAuthenticationEndpoints(SITE_ORIGIN, loginEntryUrl = CUSTOM_LOGIN_URL),
+            USERNAME,
+            PASSWORD
+        )
+
+        assertFailed(Nonce.CookieNonceErrorType.INVALID_RESPONSE, actual, "ambiguous forms")
+        verifyNoCredentialPost()
+    }
+
+    @Test
+    fun `given hidden credential decoys in a core form, when preflighting, then never post credentials`() = test {
+        givenLoginForm(
+            CUSTOM_LOGIN_URL,
             """
-            <html>
-              <script>${NonceRestClient.INVALID_CREDENTIAL_HTML_PATTERN}</script>
-              <head>
-                    <div id="login_error">Please enter the captcha to continue</div>
-              </head>
-            </html>
-        """.trimIndent(), emptyList()
+            <form name="loginform" id="loginform" method="post">
+                <input type="hidden" name="log" id="user_login">
+                <input type="hidden" name="pwd" id="user_pass">
+            </form>
+            """.trimIndent()
         )
-        givenLoginResponse(loginResponse)
 
-        val actual = subject.requestNonce(site)
+        val actual = subject.requestNonce(
+            CookieNonceAuthenticationEndpoints(SITE_ORIGIN, loginEntryUrl = CUSTOM_LOGIN_URL),
+            USERNAME,
+            PASSWORD
+        )
 
-        assertIs<Nonce.FailedRequest>(actual)
-        assertEquals(Nonce.CookieNonceErrorType.INVALID_RESPONSE, actual.type)
-        assertEquals("Please enter the captcha to continue", actual.errorMessage)
+        assertFailed(Nonce.CookieNonceErrorType.INVALID_RESPONSE, actual, "hidden credential decoys")
+        verifyNoCredentialPost()
     }
 
     @Test
-    fun `invalid nonce of '0' returns FailedRequest`() = test {
-        val redirectUrl = "${site.url}/wp-admin/admin-ajax.php?action=rest-nonce"
+    fun `given duplicate enabled core username fields, when preflighting, then never post credentials`() = test {
+        givenLoginForm(
+            CUSTOM_LOGIN_URL,
+            """
+            <form name="loginform" id="loginform" method="post">
+                <input type="text" name="log" id="user_login">
+                <input type="text" name="log" id="user_login">
+                <input type="password" name="pwd" id="user_pass">
+            </form>
+            """.trimIndent()
+        )
 
-        val redirectResponse = WPAPIResponse.Error<String>(
-            WPAPINetworkError(
-                BaseNetworkError(
-                    VolleyError(
-                        NetworkResponse(
-                            301,
-                            byteArrayOf(),
-                            false,
-                            System.currentTimeMillis(),
-                            listOf(com.android.volley.Header("Location", redirectUrl))
-                        )
-                    )
-                ),
-                null
+        val actual = subject.requestNonce(
+            CookieNonceAuthenticationEndpoints(SITE_ORIGIN, loginEntryUrl = CUSTOM_LOGIN_URL),
+            USERNAME,
+            PASSWORD
+        )
+
+        assertFailed(Nonce.CookieNonceErrorType.INVALID_RESPONSE, actual, "duplicate username fields")
+        verifyNoCredentialPost()
+    }
+
+    @Test
+    fun `given WPS Hide Login core markup, when authenticating, then use login action`() = test {
+        val submissionUrl = "$SITE_ORIGIN/hidden-login/?provider=wps"
+        givenLoginForm(
+            CUSTOM_LOGIN_URL,
+            """
+            <form role="search" method="get" action="/"><input type="search" name="s"></form>
+            <form name="loginform" id="loginform" action="/store/hidden-login/?provider=wps" method="post">
+                <p><input type="text" name="log" id="user_login" autocomplete="username" required></p>
+                <p><input type='password' name='pwd' id='user_pass' autocomplete='current-password' required /></p>
+                <input type="hidden" name="redirect_to" value="/wp-admin/">
+            </form>
+            """.trimIndent()
+        )
+        givenCredentialRedirect(submissionUrl, DEFAULT_NONCE_URL, DEFAULT_NONCE_URL)
+        givenNonce(DEFAULT_NONCE_URL)
+
+        val actual = subject.requestNonce(
+            CookieNonceAuthenticationEndpoints(SITE_ORIGIN, loginEntryUrl = CUSTOM_LOGIN_URL),
+            USERNAME,
+            PASSWORD
+        )
+
+        assertIs<Nonce.Available>(actual)
+        verifyCredentialPost(submissionUrl, DEFAULT_NONCE_URL)
+    }
+
+    @Test
+    fun `given a safe relative form action, when authenticating, then post to its decoded exact target`() = test {
+        val submissionUrl = "$SITE_ORIGIN/session?mode=login&source=app"
+        givenLoginForm(
+            CUSTOM_LOGIN_URL,
+            loginForm("action=\"/store/session?mode=login&amp;source=app\"")
+        )
+        givenCredentialRedirect(submissionUrl, DEFAULT_NONCE_URL, DEFAULT_NONCE_URL)
+        givenNonce(DEFAULT_NONCE_URL)
+
+        val actual = subject.requestNonce(
+            CookieNonceAuthenticationEndpoints(SITE_ORIGIN, loginEntryUrl = CUSTOM_LOGIN_URL),
+            USERNAME,
+            PASSWORD
+        )
+
+        assertIs<Nonce.Available>(actual)
+        verifyCredentialPost(submissionUrl, DEFAULT_NONCE_URL)
+    }
+
+    @Test
+    fun `given a safe absolute form action, when authenticating, then post to its exact target`() = test {
+        val submissionUrl = "$SITE_HOST/store/authenticate"
+        givenLoginForm(CUSTOM_LOGIN_URL, loginForm("action=\"$submissionUrl\""))
+        givenCredentialRedirect(submissionUrl, DEFAULT_NONCE_URL, DEFAULT_NONCE_URL)
+        givenNonce(DEFAULT_NONCE_URL)
+
+        val actual = subject.requestNonce(
+            CookieNonceAuthenticationEndpoints(SITE_ORIGIN, loginEntryUrl = CUSTOM_LOGIN_URL),
+            USERNAME,
+            PASSWORD
+        )
+
+        assertIs<Nonce.Available>(actual)
+        verifyCredentialPost(submissionUrl, DEFAULT_NONCE_URL)
+    }
+
+    @Test
+    fun `given a missing form action after redirects, when authenticating, then post to the final page URL`() = test {
+        val finalLoginUrl = "$SITE_HOST/auth/login/"
+        givenGet(CUSTOM_LOGIN_URL, redirect(finalLoginUrl))
+        givenLoginForm(finalLoginUrl, loginForm())
+        givenCredentialRedirect(finalLoginUrl, DEFAULT_NONCE_URL, DEFAULT_NONCE_URL)
+        givenNonce(DEFAULT_NONCE_URL)
+
+        val actual = subject.requestNonce(
+            CookieNonceAuthenticationEndpoints(SITE_ORIGIN, loginEntryUrl = CUSTOM_LOGIN_URL),
+            USERNAME,
+            PASSWORD
+        )
+
+        assertIs<Nonce.Available>(actual)
+        verifyCredentialPost(finalLoginUrl, DEFAULT_NONCE_URL)
+    }
+
+    @Test
+    fun `given unsafe form actions, when preflighting, then never post credentials`() = test {
+        mapOf(
+            "malformed" to "https://[invalid",
+            "userinfo" to "https://user:password@site.example/login",
+            "off-origin" to "https://attacker.example/login",
+            "downgrade" to "http://site.example/login",
+            "port" to "https://site.example:8443/login"
+        ).forEach { (label, action) ->
+            givenLoginForm(CUSTOM_LOGIN_URL, loginForm("action=\"$action\""))
+
+            val actual = subject.requestNonce(
+                CookieNonceAuthenticationEndpoints(SITE_ORIGIN, loginEntryUrl = CUSTOM_LOGIN_URL),
+                USERNAME,
+                PASSWORD
             )
-        )
 
-        val invalidNonce = "0"
-        val response = WPAPIResponse.Success(invalidNonce, emptyList())
-        givenLoginResponse(redirectResponse)
-        whenever(wpApiEncodedRequestBuilder.syncGetRequest(subject, redirectUrl))
-            .thenReturn(response)
-
-        val actual = subject.requestNonce(site)
-        assertIs<Nonce.FailedRequest>(actual)
-        assertEquals(time, actual.timeOfResponse)
-        assertEquals(Nonce.CookieNonceErrorType.INVALID_NONCE, actual.type)
+            assertFailed(Nonce.CookieNonceErrorType.INVALID_RESPONSE, actual, label)
+        }
+        verifyNoCredentialPost()
     }
 
     @Test
-    fun `failed nonce request return FailedRequest`() = test {
-        val baseNetworkError = WPAPINetworkError(
-            BaseNetworkError(
-                VolleyError(
-                    NetworkResponse(400, byteArrayOf(), false, System.currentTimeMillis(), listOf())
-                )
-            )
+    fun `given a non-POST login form, when preflighting, then never post credentials`() = test {
+        givenLoginForm(CUSTOM_LOGIN_URL, loginForm(method = "get"))
+
+        val actual = subject.requestNonce(
+            CookieNonceAuthenticationEndpoints(SITE_ORIGIN, loginEntryUrl = CUSTOM_LOGIN_URL),
+            USERNAME,
+            PASSWORD
         )
-        givenLoginResponse(WPAPIResponse.Error(baseNetworkError))
 
-        val actual = subject.requestNonce(site)
-
-        assertIs<Nonce.FailedRequest>(actual)
-        assertEquals(time, actual.timeOfResponse)
-        assertEquals(Nonce.CookieNonceErrorType.GENERIC_ERROR, actual.type)
-        assertEquals(baseNetworkError, actual.networkError)
+        assertFailed(Nonce.CookieNonceErrorType.INVALID_RESPONSE, actual, "GET form")
+        verifyNoCredentialPost()
     }
 
     @Test
-    fun `failed nonce request with connection error returns Unknown`() = test {
-        val baseNetworkError = mock<WPAPINetworkError>()
-        baseNetworkError.volleyError = NoConnectionError()
-        givenLoginResponse(WPAPIResponse.Error(baseNetworkError))
-
-        val actual = subject.requestNonce(site)
-        TestCase.assertEquals(Nonce.Unknown(site.username), actual)
-    }
-
-    @Test
-    fun `custom login URL returns correct error type`() = test {
-        val error = WPAPINetworkError(
-            BaseNetworkError(
-                VolleyError(
-                    NetworkResponse(
-                        404,
-                        byteArrayOf(),
-                        false,
-                        System.currentTimeMillis(),
-                        listOf()
-                    )
-                )
-            )
-        )
-        givenLoginResponse(WPAPIResponse.Error(error))
-
-        val actual = subject.requestNonce(site)
-
-        assertIs<Nonce.FailedRequest>(actual)
-        assertEquals(Nonce.CookieNonceErrorType.CUSTOM_LOGIN_URL, actual.type)
-    }
-
-    @Test
-    fun `custom admin URL returns correct error type`() = test {
-        val redirectResponse = WPAPINetworkError(
-            BaseNetworkError(
-                VolleyError(
-                    NetworkResponse(
-                        301,
-                        byteArrayOf(),
-                        false,
-                        System.currentTimeMillis(),
-                        listOf(com.android.volley.Header("Location", nonceRequestUrl))
-                    )
-                )
-            ),
-            null
-        )
-        val nonceError = WPAPINetworkError(
-            BaseNetworkError(
-                VolleyError(
-                    NetworkResponse(404, byteArrayOf(), false, System.currentTimeMillis(), listOf())
-                )
-            )
-        )
-        givenLoginResponse(WPAPIResponse.Error(redirectResponse))
-        givenNonceRequestResponse(WPAPIResponse.Error(nonceError))
-
-        val actual = subject.requestNonce(site)
-
-        assertIs<Nonce.FailedRequest>(actual)
-        assertEquals(Nonce.CookieNonceErrorType.CUSTOM_ADMIN_URL, actual.type)
-    }
-
-    @Test
-    fun `given http site that 302s to https on wp-login, when requesting nonce, then retries POST against https`() =
+    fun `given WPS reaches the expected dashboard URL, when requesting a nonce, then never post credentials`() =
         test {
-            val httpSite = "http://example.com"
-            val httpsSite = "https://example.com"
-            val nonceUrl = "$httpsSite/wp-admin/admin-ajax.php?action=rest-nonce"
-            givenPostRedirect(siteUrl = httpSite, location = "$httpsSite/wp-login.php")
-            givenPostRedirect(siteUrl = httpsSite, location = nonceUrl)
-            whenever(wpApiEncodedRequestBuilder.syncGetRequest(subject, nonceUrl))
-                .thenReturn(WPAPIResponse.Success("expectedNONCE", emptyList()))
+            val origin = "http://127.0.0.1:18080"
+            val loginUrl = "$origin/login"
+            val normalizedLoginUrl = "$loginUrl/"
+            val dashboardUrl = "$origin/wp-admin/"
+            val nonceUrl = "${dashboardUrl}admin-ajax.php?action=rest-nonce"
+            givenGet(loginUrl, redirect(normalizedLoginUrl))
+            givenGet(normalizedLoginUrl, redirect(dashboardUrl))
+            givenGet(dashboardUrl, WPAPIResponse.Success(HOME_PAGE, emptyList()))
+            givenNonce(nonceUrl)
 
-            val actual = subject.requestNonce(httpSite, "user", "pwd")
+            val actual = subject.requestNonce(
+                CookieNonceAuthenticationEndpoints(origin, loginEntryUrl = loginUrl),
+                USERNAME,
+                PASSWORD
+            )
 
             assertIs<Nonce.Available>(actual)
-            assertEquals("expectedNONCE", actual.value)
+            verifyNoCredentialPost()
+            verify(requestBuilder).syncGetRequest(subject, nonceUrl)
         }
 
     @Test
-    fun `given redirect to a different host, when requesting nonce, then returns INVALID_NONCE without following`() =
+    fun `given WPS reaches admin index, when requesting a nonce, then treat it as the reusable admin base`() = test {
+        val dashboardIndexUrl = "$SITE_ORIGIN/wp-admin/index.php"
+        givenGet(DEFAULT_LOGIN_URL, redirect(dashboardIndexUrl))
+        givenGet(dashboardIndexUrl, WPAPIResponse.Success(ADMIN_DASHBOARD, emptyList()))
+        givenNonce(DEFAULT_NONCE_URL)
+
+        val actual = subject.requestNonce(SITE_ORIGIN, USERNAME, PASSWORD)
+
+        assertIs<Nonce.Available>(actual)
+        verifyNoCredentialPost()
+        verify(requestBuilder).syncGetRequest(subject, DEFAULT_NONCE_URL)
+    }
+
+    @Test
+    fun `given preflight reaches an unexpected dashboard URL, when requesting a nonce, then reject it`() = test {
+        givenGet(DEFAULT_LOGIN_URL, redirect(CUSTOM_ADMIN_URL))
+        givenGet(CUSTOM_ADMIN_URL, WPAPIResponse.Success(ADMIN_DASHBOARD, emptyList()))
+        givenNonce(DEFAULT_NONCE_URL)
+
+        val actual = subject.requestNonce(SITE_ORIGIN, USERNAME, PASSWORD)
+
+        assertFailed(Nonce.CookieNonceErrorType.CUSTOM_ADMIN_URL, actual, "unexpected dashboard")
+        verifyNoCredentialPost()
+        verify(requestBuilder, never()).syncGetRequest(subject, DEFAULT_NONCE_URL)
+    }
+
+    @Test
+    fun `given manual admin recovery, when dashboard and derived nonce are valid, then authenticate`() = test {
+        givenLoginForm(DEFAULT_LOGIN_URL)
+        givenCredentialRedirect(DEFAULT_LOGIN_URL, CUSTOM_NONCE_URL, CUSTOM_NONCE_URL)
+        givenGet(CUSTOM_ADMIN_URL, WPAPIResponse.Success(ADMIN_DASHBOARD, emptyList()))
+        givenNonce(CUSTOM_NONCE_URL)
+
+        val actual = subject.requestNonce(MANUAL_ADMIN_ENDPOINTS, USERNAME, PASSWORD)
+
+        assertIs<Nonce.Available>(actual)
+        verify(requestBuilder).syncGetRequest(subject, CUSTOM_ADMIN_URL)
+        verify(requestBuilder).syncGetRequest(subject, CUSTOM_NONCE_URL)
+    }
+
+    @Test
+    fun `given manual admin recovery, when dashboard proof is arbitrary, then reject before nonce`() = test {
+        givenLoginForm(DEFAULT_LOGIN_URL)
+        givenCredentialRedirect(DEFAULT_LOGIN_URL, CUSTOM_NONCE_URL, CUSTOM_NONCE_URL)
+        givenGet(CUSTOM_ADMIN_URL, WPAPIResponse.Success(HOME_PAGE, emptyList()))
+
+        val actual = subject.requestNonce(MANUAL_ADMIN_ENDPOINTS, USERNAME, PASSWORD)
+
+        assertFailed(Nonce.CookieNonceErrorType.CUSTOM_ADMIN_URL, actual, "manual dashboard")
+        verify(requestBuilder, never()).syncGetRequest(subject, CUSTOM_NONCE_URL)
+    }
+
+    @Test
+    fun `given arbitrary successful login content, when preflighting, then never post credentials`() = test {
+        givenGet(CUSTOM_LOGIN_URL, WPAPIResponse.Success(HOME_PAGE, emptyList()))
+
+        val actual = subject.requestNonce(
+            CookieNonceAuthenticationEndpoints(SITE_ORIGIN, loginEntryUrl = CUSTOM_LOGIN_URL),
+            USERNAME,
+            PASSWORD
+        )
+
+        assertFailed(Nonce.CookieNonceErrorType.INVALID_RESPONSE, actual, "soft 2xx")
+        assertEquals(false, (actual as Nonce.FailedRequest).loginEntryVerified)
+        verifyNoCredentialPost()
+    }
+
+    @Test
+    fun `given verified custom login, when later requests fail, then retain login provenance`() = test {
+        givenLoginForm(CUSTOM_LOGIN_URL)
+        val endpoints = CookieNonceAuthenticationEndpoints(SITE_ORIGIN, loginEntryUrl = CUSTOM_LOGIN_URL)
+
+        givenCredentialResponse(
+            CUSTOM_LOGIN_URL,
+            DEFAULT_NONCE_URL,
+            WPAPIResponse.Success(HOME_PAGE, emptyList())
+        )
+        val responseFailure = subject.requestNonce(endpoints, USERNAME, PASSWORD)
+        assertFailed(Nonce.CookieNonceErrorType.INVALID_RESPONSE, responseFailure, "post response")
+        assertEquals(true, (responseFailure as Nonce.FailedRequest).loginEntryVerified)
+
+        val networkError = mock<WPAPINetworkError>()
+        networkError.volleyError = NoConnectionError()
+        givenCredentialResponse(CUSTOM_LOGIN_URL, DEFAULT_NONCE_URL, WPAPIResponse.Error(networkError))
+        val networkFailure = subject.requestNonce(endpoints, USERNAME, PASSWORD)
+        assertEquals(Nonce.Unknown(USERNAME, loginEntryVerified = true), networkFailure)
+
+        givenCredentialRedirect(CUSTOM_LOGIN_URL, DEFAULT_NONCE_URL, DEFAULT_NONCE_URL)
+        givenGet(DEFAULT_NONCE_URL, WPAPIResponse.Success("x", emptyList()))
+        val nonceFailure = subject.requestNonce(endpoints, USERNAME, PASSWORD)
+        assertFailed(Nonce.CookieNonceErrorType.INVALID_NONCE, nonceFailure, "nonce response")
+        assertEquals(true, (nonceFailure as Nonce.FailedRequest).loginEntryVerified)
+    }
+
+    @Test
+    fun `given unsafe endpoint inputs, when requesting a nonce, then reject without network access`() = test {
+        mapOf(
+            "userinfo" to "https://user:password@site.example/login",
+            "host" to "https://attacker.example/login",
+            "downgrade" to "http://site.example/login",
+            "port" to "https://site.example:8443/login"
+        ).forEach { (label, unsafeLogin) ->
+            val actual = subject.requestNonce(
+                CookieNonceAuthenticationEndpoints(SITE_ORIGIN, loginEntryUrl = unsafeLogin),
+                USERNAME,
+                PASSWORD
+            )
+
+            assertFailed(Nonce.CookieNonceErrorType.CUSTOM_LOGIN_URL, actual, label)
+            verify(requestBuilder, never()).syncGetRequest(subject, unsafeLogin)
+        }
+    }
+
+    @Test
+    fun `given unsafe preflight redirects, when requesting a nonce, then reject without posting credentials`() = test {
+        mapOf(
+            "host" to "https://attacker.example/login",
+            "downgrade" to "http://site.example/login",
+            "port" to "https://site.example:8443/login",
+            "userinfo" to "https://user@site.example/login"
+        ).forEach { (label, unsafeRedirect) ->
+            givenGet(CUSTOM_LOGIN_URL, redirect(unsafeRedirect))
+
+            val actual = subject.requestNonce(
+                CookieNonceAuthenticationEndpoints(SITE_ORIGIN, loginEntryUrl = CUSTOM_LOGIN_URL),
+                USERNAME,
+                PASSWORD
+            )
+
+            assertFailed(Nonce.CookieNonceErrorType.CUSTOM_LOGIN_URL, actual, label)
+        }
+        verifyNoCredentialPost()
+    }
+
+    @Test
+    fun `given more than three safe redirects, when preflighting, then stop before the fourth destination`() = test {
+        val redirects = (1..4).map { "$SITE_HOST/login/$it" }
+        givenGet(CUSTOM_LOGIN_URL, redirect(redirects[0]))
+        redirects.zipWithNext().forEach { (from, to) -> givenGet(from, redirect(to)) }
+
+        val actual = subject.requestNonce(
+            CookieNonceAuthenticationEndpoints(SITE_ORIGIN, loginEntryUrl = CUSTOM_LOGIN_URL),
+            USERNAME,
+            PASSWORD
+        )
+
+        assertFailed(Nonce.CookieNonceErrorType.CUSTOM_LOGIN_URL, actual, "redirect cap")
+        verify(requestBuilder, never()).syncGetRequest(subject, redirects.last())
+        verifyNoCredentialPost()
+    }
+
+    @Test
+    fun `given exact and mismatched nonce redirects, when posting credentials, then follow only the derived URL`() =
         test {
-            val httpSite = "http://example.com"
-            givenPostRedirect(siteUrl = httpSite, location = "https://attacker.example/wp-login.php")
+            givenLoginForm(DEFAULT_LOGIN_URL)
+            givenCredentialRedirect(
+                DEFAULT_LOGIN_URL,
+                DEFAULT_NONCE_URL,
+                "/store/wp-admin/admin-ajax.php?action=rest-nonce"
+            )
+            givenNonce(DEFAULT_NONCE_URL)
+            assertIs<Nonce.Available>(subject.requestNonce(SITE_ORIGIN, USERNAME, PASSWORD))
 
-            val actual = subject.requestNonce(httpSite, "user", "pwd")
-
-            assertIs<Nonce.FailedRequest>(actual)
-            assertEquals(Nonce.CookieNonceErrorType.INVALID_NONCE, actual.type)
-        }
-
-    @Test
-    fun `given a second scheme upgrade redirect, when requesting nonce, then recursion guard returns INVALID_NONCE`() =
-        test {
-            val httpSite = "http://example.com"
-            val httpsSite = "https://example.com"
-            givenPostRedirect(siteUrl = httpSite, location = "$httpsSite/wp-login.php")
-            // After the upgrade retry, the upgraded host redirects back to itself again — pathological
-            // case that should NOT recurse a third time.
-            givenPostRedirect(siteUrl = httpsSite, location = "$httpsSite/wp-login.php")
-
-            val actual = subject.requestNonce(httpSite, "user", "pwd")
-
-            assertIs<Nonce.FailedRequest>(actual)
-        }
-
-    @Test
-    fun `when basic auth required, then NetworkResponse returns correct error type`() = test {
-        val error = WPAPINetworkError(
-            BaseNetworkError(
-                VolleyError(
-                    NetworkResponse(
-                        401,
-                        byteArrayOf(),
-                        false,
-                        System.currentTimeMillis(),
-                        listOf(
-                            com.android.volley.Header(
-                                "www-Authenticate",
-                                "Basic realm=token24433434"
-                            )
-                        )
+            mapOf(
+                "literal custom admin" to (
+                    "$SITE_HOST/private-admin/admin-ajax.php?action=rest-nonce" to
+                        Nonce.CookieNonceErrorType.CUSTOM_ADMIN_URL
+                    ),
+                "path lookalike" to (
+                    "$SITE_HOST/private-admin/not-admin-ajax.php?action=rest-nonce" to
+                        Nonce.CookieNonceErrorType.INVALID_NONCE
+                    ),
+                "wrong action" to (
+                    "$SITE_HOST/private-admin/admin-ajax.php?action=other" to
+                        Nonce.CookieNonceErrorType.INVALID_NONCE
+                    ),
+                "extra query" to (
+                    "$SITE_HOST/private-admin/admin-ajax.php?action=rest-nonce&extra=1" to
+                        Nonce.CookieNonceErrorType.INVALID_NONCE
                     )
-                )
+            ).forEach { (label, case) ->
+                givenCredentialRedirect(DEFAULT_LOGIN_URL, DEFAULT_NONCE_URL, case.first)
+
+                val actual = subject.requestNonce(SITE_ORIGIN, USERNAME, PASSWORD)
+
+                assertFailed(case.second, actual, label)
+                verify(requestBuilder, never()).syncGetRequest(subject, case.first)
+            }
+        }
+
+    @Test
+    fun `given HTTP safely upgrades to HTTPS, when authenticating, then keep the transaction on HTTPS`() = test {
+        val httpOrigin = "http://site.example"
+        val httpLoginUrl = "$httpOrigin/wp-login.php"
+        val httpsLoginUrl = "$SITE_HOST/wp-login.php"
+        val httpsNonceUrl = "$SITE_HOST/wp-admin/admin-ajax.php?action=rest-nonce"
+        givenGet(httpLoginUrl, redirect(httpsLoginUrl))
+        givenLoginForm(httpsLoginUrl)
+        givenCredentialRedirect(httpsLoginUrl, httpsNonceUrl, httpsNonceUrl)
+        givenNonce(httpsNonceUrl)
+
+        val actual = subject.requestNonce(httpOrigin, USERNAME, PASSWORD)
+
+        assertIs<Nonce.Available>(actual)
+        verifyCredentialPost(httpsLoginUrl, httpsNonceUrl)
+    }
+
+    @Test
+    fun `given invalid credentials, when posting, then preserve the extracted authentication error`() = test {
+        givenLoginForm(DEFAULT_LOGIN_URL)
+        givenCredentialResponse(
+            DEFAULT_LOGIN_URL,
+            DEFAULT_NONCE_URL,
+            WPAPIResponse.Success(
+                """
+                <script>${NonceRestClient.INVALID_CREDENTIAL_HTML_PATTERN}</script>
+                <div id="login_error"><strong>Error:</strong> Incorrect password.
+                <a href="lost">Lost?</a></div>
+                """.trimIndent(),
+                emptyList()
             )
         )
-        givenLoginResponse(WPAPIResponse.Error(error))
 
-        val actual = subject.requestNonce(site)
+        val actual = subject.requestNonce(SITE_ORIGIN, USERNAME, PASSWORD)
 
-        assertIs<Nonce.FailedRequest>(actual)
-        assertEquals(Nonce.CookieNonceErrorType.BASIC_AUTH_REQUIRED, actual.type)
+        assertFailed(Nonce.CookieNonceErrorType.INVALID_CREDENTIALS, actual, "invalid credentials")
+        assertEquals("Error: Incorrect password.", (actual as Nonce.FailedRequest).errorMessage)
     }
 
-    private suspend fun givenLoginResponse(response: WPAPIResponse<String>) {
-        val body = mapOf(
-            "log" to site.username,
-            "pwd" to site.password,
-            "redirect_to" to nonceRequestUrl
+    @Test
+    fun `given Basic Auth or no connection, when preflighting, then preserve the failure type`() = test {
+        givenGet(DEFAULT_LOGIN_URL, error(401, listOf(Header("WWW-Authenticate", "Basic realm=restricted"))))
+        assertFailed(
+            Nonce.CookieNonceErrorType.BASIC_AUTH_REQUIRED,
+            subject.requestNonce(SITE_ORIGIN, USERNAME, PASSWORD),
+            "basic auth"
         )
 
-        whenever(wpApiEncodedRequestBuilder.syncPostRequest(subject, "${site.url}/wp-login.php", body = body))
+        val networkError = mock<WPAPINetworkError>()
+        networkError.volleyError = NoConnectionError()
+        givenGet(DEFAULT_LOGIN_URL, WPAPIResponse.Error(networkError))
+        assertEquals(
+            Nonce.Unknown(USERNAME),
+            subject.requestNonce(SITE_ORIGIN, USERNAME, PASSWORD),
+            "network error"
+        )
+
+        givenGet(DEFAULT_LOGIN_URL, error(500))
+        val serverFailure = subject.requestNonce(SITE_ORIGIN, USERNAME, PASSWORD)
+        assertFailed(Nonce.CookieNonceErrorType.GENERIC_ERROR, serverFailure, "server error")
+        assertEquals(false, (serverFailure as Nonce.FailedRequest).loginEntryVerified)
+    }
+
+    private suspend fun givenLoginForm(url: String, html: String = LOGIN_FORM) {
+        givenGet(url, WPAPIResponse.Success(html, emptyList()))
+    }
+
+    private suspend fun givenCredentialRedirect(loginUrl: String, nonceUrl: String, location: String) {
+        givenCredentialResponse(loginUrl, nonceUrl, redirect(location))
+    }
+
+    private suspend fun givenCredentialResponse(
+        loginUrl: String,
+        nonceUrl: String,
+        response: WPAPIResponse<String>
+    ) {
+        whenever(requestBuilder.syncPostRequest(subject, loginUrl, body = credentialBody(nonceUrl)))
             .thenReturn(response)
     }
 
-    private suspend fun givenNonceRequestResponse(response: WPAPIResponse<String>) {
-        whenever(wpApiEncodedRequestBuilder.syncGetRequest(subject, nonceRequestUrl))
-            .thenReturn(response)
+    private suspend fun givenNonce(url: String) {
+        givenGet(url, WPAPIResponse.Success(EXPECTED_NONCE, emptyList()))
     }
 
-    private suspend fun givenPostRedirect(siteUrl: String, location: String, statusCode: Int = 302) {
-        val wpLoginUrl = "$siteUrl/wp-login.php"
-        val nonceRedirectUrl = "$siteUrl/wp-admin/admin-ajax.php?action=rest-nonce"
-        val body = mapOf("log" to "user", "pwd" to "pwd", "redirect_to" to nonceRedirectUrl)
-        val response = WPAPIResponse.Error<String>(
+    private suspend fun givenGet(url: String, response: WPAPIResponse<String>) {
+        whenever(requestBuilder.syncGetRequest(subject, url)).thenReturn(response)
+    }
+
+    private suspend fun verifyCredentialPost(loginUrl: String, nonceUrl: String) {
+        verify(requestBuilder).syncPostRequest(subject, loginUrl, body = credentialBody(nonceUrl))
+    }
+
+    private suspend fun verifyNoCredentialPost() {
+        verify(requestBuilder, never()).syncPostRequest(
+            restClient = any(),
+            url = any(),
+            params = any(),
+            body = any(),
+            enableCaching = any(),
+            cacheTimeToLive = any(),
+            nonce = anyOrNull()
+        )
+    }
+
+    private fun credentialBody(nonceUrl: String) = mapOf(
+        "log" to USERNAME,
+        "pwd" to PASSWORD,
+        "redirect_to" to nonceUrl
+    )
+
+    private fun loginForm(actionAttribute: String? = null, method: String = "post"): String {
+        val action = actionAttribute?.let { " $it" }.orEmpty()
+        return "<form name=\"loginform\" id=\"loginform\" method=\"$method\"$action>" +
+            "<input type=\"text\" name=\"log\" id=\"user_login\">" +
+            "<input type=\"password\" name=\"pwd\" id=\"user_pass\"></form>"
+    }
+
+    private fun redirect(location: String) = error(302, listOf(Header("Location", location)))
+
+    private fun error(statusCode: Int, headers: List<Header> = emptyList()): WPAPIResponse.Error<String> =
+        WPAPIResponse.Error(
             WPAPINetworkError(
                 BaseNetworkError(
                     VolleyError(
@@ -333,14 +686,43 @@ class NonceRestClientTest {
                             byteArrayOf(),
                             false,
                             System.currentTimeMillis(),
-                            listOf(com.android.volley.Header("Location", location))
+                            headers
                         )
                     )
-                ),
-                null
+                )
             )
         )
-        whenever(wpApiEncodedRequestBuilder.syncPostRequest(subject, wpLoginUrl, body = body))
-            .thenReturn(response)
+
+    private fun assertFailed(expectedType: Nonce.CookieNonceErrorType, actual: Nonce, label: String) {
+        assertIs<Nonce.FailedRequest>(actual, label)
+        assertEquals(RESPONSE_TIME, actual.timeOfResponse, label)
+        assertEquals(expectedType, actual.type, label)
+    }
+
+    private companion object {
+        const val RESPONSE_TIME = 123456L
+        const val SITE_HOST = "https://site.example"
+        const val SITE_ORIGIN = "$SITE_HOST/store"
+        const val DEFAULT_LOGIN_URL = "$SITE_ORIGIN/wp-login.php"
+        const val DEFAULT_NONCE_URL = "$SITE_ORIGIN/wp-admin/admin-ajax.php?action=rest-nonce"
+        const val CUSTOM_LOGIN_URL = "$SITE_HOST/secret-login"
+        const val CUSTOM_ADMIN_URL = "$SITE_HOST/private-dashboard/"
+        const val CUSTOM_NONCE_URL = "$SITE_HOST/private-dashboard/admin-ajax.php?action=rest-nonce"
+        const val USERNAME = "a_username"
+        const val PASSWORD = "a_password"
+        const val EXPECTED_NONCE = "1expectedNONCE"
+        const val LOGIN_FORM =
+            "<form name=\"loginform\" id=\"loginform\" method=\"post\">" +
+                "<input type=\"text\" name=\"log\" id=\"user_login\">" +
+                "<input type=\"password\" name=\"pwd\" id=\"user_pass\"></form>"
+        const val HOME_PAGE = "<html><body class=\"home page\"><main>Storefront</main></body></html>"
+        const val ADMIN_DASHBOARD =
+            "<html><body class=\"wp-admin wp-core-ui index-php\">" +
+                "<div id=\"dashboard-widgets-wrap\"></div></body></html>"
+        val MANUAL_ADMIN_ENDPOINTS = CookieNonceAuthenticationEndpoints(
+            canonicalSiteOrigin = SITE_ORIGIN,
+            adminBaseUrl = CUSTOM_ADMIN_URL,
+            adminBaseVerification = AdminBaseVerification.AUTHENTICATED_DASHBOARD
+        )
     }
 }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/CookieNonceAuthenticationEndpoints.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/CookieNonceAuthenticationEndpoints.kt
@@ -1,0 +1,100 @@
+package org.wordpress.android.fluxc.network.rest.wpapi
+
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.utils.extensions.slashJoin
+
+data class CookieNonceAuthenticationEndpoints(
+    val canonicalSiteOrigin: String,
+    val loginEntryUrl: String? = null,
+    val adminBaseUrl: String? = null,
+    val adminBaseVerification: AdminBaseVerification = AdminBaseVerification.NONE
+) {
+    fun validate(): ValidationResult {
+        val canonical = canonicalSiteOrigin.networkUrl()
+            ?: return invalid(Endpoint.CANONICAL, ValidationError.INVALID_URL)
+        if (canonical.hasUserInfo() || canonical.query != null) {
+            return invalid(Endpoint.CANONICAL, ValidationError.UNSAFE_ORIGIN)
+        }
+
+        val (login, loginError) = validatedEndpoint(
+            loginEntryUrl ?: canonical.toString().slashJoin("wp-login.php"),
+            canonical
+        )
+        if (loginError != null) return invalid(Endpoint.LOGIN, loginError)
+
+        val (admin, adminError) = validatedEndpoint(
+            adminBaseUrl ?: canonical.toString().slashJoin("wp-admin"),
+            canonical,
+            allowQuery = false
+        )
+        if (adminError != null) return invalid(Endpoint.ADMIN, adminError)
+
+        return ValidationResult.Valid(canonical, requireNotNull(login), requireNotNull(admin).reusableAdminBase())
+    }
+
+    private fun validatedEndpoint(
+        rawUrl: String,
+        canonical: HttpUrl,
+        allowQuery: Boolean = true
+    ): Pair<HttpUrl?, ValidationError?> {
+        val url = rawUrl.networkUrl()
+            ?: return null to ValidationError.INVALID_URL
+        if ((!allowQuery && url.query != null) || !isSafeFor(url, canonical)) {
+            return null to ValidationError.UNSAFE_ORIGIN
+        }
+        return url to null
+    }
+
+    enum class Endpoint { CANONICAL, LOGIN, ADMIN }
+    enum class ValidationError { INVALID_URL, UNSAFE_ORIGIN }
+    enum class AdminBaseVerification { NONE, AUTHENTICATED_DASHBOARD }
+
+    sealed interface ValidationResult {
+        data class Valid(val canonicalSiteOrigin: HttpUrl, val loginEntryUrl: HttpUrl, val adminBaseUrl: HttpUrl) :
+            ValidationResult
+
+        data class Invalid(val endpoint: Endpoint, val error: ValidationError) : ValidationResult
+    }
+
+    companion object {
+        fun from(site: SiteModel) = CookieNonceAuthenticationEndpoints(
+            canonicalSiteOrigin = site.url,
+            loginEntryUrl = site.loginUrl?.takeUnless(String::isBlank),
+            adminBaseUrl = site.adminUrl?.takeUnless(String::isBlank)
+        )
+
+        fun isSafeFor(candidate: HttpUrl, canonical: HttpUrl, previous: HttpUrl? = null): Boolean {
+            if (candidate.hasUserInfo() || candidate.host != canonical.host) return false
+            if (previous?.scheme == "https" && candidate.scheme != "https") return false
+            return when (canonical.scheme) {
+                "https" -> candidate.scheme == "https" && candidate.port == canonical.port
+                "http" -> canonical.port == HTTP_PORT &&
+                    candidate.scheme == "https" && candidate.port == HTTPS_PORT ||
+                    candidate.scheme == "http" && candidate.port == canonical.port
+                else -> false
+            }
+        }
+
+        private fun invalid(endpoint: Endpoint, error: ValidationError) =
+            ValidationResult.Invalid(endpoint, error)
+
+        private fun String.networkUrl() = toHttpUrlOrNull()?.takeIf { it.scheme == "http" || it.scheme == "https" }
+            ?.newBuilder()?.fragment(null)?.build()
+
+        private fun HttpUrl.reusableAdminBase(): HttpUrl {
+            val base = if (encodedPathSegments.lastOrNull().equals(ADMIN_INDEX, ignoreCase = true)) {
+                newBuilder().removePathSegment(encodedPathSegments.lastIndex).build()
+            } else {
+                this
+            }
+            return if (base.encodedPath.endsWith('/')) base else base.newBuilder().addPathSegment("").build()
+        }
+
+        private fun HttpUrl.hasUserInfo() = encodedUsername.isNotEmpty() || encodedPassword.isNotEmpty()
+        private const val HTTP_PORT = 80
+        private const val HTTPS_PORT = 443
+        private const val ADMIN_INDEX = "index.php"
+    }
+}

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/CookieNonceAuthenticationEndpoints.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/CookieNonceAuthenticationEndpoints.kt
@@ -6,46 +6,51 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.utils.extensions.slashJoin
 
 data class CookieNonceAuthenticationEndpoints(
-    val canonicalSiteOrigin: String,
+    val siteUrl: String,
     val loginEntryUrl: String? = null,
     val adminBaseUrl: String? = null,
     val adminBaseVerification: AdminBaseVerification = AdminBaseVerification.NONE
 ) {
     fun validate(): ValidationResult {
-        val canonical = canonicalSiteOrigin.networkUrl()
+        val validatedSiteUrl = siteUrl.networkUrl()
             ?: return invalid(Endpoint.CANONICAL, ValidationError.INVALID_URL)
-        return if (canonical.hasUserInfo() || canonical.query != null) {
+        return if (validatedSiteUrl.hasUserInfo() || validatedSiteUrl.query != null) {
             invalid(Endpoint.CANONICAL, ValidationError.UNSAFE_ORIGIN)
         } else {
-            validateEndpoints(canonical)
+            validateEndpoints(validatedSiteUrl)
         }
     }
 
-    private fun validateEndpoints(canonical: HttpUrl): ValidationResult {
+    private fun validateEndpoints(siteUrl: HttpUrl): ValidationResult {
         val (login, loginError) = validatedEndpoint(
-            loginEntryUrl ?: canonical.toString().slashJoin("wp-login.php"),
-            canonical
+            loginEntryUrl ?: siteUrl.toString().slashJoin("wp-login.php"),
+            siteUrl
         )
         if (loginError != null) return invalid(Endpoint.LOGIN, loginError)
 
         val (admin, adminError) = validatedEndpoint(
-            adminBaseUrl ?: canonical.toString().slashJoin("wp-admin"),
-            canonical,
+            adminBaseUrl ?: siteUrl.toString().slashJoin("wp-admin"),
+            siteUrl,
             allowQuery = false
         )
         if (adminError != null) return invalid(Endpoint.ADMIN, adminError)
 
-        return ValidationResult.Valid(canonical, requireNotNull(login), requireNotNull(admin).reusableAdminBase())
+        return ValidationResult.Valid(
+            siteUrl = siteUrl,
+            loginEntryUrl = requireNotNull(login),
+            adminBaseUrl = requireNotNull(admin).asAdminBaseUrl(),
+            adminBaseVerification = adminBaseVerification
+        )
     }
 
     private fun validatedEndpoint(
         rawUrl: String,
-        canonical: HttpUrl,
+        siteUrl: HttpUrl,
         allowQuery: Boolean = true
     ): Pair<HttpUrl?, ValidationError?> {
         val url = rawUrl.networkUrl()
             ?: return null to ValidationError.INVALID_URL
-        if ((!allowQuery && url.query != null) || !isSafeFor(url, canonical)) {
+        if ((!allowQuery && url.query != null) || !isAllowedForSite(url, siteUrl)) {
             return null to ValidationError.UNSAFE_ORIGIN
         }
         return url to null
@@ -56,27 +61,53 @@ data class CookieNonceAuthenticationEndpoints(
     enum class AdminBaseVerification { NONE, AUTHENTICATED_DASHBOARD }
 
     sealed interface ValidationResult {
-        data class Valid(val canonicalSiteOrigin: HttpUrl, val loginEntryUrl: HttpUrl, val adminBaseUrl: HttpUrl) :
-            ValidationResult
+        data class Valid(
+            val siteUrl: HttpUrl,
+            val loginEntryUrl: HttpUrl,
+            val adminBaseUrl: HttpUrl,
+            val adminBaseVerification: AdminBaseVerification
+        ) : ValidationResult {
+            fun allows(candidateUrl: HttpUrl, previousUrl: HttpUrl? = null): Boolean =
+                isAllowedForSite(candidateUrl, siteUrl, previousUrl)
+
+            fun isAdminBase(candidateUrl: HttpUrl): Boolean =
+                candidateUrl.asAdminBaseUrl() == adminBaseUrlFor(candidateUrl)
+
+            fun adminBaseUrlFor(loginUrl: HttpUrl): HttpUrl =
+                adminBaseUrl.withSecureLoginScheme(loginUrl, siteUrl)
+
+            fun nonceUrlFor(loginUrl: HttpUrl): HttpUrl = adminBaseUrlFor(loginUrl)
+                .newBuilder()
+                .addPathSegment(ADMIN_AJAX_PATH_SEGMENT)
+                .encodedQuery(REST_NONCE_QUERY)
+                .build()
+
+            fun isNonceEndpoint(candidateUrl: HttpUrl?): Boolean =
+                candidateUrl != null &&
+                    candidateUrl.encodedPathSegments.lastOrNull() == ADMIN_AJAX_PATH_SEGMENT &&
+                    candidateUrl.encodedQuery == REST_NONCE_QUERY
+        }
 
         data class Invalid(val endpoint: Endpoint, val error: ValidationError) : ValidationResult
     }
 
     companion object {
         fun from(site: SiteModel) = CookieNonceAuthenticationEndpoints(
-            canonicalSiteOrigin = site.url,
+            siteUrl = site.url,
             loginEntryUrl = site.loginUrl?.takeUnless(String::isBlank),
             adminBaseUrl = site.adminUrl?.takeUnless(String::isBlank)
         )
 
-        fun isSafeFor(candidate: HttpUrl, canonical: HttpUrl, previous: HttpUrl? = null): Boolean {
-            if (candidate.hasUserInfo() || candidate.host != canonical.host) return false
+        private fun isAllowedForSite(candidate: HttpUrl, siteUrl: HttpUrl, previous: HttpUrl? = null): Boolean {
+            if (candidate.hasUserInfo() || candidate.host != siteUrl.host) return false
             if (previous?.scheme == "https" && candidate.scheme != "https") return false
-            return when (canonical.scheme) {
-                "https" -> candidate.scheme == "https" && candidate.port == canonical.port
-                "http" -> canonical.port == HTTP_PORT &&
-                    candidate.scheme == "https" && candidate.port == HTTPS_PORT ||
-                    candidate.scheme == "http" && candidate.port == canonical.port
+            return when (siteUrl.scheme) {
+                "https" -> candidate.scheme == "https" && candidate.port == siteUrl.port
+                "http" -> when (candidate.scheme) {
+                    "https" -> siteUrl.port == HTTP_PORT && candidate.port == HTTPS_PORT
+                    "http" -> candidate.port == siteUrl.port
+                    else -> false
+                }
                 else -> false
             }
         }
@@ -87,18 +118,32 @@ data class CookieNonceAuthenticationEndpoints(
         private fun String.networkUrl() = toHttpUrlOrNull()?.takeIf { it.scheme == "http" || it.scheme == "https" }
             ?.newBuilder()?.fragment(null)?.build()
 
-        private fun HttpUrl.reusableAdminBase(): HttpUrl {
-            val base = if (encodedPathSegments.lastOrNull().equals(ADMIN_INDEX, ignoreCase = true)) {
+        private fun HttpUrl.asAdminBaseUrl(): HttpUrl {
+            val baseUrl = if (encodedPathSegments.lastOrNull().equals("index.php", ignoreCase = true)) {
                 newBuilder().removePathSegment(encodedPathSegments.lastIndex).build()
             } else {
                 this
             }
-            return if (base.encodedPath.endsWith('/')) base else base.newBuilder().addPathSegment("").build()
+            return if (baseUrl.encodedPath.endsWith('/')) {
+                baseUrl
+            } else {
+                baseUrl.newBuilder().addPathSegment("").build()
+            }
         }
+
+        private fun HttpUrl.withSecureLoginScheme(loginUrl: HttpUrl, siteUrl: HttpUrl): HttpUrl =
+            if (siteUrl.isDefaultHttp() && isDefaultHttp() && loginUrl.scheme == "https") {
+                newBuilder().scheme("https").port(HTTPS_PORT).build()
+            } else {
+                this
+            }
+
+        private fun HttpUrl.isDefaultHttp(): Boolean = scheme == "http" && port == HTTP_PORT
 
         private fun HttpUrl.hasUserInfo() = encodedUsername.isNotEmpty() || encodedPassword.isNotEmpty()
         private const val HTTP_PORT = 80
         private const val HTTPS_PORT = 443
-        private const val ADMIN_INDEX = "index.php"
+        private const val ADMIN_AJAX_PATH_SEGMENT = "admin-ajax.php"
+        private const val REST_NONCE_QUERY = "action=rest-nonce"
     }
 }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/CookieNonceAuthenticationEndpoints.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/CookieNonceAuthenticationEndpoints.kt
@@ -14,10 +14,14 @@ data class CookieNonceAuthenticationEndpoints(
     fun validate(): ValidationResult {
         val canonical = canonicalSiteOrigin.networkUrl()
             ?: return invalid(Endpoint.CANONICAL, ValidationError.INVALID_URL)
-        if (canonical.hasUserInfo() || canonical.query != null) {
-            return invalid(Endpoint.CANONICAL, ValidationError.UNSAFE_ORIGIN)
+        return if (canonical.hasUserInfo() || canonical.query != null) {
+            invalid(Endpoint.CANONICAL, ValidationError.UNSAFE_ORIGIN)
+        } else {
+            validateEndpoints(canonical)
         }
+    }
 
+    private fun validateEndpoints(canonical: HttpUrl): ValidationResult {
         val (login, loginError) = validatedEndpoint(
             loginEntryUrl ?: canonical.toString().slashJoin("wp-login.php"),
             canonical

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/Nonce.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/Nonce.kt
@@ -12,9 +12,13 @@ sealed interface Nonce {
         val type: CookieNonceErrorType,
         val networkError: WPAPINetworkError? = null,
         val errorMessage: String? = null,
+        val loginEntryVerified: Boolean = false,
     ) : Nonce
 
-    data class Unknown(override val username: String?) : Nonce
+    data class Unknown(
+        override val username: String?,
+        val loginEntryVerified: Boolean = false,
+    ) : Nonce
 
     enum class CookieNonceErrorType {
         INVALID_RESPONSE,

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/NonceRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/NonceRestClient.kt
@@ -24,7 +24,10 @@ import javax.inject.Named
 import javax.inject.Singleton
 
 private const val NOT_FOUND_STATUS_CODE = 404
+private const val GONE_STATUS_CODE = 410
 private const val MAX_ENDPOINT_REDIRECTS = 3
+private const val REDIRECT_STATUS_CODE_START = 300
+private const val REDIRECT_STATUS_CODE_END = 399
 private typealias ValidatedEndpoints = CookieNonceAuthenticationEndpoints.ValidationResult.Valid
 
 @Singleton
@@ -79,26 +82,21 @@ class NonceRestClient @Inject constructor(
             preflight.transactionUrl,
             validated.canonicalSiteOrigin
         )
+        val transaction = LoginTransaction(
+            endpoints = validated,
+            verification = endpoints.adminBaseVerification,
+            loginUrl = preflight.transactionUrl,
+            nonceUrl = nonceUrl,
+            username = username
+        )
         val nonce = when (preflight) {
-            is LoginPreflight.LoginForm -> postCredentials(
-                validated,
-                endpoints.adminBaseVerification,
-                preflight.transactionUrl,
-                nonceUrl,
-                username,
-                password
-            )
-            is LoginPreflight.AlreadyAuthenticated -> verifyAdminDashboardAndRequestNonce(
-                validated,
-                endpoints.adminBaseVerification,
-                preflight.transactionUrl,
-                nonceUrl,
-                username
-            )
+            is LoginPreflight.LoginForm -> postCredentials(transaction, password)
+            is LoginPreflight.AlreadyAuthenticated -> verifyAdminDashboardAndRequestNonce(transaction)
         }
         return cache(endpoints.canonicalSiteOrigin, nonce.withVerifiedLoginEntry())
     }
 
+    @Suppress("NestedBlockDepth", "ReturnCount")
     private suspend fun preflightLogin(endpoints: ValidatedEndpoints, username: String): LoginPreflight {
         var currentUrl = endpoints.loginEntryUrl
         var redirectsFollowed = 0
@@ -149,71 +147,59 @@ class NonceRestClient @Inject constructor(
     }
 
     private suspend fun postCredentials(
-        endpoints: ValidatedEndpoints,
-        verification: AdminBaseVerification,
-        loginUrl: HttpUrl,
-        nonceUrl: HttpUrl,
-        username: String,
+        transaction: LoginTransaction,
         password: String
     ): Nonce {
         return when (val response = wpApiEncodedBodyRequestBuilder.syncPostRequest(
             restClient = this,
-            url = loginUrl.toString(),
+            url = transaction.loginUrl.toString(),
             body = mapOf(
-                "log" to username,
+                "log" to transaction.username,
                 "pwd" to password,
-                "redirect_to" to nonceUrl.toString()
+                "redirect_to" to transaction.nonceUrl.toString()
             )
         )) {
-            is Success -> loginBodyFailure(response, username)
-            is Error -> handleCredentialError(response, endpoints, verification, loginUrl, nonceUrl, username)
+            is Success -> loginBodyFailure(response, transaction.username)
+            is Error -> handleCredentialError(response, transaction)
         }
     }
 
     private suspend fun handleCredentialError(
         response: Error<String>,
-        endpoints: ValidatedEndpoints,
-        verification: AdminBaseVerification,
-        loginUrl: HttpUrl,
-        nonceUrl: HttpUrl,
-        username: String
+        transaction: LoginTransaction
     ): Nonce {
-        if (response.error.volleyError is NoConnectionError) return Unknown(username)
+        if (response.error.volleyError is NoConnectionError) return Unknown(transaction.username)
 
         val networkResponse = response.error.volleyError?.networkResponse
         if (networkResponse?.statusCode?.isRedirect() != true) {
-            return loginFailure(username, response, networkResponse)
+            return loginFailure(transaction.username, response, networkResponse)
         }
 
         val redirectUrl = networkResponse.location()
-            ?.let(loginUrl::resolve)
+            ?.let(transaction.loginUrl::resolve)
             ?.withoutFragment()
-            ?.takeIf { it.isSafeFor(endpoints.canonicalSiteOrigin, loginUrl) }
+            ?.takeIf { it.isSafeFor(transaction.endpoints.canonicalSiteOrigin, transaction.loginUrl) }
         return when {
-            redirectUrl == nonceUrl -> verifyAdminDashboardAndRequestNonce(
-                endpoints, verification, loginUrl, nonceUrl, username
-            )
+            redirectUrl == transaction.nonceUrl -> verifyAdminDashboardAndRequestNonce(transaction)
             redirectUrl?.isNonceEndpoint() == true -> {
-                failed(username, CookieNonceErrorType.CUSTOM_ADMIN_URL, response)
+                failed(transaction.username, CookieNonceErrorType.CUSTOM_ADMIN_URL, response)
             }
-            else -> failed(username, CookieNonceErrorType.INVALID_NONCE, response)
+            else -> failed(transaction.username, CookieNonceErrorType.INVALID_NONCE, response)
         }
     }
 
-    private suspend fun verifyAdminDashboardAndRequestNonce(
-        endpoints: ValidatedEndpoints,
-        verification: AdminBaseVerification,
-        loginUrl: HttpUrl,
-        nonceUrl: HttpUrl,
-        username: String
-    ): Nonce {
-        if (verification == AdminBaseVerification.AUTHENTICATED_DASHBOARD) {
-            val dashboardUrl = endpoints.adminBaseUrl.upgradeForSecureLogin(loginUrl, endpoints.canonicalSiteOrigin)
-            verifyAdminDashboard(endpoints, dashboardUrl, username)?.let { return it }
+    private suspend fun verifyAdminDashboardAndRequestNonce(transaction: LoginTransaction): Nonce {
+        if (transaction.verification == AdminBaseVerification.AUTHENTICATED_DASHBOARD) {
+            val dashboardUrl = transaction.endpoints.adminBaseUrl.upgradeForSecureLogin(
+                transaction.loginUrl,
+                transaction.endpoints.canonicalSiteOrigin
+            )
+            verifyAdminDashboard(transaction.endpoints, dashboardUrl, transaction.username)?.let { return it }
         }
-        return requestNonce(nonceUrl, username)
+        return requestNonce(transaction.nonceUrl, transaction.username)
     }
 
+    @Suppress("ReturnCount")
     private suspend fun verifyAdminDashboard(
         endpoints: ValidatedEndpoints,
         initialUrl: HttpUrl,
@@ -271,7 +257,7 @@ class NonceRestClient @Inject constructor(
 
     private fun getLoginErrorType(networkResponse: NetworkResponse?): CookieNonceErrorType = when {
         networkResponse?.statusCode == NOT_FOUND_STATUS_CODE ||
-            networkResponse?.statusCode == 410 -> CookieNonceErrorType.CUSTOM_LOGIN_URL
+            networkResponse?.statusCode == GONE_STATUS_CODE -> CookieNonceErrorType.CUSTOM_LOGIN_URL
         isBasicAuthError(networkResponse) -> CookieNonceErrorType.BASIC_AUTH_REQUIRED
         else -> CookieNonceErrorType.GENERIC_ERROR
     }
@@ -318,14 +304,14 @@ class NonceRestClient @Inject constructor(
     }
 
     private fun HttpUrl.upgradeForSecureLogin(loginUrl: HttpUrl, canonicalOrigin: HttpUrl): HttpUrl {
-        return if (canonicalOrigin.scheme == "http" && canonicalOrigin.port == HTTP_DEFAULT_PORT &&
-            scheme == "http" && port == HTTP_DEFAULT_PORT && loginUrl.scheme == "https"
-        ) {
+        return if (canonicalOrigin.isDefaultHttp() && isDefaultHttp() && loginUrl.scheme == "https") {
             newBuilder().scheme("https").port(HTTPS_DEFAULT_PORT).build()
         } else {
             this
         }
     }
+
+    private fun HttpUrl.isDefaultHttp(): Boolean = scheme == "http" && port == HTTP_DEFAULT_PORT
 
     private fun HttpUrl.withoutFragment(): HttpUrl = newBuilder().fragment(null).build()
 
@@ -337,7 +323,7 @@ class NonceRestClient @Inject constructor(
         encodedPathSegments.lastOrNull() == ADMIN_AJAX_PATH_SEGMENT &&
             encodedQuery == REST_NONCE_QUERY
 
-    private fun Int.isRedirect(): Boolean = this in 300..399
+    private fun Int.isRedirect(): Boolean = this in REDIRECT_STATUS_CODE_START..REDIRECT_STATUS_CODE_END
 
     private fun NetworkResponse.location(): String? = allHeaders
         ?.firstOrNull { it.name.equals(LOCATION_HEADER, ignoreCase = true) }
@@ -367,6 +353,7 @@ class NonceRestClient @Inject constructor(
         return HtmlUtils.fastStripHtml(errorHtml).trim(' ', '\n')
     }
 
+    @Suppress("ReturnCount")
     private fun String?.loginFormSubmissionUrl(documentUrl: HttpUrl, canonicalOrigin: HttpUrl): HttpUrl? {
         val renderedHtml = this?.replace(NON_RENDERED_REGION_PATTERN, "") ?: return null
         if (NON_RENDERED_MARKER_PATTERN.containsMatchIn(renderedHtml)) return null
@@ -442,6 +429,14 @@ class NonceRestClient @Inject constructor(
         data class AlreadyAuthenticated(override val transactionUrl: HttpUrl) : Success
         data class Failure(val nonce: Nonce) : LoginPreflight
     }
+
+    private data class LoginTransaction(
+        val endpoints: ValidatedEndpoints,
+        val verification: AdminBaseVerification,
+        val loginUrl: HttpUrl,
+        val nonceUrl: HttpUrl,
+        val username: String
+    )
 
     companion object {
         const val INVALID_CREDENTIAL_HTML_PATTERN = "document.querySelector('form').classList.add('shake')"

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/NonceRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/NonceRestClient.kt
@@ -3,10 +3,15 @@ package org.wordpress.android.fluxc.network.rest.wpapi
 import com.android.volley.NetworkResponse
 import com.android.volley.NoConnectionError
 import com.android.volley.RequestQueue
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import org.apache.commons.text.StringEscapeUtils
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.rest.wpapi.CookieNonceAuthenticationEndpoints.AdminBaseVerification
 import org.wordpress.android.fluxc.network.rest.wpapi.Nonce.Available
+import org.wordpress.android.fluxc.network.rest.wpapi.Nonce.CookieNonceErrorType
 import org.wordpress.android.fluxc.network.rest.wpapi.Nonce.FailedRequest
 import org.wordpress.android.fluxc.network.rest.wpapi.Nonce.Unknown
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse.Error
@@ -19,6 +24,8 @@ import javax.inject.Named
 import javax.inject.Singleton
 
 private const val NOT_FOUND_STATUS_CODE = 404
+private const val MAX_ENDPOINT_REDIRECTS = 3
+private typealias ValidatedEndpoints = CookieNonceAuthenticationEndpoints.ValidationResult.Valid
 
 @Singleton
 class NonceRestClient @Inject constructor(
@@ -29,174 +36,466 @@ class NonceRestClient @Inject constructor(
     userAgent: UserAgent
 ) : BaseWPAPIRestClient(dispatcher, requestQueue, userAgent) {
     private val nonceMap: MutableMap<String, Nonce> = mutableMapOf()
-    fun getNonce(siteUrl: String, username: String?): Nonce? = nonceMap[siteUrl]?.takeIf { it.username == username }
+
+    fun getNonce(siteUrl: String, username: String?): Nonce? =
+        nonceMap[siteUrl.nonceCacheIdentity()]?.takeIf { it.username == username }
+
     fun getNonce(site: SiteModel): Nonce? = getNonce(site.url, site.username)
 
-    /**
-     *  Requests a nonce using the
-     *  [rest-nonce endpoint](https://developer.wordpress.org/reference/functions/wp_ajax_rest_nonce/)
-     *  that became available in WordPress 5.3.
-     */
     suspend fun requestNonce(site: SiteModel): Nonce {
         if (site.username == null || site.password == null) return Unknown(site.username)
-        return requestNonce(site.url, site.username, site.password)
+        return requestNonce(CookieNonceAuthenticationEndpoints.from(site), site.username, site.password)
     }
 
-    /**
-     *  Requests a nonce using the
-     *  [rest-nonce endpoint](https://developer.wordpress.org/reference/functions/wp_ajax_rest_nonce/)
-     *  that became available in WordPress 5.3.
-     */
-    @Suppress("NestedBlockDepth", "LongMethod")
-    suspend fun requestNonce(siteUrl: String, username: String, password: String): Nonce {
-        @Suppress("MagicNumber")
-        fun Int.isRedirect(): Boolean = this in 300..399
-        val wpLoginUrl = siteUrl.slashJoin("wp-login.php")
-        val redirectUrl = siteUrl.slashJoin("wp-admin/admin-ajax.php?action=rest-nonce")
-        val body = mapOf(
-            "log" to username,
-            "pwd" to password,
-            "redirect_to" to redirectUrl
-        )
-        val response =
-            wpApiEncodedBodyRequestBuilder.syncPostRequest(this, wpLoginUrl, body = body)
-        val nonce = when (response) {
-            is Success -> {
-                // A success means we got 200 from the wp-login.php call, which means
-                // a login error: https://core.trac.wordpress.org/ticket/25446
-                // A successful login should result in a redirection to the redirect URL
+    suspend fun requestNonce(siteUrl: String, username: String, password: String) =
+        requestNonce(CookieNonceAuthenticationEndpoints(siteUrl), username, password)
 
-                // Let's try to extract the login error from the web page, and if we have it, then we'll assume
-                // that it's an authentication issue, otherwise we'll assume it's an invalid response
-                val errorMessage = extractErrorMessage(response.data.orEmpty())
-
-                val errorType = if (hasInvalidCredentialsPattern(response.data.orEmpty()) &&
-                    errorMessage?.contains("captcha", ignoreCase = true) != true
-                ) {
-                    Nonce.CookieNonceErrorType.INVALID_CREDENTIALS
+    suspend fun requestNonce(
+        endpoints: CookieNonceAuthenticationEndpoints,
+        username: String,
+        password: String
+    ): Nonce {
+        val validated = when (val result = endpoints.validate()) {
+            is CookieNonceAuthenticationEndpoints.ValidationResult.Valid -> result
+            is CookieNonceAuthenticationEndpoints.ValidationResult.Invalid -> {
+                val type = if (result.endpoint == CookieNonceAuthenticationEndpoints.Endpoint.ADMIN) {
+                    CookieNonceErrorType.CUSTOM_ADMIN_URL
                 } else {
-                    Nonce.CookieNonceErrorType.INVALID_RESPONSE
+                    CookieNonceErrorType.CUSTOM_LOGIN_URL
                 }
-
-                FailedRequest(
-                    timeOfResponse = currentTimeProvider.currentDate().time,
-                    username = username,
-                    type = errorType,
-                    errorMessage = errorMessage
-                )
+                return cache(endpoints.canonicalSiteOrigin, failed(username, type))
             }
+        }
+        val derivedNonceUrl = validated.adminBaseUrl.toString()
+            .slashJoin("$ADMIN_AJAX_PATH_SEGMENT?$REST_NONCE_QUERY")
+            .toNetworkUrlOrNull()
+            ?: return cache(endpoints.canonicalSiteOrigin, failed(username, CookieNonceErrorType.CUSTOM_ADMIN_URL))
 
-            is Error -> {
-                if (response.error.volleyError is NoConnectionError) {
-                    // No connection, so we do not know if a nonce is available
-                    Unknown(username)
-                } else {
+        val preflight = when (val result = preflightLogin(validated, username)) {
+            is LoginPreflight.Success -> result
+            is LoginPreflight.Failure -> return cache(endpoints.canonicalSiteOrigin, result.nonce)
+        }
+        val nonceUrl = derivedNonceUrl.upgradeForSecureLogin(
+            preflight.transactionUrl,
+            validated.canonicalSiteOrigin
+        )
+        val nonce = when (preflight) {
+            is LoginPreflight.LoginForm -> postCredentials(
+                validated,
+                endpoints.adminBaseVerification,
+                preflight.transactionUrl,
+                nonceUrl,
+                username,
+                password
+            )
+            is LoginPreflight.AlreadyAuthenticated -> verifyAdminDashboardAndRequestNonce(
+                validated,
+                endpoints.adminBaseVerification,
+                preflight.transactionUrl,
+                nonceUrl,
+                username
+            )
+        }
+        return cache(endpoints.canonicalSiteOrigin, nonce.withVerifiedLoginEntry())
+    }
+
+    private suspend fun preflightLogin(endpoints: ValidatedEndpoints, username: String): LoginPreflight {
+        var currentUrl = endpoints.loginEntryUrl
+        var redirectsFollowed = 0
+        while (true) {
+            when (val response = wpApiEncodedBodyRequestBuilder.syncGetRequest(this, currentUrl.toString())) {
+                is Success -> {
+                    val expectedAdminUrl = endpoints.adminBaseUrl.upgradeForSecureLogin(
+                        currentUrl,
+                        endpoints.canonicalSiteOrigin
+                    )
+                    val isExpectedAdminUrl = currentUrl.asReusableAdminBase() == expectedAdminUrl
+                    if (response.data.isWordPressAdminDashboard()) {
+                        return if (isExpectedAdminUrl) LoginPreflight.AlreadyAuthenticated(currentUrl)
+                        else LoginPreflight.Failure(failed(username, CookieNonceErrorType.CUSTOM_ADMIN_URL))
+                    }
+                    if (isExpectedAdminUrl) return LoginPreflight.AlreadyAuthenticated(currentUrl)
+                    val submissionUrl = response.data.loginFormSubmissionUrl(
+                        currentUrl,
+                        endpoints.canonicalSiteOrigin
+                    ) ?: return LoginPreflight.Failure(failed(username, CookieNonceErrorType.INVALID_RESPONSE))
+                    return LoginPreflight.LoginForm(submissionUrl)
+                }
+                is Error -> {
+                    if (response.error.volleyError is NoConnectionError) {
+                        return LoginPreflight.Failure(Unknown(username))
+                    }
                     val networkResponse = response.error.volleyError?.networkResponse
-                    if (networkResponse?.statusCode?.isRedirect() == true) {
-                        val location = networkResponse.headers?.get("Location") ?: redirectUrl
-                        if (location.contains("admin-ajax.php") && location.contains("rest-nonce")) {
-                            requestNonce(location, username)
-                        } else if (isSchemeUpgrade(wpLoginUrl, location)) {
-                            requestNonce(
-                                location.replace("wp-login.php", "").trimEnd('/'),
-                                username,
-                                password
-                            )
-                        } else {
-                            FailedRequest(
-                                timeOfResponse = currentTimeProvider.currentDate().time,
-                                username = username,
-                                type = Nonce.CookieNonceErrorType.INVALID_NONCE,
-                                networkError = response.error,
-                                errorMessage = response.error.message,
-                            )
-                        }
-                    } else {
-                        FailedRequest(
-                            timeOfResponse = currentTimeProvider.currentDate().time,
-                            username = username,
-                            type = getErrorType(networkResponse),
-                            networkError = response.error,
-                            errorMessage = response.error.message,
+                    if (networkResponse?.statusCode?.isRedirect() != true) {
+                        return LoginPreflight.Failure(loginFailure(username, response, networkResponse))
+                    }
+                    if (redirectsFollowed == MAX_ENDPOINT_REDIRECTS) {
+                        return LoginPreflight.Failure(
+                            failed(username, CookieNonceErrorType.CUSTOM_LOGIN_URL, response)
                         )
                     }
+                    val redirectUrl = networkResponse.location()
+                        ?.let(currentUrl::resolve)
+                        ?.withoutFragment()
+                        ?.takeIf { it.isSafeFor(endpoints.canonicalSiteOrigin, currentUrl) }
+                        ?: return LoginPreflight.Failure(
+                            failed(username, CookieNonceErrorType.CUSTOM_LOGIN_URL, response)
+                        )
+                    currentUrl = redirectUrl
+                    redirectsFollowed++
                 }
             }
         }
-        return nonce.also {
-            nonceMap[siteUrl] = it
+    }
+
+    private suspend fun postCredentials(
+        endpoints: ValidatedEndpoints,
+        verification: AdminBaseVerification,
+        loginUrl: HttpUrl,
+        nonceUrl: HttpUrl,
+        username: String,
+        password: String
+    ): Nonce {
+        return when (val response = wpApiEncodedBodyRequestBuilder.syncPostRequest(
+            restClient = this,
+            url = loginUrl.toString(),
+            body = mapOf(
+                "log" to username,
+                "pwd" to password,
+                "redirect_to" to nonceUrl.toString()
+            )
+        )) {
+            is Success -> loginBodyFailure(response, username)
+            is Error -> handleCredentialError(response, endpoints, verification, loginUrl, nonceUrl, username)
         }
     }
 
-    private fun isSchemeUpgrade(originalUrl: String, redirectUrl: String): Boolean {
-        return originalUrl.startsWith("http://") &&
-            redirectUrl.startsWith("https://") &&
-            redirectUrl.removePrefix("https://") == originalUrl.removePrefix("http://")
-    }
+    private suspend fun handleCredentialError(
+        response: Error<String>,
+        endpoints: ValidatedEndpoints,
+        verification: AdminBaseVerification,
+        loginUrl: HttpUrl,
+        nonceUrl: HttpUrl,
+        username: String
+    ): Nonce {
+        if (response.error.volleyError is NoConnectionError) return Unknown(username)
 
-    private fun getErrorType(networkResponse: NetworkResponse?): Nonce.CookieNonceErrorType = when {
-        networkResponse?.statusCode == NOT_FOUND_STATUS_CODE -> {
-            Nonce.CookieNonceErrorType.CUSTOM_LOGIN_URL
+        val networkResponse = response.error.volleyError?.networkResponse
+        if (networkResponse?.statusCode?.isRedirect() != true) {
+            return loginFailure(username, response, networkResponse)
         }
 
-        isBasicAuthError(networkResponse) -> Nonce.CookieNonceErrorType.BASIC_AUTH_REQUIRED
-
-        else -> {
-            Nonce.CookieNonceErrorType.GENERIC_ERROR
+        val redirectUrl = networkResponse.location()
+            ?.let(loginUrl::resolve)
+            ?.withoutFragment()
+            ?.takeIf { it.isSafeFor(endpoints.canonicalSiteOrigin, loginUrl) }
+        return when {
+            redirectUrl == nonceUrl -> verifyAdminDashboardAndRequestNonce(
+                endpoints, verification, loginUrl, nonceUrl, username
+            )
+            redirectUrl?.isNonceEndpoint() == true -> {
+                failed(username, CookieNonceErrorType.CUSTOM_ADMIN_URL, response)
+            }
+            else -> failed(username, CookieNonceErrorType.INVALID_NONCE, response)
         }
     }
+
+    private suspend fun verifyAdminDashboardAndRequestNonce(
+        endpoints: ValidatedEndpoints,
+        verification: AdminBaseVerification,
+        loginUrl: HttpUrl,
+        nonceUrl: HttpUrl,
+        username: String
+    ): Nonce {
+        if (verification == AdminBaseVerification.AUTHENTICATED_DASHBOARD) {
+            val dashboardUrl = endpoints.adminBaseUrl.upgradeForSecureLogin(loginUrl, endpoints.canonicalSiteOrigin)
+            verifyAdminDashboard(endpoints, dashboardUrl, username)?.let { return it }
+        }
+        return requestNonce(nonceUrl, username)
+    }
+
+    private suspend fun verifyAdminDashboard(
+        endpoints: ValidatedEndpoints,
+        initialUrl: HttpUrl,
+        username: String
+    ): Nonce? {
+        var currentUrl = initialUrl
+        var redirectsFollowed = 0
+        while (true) {
+            when (val response = wpApiEncodedBodyRequestBuilder.syncGetRequest(this, currentUrl.toString())) {
+                is Success -> {
+                    return if (response.data.isWordPressAdminDashboard()) null
+                    else failed(username, CookieNonceErrorType.CUSTOM_ADMIN_URL)
+                }
+                is Error -> {
+                    if (response.error.volleyError is NoConnectionError) {
+                        return Unknown(username)
+                    }
+                    val networkResponse = response.error.volleyError?.networkResponse
+                    if (networkResponse?.statusCode?.isRedirect() != true) {
+                        return failed(username, CookieNonceErrorType.CUSTOM_ADMIN_URL, response)
+                    }
+                    if (redirectsFollowed == MAX_ENDPOINT_REDIRECTS) {
+                        return failed(username, CookieNonceErrorType.CUSTOM_ADMIN_URL, response)
+                    }
+                    val redirectUrl = networkResponse.location()
+                        ?.let(currentUrl::resolve)
+                        ?.withoutFragment()
+                        ?.takeIf { it.isSafeFor(endpoints.canonicalSiteOrigin, currentUrl) }
+                        ?: return failed(username, CookieNonceErrorType.CUSTOM_ADMIN_URL, response)
+                    currentUrl = redirectUrl
+                    redirectsFollowed++
+                }
+            }
+        }
+    }
+
+    private fun loginBodyFailure(response: Success<String>, username: String): Nonce {
+        val responseBody = response.data.orEmpty()
+        val errorMessage = extractErrorMessage(responseBody)
+        val errorType = if (responseBody.contains(INVALID_CREDENTIAL_HTML_PATTERN) &&
+            errorMessage?.contains("captcha", ignoreCase = true) != true
+        ) {
+            CookieNonceErrorType.INVALID_CREDENTIALS
+        } else {
+            CookieNonceErrorType.INVALID_RESPONSE
+        }
+        return failed(username, errorType, errorMessage = errorMessage)
+    }
+
+    private fun loginFailure(
+        username: String,
+        response: Error<String>,
+        networkResponse: NetworkResponse?
+    ): Nonce = failed(username, getLoginErrorType(networkResponse), response)
+
+    private fun getLoginErrorType(networkResponse: NetworkResponse?): CookieNonceErrorType = when {
+        networkResponse?.statusCode == NOT_FOUND_STATUS_CODE ||
+            networkResponse?.statusCode == 410 -> CookieNonceErrorType.CUSTOM_LOGIN_URL
+        isBasicAuthError(networkResponse) -> CookieNonceErrorType.BASIC_AUTH_REQUIRED
+        else -> CookieNonceErrorType.GENERIC_ERROR
+    }
+
+    private fun failed(
+        username: String,
+        type: CookieNonceErrorType,
+        response: Error<String>? = null,
+        errorMessage: String? = response?.error?.message
+    ) = FailedRequest(
+        timeOfResponse = currentTimeProvider.currentDate().time,
+        username = username,
+        type = type,
+        networkError = response?.error,
+        errorMessage = errorMessage
+    )
 
     private fun isBasicAuthError(networkResponse: NetworkResponse?): Boolean =
         networkResponse?.headers?.keys?.any { it.equals(AUTH_HEADER_KEY, ignoreCase = true) } == true &&
-            networkResponse?.headers?.values?.any { it.contains(BASIC_AUTH_REALM, ignoreCase = true) } == true
+            networkResponse.headers?.values?.any { it.contains(BASIC_AUTH_REALM, ignoreCase = true) } == true
 
-    private suspend fun requestNonce(redirectUrl: String, username: String): Nonce {
-        return when (
-            val response = wpApiEncodedBodyRequestBuilder.syncGetRequest(this, redirectUrl)
-        ) {
-            is Success -> {
-                if (response.data?.matches("[0-9a-zA-Z]{2,}".toRegex()) == true) {
-                    Available(value = response.data, username = username)
-                } else {
-                    FailedRequest(
-                        timeOfResponse = currentTimeProvider.currentDate().time,
-                        username = username,
-                        type = Nonce.CookieNonceErrorType.INVALID_NONCE
-                    )
-                }
-            }
+    private suspend fun requestNonce(nonceUrl: HttpUrl, username: String): Nonce {
+        return when (val response = wpApiEncodedBodyRequestBuilder.syncGetRequest(this, nonceUrl.toString())) {
+            is Success -> if (response.data?.matches("[0-9a-zA-Z]{2,}".toRegex()) == true) {
+                Available(value = response.data, username = username)
+            } else failed(username, CookieNonceErrorType.INVALID_NONCE)
 
             is Error -> {
                 val statusCode = response.error.volleyError?.networkResponse?.statusCode
-                FailedRequest(
-                    timeOfResponse = currentTimeProvider.currentDate().time,
-                    username = username,
-                    type = if (statusCode == NOT_FOUND_STATUS_CODE) Nonce.CookieNonceErrorType.CUSTOM_ADMIN_URL
-                    else Nonce.CookieNonceErrorType.GENERIC_ERROR,
-                    networkError = response.error,
-                    errorMessage = response.error.message,
-                )
+                val errorType = if (statusCode == NOT_FOUND_STATUS_CODE) {
+                    CookieNonceErrorType.CUSTOM_ADMIN_URL
+                } else {
+                    CookieNonceErrorType.GENERIC_ERROR
+                }
+                failed(username, errorType, response)
             }
         }
+    }
+
+    private fun String.toNetworkUrlOrNull() = toHttpUrlOrNull()?.takeIf { it.scheme == "http" || it.scheme == "https" }
+
+    private fun HttpUrl.isSafeFor(canonicalOrigin: HttpUrl, previousUrl: HttpUrl? = null): Boolean {
+        return CookieNonceAuthenticationEndpoints.isSafeFor(this, canonicalOrigin, previousUrl)
+    }
+
+    private fun HttpUrl.upgradeForSecureLogin(loginUrl: HttpUrl, canonicalOrigin: HttpUrl): HttpUrl {
+        return if (canonicalOrigin.scheme == "http" && canonicalOrigin.port == HTTP_DEFAULT_PORT &&
+            scheme == "http" && port == HTTP_DEFAULT_PORT && loginUrl.scheme == "https"
+        ) {
+            newBuilder().scheme("https").port(HTTPS_DEFAULT_PORT).build()
+        } else {
+            this
+        }
+    }
+
+    private fun HttpUrl.withoutFragment(): HttpUrl = newBuilder().fragment(null).build()
+
+    private fun HttpUrl.asReusableAdminBase(): HttpUrl = takeUnless {
+        encodedPathSegments.lastOrNull().equals(ADMIN_INDEX, ignoreCase = true)
+    } ?: newBuilder().removePathSegment(encodedPathSegments.lastIndex).addPathSegment("").build()
+
+    private fun HttpUrl.isNonceEndpoint(): Boolean =
+        encodedPathSegments.lastOrNull() == ADMIN_AJAX_PATH_SEGMENT &&
+            encodedQuery == REST_NONCE_QUERY
+
+    private fun Int.isRedirect(): Boolean = this in 300..399
+
+    private fun NetworkResponse.location(): String? = allHeaders
+        ?.firstOrNull { it.name.equals(LOCATION_HEADER, ignoreCase = true) }
+        ?.value
+
+    private fun <T : Nonce> cache(siteIdentity: String, nonce: T): T = nonce.also {
+        nonceMap[siteIdentity.nonceCacheIdentity()] = it
+    }
+
+    private fun Nonce.withVerifiedLoginEntry(): Nonce = when (this) {
+        is Available -> this
+        is FailedRequest -> copy(loginEntryVerified = true)
+        is Unknown -> copy(loginEntryVerified = true)
+    }
+
+    private fun String.nonceCacheIdentity(): String {
+        val siteBase = toNetworkUrlOrNull()?.withoutFragment() ?: return this
+        val normalizedPath = siteBase.encodedPath.trimEnd('/').ifEmpty { "/" }
+        return siteBase.newBuilder().encodedPath(normalizedPath).build().toString()
     }
 
     private fun extractErrorMessage(htmlResponse: String): String? {
         val regex = Regex("<div[^>]*id=\"login_error\"[^>]*>([\\s\\S]+?)</div>")
         val loginErrorDiv = regex.find(htmlResponse)?.groupValues?.get(1) ?: return null
         val urlRegex = Regex("<a[^>]*href=\".*\"[^>]*>[\\s\\S]+?</a>")
-
         val errorHtml = loginErrorDiv.replace(urlRegex, "")
-        // Strip HTML tags
-        return HtmlUtils.fastStripHtml(errorHtml)
-            .trim(' ', '\n')
+        return HtmlUtils.fastStripHtml(errorHtml).trim(' ', '\n')
     }
 
-    private fun hasInvalidCredentialsPattern(htmlResponse: String) =
-        htmlResponse.contains(INVALID_CREDENTIAL_HTML_PATTERN)
+    private fun String?.loginFormSubmissionUrl(documentUrl: HttpUrl, canonicalOrigin: HttpUrl): HttpUrl? {
+        val renderedHtml = this?.replace(NON_RENDERED_REGION_PATTERN, "") ?: return null
+        if (NON_RENDERED_MARKER_PATTERN.containsMatchIn(renderedHtml)) return null
+
+        val forms = FORM_REGION_PATTERN.findAll(renderedHtml).toList()
+        if (FORM_TAG_PATTERN.findAll(renderedHtml).count() != forms.size * 2) return null
+        val credentialForms = forms.map { form ->
+            val formAttributes = form.groupValues[1].htmlAttributes() ?: return null
+            val inputAttributes = form.groupValues[2].inputAttributes() ?: return null
+            formAttributes to inputAttributes
+        }.filter { (formAttributes, inputAttributes) ->
+            formAttributes.isWordPressLoginForm() && inputAttributes.hasWordPressLoginFields()
+        }.take(2)
+        val formAttributes = credentialForms.singleOrNull()?.first ?: return null
+        if (!formAttributes.value("method").equals(POST_METHOD, ignoreCase = true)) return null
+
+        val action = formAttributes.value("action")?.let(StringEscapeUtils::unescapeHtml4)?.trim().orEmpty()
+        val submissionUrl = if (action.isEmpty()) documentUrl else documentUrl.resolve(action) ?: return null
+        return submissionUrl.withoutFragment().takeIf { it.isSafeFor(canonicalOrigin, documentUrl) }
+    }
+
+    private fun String.inputAttributes(): List<List<MatchResult>>? = INPUT_PATTERN.findAll(this).toList().map { input ->
+        input.groupValues[1].htmlAttributes() ?: return null
+    }
+
+    private fun List<MatchResult>.isWordPressLoginForm(): Boolean =
+        value(ID_ATTRIBUTE) == LOGIN_FORM_ID && value(NAME_ATTRIBUTE) == LOGIN_FORM_NAME
+
+    private fun List<List<MatchResult>>.hasWordPressLoginFields(): Boolean {
+        val loginInput = filter { it.isEnabledInput(LOGIN_FIELD_NAME) }.singleOrNull()
+        val passwordInput = filter { it.isEnabledInput(PASSWORD_FIELD_NAME) }.singleOrNull()
+        return loginInput?.hasLoginSemantics(LOGIN_FIELD_ID, TEXT_INPUT_TYPE) == true &&
+            passwordInput?.hasLoginSemantics(PASSWORD_FIELD_ID, PASSWORD_INPUT_TYPE) == true
+    }
+
+    private fun List<MatchResult>.isEnabledInput(name: String): Boolean =
+        !has(FORM_ATTRIBUTE) &&
+            !has(DISABLED_ATTRIBUTE) &&
+            value(NAME_ATTRIBUTE) == name
+
+    private fun List<MatchResult>.hasLoginSemantics(id: String, type: String): Boolean =
+        value(ID_ATTRIBUTE) == id && value(TYPE_ATTRIBUTE).equals(type, ignoreCase = true)
+
+    private fun String.htmlAttributes(): List<MatchResult>? {
+        val attributes = ATTRIBUTE_PATTERN.findAll(this).toList()
+        return attributes.takeIf {
+            ATTRIBUTE_PATTERN.replace(this, "").isBlank() &&
+                attributes.map { match -> match.groupValues[1].lowercase() }.distinct().size == attributes.size
+        }
+    }
+
+    private fun List<MatchResult>.has(name: String) = any { it.groupValues[1].equals(name, ignoreCase = true) }
+
+    private fun List<MatchResult>.value(name: String): String? = firstOrNull {
+        it.groupValues[1].equals(name, ignoreCase = true)
+    }?.groups?.drop(2)?.firstNotNullOfOrNull { it?.value }
+
+    private fun String?.isWordPressAdminDashboard(): Boolean {
+        val body = this ?: return false
+        val bodyClasses = BODY_CLASS_PATTERN.find(body)?.groupValues?.get(2) ?: return false
+        val classNames = bodyClasses.lowercase().split(WHITESPACE_PATTERN).toSet()
+        return "wp-admin" in classNames &&
+            "index-php" in classNames &&
+            DASHBOARD_WIDGETS_PATTERN.containsMatchIn(body)
+    }
+
+    private sealed interface LoginPreflight {
+        sealed interface Success : LoginPreflight {
+            val transactionUrl: HttpUrl
+        }
+
+        data class LoginForm(override val transactionUrl: HttpUrl) : Success
+        data class AlreadyAuthenticated(override val transactionUrl: HttpUrl) : Success
+        data class Failure(val nonce: Nonce) : LoginPreflight
+    }
 
     companion object {
         const val INVALID_CREDENTIAL_HTML_PATTERN = "document.querySelector('form').classList.add('shake')"
         const val AUTH_HEADER_KEY = "WWW-Authenticate"
         const val BASIC_AUTH_REALM = "Basic realm"
+        private val BODY_CLASS_PATTERN = Regex(
+            """<body\b[^>]*\bclass\s*=\s*(['"])(.*?)\1""", RegexOption.IGNORE_CASE
+        )
+        private val DASHBOARD_WIDGETS_PATTERN = Regex(
+            pattern = """<[^>]*\bid\s*=\s*(['"])dashboard-widgets-wrap\1[^>]*>""",
+            option = RegexOption.IGNORE_CASE
+        )
+        private val NON_RENDERED_REGION_PATTERN = Regex(
+            pattern = """<!--.*?-->|<(script|style|template|textarea|title|iframe|noembed|noframes|xmp|svg|math)""" +
+                """\b[^>]*>.*?</\1\s*>""",
+            options = setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL)
+        )
+        private val NON_RENDERED_MARKER_PATTERN = Regex(
+            pattern = """<!--|</?(?:script|style|template|textarea|title|iframe|noembed|noframes|xmp|svg|math)\b""",
+            option = RegexOption.IGNORE_CASE
+        )
+        private val FORM_REGION_PATTERN = Regex(
+            pattern = """<form\b([^>]*)>(.*?)</form\s*>""",
+            options = setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL)
+        )
+        private val FORM_TAG_PATTERN = Regex("""</?form\b[^>]*>""", RegexOption.IGNORE_CASE)
+        private val INPUT_PATTERN = Regex(
+            pattern = """<input\b([^>]*?)\s*/?>""",
+            option = RegexOption.IGNORE_CASE
+        )
+        private val ATTRIBUTE_PATTERN = Regex(
+            pattern = """(?:^|\s+)([A-Za-z_:][A-Za-z0-9_.:-]*)""" +
+                """(?:\s*=\s*(?:\"([^\"]*)\"|'([^']*)'|([^\s\"'=<>`]+)))?"""
+        )
+        private val WHITESPACE_PATTERN = Regex("\\s+")
+        private const val ID_ATTRIBUTE = "id"
+        private const val NAME_ATTRIBUTE = "name"
+        private const val TYPE_ATTRIBUTE = "type"
+        private const val FORM_ATTRIBUTE = "form"
+        private const val DISABLED_ATTRIBUTE = "disabled"
+        private const val LOGIN_FORM_ID = "loginform"
+        private const val LOGIN_FORM_NAME = "loginform"
+        private const val LOGIN_FIELD_NAME = "log"
+        private const val LOGIN_FIELD_ID = "user_login"
+        private const val PASSWORD_FIELD_NAME = "pwd"
+        private const val PASSWORD_FIELD_ID = "user_pass"
+        private const val TEXT_INPUT_TYPE = "text"
+        private const val PASSWORD_INPUT_TYPE = "password"
+        private const val POST_METHOD = "post"
+        private const val ADMIN_INDEX = "index.php"
+        private const val LOCATION_HEADER = "Location"
+        private const val HTTP_DEFAULT_PORT = 80
+        private const val HTTPS_DEFAULT_PORT = 443
+        private const val ADMIN_AJAX_PATH_SEGMENT = "admin-ajax.php"
+        private const val REST_NONCE_QUERY = "action=rest-nonce"
     }
 }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/NonceRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/NonceRestClient.kt
@@ -17,17 +17,11 @@ import org.wordpress.android.fluxc.network.rest.wpapi.Nonce.Unknown
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse.Error
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse.Success
 import org.wordpress.android.fluxc.utils.CurrentTimeProvider
-import org.wordpress.android.fluxc.utils.extensions.slashJoin
 import org.wordpress.android.util.HtmlUtils
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
 
-private const val NOT_FOUND_STATUS_CODE = 404
-private const val GONE_STATUS_CODE = 410
-private const val MAX_ENDPOINT_REDIRECTS = 3
-private const val REDIRECT_STATUS_CODE_START = 300
-private const val REDIRECT_STATUS_CODE_END = 399
 private typealias ValidatedEndpoints = CookieNonceAuthenticationEndpoints.ValidationResult.Valid
 
 @Singleton
@@ -58,6 +52,7 @@ class NonceRestClient @Inject constructor(
         username: String,
         password: String
     ): Nonce {
+        val siteIdentity = endpoints.siteUrl
         val validated = when (val result = endpoints.validate()) {
             is CookieNonceAuthenticationEndpoints.ValidationResult.Valid -> result
             is CookieNonceAuthenticationEndpoints.ValidationResult.Invalid -> {
@@ -66,34 +61,25 @@ class NonceRestClient @Inject constructor(
                 } else {
                     CookieNonceErrorType.CUSTOM_LOGIN_URL
                 }
-                return cache(endpoints.canonicalSiteOrigin, failed(username, type))
+                return cache(siteIdentity, failed(username, type))
             }
         }
-        val derivedNonceUrl = validated.adminBaseUrl.toString()
-            .slashJoin("$ADMIN_AJAX_PATH_SEGMENT?$REST_NONCE_QUERY")
-            .toNetworkUrlOrNull()
-            ?: return cache(endpoints.canonicalSiteOrigin, failed(username, CookieNonceErrorType.CUSTOM_ADMIN_URL))
 
         val preflight = when (val result = preflightLogin(validated, username)) {
             is LoginPreflight.Success -> result
-            is LoginPreflight.Failure -> return cache(endpoints.canonicalSiteOrigin, result.nonce)
+            is LoginPreflight.Failure -> return cache(siteIdentity, result.nonce)
         }
-        val nonceUrl = derivedNonceUrl.upgradeForSecureLogin(
-            preflight.transactionUrl,
-            validated.canonicalSiteOrigin
-        )
         val transaction = LoginTransaction(
             endpoints = validated,
-            verification = endpoints.adminBaseVerification,
             loginUrl = preflight.transactionUrl,
-            nonceUrl = nonceUrl,
+            nonceUrl = validated.nonceUrlFor(preflight.transactionUrl),
             username = username
         )
         val nonce = when (preflight) {
             is LoginPreflight.LoginForm -> postCredentials(transaction, password)
             is LoginPreflight.AlreadyAuthenticated -> verifyAdminDashboardAndRequestNonce(transaction)
         }
-        return cache(endpoints.canonicalSiteOrigin, nonce.withVerifiedLoginEntry())
+        return cache(siteIdentity, nonce.withVerifiedLoginEntry())
     }
 
     @Suppress("NestedBlockDepth", "ReturnCount")
@@ -103,21 +89,15 @@ class NonceRestClient @Inject constructor(
         while (true) {
             when (val response = wpApiEncodedBodyRequestBuilder.syncGetRequest(this, currentUrl.toString())) {
                 is Success -> {
-                    val expectedAdminUrl = endpoints.adminBaseUrl.upgradeForSecureLogin(
-                        currentUrl,
-                        endpoints.canonicalSiteOrigin
-                    )
-                    val isExpectedAdminUrl = currentUrl.asReusableAdminBase() == expectedAdminUrl
-                    if (response.data.isWordPressAdminDashboard()) {
-                        return if (isExpectedAdminUrl) LoginPreflight.AlreadyAuthenticated(currentUrl)
-                        else LoginPreflight.Failure(failed(username, CookieNonceErrorType.CUSTOM_ADMIN_URL))
+                    return when {
+                        endpoints.isAdminBase(currentUrl) -> LoginPreflight.AlreadyAuthenticated(currentUrl)
+                        response.data.isWordPressAdminDashboard() -> {
+                            LoginPreflight.Failure(failed(username, CookieNonceErrorType.CUSTOM_ADMIN_URL))
+                        }
+                        else -> response.data.loginFormSubmissionUrl(currentUrl, endpoints)
+                            ?.let(LoginPreflight::LoginForm)
+                            ?: LoginPreflight.Failure(failed(username, CookieNonceErrorType.INVALID_RESPONSE))
                     }
-                    if (isExpectedAdminUrl) return LoginPreflight.AlreadyAuthenticated(currentUrl)
-                    val submissionUrl = response.data.loginFormSubmissionUrl(
-                        currentUrl,
-                        endpoints.canonicalSiteOrigin
-                    ) ?: return LoginPreflight.Failure(failed(username, CookieNonceErrorType.INVALID_RESPONSE))
-                    return LoginPreflight.LoginForm(submissionUrl)
                 }
                 is Error -> {
                     if (response.error.volleyError is NoConnectionError) {
@@ -135,7 +115,7 @@ class NonceRestClient @Inject constructor(
                     val redirectUrl = networkResponse.location()
                         ?.let(currentUrl::resolve)
                         ?.withoutFragment()
-                        ?.takeIf { it.isSafeFor(endpoints.canonicalSiteOrigin, currentUrl) }
+                        ?.takeIf { endpoints.allows(it, currentUrl) }
                         ?: return LoginPreflight.Failure(
                             failed(username, CookieNonceErrorType.CUSTOM_LOGIN_URL, response)
                         )
@@ -178,10 +158,10 @@ class NonceRestClient @Inject constructor(
         val redirectUrl = networkResponse.location()
             ?.let(transaction.loginUrl::resolve)
             ?.withoutFragment()
-            ?.takeIf { it.isSafeFor(transaction.endpoints.canonicalSiteOrigin, transaction.loginUrl) }
+            ?.takeIf { transaction.endpoints.allows(it, transaction.loginUrl) }
         return when {
             redirectUrl == transaction.nonceUrl -> verifyAdminDashboardAndRequestNonce(transaction)
-            redirectUrl?.isNonceEndpoint() == true -> {
+            transaction.endpoints.isNonceEndpoint(redirectUrl) -> {
                 failed(transaction.username, CookieNonceErrorType.CUSTOM_ADMIN_URL, response)
             }
             else -> failed(transaction.username, CookieNonceErrorType.INVALID_NONCE, response)
@@ -189,11 +169,8 @@ class NonceRestClient @Inject constructor(
     }
 
     private suspend fun verifyAdminDashboardAndRequestNonce(transaction: LoginTransaction): Nonce {
-        if (transaction.verification == AdminBaseVerification.AUTHENTICATED_DASHBOARD) {
-            val dashboardUrl = transaction.endpoints.adminBaseUrl.upgradeForSecureLogin(
-                transaction.loginUrl,
-                transaction.endpoints.canonicalSiteOrigin
-            )
+        if (transaction.endpoints.adminBaseVerification == AdminBaseVerification.AUTHENTICATED_DASHBOARD) {
+            val dashboardUrl = transaction.endpoints.adminBaseUrlFor(transaction.loginUrl)
             verifyAdminDashboard(transaction.endpoints, dashboardUrl, transaction.username)?.let { return it }
         }
         return requestNonce(transaction.nonceUrl, transaction.username)
@@ -227,7 +204,7 @@ class NonceRestClient @Inject constructor(
                     val redirectUrl = networkResponse.location()
                         ?.let(currentUrl::resolve)
                         ?.withoutFragment()
-                        ?.takeIf { it.isSafeFor(endpoints.canonicalSiteOrigin, currentUrl) }
+                        ?.takeIf { endpoints.allows(it, currentUrl) }
                         ?: return failed(username, CookieNonceErrorType.CUSTOM_ADMIN_URL, response)
                     currentUrl = redirectUrl
                     redirectsFollowed++
@@ -299,29 +276,7 @@ class NonceRestClient @Inject constructor(
 
     private fun String.toNetworkUrlOrNull() = toHttpUrlOrNull()?.takeIf { it.scheme == "http" || it.scheme == "https" }
 
-    private fun HttpUrl.isSafeFor(canonicalOrigin: HttpUrl, previousUrl: HttpUrl? = null): Boolean {
-        return CookieNonceAuthenticationEndpoints.isSafeFor(this, canonicalOrigin, previousUrl)
-    }
-
-    private fun HttpUrl.upgradeForSecureLogin(loginUrl: HttpUrl, canonicalOrigin: HttpUrl): HttpUrl {
-        return if (canonicalOrigin.isDefaultHttp() && isDefaultHttp() && loginUrl.scheme == "https") {
-            newBuilder().scheme("https").port(HTTPS_DEFAULT_PORT).build()
-        } else {
-            this
-        }
-    }
-
-    private fun HttpUrl.isDefaultHttp(): Boolean = scheme == "http" && port == HTTP_DEFAULT_PORT
-
     private fun HttpUrl.withoutFragment(): HttpUrl = newBuilder().fragment(null).build()
-
-    private fun HttpUrl.asReusableAdminBase(): HttpUrl = takeUnless {
-        encodedPathSegments.lastOrNull().equals(ADMIN_INDEX, ignoreCase = true)
-    } ?: newBuilder().removePathSegment(encodedPathSegments.lastIndex).addPathSegment("").build()
-
-    private fun HttpUrl.isNonceEndpoint(): Boolean =
-        encodedPathSegments.lastOrNull() == ADMIN_AJAX_PATH_SEGMENT &&
-            encodedQuery == REST_NONCE_QUERY
 
     private fun Int.isRedirect(): Boolean = this in REDIRECT_STATUS_CODE_START..REDIRECT_STATUS_CODE_END
 
@@ -354,7 +309,7 @@ class NonceRestClient @Inject constructor(
     }
 
     @Suppress("ReturnCount")
-    private fun String?.loginFormSubmissionUrl(documentUrl: HttpUrl, canonicalOrigin: HttpUrl): HttpUrl? {
+    private fun String?.loginFormSubmissionUrl(documentUrl: HttpUrl, endpoints: ValidatedEndpoints): HttpUrl? {
         val renderedHtml = this?.replace(NON_RENDERED_REGION_PATTERN, "") ?: return null
         if (NON_RENDERED_MARKER_PATTERN.containsMatchIn(renderedHtml)) return null
 
@@ -372,7 +327,7 @@ class NonceRestClient @Inject constructor(
 
         val action = formAttributes.value("action")?.let(StringEscapeUtils::unescapeHtml4)?.trim().orEmpty()
         val submissionUrl = if (action.isEmpty()) documentUrl else documentUrl.resolve(action) ?: return null
-        return submissionUrl.withoutFragment().takeIf { it.isSafeFor(canonicalOrigin, documentUrl) }
+        return submissionUrl.withoutFragment().takeIf { endpoints.allows(it, documentUrl) }
     }
 
     private fun String.inputAttributes(): List<List<MatchResult>>? = INPUT_PATTERN.findAll(this).toList().map { input ->
@@ -432,7 +387,6 @@ class NonceRestClient @Inject constructor(
 
     private data class LoginTransaction(
         val endpoints: ValidatedEndpoints,
-        val verification: AdminBaseVerification,
         val loginUrl: HttpUrl,
         val nonceUrl: HttpUrl,
         val username: String
@@ -486,11 +440,11 @@ class NonceRestClient @Inject constructor(
         private const val TEXT_INPUT_TYPE = "text"
         private const val PASSWORD_INPUT_TYPE = "password"
         private const val POST_METHOD = "post"
-        private const val ADMIN_INDEX = "index.php"
         private const val LOCATION_HEADER = "Location"
-        private const val HTTP_DEFAULT_PORT = 80
-        private const val HTTPS_DEFAULT_PORT = 443
-        private const val ADMIN_AJAX_PATH_SEGMENT = "admin-ajax.php"
-        private const val REST_NONCE_QUERY = "action=rest-nonce"
+        private const val NOT_FOUND_STATUS_CODE = 404
+        private const val GONE_STATUS_CODE = 410
+        private const val MAX_ENDPOINT_REDIRECTS = 3
+        private const val REDIRECT_STATUS_CODE_START = 300
+        private const val REDIRECT_STATUS_CODE_END = 399
     }
 }


### PR DESCRIPTION
### Description
Fixes WOOMOB-3799

Part 1 of 3. Followed by #16397 and #16398.

> [!NOTE]
> The PR is a bit big, but the bulk is just tests. 

This is one direct-site-credentials fix split into three PRs for review; the parts are not intended to ship independently. Merge order is 1 → 2 → 3, once the whole stack is approved.

Cookie/nonce authentication assumed that every store exposed `/wp-login.php` and `/wp-admin/`. It also posted credentials without first establishing that the destination was a WordPress login form. That prevents login on stores where a security plugin moves either endpoint and makes redirect handling too permissive for a credential-bearing transaction.

This PR adds a validated endpoint model containing the canonical store origin plus optional login-entry and admin-base overrides, then rebuilds nonce acquisition around it.

```mermaid
flowchart LR
    A["GET login entry<br/>up to 3 safe redirects"] --> B{"Verified WordPress<br/>login form?"}
    B -->|No| X["Fail before sending credentials"]
    B -->|Yes| C["POST credentials to the<br/>validated form action"]
    B -->|Already signed in at<br/>the expected admin base| D
    C -->|Redirect must exactly match<br/>the derived nonce URL| D["GET REST nonce<br/>without following redirects"]
```

The important constraints are:

- Every supplied or redirected URL must stay on the canonical host, contain no user information, preserve the approved port, and never downgrade HTTPS. A default-port HTTP origin may upgrade to HTTPS on port 443.
- The login preflight accepts exactly one core-compatible `loginform`, with one enabled username field and one enabled password field. Its form action is resolved against the final preflight URL and validated before use.
- The credential POST remains deliberately small: `log`, `pwd`, and `redirect_to` only.
- The successful credential redirect must equal the nonce URL derived from the validated admin base. A same-origin lookalike is classified as a custom-admin failure but is never followed or persisted.
- WPS Hide Login's already-authenticated `/login` → `/wp-admin/` path is handled without posting credentials to the dashboard; a valid nonce still has to prove the session.
- Nonce cache identity now normalizes terminal slashes while continuing to isolate usernames, subdirectories, schemes, hosts, and ports.
- Nonce failures record whether the login entry had already been verified. PR2 and PR3 use that provenance to distinguish “wrong login address” from a later credential, network, or nonce failure.

The form check intentionally fails closed. A store whose theme or plugin substantially changes WordPress's form identity or field semantics may be rejected rather than receiving credentials. Rejection is not limited to the login form itself: malformed form markup elsewhere on the page, or a comment/script marker that survives stripping, rejects the page with the same non-diagnostic invalid-response result. Supporting interactive 2FA, CAPTCHA, SSO, or arbitrary custom form markup is outside this stack.

This PR also introduces optional authenticated-dashboard verification for a supplied admin base; the user-facing recovery flow activates it in PR3. QR login, XML-RPC, and Application Password architecture are unchanged.

Review map:

- `CookieNonceAuthenticationEndpoints.kt`: endpoint validation and same-origin policy.
- `NonceRestClient.kt`: preflight, form-action selection, redirect rules, dashboard/nonce checks, and cache identity.
- `Nonce.kt`: verified-login-entry provenance.
- `NonceRestClientTest.kt`: the safety and compatibility matrix.

### Test Steps

This PR has no custom-endpoint UI. Use the top-of-stack (PR3) build for step 4.

1. Sign in to a self-hosted store that uses the default `/wp-login.php` and `/wp-admin/` paths. Confirm the store opens normally.
2. Sign out and try again with an incorrect password. Confirm an invalid-credentials error appears and the store does not open.
3. On a store whose HTTP URL redirects to HTTPS on the same host, enter its `http://` address and valid credentials. Confirm login succeeds normally.
4. Using the PR3 build, sign in to a store with WPS Hide Login enabled. Enter its custom sign-in URL when prompted and confirm login succeeds.

### Images/gif

N/A — this PR changes the networking layer; the transaction diagram above is the relevant visual.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

The stack's single user-facing release note is owned by PR3.

