### PR TITLE
[WOOMOB-3842] Use the locale's date order for Wear dates

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 
 25.5
 -----
+- [WEAR][*] Order and stats dates on the watch now follow the language's date order [https://github.com/woocommerce/woocommerce-android/pull/16429]
 - [Internal] Fixed duplicated device registration API calls fired concurrently during login [https://github.com/woocommerce/woocommerce-android/pull/16354]
 - [*] The Pay In Person toggle on the Payments screen no longer looks turned off when its status could not be loaded
 - [Internal] Woo POS: every POS analytics event now carries device_type (phone/tablet) and entry_point, so POS usage can be split by form factor and attributed to where POS was opened from [https://github.com/woocommerce/woocommerce-android/pull/16414]

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/wear/extensions/DateExt.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/wear/extensions/DateExt.kt
@@ -1,12 +1,14 @@
 package com.woocommerce.android.wear.extensions
 
+import android.text.format.DateFormat
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Date
 import java.util.Locale
 
-fun Date.formatToMMMddYYYY(locale: Locale = Locale.getDefault()): String = SimpleDateFormat(
-    "MMM d, yyyy",
+/** Abbreviated month, day and year in the locale's own order. */
+fun Date.formatToLocalizedMonthDayYear(locale: Locale = Locale.getDefault()): String = SimpleDateFormat(
+    DateFormat.getBestDateTimePattern(locale, "yMMMd"),
     locale
 ).format(this)
 

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/wear/ui/stats/range/TodayRangeData.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/wear/ui/stats/range/TodayRangeData.kt
@@ -1,7 +1,7 @@
 package com.woocommerce.android.wear.ui.stats.range
 
 import com.woocommerce.android.wear.extensions.endOfCurrentDay
-import com.woocommerce.android.wear.extensions.formatToMMMddYYYY
+import com.woocommerce.android.wear.extensions.formatToLocalizedMonthDayYear
 import com.woocommerce.android.wear.extensions.oneDayAgo
 import com.woocommerce.android.wear.extensions.startOfCurrentDay
 import com.woocommerce.android.wear.util.DateUtils
@@ -38,7 +38,7 @@ class TodayRangeData(
             start = currentStart,
             end = currentEnd
         )
-        formattedCurrentRange = referenceDate.formatToMMMddYYYY(locale)
+        formattedCurrentRange = referenceDate.formatToLocalizedMonthDayYear(locale)
 
         val yesterday = referenceDate.oneDayAgo()
         calendar.time = yesterday
@@ -47,6 +47,6 @@ class TodayRangeData(
             start = previousStart,
             end = yesterday
         )
-        formattedPreviousRange = yesterday.formatToMMMddYYYY(locale)
+        formattedPreviousRange = yesterday.formatToLocalizedMonthDayYear(locale)
     }
 }

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/wear/util/DateUtils.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/wear/util/DateUtils.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.wear.util
 
+import android.text.format.DateFormat
 import com.woocommerce.android.wear.ui.login.LoginRepository
 import org.wordpress.android.fluxc.utils.SiteUtils
 import org.wordpress.android.util.DateTimeUtils
@@ -19,8 +20,11 @@ class DateUtils @Inject constructor(
 ) {
     private val selectedSite get() = loginRepository.selectedSiteFlow.value
     private val yyyyMMddFormat = SimpleDateFormat("yyyy-MM-dd", locale)
-    private val friendlyMonthDayFormat = SimpleDateFormat("MMM d", locale)
-    private val friendlyMonthDayYearFormat = SimpleDateFormat("MMM d, yyyy", locale)
+    private val friendlyMonthDayFormat = localizedDateFormat("MMMd")
+    private val friendlyMonthDayYearFormat = localizedDateFormat("yMMMd")
+
+    private fun localizedDateFormat(skeleton: String) =
+        SimpleDateFormat(DateFormat.getBestDateTimePattern(locale, skeleton), locale)
 
     fun getFormattedDateWithSiteTimeZone(dateCreated: String): String? {
         val currentSiteDate = getCurrentDateInSiteTimeZone() ?: Date()


### PR DESCRIPTION
### Description

Fixes WOOMOB-3842

The Wear app formatted order and stats dates with fixed `MMM d` and `MMM d, yyyy` patterns, so every language got the month before the day. British English showed `Aug 17` where it should read `17 Aug`.

Both helpers now build their pattern with `DateFormat.getBestDateTimePattern`, the same approach the phone app took in https://github.com/woocommerce/woocommerce-android/pull/16346. The Wear module keeps its own copies of the date helpers, which is why that fix never reached it.

The formatters have no dedicated test: each is a single line handing a skeleton to `getBestDateTimePattern`, with no logic of its own to cover.

### Test Steps

1. Install the Wear app on a watch paired with a phone signed in to a store that has orders.
2. On the watch, set the app language to British English.
3. Open the Wear app.
4. Swipe to the order list.
5. Confirm this year's order dates read `17 Aug`, not `Aug 17`.
6. Confirm an order from a previous year reads `17 Aug 2025`, not `Aug 17, 2025`.

### Images/gif

British English order list.

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/822fd405-04b3-4d6b-9e95-fe2e404a6df2" width="400" /> | <img src="https://github.com/user-attachments/assets/cdf04e8d-a1d4-43a2-83ea-dc07ad5a6757" width="400" /> |

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
