### PR TITLE
[WOOMOB-3270] Follow the store's day in the custom date range pickers

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 -----
 - [*] Woo POS: Remote Tap to Pay failures now explain what went wrong - phone not eligible for Tap to Pay, NFC turned off, or a payment service error - instead of a generic message or raw error text [https://github.com/woocommerce/woocommerce-android/pull/16384]
 - [*] QR login now asks you to choose a store when your WordPress.com account has multiple sites instead of preselecting one [https://github.com/woocommerce/woocommerce-android/pull/16400]
+- [*] Custom date ranges now follow the store's current day and no longer shift when the device time zone changes [https://github.com/woocommerce/woocommerce-android/pull/16410]
 - [Internal] Close analytics gaps in the Remote Tap to Pay flow: transport on the reader-ready event, cause chains in error descriptions, no stale card reader model, and a real session ended reason [https://github.com/woocommerce/woocommerce-android/pull/16368]
 - [*] Tap to Pay no longer disappears from the Payments screen shortly after it appears [https://github.com/woocommerce/woocommerce-android/pull/16370]
 - [*] Fixed a crash when pressing Back on the "You're already signed in" warning shown after opening a QR login link while signed in [https://github.com/woocommerce/woocommerce-android/pull/16347]

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -24,7 +24,9 @@ import com.woocommerce.android.AppPrefs.DeletablePrefKey.CLIENT_SIDE_BANNER_HIDD
 import com.woocommerce.android.AppPrefs.DeletablePrefKey.DATABASE_DOWNGRADED
 import com.woocommerce.android.AppPrefs.DeletablePrefKey.IMAGE_OPTIMIZE_ENABLED
 import com.woocommerce.android.AppPrefs.DeletablePrefKey.ORDER_FILTER_CUSTOM_DATE_RANGE_END
+import com.woocommerce.android.AppPrefs.DeletablePrefKey.ORDER_FILTER_CUSTOM_DATE_RANGE_END_DAY
 import com.woocommerce.android.AppPrefs.DeletablePrefKey.ORDER_FILTER_CUSTOM_DATE_RANGE_START
+import com.woocommerce.android.AppPrefs.DeletablePrefKey.ORDER_FILTER_CUSTOM_DATE_RANGE_START_DAY
 import com.woocommerce.android.AppPrefs.DeletablePrefKey.ORDER_FILTER_PREFIX
 import com.woocommerce.android.AppPrefs.DeletablePrefKey.PRODUCT_SORTING_PREFIX
 import com.woocommerce.android.AppPrefs.DeletablePrefKey.RECEIPT_PREFIX
@@ -104,6 +106,8 @@ object AppPrefs {
         ORDER_FILTER_PREFIX,
         ORDER_FILTER_CUSTOM_DATE_RANGE_START,
         ORDER_FILTER_CUSTOM_DATE_RANGE_END,
+        ORDER_FILTER_CUSTOM_DATE_RANGE_START_DAY,
+        ORDER_FILTER_CUSTOM_DATE_RANGE_END_DAY,
         PRODUCT_SORTING_PREFIX,
         PRE_LOGIN_NOTIFICATION_WORK_REQUEST,
         PRE_LOGIN_NOTIFICATION_DISPLAYED,
@@ -989,6 +993,7 @@ object AppPrefs {
     private fun getOrderFilterKey(currentSiteId: Int, filterCategory: String) =
         PrefKeyString("$ORDER_FILTER_PREFIX:$currentSiteId:$filterCategory")
 
+    // Only used by the order filter date range migration. Delete in 25.9, see WOOMOB-3841.
     fun getOrderFilterCustomDateRange(selectedSiteId: Int): Pair<Long, Long> {
         val startDateMillis = getLong(
             PrefKeyString("$ORDER_FILTER_CUSTOM_DATE_RANGE_START:$selectedSiteId")
@@ -999,14 +1004,29 @@ object AppPrefs {
         return Pair(startDateMillis, endDateMillis)
     }
 
-    fun setOrderFilterCustomDateRange(selectedSiteId: Int, startDateMillis: Long, endDateMillis: Long) {
+    fun removeOrderFilterCustomDateRange(selectedSiteId: Int) {
+        remove(PrefKeyString("$ORDER_FILTER_CUSTOM_DATE_RANGE_START:$selectedSiteId"))
+        remove(PrefKeyString("$ORDER_FILTER_CUSTOM_DATE_RANGE_END:$selectedSiteId"))
+    }
+
+    fun getOrderFilterCustomDateRangeDays(selectedSiteId: Int): Pair<Long, Long> {
+        val startDay = getLong(
+            PrefKeyString("$ORDER_FILTER_CUSTOM_DATE_RANGE_START_DAY:$selectedSiteId")
+        )
+        val endDay = getLong(
+            PrefKeyString("$ORDER_FILTER_CUSTOM_DATE_RANGE_END_DAY:$selectedSiteId")
+        )
+        return Pair(startDay, endDay)
+    }
+
+    fun setOrderFilterCustomDateRangeDays(selectedSiteId: Int, startDay: Long, endDay: Long) {
         setLong(
-            PrefKeyString("$ORDER_FILTER_CUSTOM_DATE_RANGE_START:$selectedSiteId"),
-            startDateMillis
+            PrefKeyString("$ORDER_FILTER_CUSTOM_DATE_RANGE_START_DAY:$selectedSiteId"),
+            startDay
         )
         setLong(
-            PrefKeyString("$ORDER_FILTER_CUSTOM_DATE_RANGE_END:$selectedSiteId"),
-            endDateMillis
+            PrefKeyString("$ORDER_FILTER_CUSTOM_DATE_RANGE_END_DAY:$selectedSiteId"),
+            endDay
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -196,12 +196,20 @@ open class AppPrefsWrapper @Inject constructor() {
     fun getOrderFilters(selectedSiteId: Int, filterCategory: String) =
         AppPrefs.getOrderFilters(selectedSiteId, filterCategory)
 
-    fun setOrderFilterCustomDateRange(selectedSiteId: Int, startDateMillis: Long, endDateMillis: Long) {
-        AppPrefs.setOrderFilterCustomDateRange(selectedSiteId, startDateMillis, endDateMillis)
-    }
-
+    // Only used by the order filter date range migration. Delete in 25.9, see WOOMOB-3841.
     fun getOrderFilterCustomDateRange(selectedSiteId: Int): Pair<Long, Long> =
         AppPrefs.getOrderFilterCustomDateRange(selectedSiteId)
+
+    fun removeOrderFilterCustomDateRange(selectedSiteId: Int) {
+        AppPrefs.removeOrderFilterCustomDateRange(selectedSiteId)
+    }
+
+    fun setOrderFilterCustomDateRangeDays(selectedSiteId: Int, startDay: Long, endDay: Long) {
+        AppPrefs.setOrderFilterCustomDateRangeDays(selectedSiteId, startDay, endDay)
+    }
+
+    fun getOrderFilterCustomDateRangeDays(selectedSiteId: Int): Pair<Long, Long> =
+        AppPrefs.getOrderFilterCustomDateRangeDays(selectedSiteId)
 
     fun setV4StatsSupported(supported: Boolean) {
         AppPrefs.setV4StatsSupported(supported)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/datastore/DataStoreModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/datastore/DataStoreModule.kt
@@ -20,6 +20,7 @@ import com.woocommerce.android.datastore.DataStoreType.TOP_PERFORMER_PRODUCTS
 import com.woocommerce.android.datastore.DataStoreType.TRACKER
 import com.woocommerce.android.datastore.DataStoreType.WOO_CORE_PUSH_NOTIFICATIONS_TOKENS
 import com.woocommerce.android.di.AppCoroutineScope
+import com.woocommerce.android.ui.dashboard.data.CustomDateRangeDayMigration
 import com.woocommerce.android.ui.dashboard.data.CustomDateRangeSerializer
 import com.woocommerce.android.ui.mystore.data.CustomDateRange
 import dagger.Module
@@ -102,6 +103,7 @@ class DataStoreModule {
             crashLogging.recordEvent("Corrupted data store. DataStore Type: ${DASHBOARD_STATS.name}")
             CustomDateRange.getDefaultInstance()
         },
+        migrations = listOf(CustomDateRangeDayMigration),
         scope = CoroutineScope(appCoroutineScope.coroutineContext + Dispatchers.IO),
         serializer = CustomDateRangeSerializer
     )
@@ -121,6 +123,7 @@ class DataStoreModule {
             crashLogging.recordEvent("Corrupted data store. DataStore Type: ${TOP_PERFORMER_PRODUCTS.name}")
             CustomDateRange.getDefaultInstance()
         },
+        migrations = listOf(CustomDateRangeDayMigration),
         scope = CoroutineScope(appCoroutineScope.coroutineContext + Dispatchers.IO),
         serializer = CustomDateRangeSerializer
     )
@@ -140,6 +143,7 @@ class DataStoreModule {
             crashLogging.recordEvent("Corrupted data store. DataStore Type: ${COUPONS.name}")
             CustomDateRange.getDefaultInstance()
         },
+        migrations = listOf(CustomDateRangeDayMigration),
         scope = CoroutineScope(appCoroutineScope.coroutineContext + Dispatchers.IO),
         serializer = CustomDateRangeSerializer
     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/DateExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/DateExt.kt
@@ -5,6 +5,7 @@ import android.text.format.DateFormat
 import java.text.DateFormatSymbols
 import java.text.SimpleDateFormat
 import java.time.LocalDate
+import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
 import java.util.Calendar
@@ -199,3 +200,9 @@ private const val THREE_MONTHS = 3
 private const val SEVEN_DAYS = 7
 
 fun LocalDate.formatStyleFull(): String = format(DateTimeFormatter.ofLocalizedDate(FormatStyle.FULL))
+
+fun Date.toEpochDay(): Long =
+    toInstant().atZone(ZoneId.systemDefault()).toLocalDate().toEpochDay()
+
+fun Long.toDateAtStartOfDay(): Date =
+    Date.from(LocalDate.ofEpochDay(this).atStartOfDay(ZoneId.systemDefault()).toInstant())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
@@ -22,10 +22,9 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.parcelize.Parcelize
 import kotlinx.parcelize.RawValue
-import java.time.Instant
-import java.time.ZoneId
-import java.time.ZonedDateTime
+import java.util.Date
 import java.util.UUID
+import java.util.concurrent.TimeUnit
 import kotlin.math.abs
 
 /**
@@ -294,43 +293,36 @@ fun Fragment.navigateToHelpScreen(origin: HelpOrigin) {
 }
 
 fun Fragment.showDateRangePicker(
-    fromMillis: Long = System.currentTimeMillis(),
-    toMillis: Long = System.currentTimeMillis(),
-    onCustomRangeSelected: (Long, Long) -> Unit
+    fromDate: Date,
+    toDate: Date,
+    maxDate: Date,
+    onCustomRangeSelected: (Date, Date) -> Unit
 ) {
-    fun shiftTime(time: Long, originalZoneId: ZoneId, targetZoneId: ZoneId): Long {
-        // The timestamps returned by the MaterialDatePicker are in UTC timezone, if we use them directly
-        // we will get a shift in the selected range.
-        // To avoid this, we get the local date using UTC timestamps and then convert it to the selected timezone
-        // See: https://github.com/material-components/material-components-android/issues/882
-        val originalDateTime = ZonedDateTime.ofInstant(Instant.ofEpochMilli(time), originalZoneId).toLocalDateTime()
-        val targetDateTime = ZonedDateTime.of(originalDateTime, targetZoneId)
-        return targetDateTime.toInstant().toEpochMilli()
-    }
-
-    val deviceZoneId = ZoneId.systemDefault()
+    val maxDay = maxDate.toEpochDay()
+    // The picker's millis are UTC midnights of the picked days
+    val maxDateUtcMillis = TimeUnit.DAYS.toMillis(maxDay)
     val datePicker = MaterialDatePicker.Builder.dateRangePicker()
         .setTitleText(getString(R.string.orderfilters_date_range_picker_title))
         .setSelection(
             androidx.core.util.Pair(
-                shiftTime(fromMillis, deviceZoneId, ZoneId.of("UTC")),
-                shiftTime(toMillis, deviceZoneId, ZoneId.of("UTC"))
+                TimeUnit.DAYS.toMillis(fromDate.toEpochDay().coerceAtMost(maxDay)),
+                TimeUnit.DAYS.toMillis(toDate.toEpochDay().coerceAtMost(maxDay))
             )
         )
         .setCalendarConstraints(
             CalendarConstraints.Builder()
-                .setEnd(MaterialDatePicker.todayInUtcMilliseconds())
-                .setValidator(DateValidatorPointBackward.now())
+                .setEnd(maxDateUtcMillis)
+                .setValidator(DateValidatorPointBackward.before(maxDateUtcMillis))
                 .build()
         )
         .build()
 
     datePicker.show(parentFragmentManager, AnalyticsHubFragment.DATE_PICKER_FRAGMENT_TAG)
     datePicker.addOnPositiveButtonClickListener {
-        val start = shiftTime(it.first ?: 0, ZoneId.of("UTC"), deviceZoneId)
-        val end = shiftTime(it.second ?: 0, ZoneId.of("UTC"), deviceZoneId)
-
-        onCustomRangeSelected(start, end)
+        onCustomRangeSelected(
+            TimeUnit.MILLISECONDS.toDays(it.first ?: 0).toDateAtStartOfDay(),
+            TimeUnit.MILLISECONDS.toDays(it.second ?: 0).toDateAtStartOfDay()
+        )
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.extensions
 import android.os.Parcelable
 import android.view.View
 import androidx.annotation.IdRes
+import androidx.core.util.Pair
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.lifecycleScope
@@ -304,7 +305,7 @@ fun Fragment.showDateRangePicker(
     val datePicker = MaterialDatePicker.Builder.dateRangePicker()
         .setTitleText(getString(R.string.orderfilters_date_range_picker_title))
         .setSelection(
-            androidx.core.util.Pair(
+            Pair(
                 TimeUnit.DAYS.toMillis(fromDate.toEpochDay().coerceAtMost(maxDay)),
                 TimeUnit.DAYS.toMillis(toDate.toEpochDay().coerceAtMost(maxDay))
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubFragment.kt
@@ -31,6 +31,7 @@ import com.woocommerce.android.ui.feedback.SurveyType
 import com.woocommerce.android.ui.google.webview.GoogleAdsWebViewFragment.Companion.WEBVIEW_RESULT
 import com.woocommerce.android.ui.google.webview.GoogleAdsWebViewViewModel.EntryPointSource.ANALYTICS_HUB
 import com.woocommerce.android.ui.google.webview.GoogleAdsWebViewViewModel.UrlComparisonMode.PARTIAL
+import com.woocommerce.android.util.DateUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.launchIn
@@ -50,6 +51,9 @@ class AnalyticsHubFragment : BaseFragment(R.layout.fragment_analytics) {
 
     @Inject
     lateinit var authenticatedWebViewLauncher: AuthenticatedWebViewLauncher
+
+    @Inject
+    lateinit var dateUtils: DateUtils
 
     private var _binding: FragmentAnalyticsBinding? = null
     private val binding
@@ -100,11 +104,11 @@ class AnalyticsHubFragment : BaseFragment(R.layout.fragment_analytics) {
                 authenticatedWebViewLauncher.showAuthenticatedWebView(event)
 
             is AnalyticsViewEvent.OpenDatePicker -> showDateRangePicker(
-                event.fromMillis,
-                event.toMillis
-            ) { start, end ->
-                viewModel.onCustomRangeSelected(Date(start), Date(end))
-            }
+                event.fromDate,
+                event.toDate,
+                dateUtils.getCurrentDateInSiteTimeZone() ?: Date(),
+                viewModel::onCustomRangeSelected
+            )
 
             is AnalyticsViewEvent.OpenDateRangeSelector -> openDateRangeSelector()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewModel.kt
@@ -230,9 +230,7 @@ class AnalyticsHubViewModel @Inject constructor(
     }
 
     fun onCustomDateRangeClicked() {
-        val startTimestamp = ranges.currentRange.start.time
-        val endTimestamp = ranges.currentRange.end.time
-        triggerEvent(AnalyticsViewEvent.OpenDatePicker(startTimestamp, endTimestamp))
+        triggerEvent(AnalyticsViewEvent.OpenDatePicker(ranges.currentRange.start, ranges.currentRange.end))
     }
 
     fun onRefreshRequested() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewState.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.analytics.hub
 
 import com.woocommerce.android.ui.analytics.hub.daterangeselector.AnalyticsHubDateRangeSelectorViewState
 import com.woocommerce.android.viewmodel.MultiLiveEvent
+import java.util.Date
 
 data class AnalyticsViewState(
     val refreshIndicator: RefreshIndicator,
@@ -12,7 +13,7 @@ data class AnalyticsViewState(
 )
 
 sealed class AnalyticsViewEvent : MultiLiveEvent.Event() {
-    data class OpenDatePicker(val fromMillis: Long, val toMillis: Long) : MultiLiveEvent.Event()
+    data class OpenDatePicker(val fromDate: Date, val toDate: Date) : MultiLiveEvent.Event()
     object OpenDateRangeSelector : AnalyticsViewEvent()
     object SendFeedback : AnalyticsViewEvent()
     object OpenSettings : AnalyticsViewEvent()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
@@ -64,6 +64,7 @@ import com.woocommerce.android.ui.main.MainActivityViewModel
 import com.woocommerce.android.ui.main.MainNavigationRouter
 import com.woocommerce.android.ui.prefs.privacy.banner.PrivacyBannerFragmentDirections
 import com.woocommerce.android.util.ActivityUtils
+import com.woocommerce.android.util.DateUtils
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
@@ -73,6 +74,7 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import org.wordpress.android.util.ToastUtils
+import java.util.Date
 import javax.inject.Inject
 import kotlin.math.abs
 
@@ -91,6 +93,9 @@ class DashboardFragment :
 
     @Inject
     lateinit var selectedSite: SelectedSite
+
+    @Inject
+    lateinit var dateUtils: DateUtils
 
     @Inject
     lateinit var usageTracksEventEmitter: DashboardStatsUsageTracksEventEmitter
@@ -193,7 +198,12 @@ class DashboardFragment :
                     )
                 }
 
-                is OpenRangePicker -> showDateRangePicker(event.start, event.end, event.callback)
+                is OpenRangePicker -> showDateRangePicker(
+                    event.startDate,
+                    event.endDate,
+                    dateUtils.getCurrentDateInSiteTimeZone() ?: Date(),
+                    event.callback
+                )
 
                 is ContactSupport -> activity?.startHelpActivity(HelpOrigin.MY_STORE)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
@@ -53,6 +53,7 @@ import kotlinx.coroutines.launch
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import java.util.Calendar
+import java.util.Date
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.milliseconds
@@ -436,9 +437,9 @@ class DashboardViewModel @Inject constructor(
         data object OpenAiAssistant : DashboardEvent()
 
         data class OpenRangePicker(
-            val start: Long,
-            val end: Long,
-            val callback: (Long, Long) -> Unit
+            val startDate: Date,
+            val endDate: Date,
+            val callback: (Date, Date) -> Unit
         ) : DashboardEvent()
 
         data object ContactSupport : DashboardEvent()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/coupons/DashboardCouponsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/coupons/DashboardCouponsCard.kt
@@ -66,8 +66,8 @@ fun DashboardCouponsCard(
         event = viewModel.event,
         openDatePicker = { fromDate, toDate ->
             parentViewModel.onDashboardWidgetEvent(
-                DashboardViewModel.DashboardEvent.OpenRangePicker(fromDate, toDate) { from, to ->
-                    viewModel.onCustomRangeSelected(StatsTimeRange(Date(from), Date(to)))
+                DashboardViewModel.DashboardEvent.OpenRangePicker(fromDate, toDate) { startDate, endDate ->
+                    viewModel.onCustomRangeSelected(StatsTimeRange(startDate, endDate))
                 }
             )
         }
@@ -90,7 +90,7 @@ fun DashboardCouponsCard(
 @Composable
 private fun HandleEvents(
     event: LiveData<MultiLiveEvent.Event>,
-    openDatePicker: (Long, Long) -> Unit,
+    openDatePicker: (Date, Date) -> Unit,
 ) {
     val navController = rememberNavController()
     val lifecycleOwner = LocalLifecycleOwner.current
@@ -99,7 +99,7 @@ private fun HandleEvents(
         val observer = Observer { event: MultiLiveEvent.Event ->
             when (event) {
                 is DashboardCouponsViewModel.OpenDatePicker -> {
-                    openDatePicker(event.fromDate.time, event.toDate.time)
+                    openDatePicker(event.fromDate, event.toDate)
                 }
 
                 DashboardCouponsViewModel.ViewAllCoupons -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/coupons/DashboardCouponsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/coupons/DashboardCouponsViewModel.kt
@@ -20,6 +20,7 @@ import com.woocommerce.android.ui.dashboard.domain.DashboardDateRangeFormatter
 import com.woocommerce.android.ui.products.ParameterRepository
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.util.CouponUtils
+import com.woocommerce.android.util.DateUtils
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
@@ -62,6 +63,7 @@ class DashboardCouponsViewModel @AssistedInject constructor(
     private val couponUtils: CouponUtils,
     private val parameterRepository: ParameterRepository,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
+    private val dateUtils: DateUtils,
     coroutineDispatchers: CoroutineDispatchers
 ) : ScopedViewModel(savedStateHandle) {
     companion object {
@@ -148,10 +150,11 @@ class DashboardCouponsViewModel @AssistedInject constructor(
 
     fun onEditCustomRangeTapped() {
         parentViewModel.trackCardInteracted(DashboardWidget.Type.COUPONS.trackingIdentifier)
+        val siteToday = dateUtils.getCurrentDateInSiteTimeZone() ?: Date()
         triggerEvent(
             OpenDatePicker(
-                fromDate = dateRangeState.value?.customRange?.start ?: Date(),
-                toDate = dateRangeState.value?.customRange?.end ?: Date()
+                fromDate = dateRangeState.value?.customRange?.start ?: siteToday,
+                toDate = dateRangeState.value?.customRange?.end ?: siteToday
             )
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/CustomDateRangeDataStore.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/CustomDateRangeDataStore.kt
@@ -1,6 +1,8 @@
 package com.woocommerce.android.ui.dashboard.data
 
 import androidx.datastore.core.DataStore
+import com.woocommerce.android.extensions.toDateAtStartOfDay
+import com.woocommerce.android.extensions.toEpochDay
 import com.woocommerce.android.ui.mystore.data.CustomDateRange
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.commons.stats.StatsTimeRange
@@ -8,7 +10,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
 import java.io.IOException
-import java.util.Date
 
 abstract class CustomDateRangeDataStore(
     private val dataStore: DataStore<CustomDateRange>
@@ -24,18 +25,19 @@ abstract class CustomDateRangeDataStore(
             }
         }
         .map {
-            if (it == CustomDateRange.getDefaultInstance()) {
+            // Day 0 means no saved range
+            if (it.startDateEpochDay == 0L) {
                 null
             } else {
-                StatsTimeRange(Date(it.startDateMillis), Date(it.endDateMillis))
+                StatsTimeRange(it.startDateEpochDay.toDateAtStartOfDay(), it.endDateEpochDay.toDateAtStartOfDay())
             }
         }
 
     suspend fun updateDateRange(range: StatsTimeRange) {
         dataStore.updateData { preferences ->
             preferences.toBuilder()
-                .setStartDateMillis(range.start.time)
-                .setEndDateMillis(range.end.time)
+                .setStartDateEpochDay(range.start.toEpochDay())
+                .setEndDateEpochDay(range.end.toEpochDay())
                 .build()
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/CustomDateRangeDayMigration.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/CustomDateRangeDayMigration.kt
@@ -1,0 +1,26 @@
+package com.woocommerce.android.ui.dashboard.data
+
+import androidx.datastore.core.DataMigration
+import com.woocommerce.android.extensions.toEpochDay
+import com.woocommerce.android.ui.mystore.data.CustomDateRange
+import java.util.Date
+
+// Migrates ranges saved before 25.5 from the millis fields. Delete in 25.9, see WOOMOB-3841.
+object CustomDateRangeDayMigration : DataMigration<CustomDateRange> {
+    override suspend fun shouldMigrate(currentData: CustomDateRange): Boolean =
+        currentData.startDateMillis != 0L || currentData.endDateMillis != 0L
+
+    override suspend fun migrate(currentData: CustomDateRange): CustomDateRange =
+        currentData.toBuilder()
+            .apply {
+                if (startDateEpochDay == 0L && endDateEpochDay == 0L) {
+                    setStartDateEpochDay(Date(currentData.startDateMillis).toEpochDay())
+                    setEndDateEpochDay(Date(currentData.endDateMillis).toEpochDay())
+                }
+            }
+            .clearStartDateMillis()
+            .clearEndDateMillis()
+            .build()
+
+    override suspend fun cleanUp() = Unit
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
@@ -73,7 +73,7 @@ import java.util.Date
 
 @Composable
 fun DashboardStatsCard(
-    openDatePicker: (Long, Long, (Long, Long) -> Unit) -> Unit,
+    openDatePicker: (Date, Date, (Date, Date) -> Unit) -> Unit,
     parentViewModel: DashboardViewModel,
     modifier: Modifier = Modifier,
     viewModel: DashboardStatsViewModel = hiltViewModel(
@@ -94,8 +94,8 @@ fun DashboardStatsCard(
     HandleEvents(
         event = viewModel.event,
         openDatePicker = { fromDate, toDate ->
-            openDatePicker(fromDate, toDate) { from, to ->
-                viewModel.onCustomRangeSelected(StatsTimeRange(Date(from), Date(to)))
+            openDatePicker(fromDate, toDate) { startDate, endDate ->
+                viewModel.onCustomRangeSelected(StatsTimeRange(startDate, endDate))
             }
         }
     )
@@ -520,7 +520,7 @@ private val orderDateTypeOptions = listOf(
 @Composable
 private fun HandleEvents(
     event: LiveData<MultiLiveEvent.Event>,
-    openDatePicker: (Long, Long) -> Unit,
+    openDatePicker: (Date, Date) -> Unit,
 ) {
     val navController = rememberNavController()
     val lifecycleOwner = LocalLifecycleOwner.current
@@ -529,7 +529,7 @@ private fun HandleEvents(
         val observer = Observer { event: MultiLiveEvent.Event ->
             when (event) {
                 is DashboardStatsViewModel.OpenDatePicker -> {
-                    openDatePicker(event.fromDate.time, event.toDate.time)
+                    openDatePicker(event.fromDate, event.toDate)
                 }
 
                 is DashboardStatsViewModel.OpenAnalytics -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsViewModel.kt
@@ -162,10 +162,11 @@ class DashboardStatsViewModel @AssistedInject constructor(
         } else {
             analyticsTrackerWrapper.track(AnalyticsEvent.DASHBOARD_STATS_CUSTOM_RANGE_EDIT_BUTTON_TAPPED)
         }
+        val siteToday = dateUtils.getCurrentDateInSiteTimeZone() ?: Date()
         triggerEvent(
             OpenDatePicker(
-                fromDate = dateRangeState.value?.customRange?.start ?: Date(),
-                toDate = dateRangeState.value?.customRange?.end ?: Date()
+                fromDate = dateRangeState.value?.customRange?.start ?: siteToday,
+                toDate = dateRangeState.value?.customRange?.end ?: siteToday
             )
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topperformers/DashboardTopPerformersViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topperformers/DashboardTopPerformersViewModel.kt
@@ -163,10 +163,11 @@ class DashboardTopPerformersViewModel @AssistedInject constructor(
             analyticsTrackerWrapper.track(AnalyticsEvent.DASHBOARD_STATS_CUSTOM_RANGE_EDIT_BUTTON_TAPPED)
         }
 
+        val siteToday = dateUtils.getCurrentDateInSiteTimeZone() ?: Date()
         triggerEvent(
             OpenDatePicker(
-                fromDate = selectedDateRange.value?.customRange?.start ?: Date(),
-                toDate = selectedDateRange.value?.customRange?.end ?: Date()
+                fromDate = selectedDateRange.value?.customRange?.start ?: siteToday,
+                toDate = selectedDateRange.value?.customRange?.end ?: siteToday
             )
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topperformers/DashboardTopPerformersWidgetCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topperformers/DashboardTopPerformersWidgetCard.kt
@@ -105,7 +105,7 @@ fun DashboardTopPerformersWidgetCard(
         }
     }
 
-    val openDatePicker = { start: Long, end: Long, callback: (Long, Long) -> Unit ->
+    val openDatePicker = { start: Date, end: Date, callback: (Date, Date) -> Unit ->
         parentViewModel.onDashboardWidgetEvent(
             OpenRangePicker(start, end, callback)
         )
@@ -113,8 +113,8 @@ fun DashboardTopPerformersWidgetCard(
     HandleEvents(
         topPerformersViewModel.event,
         openDatePicker = { fromDate, toDate ->
-            openDatePicker(fromDate, toDate) { from, to ->
-                topPerformersViewModel.onCustomRangeSelected(StatsTimeRange(Date(from), Date(to)))
+            openDatePicker(fromDate, toDate) { startDate, endDate ->
+                topPerformersViewModel.onCustomRangeSelected(StatsTimeRange(startDate, endDate))
             }
         }
     )
@@ -161,7 +161,7 @@ fun DashboardTopPerformersContent(
 @Composable
 private fun HandleEvents(
     event: LiveData<Event>,
-    openDatePicker: (Long, Long) -> Unit,
+    openDatePicker: (Date, Date) -> Unit,
 ) {
     val navController = rememberNavController()
     val lifecycleOwner = LocalLifecycleOwner.current
@@ -175,7 +175,7 @@ private fun HandleEvents(
                     )
                 )
 
-                is OpenDatePicker -> openDatePicker(event.fromDate.time, event.toDate.time)
+                is OpenDatePicker -> openDatePicker(event.fromDate, event.toDate)
                 is OpenAnalytics -> {
                     navController.navigateSafely(
                         DashboardFragmentDirections.actionDashboardToAnalytics(event.analyticsPeriod)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/OrderFilterOptionsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/OrderFilterOptionsFragment.kt
@@ -10,6 +10,8 @@ import com.woocommerce.android.databinding.FragmentOrderFilterListBinding
 import com.woocommerce.android.extensions.navigateBackWithNotice
 import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.extensions.showDateRangePicker
+import com.woocommerce.android.extensions.toDateAtStartOfDay
+import com.woocommerce.android.extensions.toEpochDay
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
@@ -82,7 +84,7 @@ class OrderFilterOptionsFragment :
         }
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
-                is ShowCustomDateRangePicker -> openDateRangePicker(event.startDateMillis, event.endDateMillis)
+                is ShowCustomDateRangePicker -> openDateRangePicker(event.startDay, event.endDay)
                 is OnFilterOptionsSelectionUpdated -> navigateBackWithResult(
                     KEY_UPDATED_FILTER_OPTIONS,
                     event.category
@@ -96,12 +98,12 @@ class OrderFilterOptionsFragment :
         }
     }
 
-    private fun openDateRangePicker(startDateMillis: Long, endDateMillis: Long) {
+    private fun openDateRangePicker(startDay: Long, endDay: Long) {
         val siteToday = dateUtils.getCurrentDateInSiteTimeZone() ?: Date()
-        val selectedStart = if (startDateMillis > 0) Date(startDateMillis) else siteToday
-        val selectedEnd = if (startDateMillis > 0) Date(endDateMillis) else siteToday
+        val selectedStart = if (startDay > 0) startDay.toDateAtStartOfDay() else siteToday
+        val selectedEnd = if (startDay > 0) endDay.toDateAtStartOfDay() else siteToday
         showDateRangePicker(selectedStart, selectedEnd, siteToday) { startDate, endDate ->
-            viewModel.onCustomDateRangeChanged(startDate.time, endDate.time)
+            viewModel.onCustomDateRangeChanged(startDate.toEpochDay(), endDate.toEpochDay())
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/OrderFilterOptionsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/OrderFilterOptionsFragment.kt
@@ -20,7 +20,10 @@ import com.woocommerce.android.ui.orders.filters.model.OrderFilterEvent.OnShowOr
 import com.woocommerce.android.ui.orders.filters.model.OrderFilterEvent.ShowCustomDateRangePicker
 import com.woocommerce.android.ui.orders.filters.model.OrderFilterOptionUiModel
 import com.woocommerce.android.ui.orders.list.OrderListFragment
+import com.woocommerce.android.util.DateUtils
 import dagger.hilt.android.AndroidEntryPoint
+import java.util.Date
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class OrderFilterOptionsFragment :
@@ -32,6 +35,9 @@ class OrderFilterOptionsFragment :
 
     private val viewModel: OrderFilterOptionsViewModel by viewModels()
     lateinit var orderFilterOptionAdapter: OrderFilterOptionAdapter
+
+    @Inject
+    lateinit var dateUtils: DateUtils
 
     override val activityAppBarStatus: AppBarStatus
         get() = AppBarStatus.Visible(
@@ -91,16 +97,11 @@ class OrderFilterOptionsFragment :
     }
 
     private fun openDateRangePicker(startDateMillis: Long, endDateMillis: Long) {
-        val selectedStartMillis = when {
-            startDateMillis > 0 -> startDateMillis
-            else -> System.currentTimeMillis()
-        }
-        val selectedEndMillis = when {
-            startDateMillis > 0 -> endDateMillis
-            else -> System.currentTimeMillis()
-        }
-        showDateRangePicker(selectedStartMillis, selectedEndMillis) { start, end ->
-            viewModel.onCustomDateRangeChanged(start, end)
+        val siteToday = dateUtils.getCurrentDateInSiteTimeZone() ?: Date()
+        val selectedStart = if (startDateMillis > 0) Date(startDateMillis) else siteToday
+        val selectedEnd = if (startDateMillis > 0) Date(endDateMillis) else siteToday
+        showDateRangePicker(selectedStart, selectedEnd, siteToday) { startDate, endDate ->
+            viewModel.onCustomDateRangeChanged(startDate.time, endDate.time)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/OrderFilterOptionsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/OrderFilterOptionsViewModel.kt
@@ -6,6 +6,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.R.string
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.extensions.toDateAtStartOfDay
 import com.woocommerce.android.ui.orders.filters.data.DateRange
 import com.woocommerce.android.ui.orders.filters.data.OrderFiltersRepository
 import com.woocommerce.android.ui.orders.filters.data.OrderListFilterCategory
@@ -112,7 +113,7 @@ class OrderFilterOptionsViewModel @Inject constructor(
 
     private fun updateDateRangeFilters(dateRangeOptionClicked: OrderFilterOptionUiModel) {
         if (DateRange.fromValue(dateRangeOptionClicked.key) == DateRange.CUSTOM_RANGE) {
-            val selectedCustomDateRange = orderFilterRepository.getCustomDateRangeFilter()
+            val selectedCustomDateRange = orderFilterRepository.getCustomDateRangeDays()
             triggerEvent(
                 ShowCustomDateRangePicker(selectedCustomDateRange.first, selectedCustomDateRange.second)
             )
@@ -173,9 +174,13 @@ class OrderFilterOptionsViewModel @Inject constructor(
             SALES_CHANNEL -> resourceProvider.getString(R.string.orderfilters_sales_channel_filter)
         }
 
-    fun onCustomDateRangeChanged(startMillis: Long, endMillis: Long) {
-        orderFilterRepository.setCustomDateRange(startMillis, endMillis)
-        val dateRangeDisplayValue = toDisplayDateRange(startMillis, endMillis, dateUtils)
+    fun onCustomDateRangeChanged(startDay: Long, endDay: Long) {
+        orderFilterRepository.setCustomDateRange(startDay, endDay)
+        val dateRangeDisplayValue = toDisplayDateRange(
+            startDay.toDateAtStartOfDay().time,
+            endDay.toDateAtStartOfDay().time,
+            dateUtils
+        )
         _viewState = _viewState.copy(
             filterOptions = _viewState.filterOptions
                 .map {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/data/OrderFiltersRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/data/OrderFiltersRepository.kt
@@ -2,6 +2,8 @@ package com.woocommerce.android.ui.orders.filters.data
 
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.di.AppCoroutineScope
+import com.woocommerce.android.extensions.toDateAtStartOfDay
+import com.woocommerce.android.extensions.toEpochDay
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.filters.data.OrderListFilterCategory.CUSTOMER
 import com.woocommerce.android.ui.orders.filters.data.OrderListFilterCategory.PRODUCT
@@ -11,6 +13,7 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.store.WCCustomerStore
+import java.util.Date
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -82,18 +85,43 @@ class OrderFiltersRepository @Inject constructor(
     private fun getCustomerFilter(filterCategory: OrderListFilterCategory) =
         if (filterCategory == CUSTOMER) listOfNotNull(customerFilter?.toString()) else emptyList()
 
-    fun getCustomDateRangeFilter(): Pair<Long, Long> =
-        selectedSite.getIfExists()?.let {
-            appSharedPrefs.getOrderFilterCustomDateRange(it.id)
+    fun getCustomDateRangeDays(): Pair<Long, Long> =
+        selectedSite.getIfExists()?.let { site ->
+            val (startDay, endDay) = appSharedPrefs.getOrderFilterCustomDateRangeDays(site.id)
+            if (startDay != 0L || endDay != 0L) {
+                // Drops the legacy millis prefs if an interrupted migration left them behind. Delete in 25.9,
+                // see WOOMOB-3841.
+                appSharedPrefs.removeOrderFilterCustomDateRange(site.id)
+                Pair(startDay, endDay)
+            } else {
+                migrateLegacyCustomDateRange(site.id)
+            }
         } ?: Pair(0, 0)
 
-    fun setCustomDateRange(startDateMillis: Long, endDateMillis: Long) {
-        selectedSite.getIfExists()?.let {
-            appSharedPrefs.setOrderFilterCustomDateRange(
-                it.id,
-                startDateMillis,
-                endDateMillis
-            )
+    fun getCustomDateRangeFilter(): Pair<Long, Long> {
+        val (startDay, endDay) = getCustomDateRangeDays()
+        return if (startDay != 0L || endDay != 0L) {
+            Pair(startDay.toDateAtStartOfDay().time, endDay.toDateAtStartOfDay().time)
+        } else {
+            Pair(0, 0)
         }
+    }
+
+    fun setCustomDateRange(startDay: Long, endDay: Long) {
+        selectedSite.getIfExists()?.let { site ->
+            appSharedPrefs.setOrderFilterCustomDateRangeDays(site.id, startDay, endDay)
+        }
+    }
+
+    // Migrates ranges saved before 25.5 from the millis prefs. Delete in 25.9, see WOOMOB-3841.
+    private fun migrateLegacyCustomDateRange(siteId: Int): Pair<Long, Long> {
+        val (startMillis, endMillis) = appSharedPrefs.getOrderFilterCustomDateRange(siteId)
+        if (startMillis == 0L && endMillis == 0L) return Pair(0, 0)
+        // The legacy millis are instants, so we read the days in the current device timezone
+        val startDay = Date(startMillis).toEpochDay()
+        val endDay = Date(endMillis).toEpochDay()
+        appSharedPrefs.setOrderFilterCustomDateRangeDays(siteId, startDay, endDay)
+        appSharedPrefs.removeOrderFilterCustomDateRange(siteId)
+        return Pair(startDay, endDay)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/model/OrderFilterUiModels.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/model/OrderFilterUiModels.kt
@@ -15,8 +15,8 @@ sealed class OrderFilterEvent : MultiLiveEvent.Event() {
     ) : OrderFilterEvent()
 
     data class ShowCustomDateRangePicker(
-        val startDateMillis: Long,
-        val endDateMillis: Long
+        val startDay: Long,
+        val endDay: Long
     ) : OrderFilterEvent()
 
     object OnShowOrders : OrderFilterEvent()

--- a/WooCommerce/src/main/proto/custom_date_range.proto
+++ b/WooCommerce/src/main/proto/custom_date_range.proto
@@ -6,4 +6,6 @@ option java_multiple_files = true;
 message CustomDateRange {
   uint64 start_date_millis = 1;
   uint64 end_date_millis = 2;
+  int64 start_date_epoch_day = 3;
+  int64 end_date_epoch_day = 4;
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/coupons/DashboardCouponsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/coupons/DashboardCouponsViewModelTest.kt
@@ -127,7 +127,8 @@ class DashboardCouponsViewModelTest : BaseUnitTest() {
             coroutineDispatchers = coroutinesTestRule.testDispatchers,
             dateRangeFormatter = dateRangeFormatter,
             customDateRangeDataStore = customDateRangeDataStore,
-            analyticsTrackerWrapper = analyticsTrackerWrapper
+            analyticsTrackerWrapper = analyticsTrackerWrapper,
+            dateUtils = dateUtils
         )
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/data/CustomDateRangeDataStoreTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/data/CustomDateRangeDataStoreTest.kt
@@ -1,0 +1,67 @@
+package com.woocommerce.android.ui.dashboard.data
+
+import androidx.datastore.core.DataStore
+import com.woocommerce.android.ui.mystore.data.CustomDateRange
+import com.woocommerce.commons.stats.StatsTimeRange
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.time.LocalDate
+import java.time.ZoneId
+import java.util.Date
+import java.util.TimeZone
+
+class CustomDateRangeDataStoreTest {
+    private lateinit var defaultTimeZone: TimeZone
+
+    private val fakeDataStore = object : DataStore<CustomDateRange> {
+        private val state = MutableStateFlow(CustomDateRange.getDefaultInstance())
+        override val data: Flow<CustomDateRange> = state
+        override suspend fun updateData(
+            transform: suspend (CustomDateRange) -> CustomDateRange
+        ): CustomDateRange {
+            state.value = transform(state.value)
+            return state.value
+        }
+    }
+
+    private val sut = object : CustomDateRangeDataStore(fakeDataStore) {}
+
+    @Before
+    fun setUp() {
+        defaultTimeZone = TimeZone.getDefault()
+    }
+
+    @After
+    fun tearDown() {
+        TimeZone.setDefault(defaultTimeZone)
+    }
+
+    @Test
+    fun `given a saved range, when the device timezone changes, then the same days are returned`() = runTest {
+        TimeZone.setDefault(TimeZone.getTimeZone("Europe/Istanbul"))
+        sut.updateDateRange(
+            StatsTimeRange(
+                start = dateAtStartOfDay(LocalDate.of(2026, 8, 1), "Europe/Istanbul"),
+                end = dateAtStartOfDay(LocalDate.of(2026, 8, 5), "Europe/Istanbul")
+            )
+        )
+
+        TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"))
+        val range = sut.dateRange.first()
+
+        assertThat(range?.start?.toLocalDate("America/Los_Angeles")).isEqualTo(LocalDate.of(2026, 8, 1))
+        assertThat(range?.end?.toLocalDate("America/Los_Angeles")).isEqualTo(LocalDate.of(2026, 8, 5))
+    }
+
+    private fun dateAtStartOfDay(day: LocalDate, zoneId: String): Date =
+        Date.from(day.atStartOfDay(ZoneId.of(zoneId)).toInstant())
+
+    private fun Date.toLocalDate(zoneId: String): LocalDate =
+        toInstant().atZone(ZoneId.of(zoneId)).toLocalDate()
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsViewModelTest.kt
@@ -52,6 +52,7 @@ import org.wordpress.android.fluxc.model.WCRevenueStatsModel
 import org.wordpress.android.fluxc.model.settings.WCAnalyticsOrderDateType
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import java.util.Calendar
+import java.util.Date
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class DashboardStatsViewModelTest : BaseUnitTest() {
@@ -682,4 +683,18 @@ class DashboardStatsViewModelTest : BaseUnitTest() {
         Assertions.assertThat(visitorStatsState)
             .isEqualTo(DashboardStatsViewModel.VisitorStatsViewState.Unavailable(showJetpackIcon = false))
     }
+
+    @Test
+    fun `given no custom range, when the range picker is opened, then it opens at the site's current day`() =
+        testBlocking {
+            val siteToday = Date(1754900000000)
+            whenever(dateUtils.getCurrentDateInSiteTimeZone()).thenReturn(siteToday)
+            setup()
+
+            viewModel.onEditCustomRangeTapped()
+
+            val event = viewModel.event.getOrAwaitValue() as DashboardStatsViewModel.OpenDatePicker
+            Assertions.assertThat(event.fromDate).isEqualTo(siteToday)
+            Assertions.assertThat(event.toDate).isEqualTo(siteToday)
+        }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/filters/data/OrderFiltersRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/filters/data/OrderFiltersRepositoryTest.kt
@@ -1,0 +1,73 @@
+package com.woocommerce.android.ui.orders.filters.data
+
+import com.woocommerce.android.AppPrefsWrapper
+import com.woocommerce.android.tools.SelectedSite
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.test.TestScope
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.wordpress.android.fluxc.model.SiteModel
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.util.TimeZone
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class OrderFiltersRepositoryTest {
+    private lateinit var defaultTimeZone: TimeZone
+
+    private var storedDays = Pair(0L, 0L)
+
+    private val appSharedPrefs: AppPrefsWrapper = mock {
+        on { setOrderFilterCustomDateRangeDays(any(), any(), any()) } doAnswer {
+            storedDays = Pair(it.getArgument(1), it.getArgument(2))
+        }
+        on { getOrderFilterCustomDateRangeDays(any()) } doAnswer { storedDays }
+    }
+    private val selectedSite: SelectedSite = mock {
+        on { getIfExists() } doReturn SiteModel().apply { id = 1 }
+        on { observe() } doReturn emptyFlow()
+    }
+
+    private val sut = OrderFiltersRepository(
+        appSharedPrefs = appSharedPrefs,
+        customerStore = mock(),
+        selectedSite = selectedSite,
+        appCoroutineScope = TestScope()
+    )
+
+    @Before
+    fun setUp() {
+        defaultTimeZone = TimeZone.getDefault()
+    }
+
+    @After
+    fun tearDown() {
+        TimeZone.setDefault(defaultTimeZone)
+    }
+
+    @Test
+    fun `given a saved range, when the device timezone changes, then the same days are returned`() {
+        TimeZone.setDefault(TimeZone.getTimeZone("Europe/Istanbul"))
+        sut.setCustomDateRange(
+            startDay = LocalDate.of(2026, 8, 1).toEpochDay(),
+            endDay = LocalDate.of(2026, 8, 5).toEpochDay()
+        )
+
+        TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"))
+        val range = sut.getCustomDateRangeFilter()
+
+        assertThat(range.first.toLocalDate("America/Los_Angeles")).isEqualTo(LocalDate.of(2026, 8, 1))
+        assertThat(range.second.toLocalDate("America/Los_Angeles")).isEqualTo(LocalDate.of(2026, 8, 5))
+    }
+
+    private fun Long.toLocalDate(zoneId: String): LocalDate =
+        Instant.ofEpochMilli(this).atZone(ZoneId.of(zoneId)).toLocalDate()
+}


### PR DESCRIPTION
### Description

Fixes WOOMOB-3270

The custom date range pickers treated the device's day as today. The last selectable day and the opening day came from the device clock, so when the store and the device were on different calendar days, a day the store had not reached yet could be selected, and the store's current day could be out of reach. The web admin never offers a day the store has not reached.

Saved custom ranges had a related problem: they were stored as timestamps, so changing the device time zone shifted the saved days, for example Aug 1 - Aug 5 turned into Jul 31 - Aug 4 after moving west.

The shared date range picker now takes the store's current day, caps the calendar there, and opens on it when no range was picked before. Its three callers (Analytics Hub, dashboard cards, order filters) pass it from `DateUtils.getCurrentDateInSiteTimeZone()`.

Saved custom ranges are now stored as days instead of timestamps, on the dashboard and in the order filters. Ranges saved by earlier versions are migrated on first read, so nothing is lost on upgrade. Deleting the migration code is tracked in [WOOMOB-3841](https://linear.app/a8c/issue/WOOMOB-3841/remove-the-custom-date-range-migration-code-in-259). After that, anyone who skips every release from 25.5 to 25.8 and updates straight to 25.9 loses their saved range and picks it again.

`showDateRangePicker` now works in days, which removes the timestamp shifting it needed to keep the picked day.

### Test Steps

The examples below assume a store on Europe/Istanbul time. The picker sections need the device and the store to be on different calendar days, so pick a device time zone far enough from the store's that the day number differs, not just the clock.

#### Saved dashboard custom range keeps its days when the time zone changes

1. Set the device time zone to Europe/Istanbul.
2. Kill and reopen the app.
3. Open My store.
4. Tap the date range on the Performance card.
5. Tap Custom Range.
6. Pick the 1st and the 5th of the current month.
7. Tap Save.
8. Confirm the Performance card shows Aug 1 - Aug 5.
9. Set the device time zone to America/Los_Angeles.
10. Kill and reopen the app.
11. Confirm the card still shows Aug 1 - Aug 5, not Jul 31 - Aug 4.

#### Saved order filter custom range keeps its days when the time zone changes

The picked days are only shown on the Date Range screen. The Filters screen just says Custom Range.

1. Set the device time zone to Europe/Istanbul.
2. Kill and reopen the app.
3. Open the Orders tab.
4. Tap Filters.
5. Tap Date Range.
6. Tap Custom Range.
7. Pick the 1st and the 5th of the current month.
8. Tap Save.
9. Confirm the Custom Range row shows Aug 1, 2026 - Aug 5, 2026.
10. Tap Show Orders.
11. Set the device time zone to America/Los_Angeles.
12. Kill and reopen the app.
13. Open the Orders tab.
14. Tap Filters.
15. Tap Date Range.
16. Confirm the row still shows Aug 1, 2026 - Aug 5, 2026, not Jul 31, 2026 - Aug 4, 2026.

#### Analytics date picker follows the store's day

1. Set the device time zone so the device and the store are on different calendar days, e.g. America/Los_Angeles for a store on Europe/Istanbul time.
2. Kill and reopen the app.
3. Open View all store analytics.
4. Tap the date range selector.
5. Tap Custom.
6. Confirm the store's current day can be selected.
7. Confirm days after the store's current day cannot be selected.

#### Order filters date picker follows the store's day

1. With the device still on a different calendar day than the store, open the Orders tab.
2. Tap Filters.
3. Tap Date Range.
4. Tap Custom Range.
5. Confirm the store's current day can be selected.
6. Confirm days after the store's current day cannot be selected.

#### Ranges saved before this change survive the upgrade

1. Install a build from `trunk`.
2. Save a custom range on the Performance card.
3. Save a custom range in the order filters.
4. Install this branch over it, without clearing app data.
5. Open My store.
6. Confirm the Performance card shows the same days as before the upgrade.
7. Open the Orders tab.
8. Tap Filters.
9. Tap Date Range.
10. Confirm the Custom Range row shows the same days as before the upgrade.

### Images/gif

| | Before | After |
|---|---|---|
| Saved dashboard range after a time zone change | <img src="https://github.com/user-attachments/assets/93abbf84-b7e0-4c8c-978e-a28923ef0372" width="400" /> | <img src="https://github.com/user-attachments/assets/0f4575b3-b532-435a-94a3-fc689323bb2a" width="400" /> |
| Saved order filter range after a time zone change | <img src="https://github.com/user-attachments/assets/a186fd33-8a83-42c5-959a-7e099b4b46b0" width="400" /> | <img src="https://github.com/user-attachments/assets/ec76c71e-43a4-4cf5-8ad3-273722ed5544" width="400" /> |
| Order filters picker, device a day behind the store | <img src="https://github.com/user-attachments/assets/7175624d-35e4-4d29-92d2-250ded3a49ab" width="400" /> | <img src="https://github.com/user-attachments/assets/71ece3ef-4ef7-4256-bfc9-47422920531e" width="400" /> |
| Analytics picker, device a day behind the store | <img src="https://github.com/user-attachments/assets/e18c17a2-0779-4474-b058-c84b9d61b5b8" width="400" /> | <img src="https://github.com/user-attachments/assets/e30cb8b9-cbd9-4157-b4db-197a89606ad5" width="400" /> |

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

