### PR TITLE
[DO NOT MERGE] Validate the Sentry upload wiring for #16427

### DIFF
--- a/.buildkite/commands/validate-sentry-upload.sh
+++ b/.buildkite/commands/validate-sentry-upload.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+"$(dirname "${BASH_SOURCE[0]}")/restore-cache.sh"
+
+echo "--- :rubygems: Setting up Gems"
+install_gems
+
+echo "--- :closed_lock_with_key: Installing Secrets"
+bundle exec fastlane run configure_apply
+
+echo "+++ :sentry: Upload with the token present"
+./gradlew :WooCommerce:uploadSentryProguardMappingsVanillaRelease
+./gradlew :WooCommerce-Wear:sentryUploadSourceBundleWasabiRelease
+
+echo "--- :sentry: Guard fires when the token is missing"
+set +e
+output=$(SENTRY_AUTH_TOKEN= ./gradlew :WooCommerce-Wear:sentryUploadSourceBundleWasabiRelease --rerun-tasks 2>&1)
+status=$?
+set -e
+
+printf '%s\n' "$output" | tail -30
+
+if [[ "$status" -eq 0 ]]; then
+  echo "FAIL: expected a non-zero exit without SENTRY_AUTH_TOKEN, got success."
+  exit 1
+fi
+
+if ! printf '%s' "$output" | grep -q 'SENTRY_AUTH_TOKEN is not set'; then
+  echo "FAIL: build failed without SENTRY_AUTH_TOKEN, but not through the guard."
+  exit 1
+fi
+
+echo "Guard fired as expected."

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -20,6 +20,10 @@ steps:
   # Wait for Gradle Wrapper to be validated before running any other jobs
   - wait
 
+  - label: ":sentry: Validate Sentry Upload"
+    command: .buildkite/commands/validate-sentry-upload.sh
+    plugins: [$CI_TOOLKIT]
+
   ########################################
   - group: "🕵️ Linters"
     steps:


### PR DESCRIPTION
**Validation only — do not merge.** Stacked on #16427 ([AINFRA-2717](https://linear.app/a8c/issue/AINFRA-2717)).

### Description

#16427 moves the Sentry auth token to `SENTRY_AUTH_TOKEN` and gates uploads on CI, but nothing in the ordinary pipeline exercises that path: prototype builds assemble `JalapenoDebug` and `debug` is in `ignoredBuildTypes`, and only the API-triggered release pipeline uploads. So #16427 can go green while the token wiring is broken, and the next code freeze would be the first real test.

This adds one throwaway Buildkite step that runs the upload tasks directly against the code in #16427, and then re-runs one of them with `SENTRY_AUTH_TOKEN` blanked to confirm the missing-token guard fires rather than the upload quietly succeeding or failing opaquely.

### Test Steps

Read the `:sentry: Validate Sentry Upload` job. All steps are expected to **pass** — there are no intentional failures here.

It proves three things:

1. `:WooCommerce:uploadSentryProguardMappingsVanillaRelease` uploads with the CI-injected token.
2. `:WooCommerce-Wear:sentryUploadSourceBundleWasabiRelease` uploads — this is the one that confirms the `woocommerce-wear` project target, since Wear sets `minifyEnabled false` and so has no ProGuard mappings.
3. With `SENTRY_AUTH_TOKEN` blank, the build fails through the guard with `SENTRY_AUTH_TOKEN is not set` rather than an opaque `sentry-cli` error.

Confirm afterwards that the artifacts landed in the right Sentry projects: the mapping in `woocommerce-android`, the Wear source bundle in `woocommerce-wear`.

### Images/gif

N/A.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
