### PR TITLE
[WOOMOB-3850] Follow the locale's date order in the remaining dashboard and payments dates

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/DateExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/DateExt.kt
@@ -43,10 +43,13 @@ fun Date.formatToYYYYWmm(locale: Locale = Locale.getDefault()): String = SimpleD
     locale
 ).format(this)
 
-fun Date.formatToMMMMdd(locale: Locale = Locale.getDefault()): String = SimpleDateFormat(
-    "MMMM dd",
-    locale
-).format(this)
+/**
+ * Formats the date to a full month and day string, e.g. "August 13" in English and "13 August" in British English.
+ */
+fun Date.formatToLocalizedFullMonthDay(): String {
+    val locale = Locale.getDefault()
+    return SimpleDateFormat(DateFormat.getBestDateTimePattern(locale, "MMMMd"), locale).format(this)
+}
 
 fun Date.formatToDD(locale: Locale = Locale.getDefault()): String = SimpleDateFormat(
     "d",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/DateExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/DateExt.kt
@@ -23,10 +23,10 @@ fun Date.formatToYYYYmm(locale: Locale = Locale.getDefault()): String = SimpleDa
 /**
  * Formats the date to a full month and year string, e.g. "August 2026" in English and "2026年8月" in Japanese.
  */
-fun Date.formatToLocalizedMonthYear(): String {
-    val locale = Locale.getDefault()
-    return SimpleDateFormat(DateFormat.getBestDateTimePattern(locale, "yMMMM"), locale).format(this)
-}
+fun Date.formatToLocalizedMonthYear(locale: Locale = Locale.getDefault()): String = SimpleDateFormat(
+    DateFormat.getBestDateTimePattern(locale, "yMMMM"),
+    locale
+).format(this)
 
 fun Date.formatToYYYYmmDD(locale: Locale = Locale.getDefault()): String = SimpleDateFormat(
     "yyyy-MM-dd",
@@ -46,10 +46,10 @@ fun Date.formatToYYYYWmm(locale: Locale = Locale.getDefault()): String = SimpleD
 /**
  * Formats the date to a full month and day string, e.g. "August 13" in English and "13 August" in British English.
  */
-fun Date.formatToLocalizedFullMonthDay(): String {
-    val locale = Locale.getDefault()
-    return SimpleDateFormat(DateFormat.getBestDateTimePattern(locale, "MMMMd"), locale).format(this)
-}
+fun Date.formatToLocalizedFullMonthDay(locale: Locale = Locale.getDefault()): String = SimpleDateFormat(
+    DateFormat.getBestDateTimePattern(locale, "MMMMd"),
+    locale
+).format(this)
 
 fun Date.formatToDD(locale: Locale = Locale.getDefault()): String = SimpleDateFormat(
     "d",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/DateExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/DateExt.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.icu.text.DateIntervalFormat
 import android.icu.util.DateInterval
 import android.text.format.DateFormat
-import java.text.DateFormatSymbols
 import java.text.SimpleDateFormat
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
@@ -92,14 +91,6 @@ fun Date.formatToLocalizedMedium(locale: Locale = Locale.getDefault()): String =
 fun Date.formatToLocalizedMediumWithTime(locale: Locale = Locale.getDefault()): String = SimpleDateFormat
     .getDateTimeInstance(SimpleDateFormat.MEDIUM, SimpleDateFormat.SHORT, locale)
     .format(this)
-
-fun Date.formatToEEEEMMMddhha(locale: Locale): String {
-    val symbols = DateFormatSymbols(locale)
-    symbols.amPmStrings = arrayOf("am", "pm")
-    val dateFormat = SimpleDateFormat("EEEE, MMM dd › ha", locale)
-    dateFormat.dateFormatSymbols = symbols
-    return dateFormat.format(this)
-}
 
 fun Date.getTimeString(context: Context): String = DateFormat.getTimeFormat(context).format(this.time)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/DateExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/DateExt.kt
@@ -21,10 +21,13 @@ fun Date.formatToYYYYmm(locale: Locale = Locale.getDefault()): String = SimpleDa
     locale
 ).format(this)
 
-fun Date.formatToMMMMyyyy(locale: Locale = Locale.getDefault()): String = SimpleDateFormat(
-    "MMMM yyyy",
-    locale
-).format(this)
+/**
+ * Formats the date to a full month and year string, e.g. "August 2026" in English and "2026年8月" in Japanese.
+ */
+fun Date.formatToLocalizedMonthYear(): String {
+    val locale = Locale.getDefault()
+    return SimpleDateFormat(DateFormat.getBestDateTimePattern(locale, "yMMMM"), locale).format(this)
+}
 
 fun Date.formatToYYYYmmDD(locale: Locale = Locale.getDefault()): String = SimpleDateFormat(
     "yyyy-MM-dd",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/DateExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/DateExt.kt
@@ -64,11 +64,6 @@ fun Date.formatToLocalizedMonthDay(locale: Locale = Locale.getDefault()): String
     locale
 ).format(this)
 
-fun Date.formatToDDMMMYYYY(locale: Locale = Locale.getDefault()): String = SimpleDateFormat(
-    "dd MMM yyyy",
-    locale
-).format(this)
-
 /**
  * Formats the date to an abbreviated month, day and year string, e.g. "Aug 3, 2026" in English and
  * "3. Aug. 2026" in German. Pairs with [formatToLocalizedMonthDay], which keeps the month name in every locale.

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/StringDateFormatExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/StringDateFormatExt.kt
@@ -51,21 +51,6 @@ fun String.formatDateToWeeksInYear(locale: Locale = Locale.getDefault()): String
 }
 
 /**
- * Method to convert month string from yyyy-MM-dd HH format to EEEE, MMM dd›hha
- * i.e. 2018-08-08 07 is formatted to Wednesday, Aug 08›7am
- */
-@Throws(IllegalArgumentException::class)
-fun String.formatDateToFriendlyDayHour(locale: Locale = Locale.getDefault()): String? {
-    return try {
-        val originalFormat = SimpleDateFormat("yyyy-MM-dd HH", locale)
-        val date = originalFormat.parse(this)
-        date?.formatToEEEEMMMddhha(locale)
-    } catch (e: Exception) {
-        throw IllegalArgumentException("Date string argument is not of format yyyy-MM-dd HH: $this")
-    }
-}
-
-/**
  * Method to convert month string from yyyy-MM-dd format to MMMM
  * i.e. 2019-08-08 is formatted to 2019›August
  */
@@ -74,21 +59,6 @@ fun String.formatDateToFriendlyLongMonthYear(locale: Locale = Locale.getDefault(
     return try {
         val (year, month, _) = this.split("-")
         "$year › ${DateFormatSymbols(locale).months[month.toInt() - 1]}"
-    } catch (e: Exception) {
-        throw IllegalArgumentException("Date string argument is not of format yyyy-MM-dd: $this")
-    }
-}
-
-/**
- * Method to convert month string from yyyy-MM-dd format to MMMM dd
- * i.e. 2019-08-08 is formatted to August 08
- */
-@Throws(IllegalArgumentException::class)
-fun String.formatDateToFriendlyLongMonthDate(locale: Locale = Locale.getDefault()): String {
-    return try {
-        val (year, month, day) = this.split("-")
-        val date = GregorianCalendar(year.toInt(), month.toInt() - 1, day.toInt()).time
-        date.formatToMMMMdd(locale)
     } catch (e: Exception) {
         throw IllegalArgumentException("Date string argument is not of format yyyy-MM-dd: $this")
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/domain/DashboardDateRangeFormatter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/domain/DashboardDateRangeFormatter.kt
@@ -3,7 +3,7 @@ package com.woocommerce.android.ui.dashboard.domain
 import android.icu.text.SimpleDateFormat
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
-import com.woocommerce.android.extensions.formatToMMMMyyyy
+import com.woocommerce.android.extensions.formatToLocalizedMonthYear
 import com.woocommerce.android.extensions.formatToYYYY
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType
@@ -19,7 +19,7 @@ class DashboardDateRangeFormatter @Inject constructor(private val dateUtils: Dat
 
         return when (rangeSelection.selectionType) {
             SelectionType.TODAY -> dateFormatter.format(startDate)
-            SelectionType.MONTH_TO_DATE -> startDate.formatToMMMMyyyy()
+            SelectionType.MONTH_TO_DATE -> startDate.formatToLocalizedMonthYear()
             SelectionType.YEAR_TO_DATE -> startDate.formatToYYYY()
             SelectionType.WEEK_TO_DATE, SelectionType.CUSTOM ->
                 "${dateFormatter.format(startDate)} – ${dateFormatter.format(endDate)}"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingViewModel.kt
@@ -7,7 +7,7 @@ import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.di.PointOfSaleMode
 import com.woocommerce.android.di.StoreManagementMode
-import com.woocommerce.android.extensions.formatToMMMMdd
+import com.woocommerce.android.extensions.formatToLocalizedFullMonthDay
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.payments.cardreader.LearnMoreUrlProvider
@@ -483,5 +483,5 @@ class CardReaderOnboardingViewModel @Inject constructor(
         Locale.Builder().setRegion(countryCode.orEmpty()).build().displayName
 
     private fun formatDueDate(state: StripeAccountPendingRequirement) =
-        state.dueDate?.let { Date(it * UNIX_TO_JAVA_TIMESTAMP_OFFSET).formatToMMMMdd() }
+        state.dueDate?.let { Date(it * UNIX_TO_JAVA_TIMESTAMP_OFFSET).formatToLocalizedFullMonthDay() }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/payoutsummary/PaymentsHubPayoutSummaryStateMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/payoutsummary/PaymentsHubPayoutSummaryStateMapper.kt
@@ -1,6 +1,6 @@
 package com.woocommerce.android.ui.payments.hub.payoutsummary
 
-import com.woocommerce.android.extensions.formatToDDMMMYYYY
+import com.woocommerce.android.extensions.formatToLocalizedMonthDayYear
 import com.woocommerce.android.util.CurrencyFormatter
 import org.wordpress.android.fluxc.model.payments.woo.WooPaymentsDepositsOverview
 import java.util.Date
@@ -8,7 +8,7 @@ import javax.inject.Inject
 
 class PaymentsHubPayoutSummaryStateMapper @Inject constructor(
     private val currencyFormatter: CurrencyFormatter,
-    private val dateFormatter: DateToDDMMMYYYYStringFormatter
+    private val dateFormatter: PayoutDateStringFormatter
 ) {
     fun mapPayoutOverviewToViewModelOverviews(
         overview: WooPaymentsDepositsOverview
@@ -104,6 +104,6 @@ class PaymentsHubPayoutSummaryStateMapper @Inject constructor(
     }
 }
 
-class DateToDDMMMYYYYStringFormatter @Inject constructor() {
-    operator fun invoke(date: Date): String = date.formatToDDMMMYYYY()
+class PayoutDateStringFormatter @Inject constructor() {
+    operator fun invoke(date: Date): String = date.formatToLocalizedMonthDayYear()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosOnboardingErrorMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosOnboardingErrorMapper.kt
@@ -1,7 +1,7 @@
 package com.woocommerce.android.ui.woopos.cardreader.connection
 
 import com.woocommerce.android.R
-import com.woocommerce.android.extensions.formatToMMMMdd
+import com.woocommerce.android.extensions.formatToLocalizedFullMonthDay
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboardingState
 import com.woocommerce.android.ui.payments.cardreader.onboarding.PluginType.STRIPE_EXTENSION_GATEWAY
 import com.woocommerce.android.ui.payments.cardreader.onboarding.PluginType.WOOCOMMERCE_PAYMENTS
@@ -88,7 +88,7 @@ class WooPosOnboardingErrorMapper @Inject constructor(
 
             is CardReaderOnboardingState.StripeAccountPendingRequirement -> {
                 val message = if (state.dueDate != null) {
-                    val formattedDate = Date(state.dueDate * MILLIS_PER_SECOND).formatToMMMMdd()
+                    val formattedDate = Date(state.dueDate * MILLIS_PER_SECOND).formatToLocalizedFullMonthDay()
                     resourceProvider.getString(
                         R.string.card_reader_onboarding_account_pending_requirements_hint,
                         formattedDate

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
@@ -34,7 +34,7 @@ class DateUtils @Inject constructor(
     private val friendlyTimeFormat: SimpleDateFormat
         get() = SimpleDateFormat("h:mm a", locale)
     private val friendlyLongMonthDayFormat: SimpleDateFormat
-        get() = SimpleDateFormat("MMMM dd", locale)
+        get() = SimpleDateFormat(DateFormat.getBestDateTimePattern(locale, "MMMMd"), locale)
 
     private val weekOfYearStartingMondayFormat: SimpleDateFormat
         get() = SimpleDateFormat("yyyy-ww", locale).apply {
@@ -129,7 +129,7 @@ class DateUtils @Inject constructor(
     }
 
     /**
-     * Given an ISO8601 date of format YYYY-MM-DD, returns the String in long month ("MMMM dd") format.
+     * Given an ISO8601 date of format YYYY-MM-DD, returns the String with the full month name and day.
      *
      * For example, given 2018-07-03 returns "July 3", and given 2018-07-28 returns "July 28".
      *

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
@@ -3,7 +3,6 @@ package com.woocommerce.android.util
 import android.content.Context
 import android.text.format.DateFormat
 import com.automattic.android.tracks.crashlogging.CrashLogging
-import com.woocommerce.android.extensions.formatToEEEEMMMddhha
 import com.woocommerce.android.extensions.formatToYYYYmm
 import com.woocommerce.android.extensions.formatToYYYYmmDD
 import com.woocommerce.android.tools.SelectedSite
@@ -311,9 +310,9 @@ class DateUtils @Inject constructor(
     }
 
     /**
-     * Given an ISO8601 date of format YYYY-MM-DD HH, returns the day String in ("EEEE, MMM dd › ha") format.
+     * Given an ISO8601 date of format YYYY-MM-DD HH, returns the String with the weekday, month, day and hour.
      *
-     * For example, given 2023-12-27 12 returns "Wednesday, Dec 27 > 12 am"
+     * For example, given 2023-12-27 12 returns "Wednesday, Dec 27 › 12pm"
      *
      * return null if the argument is not a valid iso8601 date string or not in the expected format.
      */
@@ -321,14 +320,22 @@ class DateUtils @Inject constructor(
         return try {
             val originalFormat = SimpleDateFormat("yyyy-MM-dd HH", locale)
             val date = originalFormat.parse(iso8601Date)
-            date!!.formatToEEEEMMMddhha(locale)
+            date!!.toFriendlyDayHourString()
         } catch (e: Exception) {
             findMatchingDatePattern(iso8601Date)
-                ?.formatToEEEEMMMddhha(locale)
+                ?.toFriendlyDayHourString()
                 .also {
                     if (it == null) "Date string argument is not of format yyyy-MM-dd HH: $iso8601Date".reportAsError(e)
                 }
         }
+    }
+
+    private fun Date.toFriendlyDayHourString(): String {
+        val symbols = DateFormatSymbols(locale)
+        symbols.amPmStrings = arrayOf("am", "pm")
+        val dateFormat = SimpleDateFormat("${DateFormat.getBestDateTimePattern(locale, "EEEEMMMd")} › ha", locale)
+        dateFormat.dateFormatSymbols = symbols
+        return dateFormat.format(this)
     }
 
     /**

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
@@ -39,10 +39,12 @@ import com.woocommerce.android.ui.payments.cardreader.onboarding.PluginType.STRI
 import com.woocommerce.android.ui.payments.cardreader.onboarding.PluginType.WOOCOMMERCE_PAYMENTS
 import com.woocommerce.android.ui.payments.hub.PaymentsHubViewModel.CashOnDeliverySource.ONBOARDING
 import com.woocommerce.android.ui.payments.tracking.PaymentsFlowTracker
+import com.woocommerce.android.util.LocalizedDatePatternsTestRule
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
 import org.junit.Test
 import org.mockito.ArgumentMatchers
 import org.mockito.kotlin.any
@@ -65,6 +67,9 @@ import kotlin.test.assertTrue
 
 @ExperimentalCoroutinesApi
 class CardReaderOnboardingViewModelTest : BaseUnitTest() {
+    @get:Rule
+    val localizedDatePatterns = LocalizedDatePatternsTestRule()
+
     private val onboardingChecker: CardReaderOnboardingChecker = mock()
     private val tracker: PaymentsFlowTracker = mock()
     private val selectedSite: SelectedSite = mock {
@@ -1872,7 +1877,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
             ).isEqualTo(
                 UiString.UiStringRes(
                     R.string.card_reader_onboarding_account_pending_requirements_hint,
-                    listOf(UiString.UiStringText("January 01"))
+                    listOf(UiString.UiStringText("January 1"))
                 )
             )
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/hub/payoutsummary/PaymentsHubPayoutSummaryStateMapperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/hub/payoutsummary/PaymentsHubPayoutSummaryStateMapperTest.kt
@@ -21,7 +21,7 @@ class PaymentsHubPayoutSummaryStateMapperTest {
         on { formatCurrencyGivenInTheSmallestCurrencyUnit(250, "RUB") }.thenReturn("250R")
         on { formatCurrencyGivenInTheSmallestCurrencyUnit(0, "RUB") }.thenReturn("0R")
     }
-    private val dateFormatter: DateToDDMMMYYYYStringFormatter = mock()
+    private val dateFormatter: PayoutDateStringFormatter = mock()
     private val mapper = PaymentsHubPayoutSummaryStateMapper(
         currencyFormatter,
         dateFormatter,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/DateUtilsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/DateUtilsTest.kt
@@ -37,6 +37,7 @@ class DateUtilsTest {
         whenever(DateFormat.getBestDateTimePattern(any(), eq("MMMd"))).thenReturn("MMM d")
         whenever(DateFormat.getBestDateTimePattern(any(), eq("yMMMd"))).thenReturn("MMM d, y")
         whenever(DateFormat.getBestDateTimePattern(any(), eq("EEEEMMMd"))).thenReturn("EEEE, MMM d")
+        whenever(DateFormat.getBestDateTimePattern(any(), eq("MMMMd"))).thenReturn("MMMM d")
 
         dateUtilsUnderTest = DateUtils(
             Locale.US,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/DateUtilsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/DateUtilsTest.kt
@@ -2,8 +2,6 @@ package com.woocommerce.android.util
 
 import android.text.format.DateFormat
 import com.automattic.android.tracks.crashlogging.CrashLogging
-import com.woocommerce.android.extensions.formatDateToFriendlyDayHour
-import com.woocommerce.android.extensions.formatDateToFriendlyLongMonthDate
 import com.woocommerce.android.extensions.formatDateToFriendlyLongMonthYear
 import com.woocommerce.android.extensions.formatDateToWeeksInYear
 import com.woocommerce.android.extensions.formatDateToYear
@@ -357,34 +355,6 @@ class DateUtilsTest {
     }
 
     @Test
-    fun `formatDateToDayHour() returns correct values`() {
-        assertEquals("Thursday, Aug 08 › 7am", "2019-08-08 07".formatDateToFriendlyDayHour(Locale.US))
-        assertEquals("Thursday, Aug 08 › 11pm", "2019-08-08 23".formatDateToFriendlyDayHour(Locale.US))
-        assertEquals("Wednesday, Jan 02 › 12am", "2019-01-02 00".formatDateToFriendlyDayHour(Locale.US))
-        assertEquals("Tuesday, Jun 04 › 1am", "2019-06-04 01".formatDateToFriendlyDayHour(Locale.US))
-        assertEquals("Monday, Sep 09 › 1pm", "2019-09-09 13".formatDateToFriendlyDayHour(Locale.US))
-        assertEquals("Saturday, Dec 22 › 5pm", "2018-12-22 17".formatDateToFriendlyDayHour(Locale.US))
-
-        // Test for invalid value handling
-        assertFailsWith(IllegalArgumentException::class) {
-            "2019".formatDateToFriendlyDayHour(Locale.US)
-        }
-
-        assertFailsWith(IllegalArgumentException::class) {
-            "20-W12".formatDateToFriendlyDayHour(Locale.US)
-        }
-
-        // Test for invalid value handling
-        assertFailsWith(IllegalArgumentException::class) {
-            "".formatDateToFriendlyDayHour(Locale.US)
-        }
-
-        assertFailsWith(IllegalArgumentException::class) {
-            "21".formatDateToFriendlyDayHour(Locale.US)
-        }
-    }
-
-    @Test
     fun `formatDateToFriendlyLongMonth() returns correct values`() {
         assertEquals("2019 › August", "2019-08-02".formatDateToFriendlyLongMonthYear(Locale.US))
         assertEquals("2019 › January", "2019-01-02".formatDateToFriendlyLongMonthYear(Locale.US))
@@ -410,34 +380,6 @@ class DateUtilsTest {
 
         assertFailsWith(IllegalArgumentException::class) {
             "21".formatDateToFriendlyLongMonthYear(Locale.US)
-        }
-    }
-
-    @Test
-    fun `formatDateToFriendlyLongMonthDate() returns correct values`() {
-        assertEquals("August 08", "2019-08-08".formatDateToFriendlyLongMonthDate(Locale.US))
-        assertEquals("February 23", "2019-02-23".formatDateToFriendlyLongMonthDate(Locale.US))
-        assertEquals("January 02", "2019-01-02".formatDateToFriendlyLongMonthDate(Locale.US))
-        assertEquals("June 04", "2019-06-04".formatDateToFriendlyLongMonthDate(Locale.US))
-        assertEquals("September 09", "2019-09-09".formatDateToFriendlyLongMonthDate(Locale.US))
-        assertEquals("December 22", "2018-12-22".formatDateToFriendlyLongMonthDate(Locale.US))
-
-        // Test for invalid value handling
-        assertFailsWith(IllegalArgumentException::class) {
-            "2019".formatDateToFriendlyLongMonthDate(Locale.US)
-        }
-
-        assertFailsWith(IllegalArgumentException::class) {
-            "20-W12".formatDateToFriendlyLongMonthDate(Locale.US)
-        }
-
-        // Test for invalid value handling
-        assertFailsWith(IllegalArgumentException::class) {
-            "".formatDateToFriendlyLongMonthDate(Locale.US)
-        }
-
-        assertFailsWith(IllegalArgumentException::class) {
-            "21".formatDateToFriendlyLongMonthDate(Locale.US)
         }
     }
 
@@ -492,7 +434,7 @@ class DateUtilsTest {
     fun `getFriendlyDayHourString() with a valid date returns correct value`() {
         // getFriendlyDayHourString returns the expected value
         val stringDate = "2023-12-27 12"
-        assertEquals(dateUtilsUnderTest.getFriendlyDayHourString(stringDate), stringDate.formatDateToFriendlyDayHour())
+        assertEquals("Wednesday, Dec 27 › 12pm", dateUtilsUnderTest.getFriendlyDayHourString(stringDate))
     }
 
     @Test
@@ -533,10 +475,7 @@ class DateUtilsTest {
     fun `getLongMonthDayString() with a valid date returns correct value`() {
         // getLongMonthDayString returns the expected value
         val stringDate = "2023-12-27"
-        assertEquals(
-            dateUtilsUnderTest.getLongMonthDayString(stringDate),
-            stringDate.formatDateToFriendlyLongMonthDate()
-        )
+        assertEquals("December 27", dateUtilsUnderTest.getLongMonthDayString(stringDate))
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/LocalizedDatePatternsTestRule.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/LocalizedDatePatternsTestRule.kt
@@ -32,6 +32,7 @@ class LocalizedDatePatternsTestRule : TestWatcher() {
         whenever(DateFormat.getBestDateTimePattern(any(), eq("MMMd"))).thenReturn("MMM d")
         whenever(DateFormat.getBestDateTimePattern(any(), eq("yMMMd"))).thenReturn("MMM d, y")
         whenever(DateFormat.getBestDateTimePattern(any(), eq("EEEEMMMd"))).thenReturn("EEEE, MMM d")
+        whenever(DateFormat.getBestDateTimePattern(any(), eq("MMMMd"))).thenReturn("MMMM d")
 
         dateInterval = Mockito.mockConstruction(DateInterval::class.java, lenient) { mock, context ->
             whenever(mock.fromDate).thenReturn(context.arguments()[0] as Long)


### PR DESCRIPTION
Fixes WOOMOB-3850

### Description

WOOMOB-3262 moved the app's dates to locale-aware patterns, but four spots kept a fixed one. Three were pinned to the American order, so British English read `August 03` where the language calls for `3 August`. The payout date on the Payments screen was pinned the other way, to `dd MMM yyyy`, so American English read `11 Aug 2026` instead of `Aug 11, 2026`.

This branch targets [#16416](https://github.com/woocommerce/woocommerce-android/pull/16416), both touch `DateExt.kt` and the shared test rule.

The performance card's month title, its month and today chart labels and the payments onboarding due date now build their pattern from a CLDR skeleton, `yMMMM`, `MMMMd` and `EEEEMMMd`. The payout date moves to the existing `formatToLocalizedMonthDayYear`, the same `yMMMd` skeleton the analytics single dates use.

The month title only changes where the language puts the year first, Japanese reads `2026年8月` instead of `8月 2026`.

Days lose their zero padding, since the skeletons resolve to a single `d`. American English now reads `August 6` where it read `August 08` before.

The four pattern-named helpers this replaces are gone along with two string extensions that wrapped them, none had other callers.

### Test Steps

**Dashboard, British English**

1. Set the app language to English (United Kingdom) from the system settings.
2. Open My store.
3. Tap the date range selector on the Performance card.
4. Tap This Month.
5. Tap a point on the chart.
6. Confirm the label starts with the day, e.g. `3 August`.
7. Tap the date range selector.
8. Tap Today.
9. Tap a point on the chart.
10. Confirm the label starts with the day.

**Dashboard, Japanese**

1. Set the app language to Japanese from the system settings.
2. Open My store.
3. Tap the date range selector on the Performance card.
4. Tap This Month.
5. Confirm the title reads `2026年8月`.

### Images/gif

| | Before | After |
|---|---|---|
| Performance card, month day (en-GB) | <img src="https://github.com/user-attachments/assets/8dc6e337-1b37-4154-bd34-80d2f254fb31" width="400" /> | <img src="https://github.com/user-attachments/assets/47418d89-cddf-4e9c-92dd-410c5c876d48" width="400" /> |
| Performance card, hourly (en-GB) | <img src="https://github.com/user-attachments/assets/3931ed61-54f9-4aa7-a7c4-2f5609e8a640" width="400" /> | <img src="https://github.com/user-attachments/assets/a21b6b1e-f59c-4bc9-bfa9-d6a16b3455e5" width="400" /> |
| Performance card, month title (Japanese) | <img src="https://github.com/user-attachments/assets/40f9f349-580b-4b07-bb38-6982fc163e2f" width="400" /> | <img src="https://github.com/user-attachments/assets/580ca8ae-f1d5-47b9-bef7-597459adfe70" width="400" /> |
| Payments onboarding due date (en-GB) | <img src="https://github.com/user-attachments/assets/8799f5dd-cebd-4855-8b00-041a3a3807cc" width="400" /> | <img src="https://github.com/user-attachments/assets/13a6cd80-e145-4448-a2d6-cb3b30bea32a" width="400" /> |
| Payments payout date (en-US) | <img src="https://github.com/user-attachments/assets/3a7f191d-44b6-4bfd-832b-fc6875caa89c" width="400" /> | <img src="https://github.com/user-attachments/assets/a8854031-6b80-43f3-8fb1-e50fa294c2f2" width="400" /> |

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
