### PR TITLE
[WOOMOB-3845] Add device_type and entry_point to POS analytics events

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 
 25.5
 -----
+- [Internal] Woo POS: every POS analytics event now carries device_type (phone/tablet) and entry_point, so POS usage can be split by form factor and attributed to where POS was opened from [https://github.com/woocommerce/woocommerce-android/pull/16414]
 - [*] Woo POS: Remote Tap to Pay failures now explain what went wrong - phone not eligible for Tap to Pay, NFC turned off, or a payment service error - instead of a generic message or raw error text [https://github.com/woocommerce/woocommerce-android/pull/16384]
 - [*] QR login now asks you to choose a store when your WordPress.com account has multiple sites instead of preselecting one [https://github.com/woocommerce/woocommerce-android/pull/16400]
 - [Internal] Close analytics gaps in the Remote Tap to Pay flow: transport on the reader-ready event, cause chains in error descriptions, no stale card reader model, and a real session ended reason [https://github.com/woocommerce/woocommerce-android/pull/16368]

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/WooPosActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/WooPosActivity.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosThe
 import com.woocommerce.android.ui.woopos.common.composeui.modifier.gesturesOrButtonsNavigationPadding
 import com.woocommerce.android.ui.woopos.home.items.coupons.creation.WooPosCouponCreationFacade
 import com.woocommerce.android.ui.woopos.support.WooPosGetSupportFacade
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEntryPointKeeper
 import com.woocommerce.android.ui.woopos.util.ext.lockWooPosOrientation
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -23,6 +24,9 @@ class WooPosActivity : AppCompatActivity() {
 
     @Inject
     lateinit var wooPosPeriodicSyncFacade: WooPosPeriodicSyncFacade
+
+    @Inject
+    lateinit var analyticsEntryPointKeeper: WooPosAnalyticsEntryPointKeeper
 
     override fun onCreate(savedInstanceState: Bundle?) {
         // POS is session-based: cart, product cache, order cache, and data source selection
@@ -48,6 +52,20 @@ class WooPosActivity : AppCompatActivity() {
                 WooPosRootScreen(modifier = Modifier.gesturesOrButtonsNavigationPadding())
             }
         }
+    }
+
+    override fun onPause() {
+        super.onPause()
+        endPosSessionIfFinishing()
+    }
+
+    override fun onDestroy() {
+        endPosSessionIfFinishing()
+        super.onDestroy()
+    }
+
+    private fun endPosSessionIfFinishing() {
+        if (isFinishing) analyticsEntryPointKeeper.onPosSessionEnded()
     }
 
     companion object {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosTabController.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosTabController.kt
@@ -12,7 +12,9 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
 import com.woocommerce.android.ui.woopos.root.WooPosActivity
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEntryPointKeeper
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEventConstant.EntryPoint
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -22,6 +24,7 @@ class WooPosTabController @Inject constructor(
     private val selectedSite: SelectedSite,
     private val shouldPosTabBeVisible: WooPosTabShouldBeVisible,
     private val analyticsTracker: WooPosAnalyticsTracker,
+    private val analyticsEntryPointKeeper: WooPosAnalyticsEntryPointKeeper,
     private val wooPosLog: WooPosLogWrapper
 ) : DefaultLifecycleObserver {
 
@@ -57,6 +60,7 @@ class WooPosTabController @Inject constructor(
     }
 
     fun navigateToPOS() {
+        analyticsEntryPointKeeper.onPosEntered(EntryPoint.POS_TAB)
         activity.startActivity(Intent(activity, WooPosActivity::class.java))
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsCommonPropertiesProvider.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsCommonPropertiesProvider.kt
@@ -3,6 +3,8 @@ package com.woocommerce.android.ui.woopos.util.analytics
 import android.content.Context
 import android.hardware.display.DisplayManager
 import android.view.Display
+import androidx.compose.ui.unit.dp
+import com.woocommerce.android.ui.woopos.util.WooPosScreenSizeUtils
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEventConstant.DeviceType
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEventConstant.EntryPoint
 import javax.inject.Inject
@@ -19,21 +21,22 @@ class WooPosAnalyticsCommonPropertiesProvider @Inject constructor(
         }
 
     private val deviceType: DeviceType
-        get() = when (displaySmallestWidthDp >= TABLET_SMALLEST_WIDTH_DP) {
-            true -> DeviceType.TABLET
-            false -> DeviceType.PHONE
+        get() {
+            val displayConfiguration = displayContext.resources.configuration
+            val shortSize = displayConfiguration.smallestScreenWidthDp.dp
+            val longSize = maxOf(displayConfiguration.screenWidthDp, displayConfiguration.screenHeightDp).dp
+            return when (WooPosScreenSizeUtils.isTabletSize(shortSize, longSize)) {
+                true -> DeviceType.TABLET
+                false -> DeviceType.PHONE
+            }
         }
 
-    private val displaySmallestWidthDp: Int
+    private val displayContext: Context
         get() {
             val displayManager = context.getSystemService(DisplayManager::class.java)
             val display = checkNotNull(displayManager.getDisplay(Display.DEFAULT_DISPLAY))
-            return context.createDisplayContext(display).resources.configuration.smallestScreenWidthDp
+            return context.createDisplayContext(display)
         }
-
-    private companion object {
-        const val TABLET_SMALLEST_WIDTH_DP = 600
-    }
 }
 
 @Singleton

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsCommonPropertiesProvider.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsCommonPropertiesProvider.kt
@@ -1,7 +1,51 @@
 package com.woocommerce.android.ui.woopos.util.analytics
 
+import android.content.Context
+import android.hardware.display.DisplayManager
+import android.view.Display
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEventConstant.DeviceType
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEventConstant.EntryPoint
 import javax.inject.Inject
+import javax.inject.Singleton
 
-class WooPosAnalyticsCommonPropertiesProvider @Inject constructor() {
-    val commonProperties: Map<String, String> = mapOf()
+class WooPosAnalyticsCommonPropertiesProvider @Inject constructor(
+    private val context: Context,
+    private val entryPointKeeper: WooPosAnalyticsEntryPointKeeper,
+) {
+    val commonProperties: Map<String, String>
+        get() = buildMap {
+            put(DeviceType.DEVICE_TYPE, deviceType.value)
+            entryPointKeeper.entryPoint?.let { put(EntryPoint.ENTRY_POINT, it.value) }
+        }
+
+    private val deviceType: DeviceType
+        get() = when (displaySmallestWidthDp >= TABLET_SMALLEST_WIDTH_DP) {
+            true -> DeviceType.TABLET
+            false -> DeviceType.PHONE
+        }
+
+    private val displaySmallestWidthDp: Int
+        get() {
+            val displayManager = context.getSystemService(DisplayManager::class.java)
+            val display = checkNotNull(displayManager.getDisplay(Display.DEFAULT_DISPLAY))
+            return context.createDisplayContext(display).resources.configuration.smallestScreenWidthDp
+        }
+
+    private companion object {
+        const val TABLET_SMALLEST_WIDTH_DP = 600
+    }
+}
+
+@Singleton
+class WooPosAnalyticsEntryPointKeeper @Inject constructor() {
+    var entryPoint: EntryPoint? = null
+        private set
+
+    fun onPosEntered(entryPoint: EntryPoint) {
+        this.entryPoint = entryPoint
+    }
+
+    fun onPosSessionEnded() {
+        entryPoint = null
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsCommonPropertiesProvider.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsCommonPropertiesProvider.kt
@@ -41,6 +41,7 @@ class WooPosAnalyticsCommonPropertiesProvider @Inject constructor(
 
 @Singleton
 class WooPosAnalyticsEntryPointKeeper @Inject constructor() {
+    @Volatile
     var entryPoint: EntryPoint? = null
         private set
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEventConstant.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEventConstant.kt
@@ -1,6 +1,31 @@
 package com.woocommerce.android.ui.woopos.util.analytics
 
 object WooPosAnalyticsEventConstant {
+    enum class DeviceType(val value: String) {
+        PHONE("phone"),
+        TABLET("tablet");
+
+        override fun toString(): String {
+            return value
+        }
+
+        companion object {
+            const val DEVICE_TYPE = "device_type"
+        }
+    }
+
+    enum class EntryPoint(val value: String) {
+        POS_TAB("pos_tab");
+
+        override fun toString(): String {
+            return value
+        }
+
+        companion object {
+            const val ENTRY_POINT = "entry_point"
+        }
+    }
+
     enum class ItemsListProductType(val value: String) {
         SIMPLE("simple"),
         VARIATION("variation");

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsCommonPropertiesProviderTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsCommonPropertiesProviderTest.kt
@@ -40,7 +40,7 @@ class WooPosAnalyticsCommonPropertiesProviderTest {
     @Test
     fun `given tablet sized display, when common properties requested, then device type is tablet`() {
         // GIVEN
-        configuration.smallestScreenWidthDp = 800
+        givenDisplaySizeDp(shortSize = 800, longSize = 1280)
 
         // WHEN
         val properties = sut.commonProperties
@@ -52,13 +52,31 @@ class WooPosAnalyticsCommonPropertiesProviderTest {
     @Test
     fun `given phone sized display, when common properties requested, then device type is phone`() {
         // GIVEN
-        configuration.smallestScreenWidthDp = 411
+        givenDisplaySizeDp(shortSize = 411, longSize = 891)
 
         // WHEN
         val properties = sut.commonProperties
 
         // THEN
         assertThat(properties["device_type"]).isEqualTo("phone")
+    }
+
+    @Test
+    fun `given display below the POS tablet threshold, when common properties requested, then device type is phone`() {
+        // GIVEN
+        givenDisplaySizeDp(shortSize = 600, longSize = 960)
+
+        // WHEN
+        val properties = sut.commonProperties
+
+        // THEN
+        assertThat(properties["device_type"]).isEqualTo("phone")
+    }
+
+    private fun givenDisplaySizeDp(shortSize: Int, longSize: Int) {
+        configuration.smallestScreenWidthDp = shortSize
+        configuration.screenWidthDp = shortSize
+        configuration.screenHeightDp = longSize
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsCommonPropertiesProviderTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsCommonPropertiesProviderTest.kt
@@ -1,0 +1,97 @@
+package com.woocommerce.android.ui.woopos.util.analytics
+
+import android.content.Context
+import android.content.res.Configuration
+import android.content.res.Resources
+import android.hardware.display.DisplayManager
+import android.view.Display
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEventConstant.EntryPoint
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class WooPosAnalyticsCommonPropertiesProviderTest {
+    private val context: Context = mock()
+    private val displayContext: Context = mock()
+    private val displayManager: DisplayManager = mock()
+    private val display: Display = mock()
+    private val resources: Resources = mock()
+    private val configuration = Configuration()
+    private val entryPointKeeper = WooPosAnalyticsEntryPointKeeper()
+
+    private lateinit var sut: WooPosAnalyticsCommonPropertiesProvider
+
+    @Before
+    fun setup() {
+        whenever(context.getSystemService(DisplayManager::class.java)).thenReturn(displayManager)
+        whenever(displayManager.getDisplay(Display.DEFAULT_DISPLAY)).thenReturn(display)
+        whenever(context.createDisplayContext(display)).thenReturn(displayContext)
+        whenever(displayContext.resources).thenReturn(resources)
+        whenever(resources.configuration).thenReturn(configuration)
+
+        sut = WooPosAnalyticsCommonPropertiesProvider(
+            context = context,
+            entryPointKeeper = entryPointKeeper,
+        )
+    }
+
+    @Test
+    fun `given tablet sized display, when common properties requested, then device type is tablet`() {
+        // GIVEN
+        configuration.smallestScreenWidthDp = 800
+
+        // WHEN
+        val properties = sut.commonProperties
+
+        // THEN
+        assertThat(properties["device_type"]).isEqualTo("tablet")
+    }
+
+    @Test
+    fun `given phone sized display, when common properties requested, then device type is phone`() {
+        // GIVEN
+        configuration.smallestScreenWidthDp = 411
+
+        // WHEN
+        val properties = sut.commonProperties
+
+        // THEN
+        assertThat(properties["device_type"]).isEqualTo("phone")
+    }
+
+    @Test
+    fun `given pos entered from tab, when common properties requested, then entry point is pos tab`() {
+        // GIVEN
+        entryPointKeeper.onPosEntered(EntryPoint.POS_TAB)
+
+        // WHEN
+        val properties = sut.commonProperties
+
+        // THEN
+        assertThat(properties["entry_point"]).isEqualTo("pos_tab")
+    }
+
+    @Test
+    fun `given pos not entered, when common properties requested, then entry point is absent`() {
+        // WHEN
+        val properties = sut.commonProperties
+
+        // THEN
+        assertThat(properties).doesNotContainKey("entry_point")
+    }
+
+    @Test
+    fun `given pos entered and then exited, when common properties requested, then entry point is absent`() {
+        // GIVEN
+        entryPointKeeper.onPosEntered(EntryPoint.POS_TAB)
+
+        // WHEN
+        entryPointKeeper.onPosSessionEnded()
+        val properties = sut.commonProperties
+
+        // THEN
+        assertThat(properties).doesNotContainKey("entry_point")
+    }
+}


### PR DESCRIPTION
### Description

Fixes WOOMOB-3845

Adds `device_type` (`phone`/`tablet`) and `entry_point` (`pos_tab`) to every WooPos event, through the `WooPosAnalyticsCommonPropertiesProvider` hook that was already wired into the tracker but returned an empty map. The V2 POS Looker board (WOOMOB-2673) needs to split POS usage by form factor, and to attribute sessions to entry points we add later.

- `entry_point`, not `source` — `source` is already a per-event POS property (`item_added_to_cart`) and a global one would collide.
- `device_type` reads `createDisplayContext(DEFAULT_DISPLAY)`, not the app context, whose `Configuration` follows the current window: a tablet in a small multi-window pane reported `phone`.
- Tablet detection reuses `WooPosScreenSizeUtils.isTabletSize` (674x800dp), the same predicate `WooPosIsScreenSizeAllowed` uses to decide whether POS is reachable, so analytics cannot label a device `tablet` that POS itself serves the phone layout to. iOS uses the hardware idiom, so the two disagree for 600-673dp tablets and for folding devices.
- Cleared in `onPause` guarded by `isFinishing`. `onDestroy` alone was too late — `MainActivity.onResume` runs first, and the tab-visibility event fired there still carried the stale value.
- Known gap: process death while POS is open loses the entry point. Under-counting seemed better than persisting session state for one analytics property.

### Test Steps

1. On a tablet, open POS from the POS tab. Filter logcat for `Tracked: woocommerceandroid_pos`.
2. Confirm events inside POS carry `"device_type":"tablet"` and `"entry_point":"pos_tab"`.
3. Exit POS. Confirm the next `pos_tab_visibility_checked` carries `device_type` but no `entry_point`.
4. Put the app into a small freeform/split-screen window on the same tablet and reopen POS. Confirm `device_type` is still `tablet`.
5. On a phone with `WOO_POS_PHONE` enabled, repeat step 1 and confirm `"device_type":"phone"`.

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

