### PR TITLE
[WOOMOB-1879] Open the AI-generated product after saving on tablets

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailFragment.kt
@@ -140,6 +140,9 @@ class ProductDetailFragment :
 
     private val navArgs: ProductDetailFragmentArgs by navArgs()
 
+    private val isInDetailPane: Boolean
+        get() = requireContext().isTwoPanesShouldBeUsed && parentFragment?.id == R.id.detail_nav_container
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val transitionDuration = resources.getInteger(R.integer.default_fragment_transition).toLong()
@@ -158,8 +161,6 @@ class ProductDetailFragment :
 
         val productListInBackstack =
             findNavController().previousBackStackEntry?.destination?.id == BottomNavigationPosition.PRODUCTS.id
-        val isInDetailPane =
-            requireContext().isTwoPanesShouldBeUsed && (parentFragment?.id == R.id.detail_nav_container)
         val isTrashEnabled = productListInBackstack || isInDetailPane
         viewModel.setTrashActionPossible(isTrashEnabled)
 
@@ -390,9 +391,13 @@ class ProductDetailFragment :
         }
 
         viewModel.hasChanges.observe(viewLifecycleOwner) { hasChanges ->
-            productsCommunicationViewModel.pushEvent(
-                ProductsCommunicationViewModel.CommunicationEvent.ProductChanges(hasChanges)
-            )
+            // Only the detail-pane instance should report changes; a full-screen instance pushing this event
+            // could overwrite a pending ProductSelected event before the product list resubscribes
+            if (isInDetailPane) {
+                productsCommunicationViewModel.pushEvent(
+                    ProductsCommunicationViewModel.CommunicationEvent.ProductChanges(hasChanges)
+                )
+            }
         }
 
         observeEvents(viewModel)


### PR DESCRIPTION
### Description
Fixes WOOMOB-1879

On tablets in the two-pane products layout, saving a product generated with AI closed the flow but never opened the new draft in the detail pane. The full-screen `ProductDetailFragment` hands the selection to the product list by pushing a `ProductSelected` event through `ProductsCommunicationViewModel` and popping itself, but its `hasChanges` observer fires in the same frame (the underlying `StateFlow` is eager) and pushes a `ProductChanges` event that overwrites the still-pending `ProductSelected` — `MultiLiveEvent` holds a single sticky value, and the list only re-subscribes after the asynchronous pop completes.

The fix gates the `ProductChanges` push on the fragment being the detail-pane instance. That event's only consumer is the two-pane discard-changes guard in `ProductListViewModel`, so a full-screen instance reporting it never had any effect.

### Test Steps
1. On a tablet (two-pane products layout), log into a store eligible for AI product creation (e.g. WPCom hosted store).
2. In the Products tab, tap the + button and choose "Create a product with AI".
3. Enter a short product description, generate the details, and tap "Save as draft".
4. The newly created draft should open automatically in the right-hand detail pane.
5. Regression check: edit a product's title in the detail pane without saving, then tap another product in the list — the discard-changes dialog should still appear.

### Images/gif
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.