### PR TITLE
[WOOMOB-3799] Propagate and persist custom authentication endpoints (2/3)

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/WPApiSiteRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/WPApiSiteRepository.kt
@@ -189,14 +189,16 @@ class WPApiSiteRepository @Inject constructor(
                 event.rowsAffected <= 0 -> Result.failure(
                     IllegalStateException("Authentication endpoints update did not persist any site rows")
                 )
-                else -> getSiteByLocalId(site.id)?.let { persistedSite ->
+                else -> {
                     persistenceConfirmed = true
-                    Result.success(persistedSite)
-                } ?: Result.failure(
-                    IllegalStateException(
-                        "Authentication endpoints persisted but site ${site.id} could not be reloaded"
+                    getSiteByLocalId(site.id)?.let { persistedSite ->
+                        Result.success(persistedSite)
+                    } ?: Result.failure(
+                        IllegalStateException(
+                            "Authentication endpoints persisted but site ${site.id} could not be reloaded"
+                        )
                     )
-                )
+                }
             }
         } finally {
             if (!persistenceConfirmed) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/WPApiSiteRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/WPApiSiteRepository.kt
@@ -21,6 +21,7 @@ import org.wordpress.android.fluxc.generated.SiteActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpapi.CookieNonceAuthenticator
 import org.wordpress.android.fluxc.network.rest.wpapi.CookieNonceAuthenticator.CookieNonceAuthenticationResult.Error
+import org.wordpress.android.fluxc.network.rest.wpapi.CookieNonceAuthenticationEndpoints
 import org.wordpress.android.fluxc.network.rest.wpapi.Nonce
 import org.wordpress.android.fluxc.network.rest.wpapi.Nonce.CookieNonceErrorType.BASIC_AUTH_REQUIRED
 import org.wordpress.android.fluxc.network.rest.wpapi.Nonce.CookieNonceErrorType.CUSTOM_ADMIN_URL
@@ -53,14 +54,19 @@ class WPApiSiteRepository @Inject constructor(
     /**
      * Handles authentication to the given [url] using wp-admin credentials.
      */
-    suspend fun login(url: String, username: String, password: String): Result<Unit> {
+    suspend fun login(
+        url: String,
+        username: String,
+        password: String,
+        endpoints: CookieNonceAuthenticationEndpoints = CookieNonceAuthenticationEndpoints(url)
+    ): Result<Unit> {
         WooLog.d(WooLog.T.LOGIN, "Authenticating in to site $url using site credentials")
 
         // Clear cookies to make sure the new credentials are correctly checked
         cookieManager.cookieStore.removeAll()
 
         val authenticationResult = cookieNonceAuthenticator.authenticate(
-            siteUrl = url,
+            endpoints = endpoints,
             username = username,
             password = password
         )
@@ -163,6 +169,43 @@ class WPApiSiteRepository @Inject constructor(
         dispatcher.dispatchAndAwait<SiteModel, OnSiteChanged>(SiteActionBuilder.newUpdateSiteAction(site))
     }
 
+    suspend fun saveAuthenticationEndpoints(
+        site: SiteModel,
+        endpoints: CookieNonceAuthenticationEndpoints
+    ): Result<SiteModel> {
+        val originalLoginUrl = site.loginUrl
+        val originalAdminUrl = site.adminUrl
+        var persistenceConfirmed = false
+
+        return try {
+            endpoints.loginEntryUrl?.let { site.loginUrl = it }
+            endpoints.adminBaseUrl?.let { site.adminUrl = it }
+
+            val event = dispatcher.dispatchAndAwait<SiteModel, OnSiteChanged>(
+                SiteActionBuilder.newUpdateSiteAction(site)
+            )
+            when {
+                event.isError -> Result.failure(OnChangedException(event.error))
+                event.rowsAffected <= 0 -> Result.failure(
+                    IllegalStateException("Authentication endpoints update did not persist any site rows")
+                )
+                else -> getSiteByLocalId(site.id)?.let { persistedSite ->
+                    persistenceConfirmed = true
+                    Result.success(persistedSite)
+                } ?: Result.failure(
+                    IllegalStateException(
+                        "Authentication endpoints persisted but site ${site.id} could not be reloaded"
+                    )
+                )
+            }
+        } finally {
+            if (!persistenceConfirmed) {
+                site.loginUrl = originalLoginUrl
+                site.adminUrl = originalAdminUrl
+            }
+        }
+    }
+
     private fun Error.mapToException(): CookieNonceAuthenticationException {
         val networkStatusCode = extractNetworkStatusCode()
         val networkErrorMessage by lazy {
@@ -179,7 +222,8 @@ class WPApiSiteRepository @Inject constructor(
         return CookieNonceAuthenticationException(
             errorMessage,
             type,
-            networkStatusCode
+            networkStatusCode,
+            loginEntryVerified
         )
     }
 
@@ -193,21 +237,23 @@ class WPApiSiteRepository @Inject constructor(
                 type == INVALID_CREDENTIALS || type == INVALID_RESPONSE
             }?.let { HTTP_SUCCESS }
 
-    private fun Error.mapToUiString() = when (type) {
-        INVALID_CREDENTIALS -> message?.let { UiStringText(it) }
+    private fun Error.mapToUiString() = when {
+        type == CUSTOM_LOGIN_URL && loginEntryVerified -> null
+        type == INVALID_CREDENTIALS -> message?.let { UiStringText(it) }
             ?: UiStringRes(string.login_invalid_credentials_message)
 
-        INVALID_RESPONSE -> UiStringRes(string.login_site_credentials_invalid_response)
-        CUSTOM_LOGIN_URL -> UiStringRes(string.login_site_credentials_custom_login_url)
-        CUSTOM_ADMIN_URL -> UiStringRes(string.login_site_credentials_custom_admin_url)
-        BASIC_AUTH_REQUIRED -> UiStringRes(string.login_site_credentials_http_basic_auth_error)
+        type == INVALID_RESPONSE -> UiStringRes(string.login_site_credentials_invalid_response)
+        type == CUSTOM_LOGIN_URL -> UiStringRes(string.login_site_credentials_custom_login_url)
+        type == CUSTOM_ADMIN_URL -> UiStringRes(string.login_site_credentials_custom_admin_url)
+        type == BASIC_AUTH_REQUIRED -> UiStringRes(string.login_site_credentials_http_basic_auth_error)
         else -> message?.takeIf { it.isNotEmpty() }?.let { UiStringText(it) }
     }
 
     data class CookieNonceAuthenticationException(
         val errorMessage: UiString,
         val errorType: Nonce.CookieNonceErrorType,
-        val networkStatusCode: Int?
+        val networkStatusCode: Int?,
+        val loginEntryVerified: Boolean = false
     ) : Exception((errorMessage as? UiStringText)?.text)
 
     companion object {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/WPApiSiteRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/WPApiSiteRepositoryTest.kt
@@ -1,0 +1,163 @@
+package com.woocommerce.android.ui.login
+
+import com.android.volley.NetworkResponse
+import com.android.volley.VolleyError
+import com.woocommerce.android.FakeDispatcher
+import com.woocommerce.android.OnChangedException
+import com.woocommerce.android.R
+import com.woocommerce.android.applicationpasswords.ApplicationPasswordsNotifier
+import com.woocommerce.android.model.UiString.UiStringRes
+import com.woocommerce.android.model.UiString.UiStringText
+import com.woocommerce.android.ui.common.UserEligibilityFetcher
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.yield
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.action.SiteAction
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
+import org.wordpress.android.fluxc.network.rest.wpapi.CookieNonceAuthenticationEndpoints
+import org.wordpress.android.fluxc.network.rest.wpapi.CookieNonceAuthenticator
+import org.wordpress.android.fluxc.network.rest.wpapi.CookieNonceAuthenticator.CookieNonceAuthenticationResult.Error
+import org.wordpress.android.fluxc.network.rest.wpapi.CookieNonceAuthenticator.CookieNonceAuthenticationResult.Success
+import org.wordpress.android.fluxc.network.rest.wpapi.Nonce.CookieNonceErrorType.CUSTOM_LOGIN_URL
+import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordsStore
+import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged
+import org.wordpress.android.fluxc.store.SiteStore.SiteError
+import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType.GENERIC_ERROR
+import java.net.CookieManager
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class WPApiSiteRepositoryTest : BaseUnitTest() {
+    private val site = SiteModel().apply {
+        id = SITE_ID
+        loginUrl = ORIGINAL_LOGIN_URL
+        adminUrl = ORIGINAL_ADMIN_URL
+    }
+    private val siteStore: SiteStore = mock()
+    private val authenticator: CookieNonceAuthenticator = mock {
+        on { authenticate(ENDPOINTS, USERNAME, PASSWORD) } doReturn Success
+    }
+    private val testScope = CoroutineScope(coroutinesTestRule.testDispatcher)
+    private var updateEvent = OnSiteChanged(rowsAffected = 1)
+    private val dispatcher = FakeDispatcher().apply {
+        registerActionHandler(SiteAction.UPDATE_SITE) {
+            testScope.launch {
+                yield()
+                emitChange(updateEvent)
+            }
+        }
+    }
+    private val repository = WPApiSiteRepository(
+        dispatcher,
+        siteStore,
+        authenticator,
+        mock<UserEligibilityFetcher>(),
+        mock<ApplicationPasswordsNotifier>(),
+        CookieManager(),
+        mock<ApplicationPasswordsStore>()
+    )
+
+    @Test
+    fun `given structured endpoints, when logging in, then forward them to native authentication`() = testBlocking {
+        val result = repository.login(SITE_URL, USERNAME, PASSWORD, ENDPOINTS)
+
+        assertThat(result.isSuccess).isTrue()
+        verify(authenticator).authenticate(ENDPOINTS, USERNAME, PASSWORD)
+    }
+
+    @Test
+    fun `given verified login entry returns HTTP error, when logging in, then do not blame custom URL`() =
+        testBlocking {
+            whenever(authenticator.authenticate(ENDPOINTS, USERNAME, PASSWORD)).thenReturn(
+                Error(
+                    type = CUSTOM_LOGIN_URL,
+                    networkError = BaseNetworkError(
+                        VolleyError(NetworkResponse(404, byteArrayOf(), false, 0, emptyList()))
+                    ),
+                    loginEntryVerified = true
+                )
+            )
+
+            val exception = repository.login(SITE_URL, USERNAME, PASSWORD, ENDPOINTS).exceptionOrNull()
+                as WPApiSiteRepository.CookieNonceAuthenticationException
+
+            assertThat(exception.errorMessage).isEqualTo(
+                UiStringRes(R.string.login_site_credentials_http_error, listOf(UiStringText("404")))
+            )
+            assertThat(exception.loginEntryVerified).isTrue()
+        }
+
+    @Test
+    fun `given dispatch error, when saving proven endpoints, then fail without mutating caller`() = testBlocking {
+        updateEvent = OnSiteChanged(SiteError(GENERIC_ERROR))
+
+        val result = repository.saveAuthenticationEndpoints(site, ENDPOINTS)
+
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull()).isInstanceOf(OnChangedException::class.java)
+        thenOriginalEndpointsAreRetained()
+    }
+
+    @Test
+    fun `given update affects zero rows, when saving proven endpoints, then fail without mutating caller`() =
+        testBlocking {
+            updateEvent = OnSiteChanged(rowsAffected = 0)
+
+            val result = repository.saveAuthenticationEndpoints(site, ENDPOINTS)
+
+            assertThat(result.isFailure).isTrue()
+            thenOriginalEndpointsAreRetained()
+        }
+
+    @Test
+    fun `given persisted site cannot be reloaded, when saving endpoints, then fail without mutating caller`() =
+        testBlocking {
+            val result = repository.saveAuthenticationEndpoints(site, ENDPOINTS)
+
+            assertThat(result.isFailure).isTrue()
+            thenOriginalEndpointsAreRetained()
+        }
+
+    @Test
+    fun `given persistence succeeds, when saving proven endpoints, then return distinct reloaded site`() = testBlocking {
+        val reloaded = SiteModel().apply {
+            id = SITE_ID
+            loginUrl = LOGIN_URL
+            adminUrl = ADMIN_URL
+        }
+        whenever(siteStore.getSiteByLocalId(SITE_ID)).thenReturn(reloaded)
+
+        val result = repository.saveAuthenticationEndpoints(site, ENDPOINTS)
+
+        assertThat(site.loginUrl).isEqualTo(LOGIN_URL)
+        assertThat(site.adminUrl).isEqualTo(ADMIN_URL)
+        assertThat(result.getOrNull()).isSameAs(reloaded)
+        assertThat(result.getOrNull()).isNotSameAs(site)
+    }
+
+    private fun thenOriginalEndpointsAreRetained() {
+        assertThat(site.loginUrl).isEqualTo(ORIGINAL_LOGIN_URL)
+        assertThat(site.adminUrl).isEqualTo(ORIGINAL_ADMIN_URL)
+    }
+
+    private companion object {
+        const val SITE_ID = 7
+        const val SITE_URL = "https://example.com"
+        const val LOGIN_URL = "$SITE_URL/private-login"
+        const val ADMIN_URL = "$SITE_URL/private-admin/"
+        const val ORIGINAL_LOGIN_URL = "$SITE_URL/wp-login.php"
+        const val ORIGINAL_ADMIN_URL = "$SITE_URL/wp-admin/"
+        const val USERNAME = "merchant"
+        const val PASSWORD = "password"
+        val ENDPOINTS = CookieNonceAuthenticationEndpoints(SITE_URL, LOGIN_URL, ADMIN_URL)
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/WPApiSiteRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/WPApiSiteRepositoryTest.kt
@@ -119,12 +119,13 @@ class WPApiSiteRepositoryTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given persisted site cannot be reloaded, when saving endpoints, then fail without mutating caller`() =
+    fun `given update persists but site cannot be reloaded, when saving endpoints, then fail without rollback`() =
         testBlocking {
             val result = repository.saveAuthenticationEndpoints(site, ENDPOINTS)
 
             assertThat(result.isFailure).isTrue()
-            thenOriginalEndpointsAreRetained()
+            assertThat(site.loginUrl).isEqualTo(LOGIN_URL)
+            assertThat(site.adminUrl).isEqualTo(ADMIN_URL)
         }
 
     @Test

--- a/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/CookieNonceAuthenticatorTest.kt
+++ b/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/CookieNonceAuthenticatorTest.kt
@@ -1,0 +1,175 @@
+package org.wordpress.android.fluxc.network.rest.wpapi
+
+import com.android.volley.NetworkResponse
+import com.android.volley.VolleyError
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
+import org.wordpress.android.fluxc.network.discovery.DiscoveryWPAPIRestClient
+import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.fluxc.test
+import org.wordpress.android.fluxc.tools.initCoroutineEngine
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class CookieNonceAuthenticatorTest {
+    private val nonceClient: NonceRestClient = mock()
+    private val discoveryClient: DiscoveryWPAPIRestClient = mock()
+    private val siteStore: SiteStore = mock()
+    private lateinit var subject: CookieNonceAuthenticator
+
+    @Before
+    fun setUp() {
+        subject = CookieNonceAuthenticator(nonceClient, discoveryClient, siteStore, initCoroutineEngine())
+    }
+
+    @Test
+    fun `given structured endpoints, when authenticating, then require an available nonce`() = test {
+        whenever(nonceClient.requestNonce(ENDPOINTS, USERNAME, PASSWORD))
+            .thenReturn(Nonce.Available(NEW_NONCE, USERNAME))
+
+        val actual = subject.authenticate(ENDPOINTS, USERNAME, PASSWORD)
+
+        assertIs<CookieNonceAuthenticator.CookieNonceAuthenticationResult.Success>(actual)
+        verify(nonceClient).requestNonce(ENDPOINTS, USERNAME, PASSWORD)
+    }
+
+    @Test
+    fun `given verified login entry failure, when authenticating, then propagate provenance`() = test {
+        whenever(nonceClient.requestNonce(ENDPOINTS, USERNAME, PASSWORD))
+            .thenReturn(nonceFailure(loginEntryVerified = true))
+
+        val actual = subject.authenticate(ENDPOINTS, USERNAME, PASSWORD)
+
+        val error = assertIs<CookieNonceAuthenticator.CookieNonceAuthenticationResult.Error>(actual)
+        assertTrue(error.loginEntryVerified)
+    }
+
+    @Test
+    fun `given initial nonce acquisition fails, when making a protected request, then return before REST`() = test {
+        val site = site()
+        whenever(nonceClient.getNonce(SITE_URL, USERNAME)).thenReturn(null)
+        whenever(nonceClient.requestNonce(CookieNonceAuthenticationEndpoints.from(site), USERNAME, PASSWORD))
+            .thenReturn(nonceFailure())
+        var restCalls = 0
+
+        val actual = subject.makeAuthenticatedWPAPIRequest(site) {
+            restCalls++
+            WPAPIResponse.Success("unexpected", emptyList())
+        }
+
+        assertEquals(0, restCalls)
+        assertNonceFailureHasNoResponse(actual)
+        verify(siteStore, never()).insertOrUpdateSite(site)
+    }
+
+    @Test
+    fun `given nonce acquisition times out, when making a protected request, then preserve transport error`() = test {
+        val site = site()
+        whenever(nonceClient.getNonce(SITE_URL, USERNAME)).thenReturn(null)
+        whenever(nonceClient.requestNonce(CookieNonceAuthenticationEndpoints.from(site), USERNAME, PASSWORD))
+            .thenReturn(
+                nonceFailure(
+                    networkError = WPAPINetworkError(
+                        BaseNetworkError(GenericErrorType.TIMEOUT, TIMEOUT_MESSAGE)
+                    )
+                )
+            )
+
+        val actual = subject.makeAuthenticatedWPAPIRequest(site) {
+            WPAPIResponse.Success("unexpected", emptyList())
+        }
+
+        val error = assertIs<WPAPIResponse.Error<*>>(actual).error
+        assertEquals(GenericErrorType.TIMEOUT, error.type)
+        assertEquals(TIMEOUT_MESSAGE, error.message)
+        assertNull(error.volleyError)
+    }
+
+    @Test
+    fun `given cached nonce gets 401 and refresh fails, when making a protected request, then call REST once`() = test {
+        val site = site()
+        whenever(nonceClient.getNonce(SITE_URL, USERNAME)).thenReturn(Nonce.Available(OLD_NONCE, USERNAME))
+        whenever(nonceClient.requestNonce(CookieNonceAuthenticationEndpoints.from(site), USERNAME, PASSWORD))
+            .thenReturn(nonceFailure())
+        var restCalls = 0
+
+        val actual = subject.makeAuthenticatedWPAPIRequest(site) {
+            restCalls++
+            unauthorized<String>()
+        }
+
+        assertEquals(1, restCalls)
+        assertNonceFailureHasNoResponse(actual)
+    }
+
+    @Test
+    fun `given saved custom endpoints, when acquiring a nonce, then use both endpoint values`() = test {
+        val site = site().apply {
+            loginUrl = LOGIN_URL
+            adminUrl = ADMIN_URL
+        }
+        whenever(nonceClient.getNonce(SITE_URL, USERNAME)).thenReturn(null)
+        whenever(nonceClient.requestNonce(ENDPOINTS, USERNAME, PASSWORD))
+            .thenReturn(Nonce.Available(NEW_NONCE, USERNAME))
+
+        val actual = subject.makeAuthenticatedWPAPIRequest(site) {
+            WPAPIResponse.Success("response", emptyList())
+        }
+
+        assertIs<WPAPIResponse.Success<String>>(actual)
+        verify(nonceClient).requestNonce(ENDPOINTS, USERNAME, PASSWORD)
+    }
+
+    private fun site() = SiteModel().apply {
+        url = SITE_URL
+        username = USERNAME
+        password = PASSWORD
+        wpApiRestUrl = WP_API_URL
+    }
+
+    private fun nonceFailure(
+        loginEntryVerified: Boolean = false,
+        networkError: WPAPINetworkError = WPAPINetworkError(
+            BaseNetworkError(VolleyError(NetworkResponse(404, byteArrayOf(), true, 0, emptyList())))
+        )
+    ) = Nonce.FailedRequest(
+        timeOfResponse = 1L,
+        username = USERNAME,
+        type = Nonce.CookieNonceErrorType.CUSTOM_ADMIN_URL,
+        networkError = networkError,
+        loginEntryVerified = loginEntryVerified
+    )
+
+    private fun <T> unauthorized(): WPAPIResponse<T> = WPAPIResponse.Error(
+        WPAPINetworkError(
+            BaseNetworkError(VolleyError(NetworkResponse(401, byteArrayOf(), true, 0, emptyList())))
+        )
+    )
+
+    private fun assertNonceFailureHasNoResponse(actual: WPAPIResponse<*>) {
+        val error = assertIs<WPAPIResponse.Error<*>>(actual).error
+        assertNull(error.volleyError?.networkResponse)
+    }
+
+    private companion object {
+        const val SITE_URL = "https://site.example/store"
+        const val WP_API_URL = "https://site.example/wp-json/"
+        const val LOGIN_URL = "https://site.example/private-login"
+        const val ADMIN_URL = "https://site.example/private-admin/"
+        const val USERNAME = "merchant"
+        const val PASSWORD = "password"
+        const val OLD_NONCE = "oldNonce"
+        const val NEW_NONCE = "newNonce"
+        const val TIMEOUT_MESSAGE = "Request timed out"
+        val ENDPOINTS = CookieNonceAuthenticationEndpoints(SITE_URL, LOGIN_URL, ADMIN_URL)
+    }
+}

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/CookieNonceAuthenticator.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/CookieNonceAuthenticator.kt
@@ -1,9 +1,10 @@
 package org.wordpress.android.fluxc.network.rest.wpapi
 
-import android.webkit.URLUtil
 import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
 import org.wordpress.android.fluxc.network.discovery.DiscoveryWPAPIRestClient
 import org.wordpress.android.fluxc.network.rest.wpapi.Nonce.Available
 import org.wordpress.android.fluxc.network.rest.wpapi.Nonce.FailedRequest
@@ -25,34 +26,50 @@ class CookieNonceAuthenticator @Inject constructor(
         siteUrl: String,
         username: String,
         password: String
+    ): CookieNonceAuthenticationResult = authenticate(
+        endpoints = CookieNonceAuthenticationEndpoints(siteUrl),
+        username = username,
+        password = password
+    )
+
+    suspend fun authenticate(
+        endpoints: CookieNonceAuthenticationEndpoints,
+        username: String,
+        password: String
     ): CookieNonceAuthenticationResult {
         return coroutineEngine.withDefaultContext(AppLog.T.API, this, "authenticate") {
-            val siteUrlWithScheme = if (!URLUtil.isNetworkUrl(siteUrl)) {
+            val siteUrlWithScheme = if (endpoints.siteUrl.toHttpUrlOrNull() == null) {
                 // If the URL is missing a scheme, try inferring it from the API endpoint
+                val siteUrl = endpoints.siteUrl
                 val wpApiUrl = discoverApiEndpoint(UrlUtils.addUrlSchemeIfNeeded(siteUrl, false))
                 val scheme = wpApiUrl.toHttpUrl().scheme
                 UrlUtils.addUrlSchemeIfNeeded(UrlUtils.removeScheme(siteUrl), scheme == "https")
-            } else siteUrl
+            } else endpoints.siteUrl
 
-            when (val nonce = nonceRestClient.requestNonce(siteUrlWithScheme, username, password)) {
+            val resolvedEndpoints = endpoints.copy(siteUrl = siteUrlWithScheme)
+            when (val nonce = nonceRestClient.requestNonce(resolvedEndpoints, username, password)) {
                 is Available -> CookieNonceAuthenticationResult.Success
                 is FailedRequest -> {
                     CookieNonceAuthenticationResult.Error(
                         type = nonce.type,
                         message = nonce.errorMessage,
-                        networkError = nonce.networkError
+                        networkError = nonce.networkError,
+                        loginEntryVerified = nonce.loginEntryVerified
                     )
                 }
 
-                is Unknown -> CookieNonceAuthenticationResult.Error(type = Nonce.CookieNonceErrorType.UNKNOWN)
+                is Unknown -> CookieNonceAuthenticationResult.Error(
+                    type = Nonce.CookieNonceErrorType.UNKNOWN,
+                    loginEntryVerified = nonce.loginEntryVerified
+                )
             }
         }
     }
 
-    suspend fun <T : WPAPIResponse<*>> makeAuthenticatedWPAPIRequest(
+    suspend fun <T> makeAuthenticatedWPAPIRequest(
         site: SiteModel,
-        fetchMethod: suspend (Nonce) -> T
-    ): T {
+        fetchMethod: suspend (Available) -> WPAPIResponse<T>
+    ): WPAPIResponse<T> {
         val usingSavedRestUrl = site.wpApiRestUrl != null
         if (!usingSavedRestUrl) {
             site.wpApiRestUrl = discoverApiEndpoint(site.url)
@@ -64,7 +81,7 @@ class CookieNonceAuthenticator @Inject constructor(
         }
 
         val response = makeAuthenticatedWPAPIRequest(
-            siteUrl = site.url,
+            endpoints = CookieNonceAuthenticationEndpoints.from(site),
             wpApiUrl = site.wpApiRestUrl,
             username = site.username,
             password = site.password
@@ -95,18 +112,19 @@ class CookieNonceAuthenticator @Inject constructor(
         } else response
     }
 
-    private suspend fun <T : WPAPIResponse<*>> makeAuthenticatedWPAPIRequest(
-        siteUrl: String,
+    private suspend fun <T> makeAuthenticatedWPAPIRequest(
+        endpoints: CookieNonceAuthenticationEndpoints,
         wpApiUrl: String,
         username: String,
         password: String,
-        fetchMethod: suspend (wpApiUrl: String, nonce: Nonce) -> T
-    ): T {
-        var nonce = nonceRestClient.getNonce(siteUrl, username)
+        fetchMethod: suspend (wpApiUrl: String, nonce: Available) -> WPAPIResponse<T>
+    ): WPAPIResponse<T> {
+        var nonce = nonceRestClient.getNonce(endpoints.siteUrl, username)
         val usingSavedNonce = nonce is Available
         if (nonce !is Available) {
-            nonce = nonceRestClient.requestNonce(siteUrl, username, password)
+            nonce = nonceRestClient.requestNonce(endpoints, username, password)
         }
+        if (nonce !is Available) return nonce.toErrorResponse()
 
         val response = fetchMethod(wpApiUrl, nonce)
 
@@ -121,14 +139,13 @@ class CookieNonceAuthenticator @Inject constructor(
                 if (usingSavedNonce) {
                     // Call with saved nonce failed, so try getting a new one
                     val previousNonce = nonce
-                    val newNonce = nonceRestClient.requestNonce(siteUrl, username, password)
+                    val newNonce = nonceRestClient.requestNonce(endpoints, username, password)
 
                     // Try original call again if we have a new nonce
-                    val nonceIsUpdated = newNonce != previousNonce
-                    if (nonceIsUpdated) {
-                        fetchMethod(wpApiUrl, newNonce)
-                    } else {
-                        response
+                    when {
+                        newNonce !is Available -> newNonce.toErrorResponse()
+                        newNonce != previousNonce -> fetchMethod(wpApiUrl, newNonce)
+                        else -> response
                     }
                 } else {
                     response
@@ -146,12 +163,30 @@ class CookieNonceAuthenticator @Inject constructor(
             ?: WPAPIDiscoveryUtils.buildDefaultRESTBaseUrl(url)
     }
 
+    private fun <T> Nonce.toErrorResponse(): WPAPIResponse.Error<T> {
+        val (genericErrorType, message) = when (this) {
+            is FailedRequest -> Pair(
+                networkError?.type ?: GenericErrorType.NOT_AUTHENTICATED,
+                errorMessage?.takeUnless(String::isBlank)
+                    ?: networkError?.message?.takeUnless(String::isBlank)
+                    ?: "Cookie nonce acquisition failed: ${type.name}"
+            )
+            is Unknown -> Pair(
+                GenericErrorType.NETWORK_ERROR,
+                "Cookie nonce acquisition failed: ${Nonce.CookieNonceErrorType.UNKNOWN.name}"
+            )
+            is Available -> error("An available nonce cannot be converted to an error response")
+        }
+        return WPAPIResponse.Error(WPAPINetworkError(BaseNetworkError(genericErrorType, message)))
+    }
+
     sealed interface CookieNonceAuthenticationResult {
         object Success : CookieNonceAuthenticationResult
         data class Error(
             val type: Nonce.CookieNonceErrorType,
             val message: String? = null,
             val networkError: BaseNetworkError? = null,
+            val loginEntryVerified: Boolean = false,
         ) : CookieNonceAuthenticationResult
     }
 

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/site/SiteWPAPIRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/site/SiteWPAPIRestClient.kt
@@ -64,11 +64,7 @@ class SiteWPAPIRestClient @Inject constructor(
 
                     applicationPasswordsAuthorizeUrl = response?.authentication?.applicationPasswords
                         ?.endpoints?.authorization
-                    if (!applicationPasswordsAuthorizeUrl.isNullOrEmpty() &&
-                        applicationPasswordsAuthorizeUrl.contains(APPLICATION_PASSWORDS_URL_SUFFIX)) {
-                        // Infer the admin URL from the application passwords authorization URL
-                        adminUrl = applicationPasswordsAuthorizeUrl.substringBefore(APPLICATION_PASSWORDS_URL_SUFFIX)
-                    }
+                    adminUrl = inferAdminBaseUrl(applicationPasswordsAuthorizeUrl)
 
                     wpApiRestUrl = discoveredWpApiUrl
                     this.url = cleanedUrl.replaceBefore("://", urlScheme)
@@ -94,8 +90,29 @@ class SiteWPAPIRestClient @Inject constructor(
                 username = site.username,
                 password = site.password,
             )
-        )
+        ).also { refreshedSite ->
+            if (!refreshedSite.isError) {
+                site.loginUrl?.takeUnless(String::isBlank)?.let { refreshedSite.loginUrl = it }
+                site.adminUrl
+                    ?.takeUnless(String::isBlank)
+                    ?.takeUnless { it.matchesAdminBaseInferredFrom(site.applicationPasswordsAuthorizeUrl) }
+                    ?.let { refreshedSite.adminUrl = it }
+            }
+        }
     }
+
+    private fun inferAdminBaseUrl(applicationPasswordsAuthorizeUrl: String?): String? =
+        applicationPasswordsAuthorizeUrl
+            ?.takeUnless(String::isBlank)
+            ?.takeIf { it.contains(APPLICATION_PASSWORDS_URL_SUFFIX) }
+            ?.substringBefore(APPLICATION_PASSWORDS_URL_SUFFIX)
+
+    private fun String.matchesAdminBaseInferredFrom(applicationPasswordsAuthorizeUrl: String?): Boolean {
+        val inferredAdminBase = inferAdminBaseUrl(applicationPasswordsAuthorizeUrl) ?: return false
+        return normalizeAdminBase(this) == normalizeAdminBase(inferredAdminBase)
+    }
+
+    private fun normalizeAdminBase(url: String) = url.trim().trimEnd('/')
 
     private fun discoverApiEndpoint(
         url: String

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/site/SiteWPAPIRestClientTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/site/SiteWPAPIRestClientTest.kt
@@ -1,0 +1,137 @@
+package org.wordpress.android.fluxc.network.rest.wpapi.site
+
+import com.android.volley.RequestQueue
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.discovery.DiscoveryWPAPIRestClient
+import org.wordpress.android.fluxc.network.discovery.RootWPAPIRestResponse
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIGsonRequestBuilder
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
+import org.wordpress.android.fluxc.test
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class SiteWPAPIRestClientTest {
+    private val requestBuilder: WPAPIGsonRequestBuilder = mock()
+    private val discoveryClient: DiscoveryWPAPIRestClient = mock()
+    private val subject = SiteWPAPIRestClient(
+        wpapiGsonRequestBuilder = requestBuilder,
+        discoveryWPAPIRestClient = discoveryClient,
+        dispatcher = mock<Dispatcher>(),
+        requestQueue = mock<RequestQueue>(),
+        userAgent = mock<UserAgent>()
+    )
+
+    @Before
+    fun setUp() {
+        whenever(discoveryClient.discoverWPAPIBaseURL(SITE_URL)).thenReturn(WP_API_URL)
+    }
+
+    @Test
+    fun `given stale inferred admin base, when refreshing a WPAPI site, then replace it with fresh REST metadata`() =
+        test {
+            val existingSite = existingSite().apply {
+                adminUrl = STALE_REST_ADMIN_URL.trimEnd('/')
+                applicationPasswordsAuthorizeUrl = STALE_REST_ADMIN_AUTHORIZATION_URL
+            }
+            givenSiteResponse(REST_ADMIN_AUTHORIZATION_URL)
+
+            val refreshedSite = subject.fetchWPAPISite(existingSite)
+
+            assertThat(refreshedSite.adminUrl).isEqualTo(REST_ADMIN_URL)
+            assertThat(refreshedSite.applicationPasswordsAuthorizeUrl).isEqualTo(REST_ADMIN_AUTHORIZATION_URL)
+        }
+
+    @Test
+    fun `given verified admin differs from old inferred base, when refreshing, then preserve verified value`() = test {
+        val existingSite = existingSite().apply {
+            loginUrl = VERIFIED_LOGIN_URL
+            adminUrl = VERIFIED_ADMIN_URL
+            applicationPasswordsAuthorizeUrl = STALE_REST_ADMIN_AUTHORIZATION_URL
+        }
+        givenSiteResponse(REST_ADMIN_AUTHORIZATION_URL)
+
+        val refreshedSite = subject.fetchWPAPISite(existingSite)
+
+        assertThat(refreshedSite.loginUrl).isEqualTo(VERIFIED_LOGIN_URL)
+        assertThat(refreshedSite.adminUrl).isEqualTo(VERIFIED_ADMIN_URL)
+        assertThat(refreshedSite.applicationPasswordsAuthorizeUrl).isEqualTo(REST_ADMIN_AUTHORIZATION_URL)
+    }
+
+    @Test
+    fun `given manual admin without old derivation metadata, when refreshing, then preserve manual value`() = test {
+        val existingSite = SiteModel().apply {
+            url = SITE_URL
+            username = USERNAME
+            password = PASSWORD
+            origin = SiteModel.ORIGIN_WPAPI
+            loginUrl = VERIFIED_LOGIN_URL
+            adminUrl = VERIFIED_ADMIN_URL
+        }
+        givenSiteResponse(REST_ADMIN_AUTHORIZATION_URL)
+
+        val refreshedSite = subject.fetchWPAPISite(existingSite)
+
+        assertThat(refreshedSite.loginUrl).isEqualTo(VERIFIED_LOGIN_URL)
+        assertThat(refreshedSite.adminUrl).isEqualTo(VERIFIED_ADMIN_URL)
+        assertThat(refreshedSite.applicationPasswordsAuthorizeUrl).isEqualTo(REST_ADMIN_AUTHORIZATION_URL)
+    }
+
+    @Test
+    fun `given no verified admin base, when refreshing a WPAPI site, then retain REST inferred metadata`() = test {
+        val existingSite = existingSite()
+        givenSiteResponse(REST_ADMIN_AUTHORIZATION_URL)
+
+        val refreshedSite = subject.fetchWPAPISite(existingSite)
+
+        assertThat(refreshedSite.adminUrl).isEqualTo(REST_ADMIN_URL)
+    }
+
+    private fun existingSite() = SiteModel().apply {
+        url = SITE_URL
+        username = USERNAME
+        password = PASSWORD
+        origin = SiteModel.ORIGIN_WPAPI
+    }
+
+    private suspend fun givenSiteResponse(applicationPasswordsAuthorizationUrl: String) {
+        val response = RootWPAPIRestResponse(
+            authentication = RootWPAPIRestResponse.Authentication(
+                applicationPasswords = RootWPAPIRestResponse.Authentication.ApplicationPasswords(
+                    endpoints = RootWPAPIRestResponse.Authentication.ApplicationPasswords.Endpoints(
+                        authorization = applicationPasswordsAuthorizationUrl
+                    )
+                )
+            ),
+            namespaces = listOf("wc/v3")
+        )
+        whenever(
+            requestBuilder.syncGetRequest(
+                restClient = subject,
+                url = WP_API_URL,
+                clazz = RootWPAPIRestResponse::class.java,
+                params = mapOf("_fields" to "name,description,gmt_offset,url,authentication,namespaces")
+            )
+        ).thenReturn(WPAPIResponse.Success(response, emptyList()))
+    }
+
+    private companion object {
+        const val SITE_URL = "https://site.example"
+        const val WP_API_URL = "$SITE_URL/wp-json/"
+        const val USERNAME = "merchant"
+        const val PASSWORD = "password"
+        const val VERIFIED_LOGIN_URL = "$SITE_URL/private-login"
+        const val VERIFIED_ADMIN_URL = "$SITE_URL/private-admin/"
+        const val STALE_REST_ADMIN_URL = "$SITE_URL/old-wp-admin/"
+        const val STALE_REST_ADMIN_AUTHORIZATION_URL = "${STALE_REST_ADMIN_URL}authorize-application.php"
+        const val REST_ADMIN_URL = "$SITE_URL/wp-admin/"
+        const val REST_ADMIN_AUTHORIZATION_URL = "${REST_ADMIN_URL}authorize-application.php"
+    }
+}

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/site/SiteWPAPIRestClientTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/site/SiteWPAPIRestClientTest.kt
@@ -7,6 +7,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.UserAgent
@@ -15,7 +16,6 @@ import org.wordpress.android.fluxc.network.discovery.RootWPAPIRestResponse
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
 import org.wordpress.android.fluxc.test
-import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 class SiteWPAPIRestClientTest {


### PR DESCRIPTION
### Description

Fixes WOOMOB-3799

Part 2 of 3, stacked on #16396 and followed by #16398.

This is one direct-site-credentials fix split into three PRs for review; the parts are not intended to ship independently. Review this diff against PR1's head. Merge order is 1 → 2 → 3, once the whole stack is approved.

PR1 can verify custom cookie-authentication endpoints, but the app still needs to carry those values through authentication, preserve meaningful failures, and store proven endpoints safely. This PR adds that plumbing without adding user-facing recovery UI.

The changes fall into three areas:

1. **Authentication and nonce refresh**
   - Structured endpoints are used for initial nonce acquisition and later cookie-authenticated REST requests.
   - A protected request only runs with an available nonce. If initial acquisition fails, the REST callback is not invoked.
   - If a cached nonce is rejected and refreshing it fails, the original REST request runs only once and the refresh failure is returned.

2. **Failure provenance**
   - The `loginEntryVerified` signal from PR1 reaches the app, so a failure after a proven sign-in page is not misreported as an unknown custom login URL.
   - Nonce-stage failures keep their useful type and message while dropping their HTTP response metadata. This prevents a login/admin 404 from being mistaken for a stale REST root, or a nonce status from being interpreted as an Application Password endpoint result.

3. **Persistence and refresh**
   - Saving custom endpoints succeeds only after the site update affects a row and the stored `SiteModel` can be reloaded with the normalized values.
   - Dispatch, zero-row, reload, or value-mismatch failures restore the caller's original in-memory fields and surface the failure to the caller.
   - Later site refreshes preserve verified custom endpoints while still allowing stale admin metadata previously inferred from the REST Application Password authorization URL to be replaced.

Review map:

- `CookieNonceAuthenticator.kt`: endpoint-aware initial/refresh nonce flow and failure propagation.
- `SiteWPAPIRestClient.kt`: verified endpoint preservation during site refresh.
- `WPApiSiteRepository.kt`: endpoint forwarding plus persist-and-reload confirmation.
- Three focused test files cover nonce failures, refresh behavior, stale metadata, and persistence failures.

This PR adds no strings or standalone UI. QR login, XML-RPC, and Application Password architecture remain unchanged.

### Test Steps

Because custom endpoints cannot be entered until PR3, perform the custom-endpoint steps using the top-of-stack build.

1. Sign in to a self-hosted store using standard WordPress endpoints and confirm authenticated data such as Orders and Products loads.
2. Sign out, repeat with an incorrect password, and confirm no authenticated store content is shown.
3. Using the top-of-stack build and a store with custom login/admin endpoints, complete native login, force-stop the app, relaunch it, and confirm the store opens without asking for either endpoint again.
4. Refresh an authenticated screen after relaunch and confirm data loads through the persisted endpoint configuration without a browser or repeated login loop.

### Images/gif

N/A — this PR contains authentication and persistence plumbing only.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

The stack's single user-facing release note is owned by PR3.
