### PR TITLE
[WOOMOB-3799] Recover custom WordPress login and admin URLs (3/3)

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,6 +10,7 @@
 - [Internal] Close analytics gaps in the Remote Tap to Pay flow: transport on the reader-ready event, cause chains in error descriptions, no stale card reader model, and a real session ended reason [https://github.com/woocommerce/woocommerce-android/pull/16368]
 - [*] Tap to Pay no longer disappears from the Payments screen shortly after it appears [https://github.com/woocommerce/woocommerce-android/pull/16370]
 - [*] Fixed a crash when pressing Back on the "You're already signed in" warning shown after opening a QR login link while signed in [https://github.com/woocommerce/woocommerce-android/pull/16347]
+- [*] Store login now supports custom WordPress sign-in and dashboard addresses
 - [Internal] Woo POS Scan to Pay: picking an offline method such as Pay in Person on the QR page no longer reports the order as paid, and a detected payment now shows the fullscreen success screen [https://github.com/woocommerce/woocommerce-android/pull/16363]
 - [*] Woo POS: Retrying a failed connection to a phone card reader now works without having to close and reopen the reader dialog [https://github.com/woocommerce/woocommerce-android/pull/16371]
 - [*] Fixed missing back navigation in Country and State pickers when creating shipping labels on tablets [https://github.com/woocommerce/woocommerce-android/pull/16364]

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,7 +10,7 @@
 - [Internal] Close analytics gaps in the Remote Tap to Pay flow: transport on the reader-ready event, cause chains in error descriptions, no stale card reader model, and a real session ended reason [https://github.com/woocommerce/woocommerce-android/pull/16368]
 - [*] Tap to Pay no longer disappears from the Payments screen shortly after it appears [https://github.com/woocommerce/woocommerce-android/pull/16370]
 - [*] Fixed a crash when pressing Back on the "You're already signed in" warning shown after opening a QR login link while signed in [https://github.com/woocommerce/woocommerce-android/pull/16347]
-- [*] Store login now supports custom WordPress sign-in and dashboard addresses
+- [*] Store login now supports custom WordPress sign-in and dashboard addresses [https://github.com/woocommerce/woocommerce-android/pull/16398]
 - [Internal] Woo POS Scan to Pay: picking an offline method such as Pay in Person on the QR page no longer reports the order as paid, and a detected payment now shows the fullscreen success screen [https://github.com/woocommerce/woocommerce-android/pull/16363]
 - [*] Woo POS: Retrying a failed connection to a phone card reader now works without having to close and reopen the reader dialog [https://github.com/woocommerce/woocommerce-android/pull/16371]
 - [*] Fixed missing back navigation in Country and State pickers when creating shipping labels on tablets [https://github.com/woocommerce/woocommerce-android/pull/16364]

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsScreen.kt
@@ -22,8 +22,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.Preview
 import com.woocommerce.android.R
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.ui.compose.component.ProgressDialog
@@ -33,6 +33,7 @@ import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
 import com.woocommerce.android.ui.compose.component.WCPasswordField
 import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.compose.component.getText
+import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 
 @Composable
@@ -42,7 +43,9 @@ fun LoginSiteCredentialsScreen(viewModel: LoginSiteCredentialsViewModel) {
             viewState = it,
             onUsernameChanged = viewModel::onUsernameChanged,
             onPasswordChanged = viewModel::onPasswordChanged,
+            onEndpointUrlChanged = viewModel::onEndpointUrlChanged,
             onContinueClick = viewModel::onContinueClick,
+            onEndpointRecoveryCancelClick = viewModel::onEndpointRecoveryCancelClick,
             onResetPasswordClick = viewModel::onResetPasswordClick,
             onBackClick = viewModel::onBackClick,
             onHelpButtonClick = viewModel::onHelpButtonClick,
@@ -57,7 +60,9 @@ fun LoginSiteCredentialsScreen(
     viewState: LoginSiteCredentialsViewModel.ViewState,
     onUsernameChanged: (String) -> Unit,
     onPasswordChanged: (String) -> Unit,
+    onEndpointUrlChanged: (String) -> Unit,
     onContinueClick: () -> Unit,
+    onEndpointRecoveryCancelClick: () -> Unit,
     onResetPasswordClick: () -> Unit,
     onBackClick: () -> Unit,
     onHelpButtonClick: () -> Unit,
@@ -86,35 +91,41 @@ fun LoginSiteCredentialsScreen(
                     .verticalScroll(rememberScrollState())
                     .padding(dimensionResource(id = R.dimen.major_100)),
             ) {
-                Text(
-                    text = stringResource(id = R.string.enter_credentials_for_site, viewState.siteUrl),
-                    style = MaterialTheme.typography.body2
-                )
-                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
-                WCOutlinedTextField(
-                    value = viewState.username,
-                    onValueChange = onUsernameChanged,
-                    label = stringResource(id = R.string.username),
-                    singleLine = true,
-                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next)
-                )
-                WCPasswordField(
-                    value = viewState.password,
-                    onValueChange = onPasswordChanged,
-                    label = stringResource(id = R.string.password),
-                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
-                    keyboardActions = KeyboardActions(
-                        onDone = { onContinueClick() }
+                if (viewState.endpointRecovery != null) {
+                    EndpointRecoveryForm(
+                        recovery = viewState.endpointRecovery,
+                        onUrlChanged = onEndpointUrlChanged,
+                        onContinueClick = onContinueClick
                     )
-                )
-                WCTextButton(onClick = onResetPasswordClick) {
-                    Text(text = stringResource(id = R.string.reset_your_password))
+                } else {
+                    Text(
+                        text = stringResource(id = R.string.enter_credentials_for_site, viewState.siteUrl),
+                        style = MaterialTheme.typography.body2
+                    )
+                    Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
+                    WCOutlinedTextField(
+                        value = viewState.username,
+                        onValueChange = onUsernameChanged,
+                        label = stringResource(id = R.string.username),
+                        singleLine = true,
+                        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next)
+                    )
+                    WCPasswordField(
+                        value = viewState.password,
+                        onValueChange = onPasswordChanged,
+                        label = stringResource(id = R.string.password),
+                        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                        keyboardActions = KeyboardActions(onDone = { onContinueClick() })
+                    )
+                    WCTextButton(onClick = onResetPasswordClick) {
+                        Text(text = stringResource(id = R.string.reset_your_password))
+                    }
                 }
             }
 
             WCColoredButton(
                 onClick = onContinueClick,
-                enabled = viewState.isValid,
+                enabled = viewState.endpointRecovery?.url?.isNotBlank() ?: viewState.isValid,
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = dimensionResource(id = R.dimen.major_100))
@@ -122,6 +133,20 @@ fun LoginSiteCredentialsScreen(
                 Text(
                     text = stringResource(id = R.string.continue_button)
                 )
+            }
+            if (viewState.endpointRecovery != null) {
+                WCTextButton(
+                    onClick = onStartWebAuthorizationClick,
+                    modifier = Modifier.align(Alignment.CenterHorizontally)
+                ) {
+                    Text(text = stringResource(id = R.string.login_site_credentials_use_web_authorization))
+                }
+                WCTextButton(
+                    onClick = onEndpointRecoveryCancelClick,
+                    modifier = Modifier.align(Alignment.CenterHorizontally)
+                ) {
+                    Text(text = stringResource(id = R.string.cancel))
+                }
             }
             Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
         }
@@ -173,41 +198,110 @@ fun LoginSiteCredentialsScreen(
     }
 }
 
-@Preview
 @Composable
-private fun LoginSiteCredentialsScreenPreview() {
-    WooThemeWithBackground {
-        LoginSiteCredentialsScreen(
-            viewState = LoginSiteCredentialsViewModel.ViewState(
-                siteUrl = "https://wordpress.com"
-            ),
-            onUsernameChanged = {},
-            onPasswordChanged = {},
-            onContinueClick = {},
-            onResetPasswordClick = {},
-            onBackClick = {},
-            onHelpButtonClick = {},
-            onErrorDialogDismissed = {},
-            onStartWebAuthorizationClick = {}
+private fun EndpointRecoveryForm(
+    recovery: LoginSiteCredentialsViewModel.EndpointRecovery,
+    onUrlChanged: (String) -> Unit,
+    onContinueClick: () -> Unit
+) {
+    val strings = if (recovery.type == LoginSiteCredentialsViewModel.EndpointType.LOGIN) {
+        Triple(
+            R.string.login_site_credentials_login_url_title,
+            R.string.login_site_credentials_login_url_description,
+            R.string.login_site_credentials_login_url_label
+        )
+    } else {
+        Triple(
+            R.string.login_site_credentials_admin_url_title,
+            R.string.login_site_credentials_admin_url_description,
+            R.string.login_site_credentials_admin_url_label
         )
     }
+    Text(
+        text = stringResource(strings.first),
+        style = MaterialTheme.typography.h6
+    )
+    Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.minor_100)))
+    Text(
+        text = stringResource(strings.second),
+        style = MaterialTheme.typography.body2
+    )
+    Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
+    WCOutlinedTextField(
+        value = recovery.url,
+        onValueChange = onUrlChanged,
+        label = stringResource(strings.third),
+        helperText = recovery.errorMessage?.getText(),
+        isError = recovery.errorMessage != null,
+        singleLine = true,
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri, imeAction = ImeAction.Done),
+        keyboardActions = KeyboardActions(onDone = { onContinueClick() })
+    )
 }
 
-@Preview
+@LightDarkThemePreviews
+@Composable
+private fun LoginSiteCredentialsScreenPreview() {
+    LoginSiteCredentialsScreenPreview(
+        LoginSiteCredentialsViewModel.ViewState(siteUrl = "https://wordpress.com")
+    )
+}
+
+@LightDarkThemePreviews
 @Composable
 private fun LoginSiteCredentialsScreenWithErrorPreview() {
+    LoginSiteCredentialsScreenPreview(
+        LoginSiteCredentialsViewModel.ViewState(
+            siteUrl = "https://wordpress.com",
+            authenticationError = LoginSiteCredentialsViewModel.AuthenticationError(
+                errorMessage = UiString.UiStringRes(R.string.login_site_credentials_fetching_site_failed),
+                showWpAdminFallbackOption = true
+            )
+        )
+    )
+}
+
+@LightDarkThemePreviews
+@Composable
+private fun LoginSiteCredentialsLoginRecoveryPreview() {
+    LoginSiteCredentialsScreenPreview(
+        LoginSiteCredentialsViewModel.ViewState(
+            siteUrl = "example.com",
+            endpointRecovery = LoginSiteCredentialsViewModel.EndpointRecovery(
+                type = LoginSiteCredentialsViewModel.EndpointType.LOGIN,
+                url = "https://example.com/wp-login.php"
+            )
+        )
+    )
+}
+
+@LightDarkThemePreviews
+@Composable
+private fun LoginSiteCredentialsAdminRecoveryErrorPreview() {
+    LoginSiteCredentialsScreenPreview(
+        LoginSiteCredentialsViewModel.ViewState(
+            siteUrl = "example.com",
+            endpointRecovery = LoginSiteCredentialsViewModel.EndpointRecovery(
+                type = LoginSiteCredentialsViewModel.EndpointType.ADMIN,
+                url = "https://example.com/dashboard",
+                errorMessage = UiString.UiStringRes(
+                    R.string.login_site_credentials_admin_url_not_found_error
+                )
+            )
+        )
+    )
+}
+
+@Composable
+private fun LoginSiteCredentialsScreenPreview(viewState: LoginSiteCredentialsViewModel.ViewState) {
     WooThemeWithBackground {
         LoginSiteCredentialsScreen(
-            viewState = LoginSiteCredentialsViewModel.ViewState(
-                siteUrl = "https://wordpress.com",
-                authenticationError = LoginSiteCredentialsViewModel.AuthenticationError(
-                    errorMessage = UiString.UiStringRes(R.string.login_site_credentials_fetching_site_failed),
-                    showWpAdminFallbackOption = true
-                )
-            ),
+            viewState = viewState,
             onUsernameChanged = {},
             onPasswordChanged = {},
+            onEndpointUrlChanged = {},
             onContinueClick = {},
+            onEndpointRecoveryCancelClick = {},
             onResetPasswordClick = {},
             onBackClick = {},
             onHelpButtonClick = {},

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
@@ -174,8 +174,8 @@ class LoginSiteCredentialsViewModel @Inject constructor(
                 val validatedEndpoints = endpoints.withValidatedUrls(validation)
                 endpointRecovery.value = recovery.copy(
                     url = when (recovery.type) {
-                        EndpointType.LOGIN -> requireNotNull(validatedEndpoints.loginEntryUrl)
-                        EndpointType.ADMIN -> requireNotNull(validatedEndpoints.adminBaseUrl)
+                        EndpointType.LOGIN -> validation.loginEntryUrl.toString()
+                        EndpointType.ADMIN -> validation.adminBaseUrl.toString()
                     },
                     errorMessage = null
                 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
@@ -38,9 +38,18 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpapi.CookieNonceAuthenticationEndpoints
+import org.wordpress.android.fluxc.network.rest.wpapi.CookieNonceAuthenticationEndpoints.AdminBaseVerification
+import org.wordpress.android.fluxc.network.rest.wpapi.CookieNonceAuthenticationEndpoints.Endpoint as ValidationEndpoint
+import org.wordpress.android.fluxc.network.rest.wpapi.CookieNonceAuthenticationEndpoints.ValidationError.INVALID_URL
+import org.wordpress.android.fluxc.network.rest.wpapi.CookieNonceAuthenticationEndpoints.ValidationResult
 import org.wordpress.android.fluxc.network.rest.wpapi.Nonce.CookieNonceErrorType.BASIC_AUTH_REQUIRED
+import org.wordpress.android.fluxc.network.rest.wpapi.Nonce.CookieNonceErrorType.CUSTOM_ADMIN_URL
+import org.wordpress.android.fluxc.network.rest.wpapi.Nonce.CookieNonceErrorType.CUSTOM_LOGIN_URL
 import org.wordpress.android.fluxc.network.rest.wpapi.Nonce.CookieNonceErrorType.INVALID_CREDENTIALS
+import org.wordpress.android.fluxc.network.rest.wpapi.Nonce.CookieNonceErrorType.INVALID_RESPONSE
 import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordsConfiguration
 import org.wordpress.android.fluxc.store.SiteStore.SiteError
 import org.wordpress.android.login.LoginAnalyticsListener
@@ -70,6 +79,8 @@ class LoginSiteCredentialsViewModel @Inject constructor(
         private const val USERNAME_PARAMETER = "user_login"
         private const val PASSWORD_PARAMETER = "password"
         private const val HAS_RECONCILED_SITE_URL_KEY = "has-reconciled-site-url"
+        private const val LOGIN_ENTRY_URL_KEY = "login-entry-url"
+        private const val ADMIN_BASE_URL_KEY = "admin-base-url"
     }
 
     private var siteAddress: String
@@ -97,6 +108,12 @@ class LoginSiteCredentialsViewModel @Inject constructor(
     private val fetchedSiteId = savedStateHandle.getStateFlow(viewModelScope, -1, "site-id")
 
     private val loadingMessage = savedStateHandle.getStateFlow(viewModelScope, 0, "loading-message")
+    private val endpointRecovery = savedStateHandle.getNullableStateFlow(
+        scope = viewModelScope,
+        initialValue = null,
+        clazz = EndpointRecovery::class.java,
+        key = "endpoint-recovery"
+    )
 
     private val SiteModel?.fullAuthorizationUrl: String?
         get() = this?.applicationPasswordsAuthorizeUrl
@@ -109,14 +126,15 @@ class LoginSiteCredentialsViewModel @Inject constructor(
         savedStateHandle.getStateFlow(USERNAME_KEY, ""),
         savedStateHandle.getStateFlow(PASSWORD_KEY, ""),
         loadingMessage.map { message -> message.takeIf { it != 0 } },
-        authError
-    ) { siteAddress, username, password, loadingMessage, authError ->
+        combine(authError, endpointRecovery) { error, recovery -> error to recovery }
+    ) { siteAddress, username, password, loadingMessage, errors ->
         ViewState(
             siteUrl = siteAddress,
             username = username,
             password = password,
             loadingMessage = loadingMessage,
-            authenticationError = authError
+            authenticationError = errors.first,
+            endpointRecovery = errors.second
         )
     }.asLiveData()
 
@@ -144,7 +162,53 @@ class LoginSiteCredentialsViewModel @Inject constructor(
         fetchedSiteId.value = -1
     }
 
+    fun onEndpointUrlChanged(url: String) {
+        endpointRecovery.value = endpointRecovery.value?.copy(url = url, errorMessage = null)
+    }
+
+    private suspend fun continueEndpointRecovery(recovery: EndpointRecovery) {
+        val endpoints = currentAuthenticationEndpoints(recovery).withSiteSchemeFrom(recovery.url)
+        when (val validation = endpoints.validate()) {
+            is ValidationResult.Valid -> {
+                val validatedEndpoints = endpoints.withValidatedUrls(validation)
+                endpointRecovery.value = recovery.copy(
+                    url = when (recovery.type) {
+                        EndpointType.LOGIN -> requireNotNull(validatedEndpoints.loginEntryUrl)
+                        EndpointType.ADMIN -> requireNotNull(validatedEndpoints.adminBaseUrl)
+                    },
+                    errorMessage = null
+                )
+                login(validatedEndpoints, recovery.type)
+            }
+
+            is ValidationResult.Invalid -> {
+                val errorMessage = validation.error.toUiString()
+                if (validation.endpoint == recovery.type.validationEndpoint) {
+                    endpointRecovery.value = recovery.copy(errorMessage = errorMessage)
+                } else {
+                    endpointRecovery.value = recovery.copy(errorMessage = null)
+                    authError.value = AuthenticationError(
+                        errorMessage = if (validation.endpoint == ValidationEndpoint.CANONICAL) {
+                            UiStringRes(R.string.error_generic)
+                        } else {
+                            errorMessage
+                        },
+                        showWpAdminFallbackOption = true
+                    )
+                }
+            }
+        }
+    }
+
+    fun onEndpointRecoveryCancelClick() {
+        endpointRecovery.value = null
+    }
+
     fun onContinueClick() = launch {
+        endpointRecovery.value?.let {
+            continueEndpointRecovery(it)
+            return@launch
+        }
         loginAnalyticsListener.trackSubmitClicked()
         val site = fetchedSiteId.value.takeIf { it != -1 }?.let { wpApiSiteRepository.getSiteByLocalId(it) }
         if (site?.username != null) {
@@ -221,24 +285,59 @@ class LoginSiteCredentialsViewModel @Inject constructor(
         login()
     }
 
-    private suspend fun login() {
+    private suspend fun login(
+        endpoints: CookieNonceAuthenticationEndpoints = currentAuthenticationEndpoints(),
+        retryingEndpoint: EndpointType? = null
+    ) {
         val state = requireNotNull(this@LoginSiteCredentialsViewModel.viewState.value)
         loadingMessage.value = R.string.logging_in
         wpApiSiteRepository.login(
             url = siteAddress,
             username = state.username,
-            password = state.password
+            password = state.password,
+            endpoints = endpoints
         ).fold(
             onSuccess = {
+                promoteValidatedEndpoints(endpoints)
+                endpointRecovery.value = null
                 fetchSite()
             },
             onFailure = { exception ->
                 val authenticationError = exception as? CookieNonceAuthenticationException
+                val loginEntryWasVerified = authenticationError?.loginEntryVerified == true ||
+                    authenticationError?.errorType == CUSTOM_ADMIN_URL
+                val hasVerifiedCustomLoginEntry = endpoints.loginEntryUrl != null && loginEntryWasVerified
+
+                if (retryingEndpoint == EndpointType.LOGIN && hasVerifiedCustomLoginEntry) {
+                    promoteValidatedEndpoint(EndpointType.LOGIN, endpoints)
+                    endpointRecovery.value = null
+                }
 
                 when (authenticationError?.errorType) {
+                    CUSTOM_LOGIN_URL -> {
+                        if (hasVerifiedCustomLoginEntry) {
+                            authError.value = AuthenticationError(
+                                errorMessage = authenticationError.errorMessage,
+                                showWpAdminFallbackOption = false
+                            )
+                        } else {
+                            handleEndpointRecovery(
+                                EndpointType.LOGIN,
+                                retryingEndpoint == EndpointType.LOGIN
+                            )
+                        }
+                    }
+
+                    CUSTOM_ADMIN_URL -> {
+                        handleEndpointRecovery(
+                            EndpointType.ADMIN,
+                            retryingEndpoint == EndpointType.ADMIN
+                        )
+                    }
+
                     INVALID_CREDENTIALS -> authError.value = AuthenticationError(
                         errorMessage = authenticationError.errorMessage,
-                        showWpAdminFallbackOption = true
+                        showWpAdminFallbackOption = endpoints.loginEntryUrl == null
                     )
 
                     BASIC_AUTH_REQUIRED -> authError.value = AuthenticationError(
@@ -247,8 +346,24 @@ class LoginSiteCredentialsViewModel @Inject constructor(
                     )
 
                     else -> {
-                        fetchSiteForTutorial(detectedErrorMessage = authenticationError?.errorMessage)
-                        analyticsTracker.track(AnalyticsEvent.LOGIN_SITE_CREDENTIALS_INVALID_LOGIN_PAGE_DETECTED)
+                        if (hasVerifiedCustomLoginEntry) {
+                            authError.value = AuthenticationError(
+                                errorMessage = requireNotNull(authenticationError).errorMessage,
+                                showWpAdminFallbackOption = false
+                            )
+                        } else if (authenticationError?.errorType == INVALID_RESPONSE &&
+                            endpoints.loginEntryUrl != null
+                        ) {
+                            showEndpointRecovery(EndpointType.LOGIN, showError = true)
+                        } else if (retryingEndpoint != null || endpoints.loginEntryUrl != null) {
+                            authError.value = AuthenticationError(
+                                errorMessage = authenticationError?.errorMessage ?: UiStringRes(R.string.error_generic),
+                                showWpAdminFallbackOption = false
+                            )
+                        } else {
+                            fetchSiteForTutorial(detectedErrorMessage = authenticationError?.errorMessage)
+                            analyticsTracker.track(AnalyticsEvent.LOGIN_SITE_CREDENTIALS_INVALID_LOGIN_PAGE_DETECTED)
+                        }
                     }
                 }
 
@@ -318,8 +433,7 @@ class LoginSiteCredentialsViewModel @Inject constructor(
         ).fold(
             onSuccess = { site ->
                 if (site.hasWooCommerce) {
-                    fetchedSiteId.value = site.id
-                    fetchUserInfo()
+                    persistAuthenticationEndpoints(site)
                 } else {
                     triggerEvent(ShowNonWooErrorScreen(siteAddress))
                 }
@@ -345,11 +459,32 @@ class LoginSiteCredentialsViewModel @Inject constructor(
         )
     }
 
-    private suspend fun fetchUserInfo() {
-        loadingMessage.value = R.string.logging_in
-        val site = requireNotNull(wpApiSiteRepository.getSiteByLocalId(fetchedSiteId.value)) {
+    private suspend fun persistAuthenticationEndpoints(site: SiteModel) {
+        val endpoints = currentAuthenticationEndpoints(recovery = null)
+        if (endpoints.loginEntryUrl == null && endpoints.adminBaseUrl == null) {
+            fetchedSiteId.value = site.id
+            fetchUserInfo(site)
+        } else {
+            wpApiSiteRepository.saveAuthenticationEndpoints(site, endpoints).fold(
+                onSuccess = {
+                    fetchedSiteId.value = it.id
+                    fetchUserInfo(it)
+                },
+                onFailure = ::handleEndpointPersistenceFailure
+            )
+        }
+    }
+
+    private suspend fun fetchUserInfo(site: SiteModel? = null) {
+        val resolvedSite = site ?: requireNotNull(wpApiSiteRepository.getSiteByLocalId(fetchedSiteId.value)) {
             "Site credentials login: Site not found in DB after login"
         }
+        loadingMessage.value = R.string.logging_in
+        checkEligibilityAndCompleteLogin(resolvedSite)
+        loadingMessage.value = 0
+    }
+
+    private suspend fun checkEligibilityAndCompleteLogin(site: SiteModel) {
         wpApiSiteRepository.checkIfUserIsEligible(site).fold(
             onSuccess = { isEligible ->
                 if (isEligible) {
@@ -361,31 +496,41 @@ class LoginSiteCredentialsViewModel @Inject constructor(
                 selectedSite.set(site)
                 triggerEvent(LoggedIn(selectedSite.getSelectedSiteId()))
             },
-            onFailure = { exception ->
-                triggerEvent(ShowSnackbar(R.string.user_role_access_error_fetch_failed))
-                when (exception) {
-                    is ApplicationPasswordGenerationException -> {
-                        trackLoginFailure(
-                            step = Step.APPLICATION_PASSWORD_GENERATION,
-                            errorContext = exception.networkError.javaClass.simpleName,
-                            errorType = exception.networkError.type.name,
-                            errorDescription = exception.message
-                        )
-                    }
-
-                    else -> {
-                        val wooError = (exception as? WooException)?.error
-                        trackLoginFailure(
-                            step = Step.USER_ROLE,
-                            errorContext = (wooError ?: exception).javaClass.simpleName,
-                            errorType = wooError?.type?.name,
-                            errorDescription = exception.message
-                        )
-                    }
-                }
-            }
+            onFailure = ::handleUserInfoFailure
         )
-        loadingMessage.value = 0
+    }
+
+    private fun handleEndpointPersistenceFailure(exception: Throwable) {
+        triggerEvent(ShowSnackbar(R.string.login_site_credentials_endpoint_persistence_failed))
+        val siteError = (exception as? OnChangedException)?.error as? SiteError
+        val error = (exception as? OnChangedException)?.error ?: exception
+        trackLoginFailure(
+            step = Step.ENDPOINT_PERSISTENCE,
+            errorContext = error.javaClass.simpleName,
+            errorType = siteError?.type?.name,
+            errorDescription = exception.message
+        )
+    }
+
+    private fun handleUserInfoFailure(exception: Throwable) {
+        triggerEvent(ShowSnackbar(R.string.user_role_access_error_fetch_failed))
+        val applicationPasswordError = (exception as? ApplicationPasswordGenerationException)?.networkError
+        if (applicationPasswordError != null) {
+            trackLoginFailure(
+                step = Step.APPLICATION_PASSWORD_GENERATION,
+                errorContext = applicationPasswordError.javaClass.simpleName,
+                errorType = applicationPasswordError.type.name,
+                errorDescription = exception.message
+            )
+        } else {
+            val wooError = (exception as? WooException)?.error
+            trackLoginFailure(
+                step = Step.USER_ROLE,
+                errorContext = (wooError ?: exception).javaClass.simpleName,
+                errorType = wooError?.type?.name,
+                errorDescription = exception.message
+            )
+        }
     }
 
     private fun trackLoginFailure(
@@ -413,6 +558,116 @@ class LoginSiteCredentialsViewModel @Inject constructor(
 
     private fun String.removeSchemeAndSuffix() = UrlUtils.removeScheme(UrlUtils.removeXmlrpcSuffix(this))
 
+    private fun currentAuthenticationEndpoints(
+        recovery: EndpointRecovery? = endpointRecovery.value
+    ): CookieNonceAuthenticationEndpoints {
+        val savedLoginUrl = savedStateHandle.get<String>(LOGIN_ENTRY_URL_KEY)
+        val savedAdminUrl = savedStateHandle.get<String>(ADMIN_BASE_URL_KEY)
+        return CookieNonceAuthenticationEndpoints(
+            siteUrl = siteAddress,
+            loginEntryUrl = if (recovery?.type == EndpointType.LOGIN) recovery.url else savedLoginUrl,
+            adminBaseUrl = if (recovery?.type == EndpointType.ADMIN) recovery.url else savedAdminUrl,
+            adminBaseVerification = if (recovery?.type == EndpointType.ADMIN) {
+                AdminBaseVerification.AUTHENTICATED_DASHBOARD
+            } else {
+                AdminBaseVerification.NONE
+            }
+        )
+    }
+
+    private fun promoteValidatedEndpoints(endpoints: CookieNonceAuthenticationEndpoints) {
+        val validation = endpoints.withSiteSchemeFrom(
+            endpoints.loginEntryUrl ?: endpoints.adminBaseUrl
+        ).validate() as? ValidationResult.Valid ?: return
+        val validatedEndpoints = endpoints.withValidatedUrls(validation)
+        EndpointType.entries.forEach { type ->
+            promoteEndpoint(type, validatedEndpoints)
+        }
+    }
+
+    private fun promoteValidatedEndpoint(
+        type: EndpointType,
+        endpoints: CookieNonceAuthenticationEndpoints
+    ) {
+        val validation = endpoints.withSiteSchemeFrom(type.urlFrom(endpoints)).validate()
+            as? ValidationResult.Valid ?: return
+        promoteEndpoint(type, endpoints.withValidatedUrls(validation))
+    }
+
+    private fun promoteEndpoint(type: EndpointType, endpoints: CookieNonceAuthenticationEndpoints) {
+        when (type) {
+            EndpointType.LOGIN -> endpoints.loginEntryUrl?.let { savedStateHandle[LOGIN_ENTRY_URL_KEY] = it }
+            EndpointType.ADMIN -> endpoints.adminBaseUrl?.let { savedStateHandle[ADMIN_BASE_URL_KEY] = it }
+        }
+    }
+
+    private fun showEndpointRecovery(type: EndpointType, showError: Boolean) {
+        val endpoints = currentAuthenticationEndpoints(recovery = null)
+        val defaults = endpoints.withSiteSchemeFrom(
+            type.urlFrom(endpoints) ?: endpoints.loginEntryUrl ?: endpoints.adminBaseUrl
+        ).validate() as? ValidationResult.Valid
+        val url = endpointRecovery.value?.takeIf { it.type == type }?.url ?: when (type) {
+            EndpointType.LOGIN -> endpoints.loginEntryUrl ?: defaults?.loginEntryUrl?.toString().orEmpty()
+            EndpointType.ADMIN -> endpoints.adminBaseUrl ?: defaults?.adminBaseUrl?.toString().orEmpty()
+        }
+        endpointRecovery.value = EndpointRecovery(
+            type = type,
+            url = url,
+            errorMessage = UiStringRes(type.missingUrlError).takeIf { showError }
+        )
+    }
+
+    private suspend fun handleEndpointRecovery(type: EndpointType, isRetry: Boolean) {
+        if (!isRetry && !hasReconciledSiteUrl) {
+            val canonicalUrl = wpApiSiteRepository.fetchSite(url = siteAddress).getOrNull()?.url
+            val reconciledSiteAddress = canonicalUrl?.toSafeReconciledSiteAddress()
+            if (reconciledSiteAddress != null) {
+                hasReconciledSiteUrl = true
+                siteAddress = reconciledSiteAddress
+                login()
+                return
+            }
+        }
+        showEndpointRecovery(type, isRetry)
+    }
+
+    private fun String.toSafeReconciledSiteAddress(): String? {
+        if (isEmpty() || this == siteAddress) return null
+        val currentEndpoints = CookieNonceAuthenticationEndpoints(siteAddress)
+            .withSiteSchemeFrom(this)
+            .validate() as? ValidationResult.Valid ?: return null
+        val candidateEndpoints = CookieNonceAuthenticationEndpoints(this).validate()
+            as? ValidationResult.Valid ?: return null
+        return takeIf { currentEndpoints.allows(candidateEndpoints.siteUrl) }
+    }
+
+    private fun CookieNonceAuthenticationEndpoints.withSiteSchemeFrom(
+        endpointUrl: String?
+    ): CookieNonceAuthenticationEndpoints {
+        if (siteUrl.toHttpUrlOrNull() != null) return this
+        val scheme = endpointUrl?.toHttpUrlOrNull()?.scheme ?: "https"
+        val schemeLessSiteUrl = siteUrl.substringAfter("://").trimStart('/')
+        return copy(
+            siteUrl = "$scheme://$schemeLessSiteUrl"
+        )
+    }
+
+    private fun CookieNonceAuthenticationEndpoints.withValidatedUrls(
+        validation: ValidationResult.Valid
+    ) = copy(
+        siteUrl = validation.siteUrl.toString(),
+        loginEntryUrl = loginEntryUrl?.let { validation.loginEntryUrl.toString() },
+        adminBaseUrl = adminBaseUrl?.let { validation.adminBaseUrl.toString() }
+    )
+
+    private fun CookieNonceAuthenticationEndpoints.ValidationError.toUiString() = UiStringRes(
+        if (this == INVALID_URL) {
+            R.string.login_site_credentials_endpoint_invalid_url_error
+        } else {
+            R.string.login_site_credentials_endpoint_same_site_error
+        }
+    )
+
     @Suppress("SpreadOperator")
     private fun UiString.toPresentableString(): String = when (this) {
         is UiStringRes -> resourceProvider.getString(
@@ -427,7 +682,8 @@ class LoginSiteCredentialsViewModel @Inject constructor(
         val username: String = "",
         val password: String = "",
         @StringRes val loadingMessage: Int? = null,
-        val authenticationError: AuthenticationError? = null
+        val authenticationError: AuthenticationError? = null,
+        val endpointRecovery: EndpointRecovery? = null
     ) {
         val isValid = username.isNotBlank() && password.isNotBlank()
     }
@@ -438,9 +694,29 @@ class LoginSiteCredentialsViewModel @Inject constructor(
         val showWpAdminFallbackOption: Boolean = true
     ) : Parcelable
 
+    enum class EndpointType(
+        @StringRes val missingUrlError: Int,
+        val validationEndpoint: ValidationEndpoint
+    ) {
+        LOGIN(R.string.login_site_credentials_login_url_not_found_error, ValidationEndpoint.LOGIN),
+        ADMIN(R.string.login_site_credentials_admin_url_not_found_error, ValidationEndpoint.ADMIN);
+
+        fun urlFrom(endpoints: CookieNonceAuthenticationEndpoints) = when (this) {
+            LOGIN -> endpoints.loginEntryUrl
+            ADMIN -> endpoints.adminBaseUrl
+        }
+    }
+
+    @Parcelize
+    data class EndpointRecovery(
+        val type: EndpointType,
+        val url: String,
+        val errorMessage: UiString? = null
+    ) : Parcelable
+
     @VisibleForTesting
     enum class Step {
-        AUTHENTICATION, APPLICATION_PASSWORD_GENERATION, USER_ROLE
+        AUTHENTICATION, APPLICATION_PASSWORD_GENERATION, ENDPOINT_PERSISTENCE, USER_ROLE
     }
 
     data class LoggedIn(val localSiteId: Int) : MultiLiveEvent.Event()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
@@ -291,92 +291,114 @@ class LoginSiteCredentialsViewModel @Inject constructor(
     ) {
         val state = requireNotNull(this@LoginSiteCredentialsViewModel.viewState.value)
         loadingMessage.value = R.string.logging_in
-        wpApiSiteRepository.login(
+        val result = wpApiSiteRepository.login(
             url = siteAddress,
             username = state.username,
             password = state.password,
             endpoints = endpoints
-        ).fold(
-            onSuccess = {
-                promoteValidatedEndpoints(endpoints)
-                endpointRecovery.value = null
-                fetchSite()
-            },
-            onFailure = { exception ->
-                val authenticationError = exception as? CookieNonceAuthenticationException
-                val loginEntryWasVerified = authenticationError?.loginEntryVerified == true ||
-                    authenticationError?.errorType == CUSTOM_ADMIN_URL
-                val hasVerifiedCustomLoginEntry = endpoints.loginEntryUrl != null && loginEntryWasVerified
-
-                if (retryingEndpoint == EndpointType.LOGIN && hasVerifiedCustomLoginEntry) {
-                    promoteValidatedEndpoint(EndpointType.LOGIN, endpoints)
-                    endpointRecovery.value = null
-                }
-
-                when (authenticationError?.errorType) {
-                    CUSTOM_LOGIN_URL -> {
-                        if (hasVerifiedCustomLoginEntry) {
-                            authError.value = AuthenticationError(
-                                errorMessage = authenticationError.errorMessage,
-                                showWpAdminFallbackOption = false
-                            )
-                        } else {
-                            handleEndpointRecovery(
-                                EndpointType.LOGIN,
-                                retryingEndpoint == EndpointType.LOGIN
-                            )
-                        }
-                    }
-
-                    CUSTOM_ADMIN_URL -> {
-                        handleEndpointRecovery(
-                            EndpointType.ADMIN,
-                            retryingEndpoint == EndpointType.ADMIN
-                        )
-                    }
-
-                    INVALID_CREDENTIALS -> authError.value = AuthenticationError(
-                        errorMessage = authenticationError.errorMessage,
-                        showWpAdminFallbackOption = endpoints.loginEntryUrl == null
-                    )
-
-                    BASIC_AUTH_REQUIRED -> authError.value = AuthenticationError(
-                        errorMessage = authenticationError.errorMessage,
-                        showWpAdminFallbackOption = false
-                    )
-
-                    else -> {
-                        if (hasVerifiedCustomLoginEntry) {
-                            authError.value = AuthenticationError(
-                                errorMessage = requireNotNull(authenticationError).errorMessage,
-                                showWpAdminFallbackOption = false
-                            )
-                        } else if (authenticationError?.errorType == INVALID_RESPONSE &&
-                            endpoints.loginEntryUrl != null
-                        ) {
-                            showEndpointRecovery(EndpointType.LOGIN, showError = true)
-                        } else if (retryingEndpoint != null || endpoints.loginEntryUrl != null) {
-                            authError.value = AuthenticationError(
-                                errorMessage = authenticationError?.errorMessage ?: UiStringRes(R.string.error_generic),
-                                showWpAdminFallbackOption = false
-                            )
-                        } else {
-                            fetchSiteForTutorial(detectedErrorMessage = authenticationError?.errorMessage)
-                            analyticsTracker.track(AnalyticsEvent.LOGIN_SITE_CREDENTIALS_INVALID_LOGIN_PAGE_DETECTED)
-                        }
-                    }
-                }
-
-                trackLoginFailure(
-                    step = Step.AUTHENTICATION,
-                    errorContext = exception.javaClass.simpleName,
-                    errorType = authenticationError?.errorType?.name,
-                    errorDescription = exception.message,
-                    statusCode = authenticationError?.networkStatusCode
-                )
-            }
+        )
+        result.fold(
+            onSuccess = { completeNativeAuthentication(endpoints) },
+            onFailure = { handleLoginFailure(it, endpoints, retryingEndpoint) }
         )
         loadingMessage.value = 0
+    }
+
+    private suspend fun completeNativeAuthentication(endpoints: CookieNonceAuthenticationEndpoints) {
+        promoteValidatedEndpoints(endpoints)
+        endpointRecovery.value = null
+        fetchSite()
+    }
+
+    private suspend fun handleLoginFailure(
+        exception: Throwable,
+        endpoints: CookieNonceAuthenticationEndpoints,
+        retryingEndpoint: EndpointType?
+    ) {
+        val authenticationError = exception as? CookieNonceAuthenticationException
+        val loginEntryWasVerified = authenticationError?.loginEntryVerified == true ||
+            authenticationError?.errorType == CUSTOM_ADMIN_URL
+        val hasVerifiedCustomLoginEntry = endpoints.loginEntryUrl != null && loginEntryWasVerified
+
+        if (retryingEndpoint == EndpointType.LOGIN && hasVerifiedCustomLoginEntry) {
+            promoteValidatedEndpoint(EndpointType.LOGIN, endpoints)
+            endpointRecovery.value = null
+        }
+
+        routeLoginFailure(authenticationError, endpoints, retryingEndpoint, hasVerifiedCustomLoginEntry)
+        trackLoginFailure(
+            step = Step.AUTHENTICATION,
+            errorContext = exception.javaClass.simpleName,
+            errorType = authenticationError?.errorType?.name,
+            errorDescription = exception.message,
+            statusCode = authenticationError?.networkStatusCode
+        )
+    }
+
+    private suspend fun routeLoginFailure(
+        authenticationError: CookieNonceAuthenticationException?,
+        endpoints: CookieNonceAuthenticationEndpoints,
+        retryingEndpoint: EndpointType?,
+        hasVerifiedCustomLoginEntry: Boolean
+    ) {
+        when (authenticationError?.errorType) {
+            CUSTOM_LOGIN_URL -> if (hasVerifiedCustomLoginEntry) {
+                showNativeAuthenticationError(authenticationError.errorMessage)
+            } else {
+                handleEndpointRecovery(EndpointType.LOGIN, retryingEndpoint == EndpointType.LOGIN)
+            }
+
+            CUSTOM_ADMIN_URL -> handleEndpointRecovery(
+                EndpointType.ADMIN,
+                retryingEndpoint == EndpointType.ADMIN
+            )
+
+            INVALID_CREDENTIALS -> authError.value = AuthenticationError(
+                errorMessage = authenticationError.errorMessage,
+                showWpAdminFallbackOption = endpoints.loginEntryUrl == null
+            )
+
+            BASIC_AUTH_REQUIRED -> showNativeAuthenticationError(authenticationError.errorMessage)
+            else -> routeUnknownLoginFailure(
+                authenticationError,
+                endpoints,
+                retryingEndpoint,
+                hasVerifiedCustomLoginEntry
+            )
+        }
+    }
+
+    private suspend fun routeUnknownLoginFailure(
+        authenticationError: CookieNonceAuthenticationException?,
+        endpoints: CookieNonceAuthenticationEndpoints,
+        retryingEndpoint: EndpointType?,
+        hasVerifiedCustomLoginEntry: Boolean
+    ) {
+        when {
+            hasVerifiedCustomLoginEntry -> showNativeAuthenticationError(
+                requireNotNull(authenticationError).errorMessage
+            )
+
+            authenticationError?.errorType == INVALID_RESPONSE && endpoints.loginEntryUrl != null -> {
+                showEndpointRecovery(EndpointType.LOGIN, showError = true)
+            }
+
+            retryingEndpoint != null || endpoints.loginEntryUrl != null -> showNativeAuthenticationError(
+                authenticationError?.errorMessage ?: UiStringRes(R.string.error_generic)
+            )
+
+            else -> {
+                fetchSiteForTutorial(detectedErrorMessage = authenticationError?.errorMessage)
+                analyticsTracker.track(AnalyticsEvent.LOGIN_SITE_CREDENTIALS_INVALID_LOGIN_PAGE_DETECTED)
+            }
+        }
+    }
+
+    private fun showNativeAuthenticationError(errorMessage: UiString) {
+        authError.value = AuthenticationError(
+            errorMessage = errorMessage,
+            showWpAdminFallbackOption = false
+        )
     }
 
     private suspend fun fetchSiteForTutorial(detectedErrorMessage: UiString? = null) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
@@ -16,6 +16,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.applicationpasswords.ApplicationPasswordGenerationException
 import com.woocommerce.android.applicationpasswords.ApplicationPasswordsNotifier
+import com.woocommerce.android.extensions.combine
 import com.woocommerce.android.extensions.isNotNullOrEmpty
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.model.UiString.UiStringRes
@@ -31,7 +32,6 @@ import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getNullableStateFlow
 import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
@@ -126,15 +126,16 @@ class LoginSiteCredentialsViewModel @Inject constructor(
         savedStateHandle.getStateFlow(USERNAME_KEY, ""),
         savedStateHandle.getStateFlow(PASSWORD_KEY, ""),
         loadingMessage.map { message -> message.takeIf { it != 0 } },
-        combine(authError, endpointRecovery) { error, recovery -> error to recovery }
-    ) { siteAddress, username, password, loadingMessage, errors ->
+        authError,
+        endpointRecovery
+    ) { siteAddress, username, password, loadingMessage, authenticationError, endpointRecovery ->
         ViewState(
             siteUrl = siteAddress,
             username = username,
             password = password,
             loadingMessage = loadingMessage,
-            authenticationError = errors.first,
-            endpointRecovery = errors.second
+            authenticationError = authenticationError,
+            endpointRecovery = endpointRecovery
         )
     }.asLiveData()
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -397,7 +397,7 @@
     <string name="login_site_credentials_admin_url_not_found_error">We couldn\'t reach the WordPress dashboard at that address. Check it and try again.</string>
     <string name="login_site_credentials_endpoint_persistence_failed">We couldn\'t save your store\'s sign-in settings. Please try again.</string>
     <string name="login_site_credentials_http_error">Login failed with status code %1$s</string>
-    <string name="login_site_credentials_use_web_authorization">Try again with WP Admin page</string>
+    <string name="login_site_credentials_use_web_authorization">Try signing in with your browser instead</string>
     <string name="login_site_credentials_http_basic_auth_error">Basic Authentication is enabled on your site. Basic Authentication is unsupported in the WooCommerce mobile app. Please disable it, or contact support for troubleshooting.</string>
     <string name="login_site_credentials_fetching_site_failed">An error occurred while fetching your website</string>
     <string name="login_site_credentials_fetching_site">Fetching site…</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -385,6 +385,17 @@
     <string name="login_site_credentials_invalid_response">Login failed with an unexpected response from your site.</string>
     <string name="login_site_credentials_custom_login_url">Unable to login because we cannot identify your store\'s login URL</string>
     <string name="login_site_credentials_custom_admin_url">Unable to login because we cannot identify your store\'s admin URL</string>
+    <string name="login_site_credentials_login_url_title">Where do you sign in to your store?</string>
+    <string name="login_site_credentials_login_url_description">A security plugin may use a custom WordPress sign-in address. Enter the address you use to sign in.</string>
+    <string name="login_site_credentials_login_url_label">WordPress sign-in address</string>
+    <string name="login_site_credentials_admin_url_title">Where is your store\'s dashboard?</string>
+    <string name="login_site_credentials_admin_url_description">A security plugin may move the WordPress dashboard. Enter the address you use to open it.</string>
+    <string name="login_site_credentials_admin_url_label">WordPress dashboard address</string>
+    <string name="login_site_credentials_endpoint_invalid_url_error">Enter a full web address, including http:// or https://.</string>
+    <string name="login_site_credentials_endpoint_same_site_error">Enter an address on the same site without changing its secure connection or port.</string>
+    <string name="login_site_credentials_login_url_not_found_error">We couldn\'t find a WordPress sign-in page at that address. Check it and try again.</string>
+    <string name="login_site_credentials_admin_url_not_found_error">We couldn\'t reach the WordPress dashboard at that address. Check it and try again.</string>
+    <string name="login_site_credentials_endpoint_persistence_failed">We couldn\'t save your store\'s sign-in settings. Please try again.</string>
     <string name="login_site_credentials_http_error">Login failed with status code %1$s</string>
     <string name="login_site_credentials_use_web_authorization">Try again with WP Admin page</string>
     <string name="login_site_credentials_http_basic_auth_error">Basic Authentication is enabled on your site. Basic Authentication is unsupported in the WooCommerce mobile app. Please disable it, or contact support for troubleshooting.</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModelTest.kt
@@ -476,18 +476,7 @@ class LoginSiteCredentialsViewModelTest : BaseUnitTest() {
                 Nonce.CookieNonceErrorType.INVALID_CREDENTIALS,
                 loginEntryVerified = true
             )
-            whenever(repository.login(SITE_URL, USERNAME, PASSWORD, DEFAULT_ENDPOINTS))
-                .thenReturn(Result.failure(cookieNonceError(Nonce.CookieNonceErrorType.CUSTOM_LOGIN_URL)))
-            whenever(repository.login(SITE_URL, USERNAME, PASSWORD, LOGIN_ENDPOINTS))
-                .thenReturn(Result.failure(invalidCredentials))
-            whenever(repository.login(SITE_URL, USERNAME, STILL_WRONG_PASSWORD, PENDING_LOGIN_ENDPOINTS))
-                .thenReturn(Result.failure(invalidCredentials))
-            whenever(repository.login(SITE_URL, USERNAME, CORRECT_PASSWORD, PENDING_LOGIN_ENDPOINTS))
-                .thenReturn(Result.failure(cookieNonceError(Nonce.CookieNonceErrorType.CUSTOM_ADMIN_URL)))
-            whenever(repository.login(SITE_URL, USERNAME, CORRECT_PASSWORD, ADMIN_RETRY_ENDPOINTS))
-                .thenReturn(Result.success(Unit))
-            whenever(repository.fetchSite(SITE_URL, USERNAME, CORRECT_PASSWORD)).thenReturn(Result.success(site))
-            setup()
+            givenCustomLoginRetriesBeforeNativeSuccess(invalidCredentials)
 
             // GIVEN
             viewModel.viewState.observeForTesting {
@@ -809,6 +798,23 @@ class LoginSiteCredentialsViewModelTest : BaseUnitTest() {
                 override suspend fun isEnabledForJetpackAccess() = true
             }
         )
+    }
+
+    private suspend fun givenCustomLoginRetriesBeforeNativeSuccess(
+        invalidCredentials: CookieNonceAuthenticationException
+    ) {
+        whenever(repository.login(SITE_URL, USERNAME, PASSWORD, DEFAULT_ENDPOINTS))
+            .thenReturn(Result.failure(cookieNonceError(Nonce.CookieNonceErrorType.CUSTOM_LOGIN_URL)))
+        whenever(repository.login(SITE_URL, USERNAME, PASSWORD, LOGIN_ENDPOINTS))
+            .thenReturn(Result.failure(invalidCredentials))
+        whenever(repository.login(SITE_URL, USERNAME, STILL_WRONG_PASSWORD, PENDING_LOGIN_ENDPOINTS))
+            .thenReturn(Result.failure(invalidCredentials))
+        whenever(repository.login(SITE_URL, USERNAME, CORRECT_PASSWORD, PENDING_LOGIN_ENDPOINTS))
+            .thenReturn(Result.failure(cookieNonceError(Nonce.CookieNonceErrorType.CUSTOM_ADMIN_URL)))
+        whenever(repository.login(SITE_URL, USERNAME, CORRECT_PASSWORD, ADMIN_RETRY_ENDPOINTS))
+            .thenReturn(Result.success(Unit))
+        whenever(repository.fetchSite(SITE_URL, USERNAME, CORRECT_PASSWORD)).thenReturn(Result.success(site))
+        setup()
     }
 
     private fun credentialsState(siteAddress: String = SITE_URL) = SavedStateHandle(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModelTest.kt
@@ -2,452 +2,887 @@ package com.woocommerce.android.ui.login.sitecredentials
 
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.AppPrefsWrapper
+import com.woocommerce.android.OnChangedException
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
-import com.woocommerce.android.applicationpasswords.ApplicationPasswordGenerationException
 import com.woocommerce.android.applicationpasswords.ApplicationPasswordsNotifier
 import com.woocommerce.android.model.UiString.UiStringRes
 import com.woocommerce.android.model.UiString.UiStringText
-import com.woocommerce.android.notifications.push.RegisterDevice
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.login.WPApiSiteRepository
 import com.woocommerce.android.ui.login.WPApiSiteRepository.CookieNonceAuthenticationException
+import com.woocommerce.android.ui.login.sitecredentials.LoginSiteCredentialsViewModel.EndpointType
 import com.woocommerce.android.ui.login.sitecredentials.LoginSiteCredentialsViewModel.LoggedIn
-import com.woocommerce.android.ui.login.sitecredentials.LoginSiteCredentialsViewModel.ShowApplicationPasswordsUnavailableScreen
-import com.woocommerce.android.ui.login.sitecredentials.LoginSiteCredentialsViewModel.ShowNonWooErrorScreen
 import com.woocommerce.android.util.getOrAwaitValue
 import com.woocommerce.android.util.observeForTesting
-import com.woocommerce.android.util.runAndCaptureValues
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ResourceProvider
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.any
-import org.mockito.kotlin.anyOrNull
-import org.mockito.kotlin.argThat
-import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doSuspendableAnswer
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
-import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
+import org.wordpress.android.fluxc.network.rest.wpapi.CookieNonceAuthenticationEndpoints
 import org.wordpress.android.fluxc.network.rest.wpapi.Nonce
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetworkError
 import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordsConfiguration
+import org.wordpress.android.fluxc.store.SiteStore.SiteError
+import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType
 import org.wordpress.android.login.LoginAnalyticsListener
 
-@ExperimentalCoroutinesApi
+private typealias ShowApplicationPasswordTutorialScreen =
+    LoginSiteCredentialsViewModel.ShowApplicationPasswordTutorialScreen
+
+@OptIn(ExperimentalCoroutinesApi::class)
 class LoginSiteCredentialsViewModelTest : BaseUnitTest() {
-    private val testUsername = "username"
-    private val testPassword = "password"
-    private val siteAddress: String = "http://site.com"
-    private val siteAddressWithoutSchemeAndSuffix = "site.com"
-    private val clientId = "woo_android"
-
-    private val urlAuthBase = "$siteAddress/wp-admin/authorize-application.php"
-    private val urlRedirectBase = "woocommerce://login"
-    private val urlAuthFull = "$urlAuthBase?app_name=$clientId&success_url=$urlRedirectBase"
-    private val urlSuccessRedirect = "$urlRedirectBase?user_login=$testUsername&password=$testPassword"
-    private val urlRejectedRedirect = "$urlRedirectBase?success=false"
-
-    private val testSite = SiteModel().apply {
+    private val site = SiteModel().apply {
+        id = SITE_ID
+        url = SITE_URL
+        hasWooCommerce = true
+        applicationPasswordsAuthorizeUrl = "$SITE_URL/wp-admin/authorize-application.php"
+    }
+    private val persistedSite = SiteModel().apply {
+        id = SITE_ID
+        url = SITE_URL
         hasWooCommerce = true
     }
-    private val applicationPasswordsUnavailableEvents = MutableSharedFlow<WPAPINetworkError>(extraBufferCapacity = 1)
-
-    private val wpApiSiteRepository: WPApiSiteRepository = mock {
-        on { fetchSite(eq(siteAddress), any(), any()) } doReturn Result.success(testSite)
-        on { checkIfUserIsEligible(testSite) } doReturn Result.success(true)
-        on { getSiteByLocalId(testSite.id) } doReturn testSite
+    private val repository: WPApiSiteRepository = mock {
+        on { login(SITE_URL, USERNAME, PASSWORD, DEFAULT_ENDPOINTS) } doReturn Result.success(Unit)
+        on { fetchSite(SITE_URL, USERNAME, PASSWORD) } doReturn Result.success(site)
+        on { fetchSite(SITE_URL) } doReturn Result.success(site)
+        on { getSiteByLocalId(SITE_ID) } doReturn site
+        on { checkIfUserIsEligible(site) } doReturn Result.success(true)
+        on { checkIfUserIsEligible(persistedSite) } doReturn Result.success(true)
+        on { saveAuthenticationEndpoints(site, PROVEN_ENDPOINTS) } doReturn Result.success(persistedSite)
     }
-    private var isJetpackConnected: Boolean = false
     private val selectedSite: SelectedSite = mock()
-    private val applicationPasswordsNotifier: ApplicationPasswordsNotifier = mock {
-        on { featureUnavailableEvents } doReturn applicationPasswordsUnavailableEvents
+    private val notifier: ApplicationPasswordsNotifier = mock {
+        on { featureUnavailableEvents } doReturn MutableSharedFlow<WPAPINetworkError>()
     }
-    private val loginAnalyticsListener: LoginAnalyticsListener = mock()
-    private val analyticsTracker: AnalyticsTrackerWrapper = mock()
+    private val analytics: AnalyticsTrackerWrapper = mock()
+    private val loginAnalytics: LoginAnalyticsListener = mock()
     private val appPrefs: AppPrefsWrapper = mock()
     private val resourceProvider: ResourceProvider = mock {
-        on { getString(any()) } doAnswer { it.arguments[0].toString() }
+        on { getString(R.string.error_generic) } doReturn "error"
     }
-
+    private lateinit var savedState: SavedStateHandle
     private lateinit var viewModel: LoginSiteCredentialsViewModel
 
-    suspend fun setup(prepareMocks: suspend () -> Unit = {}) {
-        prepareMocks()
-
-        viewModel = LoginSiteCredentialsViewModel(
-            savedStateHandle = SavedStateHandle(
-                mapOf(
-                    LoginSiteCredentialsViewModel.SITE_ADDRESS_KEY to siteAddress,
-                    LoginSiteCredentialsViewModel.IS_JETPACK_CONNECTED_KEY to isJetpackConnected
-                )
-            ),
-            wpApiSiteRepository = wpApiSiteRepository,
-            selectedSite = selectedSite,
-            loginAnalyticsListener = loginAnalyticsListener,
-            applicationPasswordsNotifier = applicationPasswordsNotifier,
-            analyticsTracker = analyticsTracker,
-            appPrefs = appPrefs,
-            applicationPasswordsConfiguration = object : ApplicationPasswordsConfiguration {
-                override val applicationName: String = clientId
-                override suspend fun isEnabledForJetpackAccess(): Boolean = true
-            },
-            resourceProvider = resourceProvider
-        )
-    }
-
     @Test
-    fun `when displaying site credentials, then show native login form`() = testBlocking {
-        setup()
-
-        val state = viewModel.viewState.runAndCaptureValues {
-            // Do nothing, this is just to ensure the viewState is initialized
-        }.last()
-
-        assertThat(state).isEqualTo(
-            LoginSiteCredentialsViewModel.ViewState(
-                siteUrl = siteAddressWithoutSchemeAndSuffix,
-                username = "",
-                password = ""
-            )
-        )
-    }
-
-    @Test
-    fun `when changing username, then update state`() = testBlocking {
-        setup()
-
-        val state = viewModel.viewState.runAndCaptureValues {
-            viewModel.onUsernameChanged(testUsername)
-        }.last()
-
-        assertThat(state.username).isEqualTo(testUsername)
-    }
-
-    @Test
-    fun `when changing password, then update state`() = testBlocking {
-        setup()
-
-        val state = viewModel.viewState.runAndCaptureValues {
-            viewModel.onUsernameChanged(testPassword)
-        }.last()
-
-        assertThat(state.username).isEqualTo(testPassword)
-    }
-
-    @Test
-    fun `when username is empty, then mark input as invalid`() = testBlocking {
-        setup()
-
-        val state = viewModel.viewState.runAndCaptureValues {
-            viewModel.onUsernameChanged("")
-        }.last()
-
-        assertThat(state.isValid).isFalse()
-    }
-
-    @Test
-    fun `when password is empty, then mark input as invalid`() = testBlocking {
-        setup()
-
-        val state = viewModel.viewState.runAndCaptureValues {
-            viewModel.onPasswordChanged("")
-        }.last()
-
-        assertThat(state.isValid).isFalse()
-    }
-
-    @Test
-    fun `given login successful, when submitting login, then log the user successfully`() = testBlocking {
-        setup()
-
-        viewModel.viewState.observeForTesting {
-            viewModel.onUsernameChanged(testUsername)
-            viewModel.onPasswordChanged(testPassword)
-            viewModel.onContinueClick()
-        }
-
-        assertThat(viewModel.event.value).isEqualTo(LoggedIn(testSite.id))
-        verify(loginAnalyticsListener).trackSubmitClicked()
-        verify(loginAnalyticsListener).trackAnalyticsSignIn(false)
-    }
-
-    @Test
-    fun `given successful webview login, when user is eligible, then log the user successfully`() = testBlocking {
-        setup {
-            whenever(wpApiSiteRepository.getSiteByLocalId(any())).thenReturn(testSite)
-            whenever(wpApiSiteRepository.checkIfUserIsEligible(testSite)).thenReturn(Result.success(true))
-        }
-
-        viewModel.viewState.observeForTesting {
-            viewModel.onWebAuthorizationUrlLoaded(urlSuccessRedirect)
-        }
-
-        assertThat(viewModel.event.value).isEqualTo(LoggedIn(testSite.id))
-        verify(loginAnalyticsListener).trackAnalyticsSignIn(false)
-    }
-
-    @Test
-    fun `given webview login, when user rejected application password creation, then show error`() = testBlocking {
-        setup()
-
-        viewModel.viewState.observeForTesting {
-            viewModel.onWebAuthorizationUrlLoaded(urlRejectedRedirect)
-        }
-
-        assertThat(viewModel.event.value).isEqualTo(
-            ShowSnackbar(R.string.login_site_credentials_web_authorization_connection_rejected)
-        )
-    }
-
-    @Test
-    fun `given incorrect credentials, when submitting, then show error`() = testBlocking {
-        val expectedError = CookieNonceAuthenticationException(
-            errorMessage = UiStringText("Username or password incorrect"),
-            errorType = Nonce.CookieNonceErrorType.INVALID_CREDENTIALS,
-            networkStatusCode = null
-        )
-        setup {
-            whenever(wpApiSiteRepository.login(siteAddress, testUsername, testPassword)).thenReturn(
-                Result.failure(expectedError)
-            )
-        }
-
-        val state = viewModel.viewState.runAndCaptureValues {
-            viewModel.onUsernameChanged(testUsername)
-            viewModel.onPasswordChanged(testPassword)
-            viewModel.onContinueClick()
-        }.last()
-
-        assertThat(state.authenticationError?.errorMessage).isEqualTo(expectedError.errorMessage)
-        verify(analyticsTracker).track(
-            stat = eq(AnalyticsEvent.LOGIN_SITE_CREDENTIALS_LOGIN_FAILED),
-            properties = argThat {
-                get(AnalyticsTracker.KEY_STEP) == LoginSiteCredentialsViewModel.Step.AUTHENTICATION.name.lowercase()
-            },
-            errorContext = anyOrNull(),
-            errorType = eq(expectedError.errorType.name),
-            errorDescription = eq((expectedError.errorMessage as UiStringText).text)
-        )
-        verify(loginAnalyticsListener).trackFailure(anyOrNull())
-    }
-
-    @Test
-    fun `given site without Woo, when submitting, then show error screen`() = testBlocking {
-        setup {
-            whenever(wpApiSiteRepository.fetchSite(siteAddress, testUsername, testPassword))
-                .thenReturn(Result.success(testSite.apply { hasWooCommerce = false }))
-        }
-
-        viewModel.viewState.observeForTesting {
-            viewModel.onUsernameChanged(testUsername)
-            viewModel.onPasswordChanged(testPassword)
-            viewModel.onContinueClick()
-        }
-
-        assertThat(viewModel.event.value).isEqualTo(ShowNonWooErrorScreen(siteAddress))
-    }
-
-    @Test
-    fun `given application passwords generation fails, when submitting, then show snackbar`() = testBlocking {
-        setup {
-            val networkError = WPAPINetworkError(BaseNetworkError(GenericErrorType.UNKNOWN))
-            whenever(wpApiSiteRepository.checkIfUserIsEligible(testSite))
-                .thenReturn(Result.failure(ApplicationPasswordGenerationException(networkError)))
-        }
-
-        viewModel.viewState.observeForTesting {
-            viewModel.onUsernameChanged(testUsername)
-            viewModel.onPasswordChanged(testPassword)
-            viewModel.onContinueClick()
-        }
-
-        assertThat(viewModel.event.value).isEqualTo(ShowSnackbar(R.string.user_role_access_error_fetch_failed))
-        verify(analyticsTracker).track(
-            stat = eq(AnalyticsEvent.LOGIN_SITE_CREDENTIALS_LOGIN_FAILED),
-            properties = argThat {
-                get(AnalyticsTracker.KEY_STEP) ==
-                    LoginSiteCredentialsViewModel.Step.APPLICATION_PASSWORD_GENERATION.name.lowercase()
-            },
-            errorContext = anyOrNull(),
-            errorType = anyOrNull(),
-            errorDescription = anyOrNull()
-        )
-        verify(loginAnalyticsListener).trackFailure(anyOrNull())
-    }
-
-    @Test
-    fun `given site without Woo, when attempting Woo installation, then retry fetching site`() = testBlocking {
-        setup()
-
-        viewModel.viewState.observeForTesting {
-            viewModel.onWooInstallationAttempted()
-        }
-
-        verify(wpApiSiteRepository).fetchSite(any(), any(), any())
-    }
-
-    @Test
-    fun `given application pwd disabled and wp-login-php accessible, when submitting login, then show error screen`() =
+    fun `given default native authentication succeeds, when submitting, then keep the existing login flow`() =
         testBlocking {
-            setup {
-                whenever(wpApiSiteRepository.checkIfUserIsEligible(testSite)).thenReturn(Result.failure(Exception()))
+            setup()
+
+            viewModel.viewState.observeForTesting { enterCredentialsAndContinue() }
+
+            verify(repository).checkIfUserIsEligible(site)
+            verify(repository, never()).saveAuthenticationEndpoints(any(), any())
+            verify(selectedSite).set(site)
+            assertThat(viewModel.event.value).isEqualTo(LoggedIn(0))
+        }
+
+    @Test
+    fun `given default login, when credentials are invalid, then keep the browser fallback`() = testBlocking {
+        val invalidCredentials = cookieNonceError(Nonce.CookieNonceErrorType.INVALID_CREDENTIALS)
+        whenever(repository.login(SITE_URL, USERNAME, PASSWORD, DEFAULT_ENDPOINTS))
+            .thenReturn(Result.failure(invalidCredentials))
+        setup()
+
+        // WHEN
+        viewModel.viewState.observeForTesting {
+            enterCredentialsAndContinue()
+            advanceUntilIdle()
+        }
+
+        // THEN
+        val state = viewModel.viewState.value
+        assertThat(state?.endpointRecovery).isNull()
+        assertThat(state?.authenticationError?.errorMessage).isEqualTo(invalidCredentials.errorMessage)
+        assertThat(state?.authenticationError?.showWpAdminFallbackOption).isTrue()
+    }
+
+    @Test
+    fun `given scheme-less site, when recovering with full http or https login URL, then validate matching origin`() =
+        testBlocking {
+            listOf("http", "https").forEach { scheme ->
+                val loginUrl = "$scheme://$SCHEMELESS_SITE/private-login"
+                val expectedEndpoints = CookieNonceAuthenticationEndpoints(
+                    siteUrl = "$scheme://$SCHEMELESS_SITE/",
+                    loginEntryUrl = loginUrl
+                )
+                val invalidCredentials = cookieNonceError(
+                    Nonce.CookieNonceErrorType.INVALID_CREDENTIALS,
+                    loginEntryVerified = true
+                )
+                whenever(repository.login(eq(SCHEMELESS_SITE), eq(USERNAME), eq(PASSWORD), any()))
+                    .thenReturn(Result.failure(invalidCredentials))
+                setup(recoveryState(EndpointType.LOGIN, loginUrl, SCHEMELESS_SITE))
+
+                viewModel.viewState.observeForTesting {
+                    viewModel.onContinueClick()
+                    advanceUntilIdle()
+                }
+
+                assertThat(viewModel.viewState.value?.endpointRecovery).isNull()
+                assertThat(viewModel.viewState.value?.authenticationError?.errorMessage)
+                    .isEqualTo(invalidCredentials.errorMessage)
+                verify(repository).login(SCHEMELESS_SITE, USERNAME, PASSWORD, expectedEndpoints)
             }
+        }
+
+    @Test
+    fun `given scheme-less site, when recovery is first shown, then prefill a safe https URL`() = testBlocking {
+        val schemeLessSite = SiteModel().apply {
+            id = SITE_ID
+            url = SCHEMELESS_SITE
+            hasWooCommerce = true
+        }
+        whenever(repository.login(eq(SCHEMELESS_SITE), eq(USERNAME), eq(PASSWORD), any()))
+            .thenReturn(Result.failure(cookieNonceError(Nonce.CookieNonceErrorType.CUSTOM_LOGIN_URL)))
+        whenever(repository.fetchSite(SCHEMELESS_SITE)).thenReturn(Result.success(schemeLessSite))
+        setup(siteAddress = SCHEMELESS_SITE)
+
+        viewModel.viewState.observeForTesting {
+            enterCredentialsAndContinue()
+            advanceUntilIdle()
+        }
+
+        assertThat(viewModel.viewState.value?.endpointRecovery).isEqualTo(
+            LoginSiteCredentialsViewModel.EndpointRecovery(
+                EndpointType.LOGIN,
+                "https://$SCHEMELESS_SITE/wp-login.php"
+            )
+        )
+        verify(repository).login(SCHEMELESS_SITE, USERNAME, PASSWORD, SCHEMELESS_ENDPOINTS)
+    }
+
+    @Test
+    fun `given invalid edited recovery URL, when continuing, then show only its inline validation error`() =
+        testBlocking {
+            listOf(
+                "not a URL" to R.string.login_site_credentials_endpoint_invalid_url_error,
+                "https://other.example/private-login" to
+                    R.string.login_site_credentials_endpoint_same_site_error
+            ).forEach { (url, errorRes) ->
+                setup(recoveryState(EndpointType.LOGIN, url))
+
+                viewModel.viewState.observeForTesting {
+                    viewModel.onContinueClick()
+                    advanceUntilIdle()
+                }
+
+                val state = viewModel.viewState.value
+                assertThat(state?.endpointRecovery?.errorMessage).isEqualTo(UiStringRes(errorRes))
+                assertThat(state?.authenticationError).isNull()
+            }
+            verify(repository, never()).login(any(), any(), any(), any())
+        }
+
+    @Test
+    fun `given another endpoint is invalid, when validating edited URL, then show a general error without inline blame`() =
+        testBlocking {
+            val state = recoveryState(EndpointType.ADMIN, ADMIN_URL).apply {
+                this[LOGIN_ENTRY_URL_STATE_KEY] = "https://other.example/private-login"
+            }
+            setup(state)
 
             viewModel.viewState.observeForTesting {
-                viewModel.onUsernameChanged(testUsername)
-                viewModel.onPasswordChanged(testPassword)
                 viewModel.onContinueClick()
-                applicationPasswordsUnavailableEvents.tryEmit(mock())
+                advanceUntilIdle()
+            }
+
+            val viewState = viewModel.viewState.value
+            assertThat(viewState?.endpointRecovery?.errorMessage).isNull()
+            assertThat(viewState?.authenticationError?.errorMessage)
+                .isEqualTo(UiStringRes(R.string.login_site_credentials_endpoint_same_site_error))
+            assertThat(viewState?.authenticationError?.showWpAdminFallbackOption).isTrue()
+            verify(repository, never()).login(any(), any(), any(), any())
+        }
+
+    @Test
+    fun `given canonical origin is invalid, when validating edited URL, then show fallback error without inline blame`() =
+        testBlocking {
+            setup(recoveryState(EndpointType.LOGIN, LOGIN_URL, siteAddress = "not a site"))
+
+            viewModel.viewState.observeForTesting {
+                viewModel.onContinueClick()
+                advanceUntilIdle()
+            }
+
+            val state = viewModel.viewState.value
+            assertThat(state?.endpointRecovery?.errorMessage).isNull()
+            assertThat(state?.authenticationError?.errorMessage).isEqualTo(UiStringRes(R.string.error_generic))
+            assertThat(state?.authenticationError?.showWpAdminFallbackOption).isTrue()
+            verify(repository, never()).login(any(), any(), any(), any())
+        }
+
+    @Test
+    fun `given discovery returns reconciled site URL, when native retry succeeds, then complete login`() =
+        testBlocking {
+            val originalSiteUrl = "http://site.example"
+            val originalEndpoints = CookieNonceAuthenticationEndpoints(originalSiteUrl)
+            whenever(repository.login(originalSiteUrl, USERNAME, PASSWORD, originalEndpoints))
+                .thenReturn(Result.failure(cookieNonceError(Nonce.CookieNonceErrorType.CUSTOM_LOGIN_URL)))
+            whenever(repository.fetchSite(originalSiteUrl)).thenReturn(Result.success(site))
+            whenever(repository.login(SITE_URL, USERNAME, PASSWORD, DEFAULT_ENDPOINTS))
+                .thenReturn(Result.success(Unit))
+            setup(siteAddress = originalSiteUrl)
+
+            viewModel.viewState.observeForTesting {
+                enterCredentialsAndContinue()
+                advanceUntilIdle()
+            }
+
+            verify(repository).login(originalSiteUrl, USERNAME, PASSWORD, originalEndpoints)
+            verify(repository).login(SITE_URL, USERNAME, PASSWORD, DEFAULT_ENDPOINTS)
+            verify(repository).checkIfUserIsEligible(site)
+            assertThat(viewModel.viewState.value?.endpointRecovery).isNull()
+            assertThat(viewModel.event.value).isEqualTo(LoggedIn(0))
+        }
+
+    @Test
+    fun `given discovery returns an off-host URL, when recovering endpoint, then keep original origin`() =
+        testBlocking {
+            val discoveredSite = siteWithUrl("https://other.example")
+            whenever(repository.login(SITE_URL, USERNAME, PASSWORD, DEFAULT_ENDPOINTS))
+                .thenReturn(Result.failure(cookieNonceError(Nonce.CookieNonceErrorType.CUSTOM_LOGIN_URL)))
+            whenever(repository.fetchSite(SITE_URL)).thenReturn(Result.success(discoveredSite))
+            setup()
+
+            viewModel.viewState.observeForTesting {
+                enterCredentialsAndContinue()
+                advanceUntilIdle()
+            }
+
+            assertThat(viewModel.viewState.value?.siteUrl).isEqualTo("site.example")
+            assertThat(viewModel.viewState.value?.endpointRecovery?.url).isEqualTo("$SITE_URL/wp-login.php")
+            verify(repository).login(SITE_URL, USERNAME, PASSWORD, DEFAULT_ENDPOINTS)
+            verify(repository, never()).login(eq("https://other.example"), any(), any(), any())
+        }
+
+    @Test
+    fun `given discovery changes the port, when recovering endpoint, then keep original origin`() = testBlocking {
+        val originalSiteUrl = "https://site.example:8443"
+        val originalEndpoints = CookieNonceAuthenticationEndpoints(originalSiteUrl)
+        val discoveredSite = siteWithUrl("https://site.example:9443")
+        whenever(repository.login(originalSiteUrl, USERNAME, PASSWORD, originalEndpoints))
+            .thenReturn(Result.failure(cookieNonceError(Nonce.CookieNonceErrorType.CUSTOM_LOGIN_URL)))
+        whenever(repository.fetchSite(originalSiteUrl)).thenReturn(Result.success(discoveredSite))
+        setup(siteAddress = originalSiteUrl)
+
+        viewModel.viewState.observeForTesting {
+            enterCredentialsAndContinue()
+            advanceUntilIdle()
+        }
+
+        assertThat(viewModel.viewState.value?.siteUrl).isEqualTo("site.example:8443")
+        assertThat(viewModel.viewState.value?.endpointRecovery?.url)
+            .isEqualTo("$originalSiteUrl/wp-login.php")
+        verify(repository).login(originalSiteUrl, USERNAME, PASSWORD, originalEndpoints)
+        verify(repository, never()).login(eq("https://site.example:9443"), any(), any(), any())
+    }
+
+    @Test
+    fun `given discovery downgrades HTTPS to HTTP, when recovering endpoint, then keep original origin`() =
+        testBlocking {
+            val discoveredSite = siteWithUrl("http://site.example")
+            whenever(repository.login(SITE_URL, USERNAME, PASSWORD, DEFAULT_ENDPOINTS))
+                .thenReturn(Result.failure(cookieNonceError(Nonce.CookieNonceErrorType.CUSTOM_LOGIN_URL)))
+            whenever(repository.fetchSite(SITE_URL)).thenReturn(Result.success(discoveredSite))
+            setup()
+
+            viewModel.viewState.observeForTesting {
+                enterCredentialsAndContinue()
+                advanceUntilIdle()
+            }
+
+            assertThat(viewModel.viewState.value?.siteUrl).isEqualTo("site.example")
+            assertThat(viewModel.viewState.value?.endpointRecovery?.url).isEqualTo("$SITE_URL/wp-login.php")
+            verify(repository).login(SITE_URL, USERNAME, PASSWORD, DEFAULT_ENDPOINTS)
+            verify(repository, never()).login(eq("http://site.example"), any(), any(), any())
+        }
+
+    @Test
+    fun `given verified custom login, when post response fails, then retain it and show the actual error`() =
+        testBlocking {
+            val responseError = cookieNonceError(
+                Nonce.CookieNonceErrorType.INVALID_RESPONSE,
+                loginEntryVerified = true
+            )
+            whenever(repository.login(SITE_URL, USERNAME, PASSWORD, DEFAULT_ENDPOINTS))
+                .thenReturn(Result.failure(cookieNonceError(Nonce.CookieNonceErrorType.CUSTOM_LOGIN_URL)))
+            whenever(repository.login(SITE_URL, USERNAME, PASSWORD, LOGIN_ENDPOINTS))
+                .thenReturn(Result.failure(responseError))
+            whenever(repository.login(SITE_URL, USERNAME, PASSWORD, PENDING_LOGIN_ENDPOINTS))
+                .thenReturn(Result.failure(responseError))
+            setup()
+
+            viewModel.viewState.observeForTesting {
+                enterCredentialsAndContinue()
+                advanceUntilIdle()
+                viewModel.onEndpointUrlChanged(LOGIN_URL)
+                viewModel.onContinueClick()
+                advanceUntilIdle()
+            }
+
+            val state = viewModel.viewState.value
+            assertThat(state?.endpointRecovery).isNull()
+            assertThat(state?.authenticationError?.errorMessage).isEqualTo(responseError.errorMessage)
+            assertThat(state?.authenticationError?.showWpAdminFallbackOption).isFalse()
+            verify(repository, never()).saveAuthenticationEndpoints(any(), any())
+
+            viewModel.viewState.observeForTesting {
+                viewModel.onErrorDialogDismissed()
+                viewModel.onContinueClick()
+                advanceUntilIdle()
+            }
+            verify(repository).login(SITE_URL, USERNAME, PASSWORD, PENDING_LOGIN_ENDPOINTS)
+        }
+
+    @Test
+    fun `given verified custom login, when post network or nonce fails, then do not blame its URL`() = testBlocking {
+        listOf(
+            Nonce.CookieNonceErrorType.UNKNOWN,
+            Nonce.CookieNonceErrorType.INVALID_NONCE
+        ).forEach { errorType ->
+            val authenticationError = cookieNonceError(errorType, loginEntryVerified = true)
+            whenever(repository.login(SITE_URL, USERNAME, PASSWORD, DEFAULT_ENDPOINTS))
+                .thenReturn(Result.failure(cookieNonceError(Nonce.CookieNonceErrorType.CUSTOM_LOGIN_URL)))
+            whenever(repository.login(SITE_URL, USERNAME, PASSWORD, LOGIN_ENDPOINTS))
+                .thenReturn(Result.failure(authenticationError))
+            setup()
+
+            viewModel.viewState.observeForTesting {
+                enterCredentialsAndContinue()
+                advanceUntilIdle()
+                viewModel.onEndpointUrlChanged(LOGIN_URL)
+                viewModel.onContinueClick()
+                advanceUntilIdle()
+            }
+
+            val state = viewModel.viewState.value
+            assertThat(state?.endpointRecovery).isNull()
+            assertThat(state?.authenticationError?.errorMessage).isEqualTo(authenticationError.errorMessage)
+            assertThat(state?.authenticationError?.showWpAdminFallbackOption).isFalse()
+        }
+    }
+
+    @Test
+    fun `given custom login soft page, when preflight is unverified, then keep URL recovery semantics`() =
+        testBlocking {
+            whenever(repository.login(SITE_URL, USERNAME, PASSWORD, DEFAULT_ENDPOINTS))
+                .thenReturn(Result.failure(cookieNonceError(Nonce.CookieNonceErrorType.CUSTOM_LOGIN_URL)))
+            whenever(repository.login(SITE_URL, USERNAME, PASSWORD, LOGIN_ENDPOINTS))
+                .thenReturn(Result.failure(cookieNonceError(Nonce.CookieNonceErrorType.INVALID_RESPONSE)))
+            setup()
+
+            viewModel.viewState.observeForTesting {
+                enterCredentialsAndContinue()
+                advanceUntilIdle()
+                viewModel.onEndpointUrlChanged(LOGIN_URL)
+                viewModel.onContinueClick()
+                advanceUntilIdle()
+            }
+
+            val recovery = viewModel.viewState.value?.endpointRecovery
+            assertThat(recovery?.type).isEqualTo(EndpointType.LOGIN)
+            assertThat(recovery?.url).isEqualTo(LOGIN_URL)
+            assertThat(recovery?.errorMessage)
+                .isEqualTo(UiStringRes(R.string.login_site_credentials_login_url_not_found_error))
+            assertThat(viewModel.viewState.value?.authenticationError).isNull()
+        }
+
+    @Test
+    fun `given active custom login prompt, when preflight server fails, then preserve text and show actual error`() =
+        testBlocking {
+            val serverError = cookieNonceError(Nonce.CookieNonceErrorType.GENERIC_ERROR)
+            whenever(repository.login(SITE_URL, USERNAME, PASSWORD, DEFAULT_ENDPOINTS))
+                .thenReturn(Result.failure(cookieNonceError(Nonce.CookieNonceErrorType.CUSTOM_LOGIN_URL)))
+            whenever(repository.login(SITE_URL, USERNAME, PASSWORD, LOGIN_ENDPOINTS))
+                .thenReturn(Result.failure(serverError))
+            setup()
+
+            viewModel.viewState.observeForTesting {
+                enterCredentialsAndContinue()
+                advanceUntilIdle()
+                viewModel.onEndpointUrlChanged(LOGIN_URL)
+                viewModel.onContinueClick()
+                advanceUntilIdle()
+            }
+
+            val state = viewModel.viewState.value
+            assertThat(state?.endpointRecovery?.url).isEqualTo(LOGIN_URL)
+            assertThat(state?.endpointRecovery?.errorMessage).isNull()
+            assertThat(state?.authenticationError?.errorMessage).isEqualTo(serverError.errorMessage)
+            assertThat(state?.authenticationError?.showWpAdminFallbackOption).isFalse()
+        }
+
+    @Test
+    fun `given retained custom login, when next preflight loses network, then stay in native credentials`() =
+        testBlocking {
+            val invalidCredentials = cookieNonceError(
+                Nonce.CookieNonceErrorType.INVALID_CREDENTIALS,
+                loginEntryVerified = true
+            )
+            val networkError = cookieNonceError(Nonce.CookieNonceErrorType.UNKNOWN)
+            whenever(repository.login(SITE_URL, USERNAME, PASSWORD, DEFAULT_ENDPOINTS))
+                .thenReturn(Result.failure(cookieNonceError(Nonce.CookieNonceErrorType.CUSTOM_LOGIN_URL)))
+            whenever(repository.login(SITE_URL, USERNAME, PASSWORD, LOGIN_ENDPOINTS))
+                .thenReturn(Result.failure(invalidCredentials))
+            whenever(repository.login(SITE_URL, USERNAME, PASSWORD, PENDING_LOGIN_ENDPOINTS))
+                .thenReturn(Result.failure(networkError))
+            setup()
+
+            viewModel.viewState.observeForTesting {
+                enterCredentialsAndContinue()
+                advanceUntilIdle()
+                viewModel.onEndpointUrlChanged(LOGIN_URL)
+                viewModel.onContinueClick()
+                advanceUntilIdle()
+                viewModel.onErrorDialogDismissed()
+                viewModel.onContinueClick()
+                advanceUntilIdle()
+            }
+
+            val state = viewModel.viewState.value
+            assertThat(state?.endpointRecovery).isNull()
+            assertThat(state?.authenticationError?.errorMessage).isEqualTo(networkError.errorMessage)
+            assertThat(state?.authenticationError?.showWpAdminFallbackOption).isFalse()
+            verify(repository).login(SITE_URL, USERNAME, PASSWORD, PENDING_LOGIN_ENDPOINTS)
+            verify(repository, times(1)).fetchSite(SITE_URL)
+            verify(repository, never()).saveAuthenticationEndpoints(any(), any())
+        }
+
+    @Test
+    fun `given custom login invalid credentials, when retrying and recreating, then retain it until native success`() =
+        testBlocking {
+            val invalidCredentials = cookieNonceError(
+                Nonce.CookieNonceErrorType.INVALID_CREDENTIALS,
+                loginEntryVerified = true
+            )
+            whenever(repository.login(SITE_URL, USERNAME, PASSWORD, DEFAULT_ENDPOINTS))
+                .thenReturn(Result.failure(cookieNonceError(Nonce.CookieNonceErrorType.CUSTOM_LOGIN_URL)))
+            whenever(repository.login(SITE_URL, USERNAME, PASSWORD, LOGIN_ENDPOINTS))
+                .thenReturn(Result.failure(invalidCredentials))
+            whenever(repository.login(SITE_URL, USERNAME, STILL_WRONG_PASSWORD, PENDING_LOGIN_ENDPOINTS))
+                .thenReturn(Result.failure(invalidCredentials))
+            whenever(repository.login(SITE_URL, USERNAME, CORRECT_PASSWORD, PENDING_LOGIN_ENDPOINTS))
+                .thenReturn(Result.failure(cookieNonceError(Nonce.CookieNonceErrorType.CUSTOM_ADMIN_URL)))
+            whenever(repository.login(SITE_URL, USERNAME, CORRECT_PASSWORD, ADMIN_RETRY_ENDPOINTS))
+                .thenReturn(Result.success(Unit))
+            whenever(repository.fetchSite(SITE_URL, USERNAME, CORRECT_PASSWORD)).thenReturn(Result.success(site))
+            setup()
+
+            // GIVEN
+            viewModel.viewState.observeForTesting {
+                enterCredentialsAndContinue()
+                advanceUntilIdle()
+                assertThat(viewModel.viewState.value?.endpointRecovery?.type).isEqualTo(EndpointType.LOGIN)
+
+                viewModel.onEndpointUrlChanged(LOGIN_URL)
+                viewModel.onContinueClick()
+                advanceUntilIdle()
+            }
+
+            val firstFailureState = viewModel.viewState.value
+            assertThat(firstFailureState?.username).isEqualTo(USERNAME)
+            assertThat(firstFailureState?.password).isEqualTo(PASSWORD)
+            assertThat(firstFailureState?.endpointRecovery).isNull()
+            assertThat(firstFailureState?.authenticationError?.errorMessage)
+                .isEqualTo(invalidCredentials.errorMessage)
+            assertThat(firstFailureState?.authenticationError?.showWpAdminFallbackOption).isFalse()
+            verify(repository, never()).saveAuthenticationEndpoints(any(), any())
+            verify(selectedSite, never()).set(any())
+
+            // WHEN
+            viewModel.viewState.observeForTesting {
+                viewModel.onErrorDialogDismissed()
+                viewModel.onPasswordChanged(STILL_WRONG_PASSWORD)
+                viewModel.onContinueClick()
+                advanceUntilIdle()
+            }
+
+            // THEN
+            val repeatedFailureState = viewModel.viewState.value
+            assertThat(repeatedFailureState?.endpointRecovery).isNull()
+            assertThat(repeatedFailureState?.authenticationError?.errorMessage)
+                .isEqualTo(invalidCredentials.errorMessage)
+            assertThat(repeatedFailureState?.authenticationError?.showWpAdminFallbackOption).isFalse()
+            verify(repository).login(SITE_URL, USERNAME, STILL_WRONG_PASSWORD, PENDING_LOGIN_ENDPOINTS)
+
+            val restoredState = SavedStateHandle(savedState.keys().associateWith { savedState.get<Any?>(it) })
+            setup(restoredState)
+            val recreatedState = viewModel.viewState.getOrAwaitValue()
+            assertThat(recreatedState.endpointRecovery).isNull()
+            assertThat(recreatedState.authenticationError?.showWpAdminFallbackOption).isFalse()
+
+            viewModel.viewState.observeForTesting {
+                viewModel.onErrorDialogDismissed()
+                viewModel.onPasswordChanged(CORRECT_PASSWORD)
+                viewModel.onContinueClick()
+                advanceUntilIdle()
+            }
+
+            assertThat(viewModel.viewState.value?.endpointRecovery?.type).isEqualTo(EndpointType.ADMIN)
+            verify(repository).login(SITE_URL, USERNAME, CORRECT_PASSWORD, PENDING_LOGIN_ENDPOINTS)
+            verify(repository, never()).saveAuthenticationEndpoints(any(), any())
+
+            viewModel.viewState.observeForTesting {
+                viewModel.onEndpointUrlChanged(ADMIN_URL)
+                viewModel.onContinueClick()
+                advanceUntilIdle()
+            }
+
+            verify(repository).login(SITE_URL, USERNAME, CORRECT_PASSWORD, ADMIN_RETRY_ENDPOINTS)
+            verify(repository).saveAuthenticationEndpoints(site, PROVEN_ENDPOINTS)
+            verify(selectedSite).set(persistedSite)
+        }
+
+    @Test
+    fun `given login and admin recovery, when native proof succeeds, then persist endpoints before eligibility`() =
+        testBlocking {
+            whenever(repository.login(SITE_URL, USERNAME, PASSWORD, DEFAULT_ENDPOINTS))
+                .thenReturn(Result.failure(cookieNonceError(Nonce.CookieNonceErrorType.CUSTOM_LOGIN_URL)))
+            whenever(repository.login(SITE_URL, USERNAME, PASSWORD, LOGIN_ENDPOINTS))
+                .thenReturn(Result.failure(cookieNonceError(Nonce.CookieNonceErrorType.CUSTOM_ADMIN_URL)))
+            whenever(repository.login(SITE_URL, USERNAME, PASSWORD, ADMIN_RETRY_ENDPOINTS))
+                .thenReturn(Result.success(Unit))
+            whenever(repository.checkIfUserIsEligible(persistedSite))
+                .thenReturn(Result.failure(Exception("ineligible")))
+            setup()
+
+            viewModel.viewState.observeForTesting {
+                enterCredentialsAndContinue()
+                advanceUntilIdle()
+                assertThat(viewModel.viewState.value?.endpointRecovery?.type).isEqualTo(EndpointType.LOGIN)
+                viewModel.onEndpointUrlChanged(LOGIN_URL)
+                viewModel.onContinueClick()
+                advanceUntilIdle()
+                assertThat(viewModel.viewState.value?.endpointRecovery?.type).isEqualTo(EndpointType.ADMIN)
+                viewModel.onEndpointUrlChanged(ADMIN_URL)
+                viewModel.onContinueClick()
+                advanceUntilIdle()
+            }
+
+            inOrder(repository) {
+                verify(repository).saveAuthenticationEndpoints(site, PROVEN_ENDPOINTS)
+                verify(repository).checkIfUserIsEligible(persistedSite)
+            }
+            verify(selectedSite, never()).set(any())
+        }
+
+    @Test
+    fun `given admin index URL, when native proof succeeds, then promote normalized login and admin endpoints`() =
+        testBlocking {
+            whenever(repository.login(SITE_URL, USERNAME, PASSWORD, ADMIN_RETRY_ENDPOINTS))
+                .thenReturn(Result.success(Unit))
+            setup(
+                recoveryState(EndpointType.ADMIN, ADMIN_INDEX_URL).apply {
+                    this[LOGIN_ENTRY_URL_STATE_KEY] = LOGIN_URL
+                }
+            )
+
+            viewModel.viewState.observeForTesting {
+                viewModel.onContinueClick()
+                advanceUntilIdle()
+            }
+
+            verify(repository).login(SITE_URL, USERNAME, PASSWORD, ADMIN_RETRY_ENDPOINTS)
+            verify(repository).saveAuthenticationEndpoints(site, PROVEN_ENDPOINTS)
+            verify(repository).checkIfUserIsEligible(persistedSite)
+            assertThat(savedState.get<String>(LOGIN_ENTRY_URL_STATE_KEY)).isEqualTo(LOGIN_URL)
+            assertThat(savedState.get<String>(ADMIN_BASE_URL_STATE_KEY)).isEqualTo(ADMIN_URL)
+        }
+
+    @Test
+    fun `given endpoint persistence fails, when native proof succeeds, then show accurate error and SiteError analytics`() =
+        testBlocking {
+            val siteError = SiteError(SiteErrorType.GENERIC_ERROR, PERSISTENCE_ERROR)
+            val exception = OnChangedException(siteError, PERSISTENCE_ERROR)
+            whenever(repository.login(SITE_URL, USERNAME, PASSWORD, PROVEN_ENDPOINTS))
+                .thenReturn(Result.success(Unit))
+            whenever(repository.saveAuthenticationEndpoints(site, PROVEN_ENDPOINTS))
+                .thenReturn(Result.failure(exception))
+            setup(
+                credentialsState().apply {
+                    this[LOGIN_ENTRY_URL_STATE_KEY] = LOGIN_URL
+                    this[ADMIN_BASE_URL_STATE_KEY] = ADMIN_URL
+                }
+            )
+
+            viewModel.viewState.observeForTesting {
+                viewModel.onContinueClick()
+                advanceUntilIdle()
             }
 
             assertThat(viewModel.event.value)
-                .isEqualTo(ShowApplicationPasswordsUnavailableScreen(siteAddress, isJetpackConnected))
-        }
-
-    @Test
-    fun `given user role fetch fails, when submitting login, then show a snackbar`() = testBlocking {
-        setup {
-            whenever(wpApiSiteRepository.checkIfUserIsEligible(testSite)).thenReturn(Result.failure(Exception()))
-        }
-
-        viewModel.viewState.observeForTesting {
-            viewModel.onUsernameChanged(testUsername)
-            viewModel.onPasswordChanged(testPassword)
-            viewModel.onContinueClick()
-        }
-
-        assertThat(viewModel.event.value).isEqualTo(ShowSnackbar(R.string.user_role_access_error_fetch_failed))
-        verify(analyticsTracker).track(
-            stat = eq(AnalyticsEvent.LOGIN_SITE_CREDENTIALS_LOGIN_FAILED),
-            properties = argThat {
-                get(AnalyticsTracker.KEY_STEP) == LoginSiteCredentialsViewModel.Step.USER_ROLE.name.lowercase()
-            },
-            errorContext = anyOrNull(),
-            errorType = anyOrNull(),
-            errorDescription = anyOrNull()
-        )
-        verify(loginAnalyticsListener).trackFailure(anyOrNull())
-    }
-
-    @Test
-    fun `given application pwd disabled and login fails, when attempting to sign in, then show error`() = testBlocking {
-        setup {
-            whenever(wpApiSiteRepository.login(siteAddress, testUsername, testPassword))
-                .thenReturn(Result.failure(Exception()))
-            whenever(wpApiSiteRepository.fetchSite(siteAddress))
-                .thenReturn(Result.success(testSite.apply { applicationPasswordsAuthorizeUrl = null }))
-        }
-
-        viewModel.viewState.observeForTesting {
-            viewModel.onUsernameChanged(testUsername)
-            viewModel.onPasswordChanged(testPassword)
-            viewModel.onContinueClick()
-        }
-
-        assertThat(viewModel.event.value)
-            .isEqualTo(ShowApplicationPasswordsUnavailableScreen(siteAddress, isJetpackConnected))
-    }
-
-    @Test
-    fun `given application passwords enabled and login fails for an unknown reason, when user attempts to sign-in, then show WebView login flow`() =
-        testBlocking {
-            setup {
-                whenever(wpApiSiteRepository.login(siteAddress, testUsername, testPassword))
-                    .thenReturn(Result.failure(Exception()))
-                whenever(wpApiSiteRepository.fetchSite(siteAddress))
-                    .thenReturn(Result.success(testSite.apply { applicationPasswordsAuthorizeUrl = urlAuthBase }))
-            }
-
-            val event = viewModel.event.runAndCaptureValues {
-                viewModel.onUsernameChanged(testUsername)
-                viewModel.onPasswordChanged(testPassword)
-                viewModel.viewState.getOrAwaitValue()
-                viewModel.onContinueClick()
-            }.last()
-
-            assertThat(event).isInstanceOf(LoginSiteCredentialsViewModel.ShowApplicationPasswordTutorialScreen::class.java)
-            assertThat((event as LoginSiteCredentialsViewModel.ShowApplicationPasswordTutorialScreen).url)
-                .isEqualTo(urlAuthFull)
-        }
-
-    @Test
-    fun `given login fails with a status code error, when the tutorial screen is shown, then the error message resolves its params`() =
-        testBlocking {
-            val statusCode = "403"
-            val formattedError = "Login failed with status code $statusCode"
-            val httpError = CookieNonceAuthenticationException(
-                errorMessage = UiStringRes(
-                    stringRes = R.string.login_site_credentials_http_error,
-                    params = listOf(UiStringText(statusCode))
+                .isEqualTo(ShowSnackbar(R.string.login_site_credentials_endpoint_persistence_failed))
+            verify(repository, never()).checkIfUserIsEligible(any())
+            verify(analytics).track(
+                stat = AnalyticsEvent.LOGIN_SITE_CREDENTIALS_LOGIN_FAILED,
+                properties = mapOf(
+                    AnalyticsTracker.KEY_STEP to
+                        LoginSiteCredentialsViewModel.Step.ENDPOINT_PERSISTENCE.name.lowercase(),
+                    AnalyticsTracker.KEY_NETWORK_STATUS_CODE to ""
                 ),
-                errorType = Nonce.CookieNonceErrorType.GENERIC_ERROR,
-                networkStatusCode = statusCode.toInt()
+                errorContext = SiteError::class.java.simpleName,
+                errorType = SiteErrorType.GENERIC_ERROR.name,
+                errorDescription = PERSISTENCE_ERROR
             )
-
-            setup {
-                whenever(resourceProvider.getString(R.string.login_site_credentials_http_error, statusCode))
-                    .thenReturn(formattedError)
-                whenever(wpApiSiteRepository.login(siteAddress, testUsername, testPassword))
-                    .thenReturn(Result.failure(httpError))
-                whenever(wpApiSiteRepository.fetchSite(siteAddress))
-                    .thenReturn(Result.success(testSite.apply { applicationPasswordsAuthorizeUrl = urlAuthBase }))
-            }
-
-            val event = viewModel.event.runAndCaptureValues {
-                viewModel.onUsernameChanged(testUsername)
-                viewModel.onPasswordChanged(testPassword)
-                viewModel.viewState.getOrAwaitValue()
-                viewModel.onContinueClick()
-            }.last()
-
-            assertThat((event as LoginSiteCredentialsViewModel.ShowApplicationPasswordTutorialScreen).errorMessage)
-                .isEqualTo(formattedError)
         }
 
     @Test
-    fun `given canonical site URL is https but siteAddress is http, when login fails with INVALID_NONCE, then ViewModel retries with the canonical https URL and succeeds`() =
+    fun `given custom endpoints, when persistence completes, then publish fetched site marker only on success`() =
         testBlocking {
-            val canonicalHttpsAddress = "https://site.com"
-            val canonicalSite = SiteModel().apply {
-                hasWooCommerce = true
-                url = canonicalHttpsAddress
+            var persistenceResult = CompletableDeferred<Result<SiteModel>>()
+            whenever(repository.login(SITE_URL, USERNAME, PASSWORD, DEFAULT_ENDPOINTS))
+                .thenReturn(Result.failure(cookieNonceError(Nonce.CookieNonceErrorType.CUSTOM_LOGIN_URL)))
+            whenever(repository.login(SITE_URL, USERNAME, PASSWORD, LOGIN_ENDPOINTS))
+                .thenReturn(Result.failure(cookieNonceError(Nonce.CookieNonceErrorType.CUSTOM_ADMIN_URL)))
+            whenever(repository.login(SITE_URL, USERNAME, PASSWORD, ADMIN_RETRY_ENDPOINTS))
+                .thenReturn(Result.success(Unit))
+            whenever(repository.saveAuthenticationEndpoints(site, PROVEN_ENDPOINTS)).doSuspendableAnswer {
+                persistenceResult.await()
             }
-            val invalidNonce = CookieNonceAuthenticationException(
-                errorMessage = UiStringText("INVALID_NONCE"),
-                errorType = Nonce.CookieNonceErrorType.INVALID_NONCE,
-                networkStatusCode = null
-            )
-
-            setup {
-                whenever(wpApiSiteRepository.login(siteAddress, testUsername, testPassword))
-                    .thenReturn(Result.failure(invalidNonce))
-                whenever(wpApiSiteRepository.fetchSite(siteAddress))
-                    .thenReturn(Result.success(canonicalSite))
-                whenever(wpApiSiteRepository.login(canonicalHttpsAddress, testUsername, testPassword))
-                    .thenReturn(Result.success(Unit))
-                whenever(wpApiSiteRepository.fetchSite(canonicalHttpsAddress, testUsername, testPassword))
-                    .thenReturn(Result.success(canonicalSite))
-            }
+            setup()
 
             viewModel.viewState.observeForTesting {
-                viewModel.onUsernameChanged(testUsername)
-                viewModel.onPasswordChanged(testPassword)
+                enterCredentialsAndContinue()
+                advanceUntilIdle()
+                viewModel.onEndpointUrlChanged(LOGIN_URL)
                 viewModel.onContinueClick()
+                advanceUntilIdle()
+                viewModel.onEndpointUrlChanged(ADMIN_URL)
+                viewModel.onContinueClick()
+                runCurrent()
+                assertThat(savedState.get<Int>("site-id")).isEqualTo(-1)
+
+                persistenceResult.complete(Result.failure(Exception("save failed")))
+                advanceUntilIdle()
+                assertThat(savedState.get<Int>("site-id")).isEqualTo(-1)
             }
 
-            verify(wpApiSiteRepository).login(siteAddress, testUsername, testPassword)
-            verify(wpApiSiteRepository).login(canonicalHttpsAddress, testUsername, testPassword)
-            assertThat(viewModel.event.value).isEqualTo(LoggedIn(canonicalSite.id))
+            val restoredState = SavedStateHandle(savedState.keys().associateWith { savedState.get<Any?>(it) })
+            persistenceResult = CompletableDeferred()
+            whenever(repository.login(SITE_URL, USERNAME, PASSWORD, PROVEN_ENDPOINTS))
+                .thenReturn(Result.success(Unit))
+            setup(restoredState)
+
+            viewModel.viewState.observeForTesting {
+                viewModel.onContinueClick()
+                runCurrent()
+                assertThat(savedState.get<Int>("site-id")).isEqualTo(-1)
+
+                persistenceResult.complete(Result.success(persistedSite))
+                advanceUntilIdle()
+            }
+
+            assertThat(savedState.get<Int>("site-id")).isEqualTo(SITE_ID)
+            verify(repository, times(2)).saveAuthenticationEndpoints(site, PROVEN_ENDPOINTS)
+            verify(repository).checkIfUserIsEligible(persistedSite)
         }
+
+    @Test
+    fun `given edited recovery input, when recreated after process death, then restore it as pending`() = testBlocking {
+        whenever(repository.login(SITE_URL, USERNAME, PASSWORD, DEFAULT_ENDPOINTS))
+            .thenReturn(Result.failure(cookieNonceError(Nonce.CookieNonceErrorType.CUSTOM_LOGIN_URL)))
+        setup()
+        viewModel.viewState.observeForTesting {
+            enterCredentialsAndContinue()
+            viewModel.onEndpointUrlChanged(LOGIN_URL)
+        }
+        val restored = SavedStateHandle(savedState.keys().associateWith { savedState.get<Any?>(it) })
+
+        setup(restored)
+
+        assertThat(viewModel.viewState.getOrAwaitValue().endpointRecovery).isEqualTo(
+            LoginSiteCredentialsViewModel.EndpointRecovery(EndpointType.LOGIN, LOGIN_URL)
+        )
+        verify(repository, never()).saveAuthenticationEndpoints(any(), any())
+    }
+
+    @Test
+    fun `given login or admin recovery, when WP Admin fallback is selected, then open the existing tutorial`() =
+        testBlocking {
+            EndpointType.entries.forEach { type ->
+                setup(recoveryState(type, type.recoveryUrl))
+
+                viewModel.viewState.observeForTesting {
+                    viewModel.onStartWebAuthorizationClick()
+                    advanceUntilIdle()
+                }
+
+                assertThat(viewModel.viewState.value?.endpointRecovery?.type).isEqualTo(type)
+                assertThat(viewModel.event.value).isEqualTo(
+                    ShowApplicationPasswordTutorialScreen(
+                        url = "$SITE_URL/wp-admin/authorize-application.php" +
+                            "?app_name=woo_android&success_url=woocommerce://login",
+                        errorMessage = "error"
+                    )
+                )
+            }
+
+            verify(repository, never()).saveAuthenticationEndpoints(any(), any())
+            verify(repository, times(2)).fetchSite(SITE_URL)
+        }
+
+    @Test
+    fun `given login or admin recovery, when browser completes, then do not promote pending endpoints`() =
+        testBlocking {
+            EndpointType.entries.forEach { type ->
+                setup(recoveryState(type, type.recoveryUrl))
+
+                viewModel.viewState.observeForTesting {
+                    viewModel.onStartWebAuthorizationClick()
+                    advanceUntilIdle()
+                    viewModel.onWebAuthorizationUrlLoaded(WEB_SUCCESS_URL)
+                    advanceUntilIdle()
+                }
+            }
+
+            verify(repository, times(2)).saveApplicationPassword(SITE_ID, USERNAME, PASSWORD)
+            verify(repository, never()).saveAuthenticationEndpoints(any(), any())
+            verify(repository, times(2)).checkIfUserIsEligible(site)
+        }
+
+    @Test
+    fun `given recovery is cancelled, when credentials are retried, then use no pending manual endpoint`() =
+        testBlocking {
+            val customLoginError = cookieNonceError(Nonce.CookieNonceErrorType.CUSTOM_LOGIN_URL)
+            whenever(repository.login(SITE_URL, USERNAME, PASSWORD, DEFAULT_ENDPOINTS))
+                .thenReturn(Result.failure(customLoginError), Result.success(Unit))
+            setup()
+
+            viewModel.viewState.observeForTesting {
+                enterCredentialsAndContinue()
+                advanceUntilIdle()
+                viewModel.onEndpointUrlChanged(LOGIN_URL)
+                viewModel.onEndpointRecoveryCancelClick()
+                viewModel.onContinueClick()
+                advanceUntilIdle()
+            }
+
+            assertThat(viewModel.viewState.value?.endpointRecovery).isNull()
+            assertThat(savedState.get<String>(LOGIN_ENTRY_URL_STATE_KEY)).isNull()
+            verify(repository, times(2)).login(SITE_URL, USERNAME, PASSWORD, DEFAULT_ENDPOINTS)
+            verify(repository, never()).saveAuthenticationEndpoints(any(), any())
+            verify(repository).checkIfUserIsEligible(site)
+        }
+
+    private suspend fun setup(
+        restoredState: SavedStateHandle? = null,
+        siteAddress: String = SITE_URL
+    ) {
+        savedState = restoredState ?: SavedStateHandle(
+            mapOf(
+                LoginSiteCredentialsViewModel.SITE_ADDRESS_KEY to siteAddress,
+                LoginSiteCredentialsViewModel.IS_JETPACK_CONNECTED_KEY to false
+            )
+        )
+        viewModel = LoginSiteCredentialsViewModel(
+            savedState,
+            repository,
+            selectedSite,
+            loginAnalytics,
+            notifier,
+            analytics,
+            appPrefs,
+            resourceProvider,
+            object : ApplicationPasswordsConfiguration {
+                override val applicationName = "woo_android"
+                override suspend fun isEnabledForJetpackAccess() = true
+            }
+        )
+    }
+
+    private fun credentialsState(siteAddress: String = SITE_URL) = SavedStateHandle(
+        mapOf(
+            LoginSiteCredentialsViewModel.SITE_ADDRESS_KEY to siteAddress,
+            LoginSiteCredentialsViewModel.IS_JETPACK_CONNECTED_KEY to false,
+            LoginSiteCredentialsViewModel.USERNAME_KEY to USERNAME,
+            LoginSiteCredentialsViewModel.PASSWORD_KEY to PASSWORD
+        )
+    )
+
+    private fun recoveryState(
+        type: EndpointType,
+        url: String,
+        siteAddress: String = SITE_URL
+    ) = credentialsState(siteAddress).apply {
+        this[ENDPOINT_RECOVERY_STATE_KEY] = LoginSiteCredentialsViewModel.EndpointRecovery(type, url)
+    }
+
+    private fun siteWithUrl(siteUrl: String) = SiteModel().apply {
+        id = SITE_ID
+        url = siteUrl
+        hasWooCommerce = true
+    }
+
+    private val EndpointType.recoveryUrl: String
+        get() = when (this) {
+            EndpointType.LOGIN -> LOGIN_URL
+            EndpointType.ADMIN -> ADMIN_URL
+        }
+
+    private fun enterCredentialsAndContinue() {
+        viewModel.onUsernameChanged(USERNAME)
+        viewModel.onPasswordChanged(PASSWORD)
+        viewModel.viewState.getOrAwaitValue()
+        viewModel.onContinueClick()
+    }
+
+    private fun cookieNonceError(
+        type: Nonce.CookieNonceErrorType,
+        loginEntryVerified: Boolean = false
+    ) = CookieNonceAuthenticationException(
+        errorMessage = UiStringText(type.name),
+        errorType = type,
+        networkStatusCode = null,
+        loginEntryVerified = loginEntryVerified
+    )
+
+    private companion object {
+        const val SITE_ID = 7
+        const val SITE_URL = "https://site.example"
+        const val SCHEMELESS_SITE = "site.example"
+        const val LOGIN_URL = "$SITE_URL/private-login"
+        const val ADMIN_URL = "$SITE_URL/private-admin/"
+        const val ADMIN_INDEX_URL = "$SITE_URL/private-admin/index.php"
+        const val USERNAME = "merchant"
+        const val PASSWORD = "password"
+        const val STILL_WRONG_PASSWORD = "still-wrong-password"
+        const val CORRECT_PASSWORD = "correct-password"
+        const val PERSISTENCE_ERROR = "save failed"
+        const val ENDPOINT_RECOVERY_STATE_KEY = "endpoint-recovery"
+        const val LOGIN_ENTRY_URL_STATE_KEY = "login-entry-url"
+        const val ADMIN_BASE_URL_STATE_KEY = "admin-base-url"
+        const val WEB_SUCCESS_URL = "woocommerce://login?user_login=$USERNAME&password=$PASSWORD"
+        val DEFAULT_ENDPOINTS = CookieNonceAuthenticationEndpoints(SITE_URL)
+        val SCHEMELESS_ENDPOINTS = CookieNonceAuthenticationEndpoints(SCHEMELESS_SITE)
+        val LOGIN_ENDPOINTS = CookieNonceAuthenticationEndpoints("$SITE_URL/", loginEntryUrl = LOGIN_URL)
+        val PENDING_LOGIN_ENDPOINTS = CookieNonceAuthenticationEndpoints(SITE_URL, loginEntryUrl = LOGIN_URL)
+        val ADMIN_RETRY_ENDPOINTS = CookieNonceAuthenticationEndpoints(
+            "$SITE_URL/",
+            LOGIN_URL,
+            ADMIN_URL,
+            CookieNonceAuthenticationEndpoints.AdminBaseVerification.AUTHENTICATED_DASHBOARD
+        )
+        val PROVEN_ENDPOINTS = CookieNonceAuthenticationEndpoints(SITE_URL, LOGIN_URL, ADMIN_URL)
+    }
 }


### PR DESCRIPTION
### Description

Fixes WOOMOB-3799

Part 3 of 3, stacked on #16397, which is stacked on #16396.

This is the user-facing end of one direct-site-credentials fix split into three PRs for review. Review this diff against PR2's head. Merge order is 1 → 2 → 3, once the whole stack is approved.

Stores whose security plugins move the WordPress sign-in page or dashboard could not complete native credential login because the app had no way to collect and prove the replacement addresses. This PR adds focused recovery forms for both URLs while keeping the canonical store URL as the site's identity.

```mermaid
flowchart TD
    A["Submit store credentials"] --> B["Native cookie/nonce authentication"]
    B -->|Login entry not found| C["Ask for the sign-in URL"]
    C --> B
    B -->|Admin base not found| D["Ask for the dashboard URL"]
    D --> B
    B -->|Wrong password or later<br/>network/nonce failure| E["Show the actual error<br/>and retain the verified URL"]
    E --> B
    C -->|Use WP Admin instead| F["Existing browser authorization<br/>without adopting draft endpoints"]
    D -->|Use WP Admin instead| F
    B -->|Native authentication succeeds| G["Persist and reload proven endpoints"]
    G -->|Save fails| H["Show a save error<br/>and stop login completion"]
    G -->|Saved| I["Eligibility → site selection → logged in"]
```

The recovery behavior is intentionally narrow:

- The first missing login/admin response opens the matching form with the current default. Inputs are normalized and must pass PR1's same-host, scheme, user-information, query, and port rules.
- Before prompting, the app makes one canonical-address reconciliation attempt. A discovered address is adopted only when it is a safe same-origin result; off-host moves, port changes, and HTTPS downgrades are rejected.
- Once a custom sign-in page is structurally verified, that URL is retained through wrong-password retries, later network/response/nonce failures, and process recreation. The merchant sees the real error and can correct credentials without repeatedly entering the URL.
- A manual dashboard URL requires both an authenticated WordPress dashboard response and a valid nonce from its derived admin-ajax endpoint before it can be promoted.
- Cancel discards the current draft. The explicit WP Admin fallback stays available from recovery, but browser authorization is isolated from pending native values and cannot persist them.
- After native authentication succeeds, normalized endpoints are saved and reloaded before eligibility, site selection, or the logged-in event. A persistence failure stops completion instead of leaving the session dependent on transient values.

The existing direct-credentials behavior remains unchanged for stores using the default WordPress paths. QR login, XML-RPC, interactive 2FA/CAPTCHA/SSO handling, and Application Password architecture are outside this PR.

Review map:

- `LoginSiteCredentialsViewModel.kt`: recovery state, error routing, safe reconciliation, promotion, and persistence ordering.
- `LoginSiteCredentialsScreen.kt`: login/admin URL forms and the explicit WP Admin fallback.
- `strings.xml`: merchant-facing recovery and validation copy.
- `LoginSiteCredentialsViewModelTest.kt`: sequential recovery, wrong-password retries, later failures, process recreation, browser isolation, and persistence ordering.
- `RELEASE-NOTES.txt`: the stack's single user-facing note.

### Test Steps

Use direct store credentials; QR login is out of scope.

#### WPS Hide Login — custom sign-in URL

1. Provision a Jurassic Ninja store, install and activate WPS Hide Login, and configure a custom sign-in slug.
2. Start direct store-credentials login with the canonical store URL, the correct username, and an incorrect password.
3. When asked for the sign-in address, confirm that a malformed URL and an off-site URL are rejected inline.
4. Enter the custom sign-in URL. Confirm the invalid-credentials error appears, dismiss it, correct only the password, and continue without entering the sign-in URL again.
5. Confirm the store opens natively without an Application Password tutorial, WebView, Custom Tab, external browser, or retry loop. Force-stop and relaunch the app and confirm the store remains connected.

#### WP Ghost — custom sign-in and dashboard URLs

6. With Docker Desktop running, the reviewed Wasabi debug build installed, and an emulator or device connected, open 3c30a-pb and save the standalone script as `woomob-3799-wp-ghost.sh`.
7. Prepare and start the fixture:

   ```bash
   chmod +x woomob-3799-wp-ghost.sh
   ./woomob-3799-wp-ghost.sh up
   ```

   If more than one device is connected, pass `--serial DEVICE_SERIAL`. Keep the terminal open; it prints the disposable store address, credentials, sign-in URL, and dashboard URL.
8. Open the direct store-credentials screen and use the printed store address and credentials. Enter the printed sign-in URL when prompted.
9. Confirm the dashboard-address form appears after the sign-in URL succeeds. Verify that an off-site value is rejected, then enter the printed dashboard URL.
10. Confirm the store opens natively with no Application Password tutorial or browser. Force-stop and relaunch the app, refresh an authenticated screen, and confirm neither endpoint is requested again.
11. Tear down the fixture:

    ```bash
    ./woomob-3799-wp-ghost.sh down
    ```

### Images/gif
| Login URL | Admin URL |
| --- | --- |
| <img width="1080" height="2400" alt="Screenshot_1786384987" src="https://github.com/user-attachments/assets/1e15feef-c852-4ae7-82ba-13f9d0e2cc66" /> | <img width="1080" height="2400" alt="Screenshot_1786385072" src="https://github.com/user-attachments/assets/127b8cdd-dea2-47e9-a346-82006cfc04da" />  |


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

This PR carries the stack's single release note under 25.5:
`- [*] Store login now supports custom WordPress sign-in and dashboard addresses [https://github.com/woocommerce/woocommerce-android/pull/16398]`
