### PR TITLE
Filter history: product list integration

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/filter/ProductFilterHistoryMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/filter/ProductFilterHistoryMapper.kt
@@ -1,0 +1,48 @@
+package com.woocommerce.android.ui.products.filter
+
+import com.google.gson.Gson
+import com.google.gson.annotations.SerializedName
+import javax.inject.Inject
+
+/**
+ * Encodes/decodes a [ProductFilterResult] to and from the opaque `payload` string persisted in the
+ * filter history table.
+ *
+ * The payload is a JSON serialization of the selected slugs; Gson omits null fields, so logically
+ * identical selections produce identical JSON and dedup reliably. The category name is only persisted
+ * when a category id is actually selected, so clearing the category to "Any" can't leak a stale name
+ * into the payload (which would break dedup). Decoding tolerates missing/unknown fields (all data-class
+ * fields default to null).
+ */
+class ProductFilterHistoryMapper @Inject constructor(
+    private val gson: Gson
+) {
+    fun toPayload(filter: ProductFilterResult): String = gson.toJson(filter.toData())
+
+    fun fromPayload(payload: String): ProductFilterResult? =
+        runCatching { gson.fromJson(payload, ProductFilterHistoryData::class.java) }.getOrNull()?.toResult()
+
+    private fun ProductFilterResult.toData() = ProductFilterHistoryData(
+        stockStatus = stockStatus,
+        productStatus = productStatus,
+        productType = productType,
+        productCategory = productCategory,
+        productCategoryName = productCategoryName?.takeIf { productCategory != null }
+    )
+
+    private fun ProductFilterHistoryData.toResult() = ProductFilterResult(
+        stockStatus = stockStatus,
+        productType = productType,
+        productStatus = productStatus,
+        productCategory = productCategory,
+        productCategoryName = productCategoryName
+    )
+
+    data class ProductFilterHistoryData(
+        @SerializedName("stock_status") val stockStatus: String? = null,
+        @SerializedName("product_status") val productStatus: String? = null,
+        @SerializedName("product_type") val productType: String? = null,
+        @SerializedName("product_category") val productCategory: String? = null,
+        @SerializedName("product_category_name") val productCategoryName: String? = null
+    )
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/filter/ProductFilterListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/filter/ProductFilterListFragment.kt
@@ -14,12 +14,17 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentProductFilterListBinding
+import com.woocommerce.android.extensions.handleResult
 import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.filters.FilterHistoryType
+import com.woocommerce.android.ui.filters.FilterHistoryViewModel
+import com.woocommerce.android.ui.filters.SavedFilter
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.main.MainActivity
+import com.woocommerce.android.ui.products.filter.ProductFilterListViewModel.OpenFilterHistory
 import com.woocommerce.android.ui.products.list.ProductListFragment
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import dagger.hilt.android.AndroidEntryPoint
@@ -84,10 +89,12 @@ class ProductFilterListFragment :
 
     override fun onCreateMenu(menu: Menu, inflater: MenuInflater) {
         inflater.inflate(R.menu.menu_clear, menu)
+        inflater.inflate(R.menu.menu_filter_history, menu)
     }
 
     override fun onPrepareMenu(menu: Menu) {
         updateClearButtonVisibility(menu.findItem(R.id.menu_clear))
+        menu.findItem(R.id.menu_filter_history).isVisible = viewModel.isFilterHistoryEnabled
     }
 
     override fun onMenuItemSelected(item: MenuItem): Boolean {
@@ -98,6 +105,12 @@ class ProductFilterListFragment :
                 updateClearButtonVisibility(item)
                 true
             }
+
+            R.id.menu_filter_history -> {
+                viewModel.onFilterHistoryButtonClicked()
+                true
+            }
+
             else -> false
         }
     }
@@ -116,11 +129,23 @@ class ProductFilterListFragment :
                 is MultiLiveEvent.Event.ExitWithResult<*> -> {
                     navigateBackWithResult(ProductListFragment.PRODUCT_FILTER_RESULT_KEY, event.data)
                 }
+                is OpenFilterHistory -> navigateToFilterHistory()
                 else -> event.isHandled = false
             }
         }
 
+        handleResult<SavedFilter>(FilterHistoryViewModel.FILTER_HISTORY_RESULT_KEY) {
+            viewModel.onPastFilterSelected(it)
+        }
+
         viewModel.loadFilters()
