### PR TITLE
[WOOMOB-995] Make GroupedProductListRepository#getProductList suspendable

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/grouped/GroupedProductListRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/grouped/GroupedProductListRepository.kt
@@ -6,7 +6,6 @@ import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.ContinuationWrapper
 import com.woocommerce.android.util.WooLog
-import kotlinx.coroutines.runBlocking
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
@@ -63,14 +62,12 @@ class GroupedProductListRepository @Inject constructor(
     /**
      * Returns all products for the [productIds] that are in the database
      */
-    fun getProductList(productIds: List<Long>): List<Product> {
+    suspend fun getProductList(productIds: List<Long>): List<Product> {
         return if (selectedSite.exists()) {
-            val wcProducts = runBlocking {
-                productStore.getProductsByRemoteIds(
-                    selectedSite.get(),
-                    remoteProductIds = productIds
-                )
-            }
+            val wcProducts = productStore.getProductsByRemoteIds(
+                selectedSite.get(),
+                remoteProductIds = productIds
+            )
             wcProducts.map { it.toAppModel() }
         } else {
             WooLog.w(WooLog.T.PRODUCTS, "No site selected - unable to load products")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/grouped/GroupedProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/grouped/GroupedProductListViewModel.kt
@@ -86,15 +86,17 @@ class GroupedProductListViewModel @Inject constructor(
     }
 
     private fun updateProductList() {
-        _productList.value = if (selectedProductIds.isNotEmpty()) {
-            groupedProductListRepository.getProductList(selectedProductIds)
-        } else {
-            emptyList()
-        }
+        launch {
+            _productList.value = if (selectedProductIds.isNotEmpty()) {
+                groupedProductListRepository.getProductList(selectedProductIds)
+            } else {
+                emptyList()
+            }
 
-        productListViewState = productListViewState.copy(
-            isEmptyViewShown = _productList.value?.isEmpty() ?: true
-        )
+            productListViewState = productListViewState.copy(
+                isEmptyViewShown = _productList.value?.isEmpty() ?: true
+            )
+        }
     }
 
     fun onAddProductButtonClicked() {
@@ -117,21 +119,23 @@ class GroupedProductListViewModel @Inject constructor(
     }
 
     private fun loadProducts(loadMore: Boolean = false) {
-        if (selectedProductIds.isEmpty()) {
-            _productList.value = emptyList()
-            productListViewState = productListViewState.copy(isSkeletonShown = false)
-        } else {
-            val productsInDb = groupedProductListRepository.getProductList(
-                selectedProductIds
-            )
-            if (productsInDb.isNotEmpty()) {
-                _productList.value = productsInDb
+        launch {
+            if (selectedProductIds.isEmpty()) {
+                _productList.value = emptyList()
                 productListViewState = productListViewState.copy(isSkeletonShown = false)
             } else {
-                productListViewState = productListViewState.copy(isSkeletonShown = true)
-            }
+                val productsInDb = groupedProductListRepository.getProductList(
+                    selectedProductIds
+                )
+                if (productsInDb.isNotEmpty()) {
+                    _productList.value = productsInDb
+                    productListViewState = productListViewState.copy(isSkeletonShown = false)
+                } else {
+                    productListViewState = productListViewState.copy(isSkeletonShown = true)
+                }
 
-            launch { fetchProducts(selectedProductIds, loadMore = loadMore) }
+                fetchProducts(selectedProductIds, loadMore = loadMore)
+            }
         }
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/grouped/GroupedProductListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/grouped/GroupedProductListViewModelTest.kt
@@ -8,6 +8,7 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions
 import org.junit.Test
+import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
@@ -22,7 +23,9 @@ class GroupedProductListViewModelTest : BaseUnitTest() {
     private val networkStatus: NetworkStatus = mock {
         on { isConnected() } doReturn true
     }
-    private val productRepository: GroupedProductListRepository = mock()
+    private val productRepository: GroupedProductListRepository = mock {
+        on { getProductList(any()) } doReturn emptyList()
+    }
     private val savedState = GroupedProductListFragmentArgs(
         remoteProductId = PRODUCT_REMOTE_ID,
         productIds = GROUPED_PRODUCT_IDS,


### PR DESCRIPTION
Fixes WOOMOB-995

### Description

`GroupedProductListRepository.getProductList` was non-suspend and wrapped the suspend `WCProductStore.getProductsByRemoteIds` in `runBlocking`, so reading the grouped and linked products out of Room blocked the main thread.

This PR makes the function suspend and removes the `runBlocking`. `fetchProductList` already called it from a coroutine. The two `GroupedProductListViewModel` callers, `loadProducts` and `updateProductList`, now run inside `launch`, and `loadProducts` no longer needs its nested `launch` for the fetch. Part of WOOMOB-983.

### Test Steps

Needs either a grouped product with at least two products in the group, or a product with at least two upsells. Both cards open the same screen.

1. Open the **Products** tab.
2. Open the product.
3. Tap the **Grouped products** card, or **Linked products** then **Upsells**.
4. Confirm the linked products are listed.
5. Tap the delete icon on one row.
6. Confirm that row disappears and the others stay.
7. Delete every remaining row.
8. Confirm the **No products yet** empty view appears.
9. Tap back to return to the previous screen.
10. Open the same card again.
11. Confirm the empty view is shown.
12. Tap **Add product**.
13. Select two products and confirm the selection.
14. Confirm both products appear in the list.
15. Tap back and discard the changes.

### Images/gif

N/A, no UI change.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
