### PR TITLE
Require fastlane ~> 2.238.0 and remove faraday requirement

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,13 +3,9 @@
 source 'https://rubygems.org'
 
 gem 'danger-dangermattic', '~> 1.4'
-gem 'fastlane', '~> 2.237'
+gem 'fastlane', '~> 2.238'
 gem 'fastlane-plugin-firebase_app_distribution', '~> 1.0'
 gem 'rubocop', '~> 1.89'
-
-# Security: https://github.com/lostisland/faraday/pull/1665
-# Faraday 2.0 is not compatible with Fastlane
-gem 'faraday', '~> 2.14'
 
 ### Fastlane Plugins
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -386,8 +386,7 @@ PLATFORMS
 
 DEPENDENCIES
   danger-dangermattic (~> 1.4)
-  faraday (~> 2.14)
-  fastlane (~> 2.237)
+  fastlane (~> 2.238)
   fastlane-plugin-firebase_app_distribution (~> 1.0)
   fastlane-plugin-wpmreleasetoolkit (~> 14.11)
   openssl (~> 4.0)


### PR DESCRIPTION
fastlane 2.238.0 allows using faraday 2.x. The constrain on faraday was there to address a security vulnerability, but now that it resolves to latest 2.x, we no longer need it.

See https://github.com/fastlane/fastlane/pull/30089

The diff is tiny because all the bumps already occurred in https://github.com/woocommerce/woocommerce-android/pull/16409