+    }
+
+    private fun navigateToFilterHistory() {
+        findNavController().navigateSafely(
+            ProductFilterListFragmentDirections
+                .actionProductFilterListFragmentToFilterHistoryFragment(FilterHistoryType.PRODUCTS)
+        )
     }
 
     private fun showProductFilterList(productFilterList: List<ProductFilterListViewModel.FilterListItemUiModel>) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/filter/ProductFilterListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/filter/ProductFilterListViewModel.kt
@@ -16,11 +16,14 @@ import com.woocommerce.android.model.sortCategories
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.common.PluginRepository
+import com.woocommerce.android.ui.filters.SavedFilter
 import com.woocommerce.android.ui.products.ProductStatus
 import com.woocommerce.android.ui.products.ProductStockStatus
 import com.woocommerce.android.ui.products.ProductType
 import com.woocommerce.android.ui.products.categories.ProductCategoriesRepository
 import com.woocommerce.android.ui.products.filter.ProductFilterListViewModel.FilterListOptionItemUiModel.DefaultFilterListOptionItemUiModel
+import com.woocommerce.android.util.FeatureFlag
+import com.woocommerce.android.util.FeatureFlagRepository
 import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ResourceProvider
@@ -50,11 +53,16 @@ class ProductFilterListViewModel @Inject constructor(
     private val pluginRepository: PluginRepository,
     private val selectedSite: SelectedSite,
     private val analyticsTracker: AnalyticsTrackerWrapper,
+    private val saveProductFilterToHistory: SaveProductFilterToHistory,
+    private val productFilterHistoryMapper: ProductFilterHistoryMapper,
+    featureFlagRepository: FeatureFlagRepository,
 ) : ScopedViewModel(savedState) {
     companion object {
         private const val KEY_PRODUCT_FILTER_OPTIONS = "key_product_filter_options"
         private const val KEY_PRODUCT_FILTER_SELECTED_CATEGORY_NAME = "key_product_filter_selected_category_name"
     }
+
+    val isFilterHistoryEnabled: Boolean = featureFlagRepository.isEnabled(FeatureFlag.FILTER_HISTORY)
 
     private val arguments: ProductFilterListFragmentArgs by savedState.navArgs()
 
@@ -314,7 +322,29 @@ class ProductFilterListViewModel @Inject constructor(
             productCategory = getFilterByProductCategory(),
             productCategoryName = selectedCategoryName
         )
+        saveProductFilterToHistory(result)
         triggerEvent(MultiLiveEvent.Event.ExitWithResult(result))
+    }
+
+    fun onFilterHistoryButtonClicked() {
+        analyticsTracker.track(
+            AnalyticsEvent.FILTER_HISTORY_BUTTON_TAPPED,
+            mapOf(AnalyticsTracker.KEY_SOURCE to AnalyticsTracker.VALUE_FILTER_HISTORY_SOURCE_PRODUCTS)
+        )
+        triggerEvent(OpenFilterHistory)
+    }
+
+    fun onPastFilterSelected(savedFilter: SavedFilter) {
+        val result = productFilterHistoryMapper.fromPayload(savedFilter.payload) ?: return
+        productFilterOptions.clear()
+        result.stockStatus?.let { productFilterOptions[STOCK_STATUS] = it }
+        result.productStatus?.let { productFilterOptions[STATUS] = it }
+        result.productType?.let { productFilterOptions[TYPE] = it }
+        result.productCategory?.let { productFilterOptions[CATEGORY] = it }
+        selectedCategoryName = result.productCategoryName
+        savedState[KEY_PRODUCT_FILTER_OPTIONS] = productFilterOptions
+        savedState[KEY_PRODUCT_FILTER_SELECTED_CATEGORY_NAME] = selectedCategoryName
+        loadFilters()
     }
 
     private fun buildFilterListItemUiModel(): List<FilterListItemUiModel> {
@@ -449,6 +479,8 @@ class ProductFilterListViewModel @Inject constructor(
             it.filterItemKey == CATEGORY
         }?.filterOptionListItems = categoryOptions
     }
+
+    object OpenFilterHistory : MultiLiveEvent.Event()
 
     @Parcelize
     data class ProductFilterListViewState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/filter/ProductFilterListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/filter/ProductFilterListViewModel.kt
@@ -336,15 +336,37 @@ class ProductFilterListViewModel @Inject constructor(
 
     fun onPastFilterSelected(savedFilter: SavedFilter) {
         val result = productFilterHistoryMapper.fromPayload(savedFilter.payload) ?: return
-        productFilterOptions.clear()
-        result.stockStatus?.let { productFilterOptions[STOCK_STATUS] = it }
-        result.productStatus?.let { productFilterOptions[STATUS] = it }
-        result.productType?.let { productFilterOptions[TYPE] = it }
-        result.productCategory?.let { productFilterOptions[CATEGORY] = it }
-        selectedCategoryName = result.productCategoryName
-        savedState[KEY_PRODUCT_FILTER_OPTIONS] = productFilterOptions
-        savedState[KEY_PRODUCT_FILTER_SELECTED_CATEGORY_NAME] = selectedCategoryName
-        loadFilters()
+        launch {
+            productFilterOptions.clear()
+            result.stockStatus?.let { productFilterOptions[STOCK_STATUS] = it }
+            result.productStatus?.let { productFilterOptions[STATUS] = it }
+            result.productType?.let { productFilterOptions[TYPE] = it }
+            applyRestoredCategory(result.productCategory)
+            savedState[KEY_PRODUCT_FILTER_OPTIONS] = productFilterOptions
+            savedState[KEY_PRODUCT_FILTER_SELECTED_CATEGORY_NAME] = selectedCategoryName
+            loadFilters()
+        }
+    }
+
+    // Keeps a restored category only if it's in the cached category list, resolving its name for the
+    // Category row. Relies on the cache (no network) so applying a past filter never lags: a category
+    // missing from the cache is dropped up front rather than shown then cleared, while a stale entry is
+    // reconciled later when the category list is refreshed (e.g. opening the Category screen).
+    private suspend fun applyRestoredCategory(categoryId: String?) {
+        if (categoryId == null) {
+            selectedCategoryName = null
+            return
+        }
+        if (productCategories.isEmpty()) {
+            productCategories = productCategoriesRepository.getProductCategoriesList()
+        }
+        val category = productCategories.firstOrNull { it.remoteCategoryId.toString() == categoryId }
+        if (category != null) {
+            productFilterOptions[CATEGORY] = categoryId
+            selectedCategoryName = category.name
+        } else {
+            selectedCategoryName = null
+        }
     }
 
     private fun buildFilterListItemUiModel(): List<FilterListItemUiModel> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/filter/ProductFilterListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/filter/ProductFilterListViewModel.kt
@@ -357,7 +357,9 @@ class ProductFilterListViewModel @Inject constructor(
             selectedCategoryName = null
             return
         }
-        if (productCategories.isEmpty()) {
+        // Also reload when only the previously-selected category is loaded (partially filled), otherwise a
+        // different restored category would be missing from the in-memory list and wrongly dropped.
+        if (productCategories.isEmpty() || isProductCategoriesPartiallyFilled()) {
             productCategories = productCategoriesRepository.getProductCategoriesList()
         }
         val category = productCategories.firstOrNull { it.remoteCategoryId.toString() == categoryId }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/filter/SaveProductFilterToHistory.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/filter/SaveProductFilterToHistory.kt
@@ -1,0 +1,62 @@
+package com.woocommerce.android.ui.products.filter
+
+import androidx.annotation.StringRes
+import com.woocommerce.android.di.AppCoroutineScope
+import com.woocommerce.android.ui.filters.FilterHistoryRepository
+import com.woocommerce.android.ui.filters.FilterHistoryType
+import com.woocommerce.android.ui.products.ProductStatus
+import com.woocommerce.android.ui.products.ProductStockStatus
+import com.woocommerce.android.ui.products.ProductType
+import com.woocommerce.android.util.FeatureFlag
+import com.woocommerce.android.util.FeatureFlagRepository
+import com.woocommerce.android.util.WooLog
+import com.woocommerce.android.viewmodel.ResourceProvider
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * Persists the given product filter selection to the filter history.
+ *
+ * Fire-and-forget on the application scope so it survives the filter screen being dismissed, letting
+ * callers navigate away immediately without awaiting the DB write. Failures are logged rather than
+ * propagated — persisting history is best-effort and must never crash the app.
+ *
+ * Owns the human-readable label resolution (slug → localized label) so the [ProductFilterHistoryMapper]
+ * stays a pure payload codec, matching the order-list use case.
+ */
+class SaveProductFilterToHistory @Inject constructor(
+    private val featureFlagRepository: FeatureFlagRepository,
+    private val filterHistoryRepository: FilterHistoryRepository,
+    private val productFilterHistoryMapper: ProductFilterHistoryMapper,
+    private val resourceProvider: ResourceProvider,
+    @AppCoroutineScope private val appCoroutineScope: CoroutineScope
+) {
+    operator fun invoke(filter: ProductFilterResult) {
+        if (!featureFlagRepository.isEnabled(FeatureFlag.FILTER_HISTORY)) return
+        if (!filter.hasSelection()) return
+        appCoroutineScope.launch {
+            runCatching {
+                filterHistoryRepository.save(
+                    type = FilterHistoryType.PRODUCTS,
+                    payload = productFilterHistoryMapper.toPayload(filter),
+                    readableString = buildReadableString(filter)
+                )
+            }.onFailure { WooLog.e(WooLog.T.PRODUCTS, "Failed to save product filter to history", it) }
+        }
+    }
+
+    private fun buildReadableString(filter: ProductFilterResult): String =
+        listOfNotNull(
+            filter.stockStatus?.let { label(ProductStockStatus.fromString(it).stringResource) },
+            filter.productStatus?.let { status -> ProductStatus.fromString(status)?.let { label(it.stringResource) } },
+            filter.productType?.let { label(ProductType.fromString(it).stringResource) },
+            filter.productCategoryName?.takeIf { filter.productCategory != null }
+        ).joinToString(separator = ", ")
+
+    private fun label(@StringRes resId: Int): String? =
+        resId.takeIf { it != 0 }?.let { resourceProvider.getString(it) }
+
+    private fun ProductFilterResult.hasSelection(): Boolean =
+        stockStatus != null || productStatus != null || productType != null || productCategory != null
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/filter/ProductFilterHistoryMapperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/filter/ProductFilterHistoryMapperTest.kt
@@ -1,0 +1,58 @@
+package com.woocommerce.android.ui.products.filter
+
+import com.google.gson.Gson
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class ProductFilterHistoryMapperTest {
+    private val sut = ProductFilterHistoryMapper(Gson())
+
+    @Test
+    fun `given a full selection, when encoding then decoding, then it round-trips`() {
+        val filter = ProductFilterResult(
+            stockStatus = "instock",
+            productType = "simple",
+            productStatus = "draft",
+            productCategory = "5",
+            productCategoryName = "Shoes"
+        )
+
+        assertThat(sut.fromPayload(sut.toPayload(filter))).isEqualTo(filter)
+    }
+
+    @Test
+    fun `given identical selections, when encoded, then payloads are identical`() {
+        val a = ProductFilterResult("instock", null, "draft", null, null)
+        val b = ProductFilterResult("instock", null, "draft", null, null)
+
+        assertThat(sut.toPayload(a)).isEqualTo(sut.toPayload(b))
+    }
+
+    @Test
+    fun `given an invalid payload, when decoding, then null is returned`() {
+        assertThat(sut.fromPayload("not-json")).isNull()
+    }
+
+    @Test
+    fun `given an empty json payload, when decoding, then a filter with no selection is returned`() {
+        assertThat(sut.fromPayload("{}")).isEqualTo(ProductFilterResult(null, null, null, null, null))
+    }
+
+    @Test
+    fun `given a category name without a category id, when encoding, then the name is dropped`() {
+        val withStaleName = ProductFilterResult("instock", null, null, null, "Any")
+        val withoutName = ProductFilterResult("instock", null, null, null, null)
+
+        // The stale name must not leak into the payload, otherwise it breaks dedup against the same
+        // stock-only filter saved from another path.
+        assertThat(sut.toPayload(withStaleName)).isEqualTo(sut.toPayload(withoutName))
+        assertThat(sut.fromPayload(sut.toPayload(withStaleName))?.productCategoryName).isNull()
+    }
+
+    @Test
+    fun `given a category name with a category id, when encoding, then the name is kept`() {
+        val filter = ProductFilterResult(null, null, null, "5", "Shoes")
+
+        assertThat(sut.fromPayload(sut.toPayload(filter))?.productCategoryName).isEqualTo("Shoes")
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/filter/ProductFilterListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/filter/ProductFilterListViewModelTest.kt
@@ -126,7 +126,7 @@ class ProductFilterListViewModelTest : BaseUnitTest() {
         )
         whenever(productFilterHistoryMapper.fromPayload("payload")).thenReturn(applied)
 
-        productFilterListViewModel.onPastFilterSelected(SavedFilter(id = 1, readableString = "r", payload = "payload"))
+        productFilterListViewModel.onPastFilterSelected(SavedFilter(readableString = "r", payload = "payload"))
         productFilterListViewModel.onShowProductsClicked()
 
         // onShowProductsClicked rebuilds the result from the repopulated map + selectedCategoryName,
@@ -140,7 +140,7 @@ class ProductFilterListViewModelTest : BaseUnitTest() {
     fun `given an undecodable past filter, when selected, then the current selection is unchanged`() {
         whenever(productFilterHistoryMapper.fromPayload("bad")).thenReturn(null)
 
-        productFilterListViewModel.onPastFilterSelected(SavedFilter(id = 1, readableString = "r", payload = "bad"))
+        productFilterListViewModel.onPastFilterSelected(SavedFilter(readableString = "r", payload = "bad"))
 
         Assertions.assertThat(productFilterListViewModel.getFilterString()).isEqualTo("instock, any, published, 1")
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/filter/ProductFilterListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/filter/ProductFilterListViewModelTest.kt
@@ -4,6 +4,7 @@ import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.model.PluginUrls
+import com.woocommerce.android.model.ProductCategory
 import com.woocommerce.android.model.WooPlugin
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
@@ -116,7 +117,7 @@ class ProductFilterListViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when a past filter is selected, then all filter options are repopulated`() {
+    fun `when a past filter is selected, then all filter options are repopulated`() = testBlocking {
         val applied = ProductFilterResult(
             stockStatus = "outofstock",
             productType = "simple",
@@ -125,6 +126,8 @@ class ProductFilterListViewModelTest : BaseUnitTest() {
             productCategoryName = "Boots"
         )
         whenever(productFilterHistoryMapper.fromPayload("payload")).thenReturn(applied)
+        whenever(productCategoriesRepository.getProductCategoriesList())
+            .thenReturn(listOf(ProductCategory(remoteCategoryId = 7, name = "Boots")))
 
         productFilterListViewModel.onPastFilterSelected(SavedFilter(readableString = "r", payload = "payload"))
         productFilterListViewModel.onShowProductsClicked()
@@ -135,6 +138,30 @@ class ProductFilterListViewModelTest : BaseUnitTest() {
         verify(saveProductFilterToHistory).invoke(captor.capture())
         Assertions.assertThat(captor.firstValue).isEqualTo(applied)
     }
+
+    @Test
+    fun `given a saved category no longer exists, when a past filter is selected, then it is dropped`() =
+        testBlocking {
+            val applied = ProductFilterResult(
+                stockStatus = "outofstock",
+                productType = null,
+                productStatus = null,
+                productCategory = "99",
+                productCategoryName = "Deleted"
+            )
+            whenever(productFilterHistoryMapper.fromPayload("payload")).thenReturn(applied)
+            whenever(productCategoriesRepository.getProductCategoriesList())
+                .thenReturn(listOf(ProductCategory(remoteCategoryId = 7, name = "Boots")))
+
+            productFilterListViewModel.onPastFilterSelected(SavedFilter(readableString = "r", payload = "payload"))
+            productFilterListViewModel.onShowProductsClicked()
+
+            val captor = argumentCaptor<ProductFilterResult>()
+            verify(saveProductFilterToHistory).invoke(captor.capture())
+            Assertions.assertThat(captor.firstValue.productCategory).isNull()
+            Assertions.assertThat(captor.firstValue.productCategoryName).isNull()
+            Assertions.assertThat(captor.firstValue.stockStatus).isEqualTo("outofstock")
+        }
 
     @Test
     fun `given an undecodable past filter, when selected, then the current selection is unchanged`() {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/filter/ProductFilterListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/filter/ProductFilterListViewModelTest.kt
@@ -8,16 +8,20 @@ import com.woocommerce.android.model.WooPlugin
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.common.PluginRepository
+import com.woocommerce.android.ui.filters.SavedFilter
 import com.woocommerce.android.ui.products.ProductType
 import com.woocommerce.android.ui.products.categories.ProductCategoriesRepository
 import com.woocommerce.android.ui.products.filter.ProductFilterListViewModel.FilterListOptionItemUiModel
+import com.woocommerce.android.util.FeatureFlagRepository
 import com.woocommerce.android.viewmodel.BaseUnitTest
+import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
@@ -37,6 +41,9 @@ class ProductFilterListViewModelTest : BaseUnitTest() {
     private lateinit var productFilterListViewModel: ProductFilterListViewModel
     private lateinit var pluginRepository: PluginRepository
     private lateinit var analyticsTrackerWrapper: AnalyticsTrackerWrapper
+    private lateinit var saveProductFilterToHistory: SaveProductFilterToHistory
+    private lateinit var productFilterHistoryMapper: ProductFilterHistoryMapper
+    private lateinit var featureFlagRepository: FeatureFlagRepository
     private val siteModel: SiteModel = SiteModel().apply { id = 123 }
     private val selectedSiteMock: SelectedSite = mock {
         on { getIfExists() }.doReturn(siteModel)
@@ -51,6 +58,9 @@ class ProductFilterListViewModelTest : BaseUnitTest() {
         networkStatus = mock()
         pluginRepository = mock()
         analyticsTrackerWrapper = mock()
+        saveProductFilterToHistory = mock()
+        productFilterHistoryMapper = mock()
+        featureFlagRepository = mock()
         productFilterListViewModel = ProductFilterListViewModel(
             savedState = ProductFilterListFragmentArgs(
                 selectedStockStatus = "instock",
@@ -64,10 +74,75 @@ class ProductFilterListViewModelTest : BaseUnitTest() {
             networkStatus = networkStatus,
             pluginRepository = pluginRepository,
             selectedSite = selectedSiteMock,
-            analyticsTracker = analyticsTrackerWrapper
+            analyticsTracker = analyticsTrackerWrapper,
+            saveProductFilterToHistory = saveProductFilterToHistory,
+            productFilterHistoryMapper = productFilterHistoryMapper,
+            featureFlagRepository = featureFlagRepository
         )
 
         whenever(resourceProvider.getString(any())).thenReturn("")
+    }
+
+    @Test
+    fun `when show products is clicked, then the current filter is saved and returned`() {
+        productFilterListViewModel.onShowProductsClicked()
+
+        val expected = ProductFilterResult(
+            stockStatus = "instock",
+            productType = "any",
+            productStatus = "published",
+            productCategory = "1",
+            productCategoryName = "any"
+        )
+        val captor = argumentCaptor<ProductFilterResult>()
+        verify(saveProductFilterToHistory).invoke(captor.capture())
+        Assertions.assertThat(captor.firstValue).isEqualTo(expected)
+
+        val event = productFilterListViewModel.event.value
+        Assertions.assertThat(event).isInstanceOf(MultiLiveEvent.Event.ExitWithResult::class.java)
+        Assertions.assertThat((event as MultiLiveEvent.Event.ExitWithResult<*>).data).isEqualTo(expected)
+    }
+
+    @Test
+    fun `when filter history button is clicked, then entry point is tracked and history is opened`() {
+        productFilterListViewModel.onFilterHistoryButtonClicked()
+
+        verify(analyticsTrackerWrapper).track(
+            AnalyticsEvent.FILTER_HISTORY_BUTTON_TAPPED,
+            mapOf(AnalyticsTracker.KEY_SOURCE to AnalyticsTracker.VALUE_FILTER_HISTORY_SOURCE_PRODUCTS)
+        )
+        Assertions.assertThat(productFilterListViewModel.event.value)
+            .isEqualTo(ProductFilterListViewModel.OpenFilterHistory)
+    }
+
+    @Test
+    fun `when a past filter is selected, then all filter options are repopulated`() {
+        val applied = ProductFilterResult(
+            stockStatus = "outofstock",
+            productType = "simple",
+            productStatus = "draft",
+            productCategory = "7",
+            productCategoryName = "Boots"
+        )
+        whenever(productFilterHistoryMapper.fromPayload("payload")).thenReturn(applied)
+
+        productFilterListViewModel.onPastFilterSelected(SavedFilter(id = 1, readableString = "r", payload = "payload"))
+        productFilterListViewModel.onShowProductsClicked()
+
+        // onShowProductsClicked rebuilds the result from the repopulated map + selectedCategoryName,
+        // so an equal result proves every field (incl. the category name) was applied.
+        val captor = argumentCaptor<ProductFilterResult>()
+        verify(saveProductFilterToHistory).invoke(captor.capture())
+        Assertions.assertThat(captor.firstValue).isEqualTo(applied)
+    }
+
+    @Test
+    fun `given an undecodable past filter, when selected, then the current selection is unchanged`() {
+        whenever(productFilterHistoryMapper.fromPayload("bad")).thenReturn(null)
+
+        productFilterListViewModel.onPastFilterSelected(SavedFilter(id = 1, readableString = "r", payload = "bad"))
+
+        Assertions.assertThat(productFilterListViewModel.getFilterString()).isEqualTo("instock, any, published, 1")
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/filter/ProductFilterListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/filter/ProductFilterListViewModelTest.kt
@@ -164,6 +164,34 @@ class ProductFilterListViewModelTest : BaseUnitTest() {
         }
 
     @Test
+    fun `given only the active category is loaded, when a past filter's category is applied, then it is kept`() =
+        testBlocking {
+            // Reopening the filter screen with an existing category filter partially fills productCategories
+            // with just that one category (here "1"), so the restored one must still be looked up in the cache.
+            productFilterListViewModel.loadFilters()
+            val applied = ProductFilterResult(
+                stockStatus = null,
+                productType = null,
+                productStatus = null,
+                productCategory = "7",
+                productCategoryName = "Decor"
+            )
+            whenever(productFilterHistoryMapper.fromPayload("payload")).thenReturn(applied)
+            whenever(productCategoriesRepository.getProductCategoriesList())
+                .thenReturn(
+                    listOf(ProductCategory(remoteCategoryId = 1, name = "Clothing"), ProductCategory(7, "Decor"))
+                )
+
+            productFilterListViewModel.onPastFilterSelected(SavedFilter(readableString = "r", payload = "payload"))
+            productFilterListViewModel.onShowProductsClicked()
+
+            val captor = argumentCaptor<ProductFilterResult>()
+            verify(saveProductFilterToHistory).invoke(captor.capture())
+            Assertions.assertThat(captor.firstValue.productCategory).isEqualTo("7")
+            Assertions.assertThat(captor.firstValue.productCategoryName).isEqualTo("Decor")
+        }
+
+    @Test
     fun `given an undecodable past filter, when selected, then the current selection is unchanged`() {
         whenever(productFilterHistoryMapper.fromPayload("bad")).thenReturn(null)
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/filter/SaveProductFilterToHistoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/filter/SaveProductFilterToHistoryTest.kt
@@ -1,0 +1,101 @@
+package com.woocommerce.android.ui.products.filter
+
+import com.woocommerce.android.ui.filters.FilterHistoryRepository
+import com.woocommerce.android.ui.filters.FilterHistoryType
+import com.woocommerce.android.util.FeatureFlag
+import com.woocommerce.android.util.FeatureFlagRepository
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import com.woocommerce.android.viewmodel.ResourceProvider
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SaveProductFilterToHistoryTest : BaseUnitTest() {
+    private val featureFlagRepository: FeatureFlagRepository = mock()
+    private val filterHistoryRepository: FilterHistoryRepository = mock()
+    private val productFilterHistoryMapper: ProductFilterHistoryMapper = mock {
+        on { toPayload(any()) } doReturn PAYLOAD
+    }
+    private val resourceProvider: ResourceProvider = mock {
+        on { getString(any()) } doReturn "Label"
+    }
+
+    private val sut = SaveProductFilterToHistory(
+        featureFlagRepository = featureFlagRepository,
+        filterHistoryRepository = filterHistoryRepository,
+        productFilterHistoryMapper = productFilterHistoryMapper,
+        resourceProvider = resourceProvider,
+        appCoroutineScope = CoroutineScope(coroutinesTestRule.testDispatcher)
+    )
+
+    @Test
+    fun `given feature flag disabled, when invoked, then nothing is saved`() = testBlocking {
+        whenever(featureFlagRepository.isEnabled(FeatureFlag.FILTER_HISTORY)).thenReturn(false)
+
+        sut(ProductFilterResult("instock", null, null, null, null))
+
+        verify(filterHistoryRepository, never()).save(any(), any(), any())
+    }
+
+    @Test
+    fun `given no filter is selected, when invoked, then nothing is saved`() = testBlocking {
+        whenever(featureFlagRepository.isEnabled(FeatureFlag.FILTER_HISTORY)).thenReturn(true)
+
+        sut(ProductFilterResult(null, null, null, null, null))
+
+        verify(filterHistoryRepository, never()).save(any(), any(), any())
+    }
+
+    @Test
+    fun `given only a category name is set, when invoked, then nothing is saved`() = testBlocking {
+        whenever(featureFlagRepository.isEnabled(FeatureFlag.FILTER_HISTORY)).thenReturn(true)
+
+        sut(ProductFilterResult(null, null, null, null, "Shoes"))
+
+        verify(filterHistoryRepository, never()).save(any(), any(), any())
+    }
+
+    @Test
+    fun `given a filter is selected, when invoked, then it is saved with the resolved label`() = testBlocking {
+        whenever(featureFlagRepository.isEnabled(FeatureFlag.FILTER_HISTORY)).thenReturn(true)
+
+        sut(ProductFilterResult("instock", null, null, null, null))
+
+        verify(filterHistoryRepository).save(FilterHistoryType.PRODUCTS, PAYLOAD, "Label")
+    }
+
+    @Test
+    fun `given an unresolvable slug, when building the label, then it is dropped from the readable string`() =
+        testBlocking {
+            whenever(featureFlagRepository.isEnabled(FeatureFlag.FILTER_HISTORY)).thenReturn(true)
+
+            // "weirdstatus" maps to ProductStockStatus.Custom (stringResource == 0) → dropped;
+            // only the valid product type resolves, so the readable string is a single "Label".
+            sut(ProductFilterResult(stockStatus = "weirdstatus", productType = "simple", null, null, null))
+
+            verify(filterHistoryRepository).save(eq(FilterHistoryType.PRODUCTS), eq(PAYLOAD), eq("Label"))
+        }
+
+    @Test
+    fun `given a category name without a category id, when building the label, then the name is dropped`() =
+        testBlocking {
+            whenever(featureFlagRepository.isEnabled(FeatureFlag.FILTER_HISTORY)).thenReturn(true)
+
+            sut(ProductFilterResult(stockStatus = "instock", null, null, null, productCategoryName = "Any"))
+
+            // Readable is just the stock label, not "Label, Any".
+            verify(filterHistoryRepository).save(eq(FilterHistoryType.PRODUCTS), eq(PAYLOAD), eq("Label"))
+        }
+
+    private companion object {
+        const val PAYLOAD = "payload"
+    }
+}


### PR DESCRIPTION
Part of [WOOMOB-3326](https://linear.app/a8c/issue/WOOMOB-3326) — WOOMOB-3827

### Description
Final PR in the **filter history** stack: wires the shared history screen into the **product list** filters (reusing the clock entry point from #16422). Behind the `FILTER_HISTORY` flag.

- Flag-gated clock entry point on the product filter screen → history with `source=products` and `filter_history_button_tapped`.
- Saves the current selection on **Show Products** via `SaveProductFilterToHistory` (app-scope, fire-and-forget, `runCatching`). Products use a single shared ViewModel, so the save is covered whether Show Products is tapped from the list or an options sub-screen.
- Applies a picked past filter by repopulating the in-memory `productFilterOptions` map + category name, then reloading the filters.
- `ProductFilterHistoryMapper` is a pure JSON codec (matching the order side); label resolution lives in the use case. The category name is only persisted when a category id is actually selected, so clearing to "Any" can't leak a stale name or break dedup.

### Test Steps
Enable **Filter History** in the developer feature-flag screen, then on the Products tab:
- Open Filters → tap the clock → confirm empty history.
- Select filters → Show Products → reopen history → filter appears at top; confirm newest-first + dedup; swipe to delete; apply a past filter and confirm it repopulates and Show Products lists correctly; Clear History → confirm → empty state.
- Verify Tracks events fire with `source=products`.

### Images/GIFs


https://github.com/user-attachments/assets/a9064825-f566-4d20-8567-1bab2bd8c555



- [x] I have considered if this change warrants release notes — none needed (behind feature flag, not user-facing).
