### PR TITLE
[WOOMOB-994] Make blocking ProductDetailRepository functions suspendable

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationScreen.kt
@@ -143,12 +143,14 @@ fun TargetUrlDialog(
                 mutableStateOf(viewState.targetUrl)
             }
 
-            UrlOption(
-                url = viewState.productUrl,
-                targetUrl = targetUrl,
-                title = R.string.blaze_campaign_edit_ad_destination_product_url_option
-            ) {
-                targetUrl = viewState.productUrl
+            viewState.productUrl?.let { productUrl ->
+                UrlOption(
+                    url = productUrl,
+                    targetUrl = targetUrl,
+                    title = R.string.blaze_campaign_edit_ad_destination_product_url_option
+                ) {
+                    targetUrl = productUrl
+                }
             }
 
             UrlOption(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationViewModel.kt
@@ -14,6 +14,7 @@ import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
@@ -24,12 +25,11 @@ class BlazeCampaignCreationAdDestinationViewModel @Inject constructor(
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
 ) : ScopedViewModel(savedStateHandle) {
     private val navArgs: BlazeCampaignCreationAdDestinationFragmentArgs by savedStateHandle.navArgs()
-    private val productUrl = requireNotNull(productDetailRepository.getProduct(navArgs.productId)).permalink
-    private val initialDestinationValues: ViewState
+    private val initialDestination = navArgs.destinationParameters
 
     private val _viewState = MutableStateFlow(
         ViewState(
-            productUrl = productUrl,
+            productUrl = "",
             siteUrl = selectedSite.get().url,
             targetUrl = navArgs.destinationParameters.targetUrl,
             parameters = navArgs.destinationParameters.parameters,
@@ -40,14 +40,18 @@ class BlazeCampaignCreationAdDestinationViewModel @Inject constructor(
     val viewState = _viewState.asLiveData()
 
     init {
-        initialDestinationValues = _viewState.value
+        launch {
+            val productUrl = requireNotNull(productDetailRepository.getProduct(navArgs.productId)).permalink
+            _viewState.update { it.copy(productUrl = productUrl) }
+        }
     }
 
     fun onBackPressed() {
-        if (initialDestinationValues != _viewState.value) {
+        val currentDestination = DestinationParameters(_viewState.value.targetUrl, _viewState.value.parameters)
+        if (initialDestination != currentDestination) {
             analyticsTrackerWrapper.track(stat = BLAZE_CREATION_EDIT_DESTINATION_SAVE_TAPPED)
         }
-        triggerEvent(ExitWithResult(DestinationParameters(_viewState.value.targetUrl, _viewState.value.parameters)))
+        triggerEvent(ExitWithResult(currentDestination))
     }
 
     fun onUrlPropertyTapped() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationViewModel.kt
@@ -29,7 +29,7 @@ class BlazeCampaignCreationAdDestinationViewModel @Inject constructor(
 
     private val _viewState = MutableStateFlow(
         ViewState(
-            productUrl = "",
+            productUrl = null,
             siteUrl = selectedSite.get().url,
             targetUrl = navArgs.destinationParameters.targetUrl,
             parameters = navArgs.destinationParameters.parameters,
@@ -75,7 +75,7 @@ class BlazeCampaignCreationAdDestinationViewModel @Inject constructor(
     }
 
     data class ViewState(
-        val productUrl: String,
+        val productUrl: String?,
         val siteUrl: String,
         val targetUrl: String,
         val parameters: Map<String, String>,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/media/MediaFileUploadHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/media/MediaFileUploadHandler.kt
@@ -65,7 +65,7 @@ class MediaFileUploadHandler @Inject constructor(
             .launchIn(appCoroutineScope)
     }
 
-    private fun handleMediaUploadEvent(event: Event.MediaUploadEvent) {
+    private suspend fun handleMediaUploadEvent(event: Event.MediaUploadEvent) {
         val statusList = uploadsStatus.value.toMutableList()
         val index = statusList.indexOfFirst {
             it.remoteProductId == event.productId && it.localUri == event.localUri
@@ -76,6 +76,7 @@ class MediaFileUploadHandler @Inject constructor(
         }
 
         val newStatus = event.toStatus()
+        var shouldNotifyFailure = false
 
         when (event) {
             is Event.MediaUploadEvent.FetchSucceeded -> {
@@ -84,7 +85,7 @@ class MediaFileUploadHandler @Inject constructor(
 
             is Event.MediaUploadEvent.FetchFailed -> {
                 statusList[index] = newStatus
-                showUploadFailureNotifIfNoObserver(event.productId, statusList)
+                shouldNotifyFailure = true
             }
 
             is Event.MediaUploadEvent.UploadSucceeded -> {
@@ -108,10 +109,14 @@ class MediaFileUploadHandler @Inject constructor(
                         AnalyticsTracker.KEY_ERROR_DESC to event.error.message
                     )
                 )
-                showUploadFailureNotifIfNoObserver(event.productId, statusList)
+                shouldNotifyFailure = true
             }
         }
         uploadsStatus.value = statusList
+
+        if (shouldNotifyFailure) {
+            showUploadFailureNotifIfNoObserver(event.productId, statusList)
+        }
     }
 
     private fun enqueueMediaUpload(event: Event.MediaUploadEvent.FetchSucceeded) {
@@ -154,7 +159,7 @@ class MediaFileUploadHandler @Inject constructor(
             }
     }
 
-    private fun showUploadFailureNotifIfNoObserver(productId: Long, state: List<ProductImageUploadData>) {
+    private suspend fun showUploadFailureNotifIfNoObserver(productId: Long, state: List<ProductImageUploadData>) {
         if (!externalObservers.contains(productId)) {
             WooLog.d(WooLog.T.MEDIA, "MediaFileUploadHandler -> post upload failure notification")
             val errors = state.filter { it.remoteProductId == productId && it.uploadStatus is UploadStatus.Failed }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/configuration/GetChildrenProductInfo.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/configuration/GetChildrenProductInfo.kt
@@ -4,6 +4,8 @@ import com.woocommerce.android.ui.products.GetBundledProducts
 import com.woocommerce.android.ui.products.ProductType
 import com.woocommerce.android.ui.products.details.ProductDetailRepository
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
@@ -12,8 +14,8 @@ class GetChildrenProductInfo @Inject constructor(
     private val productDetailRepository: ProductDetailRepository,
     private val getBundledProducts: GetBundledProducts
 ) {
-    operator fun invoke(productId: Long): Flow<Map<Long, ProductInfo>> {
-        return productDetailRepository.getProduct(productId)
+    operator fun invoke(productId: Long): Flow<Map<Long, ProductInfo>> = flow {
+        val childrenProductInfo = productDetailRepository.getProduct(productId)
             ?.takeIf { it.productType == ProductType.BUNDLE }
             ?.let { getBundledProducts(productId) }
             ?.map { products ->
@@ -26,5 +28,6 @@ class GetChildrenProductInfo @Inject constructor(
                     )
                 }.associateBy { it.id }
             } ?: flowOf(emptyMap())
+        emitAll(childrenProductInfo)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -1056,7 +1056,7 @@ class OrderDetailViewModel @Inject constructor(
                 is OrderProduct.ProductItem -> first.product.productId
             }
 
-            val product = productDetailRepository.getProductAsync(firstProductId)
+            val product = productDetailRepository.getProduct(firstProductId)
             product?.let {
                 triggerEvent(
                     OrderNavigationTarget.AIThankYouNote(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
@@ -365,7 +365,7 @@ class EditShippingLabelPackagesViewModel @Inject constructor(
         triggerEvent(Exit)
     }
 
-    private fun Order.getShippableItems(): List<Order.Item> {
+    private suspend fun Order.getShippableItems(): List<Order.Item> {
         val refunds = orderDetailRepository.getOrderRefunds(id)
         return refunds.getNonRefundedProducts(items)
             .filter {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/GetShipments.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/GetShipments.kt
@@ -21,7 +21,7 @@ class GetShipments @Inject constructor(
         val noRefundedProducts = refunds.getNonRefundedProducts(order.items)
 
         val orderItems = noRefundedProducts.mapNotNull { item ->
-            val product = productDetailRepository.getProductAsync(item.productId)
+            val product = productDetailRepository.getProduct(item.productId)
             if (product != null && !product.isSampleProduct && !product.isVirtual) {
                 ShippableItemModel(
                     itemId = item.itemId,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductInventoryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductInventoryViewModel.kt
@@ -84,13 +84,13 @@ class ProductInventoryViewModel @Inject constructor(
             if (sku == originalSku) {
                 clearSkuError()
             } else {
-                if (!productRepository.isSkuAvailableLocally(sku)) {
-                    showSkuError()
-                } else {
-                    clearSkuError()
-                }
-
                 skuVerificationJob = launch {
+                    if (!productRepository.isSkuAvailableLocally(sku)) {
+                        showSkuError()
+                    } else {
+                        clearSkuError()
+                    }
+
                     delay(AppConstants.SEARCH_TYPING_DELAY_MS)
 
                     productRepository.isSkuAvailableRemotely(sku)?.let { isRemotelyAvailable ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailRepository.kt
@@ -128,10 +128,10 @@ class ProductDetailRepository @Inject constructor(
      */
     suspend fun updateProduct(updatedProductAggregate: ProductAggregate): Pair<Boolean, WCProductStore.ProductError?> {
         return try {
+            val cachedProduct = getCachedWCProductModel(updatedProductAggregate.remoteId)
             suspendCoroutineWithTimeout<Pair<Boolean, WCProductStore.ProductError?>>(AppConstants.REQUEST_TIMEOUT) {
                 continuationUpdateProduct = it
 
-                val cachedProduct = getCachedWCProductModel(updatedProductAggregate.remoteId)
                 val product = updatedProductAggregate.product.toDataModel(cachedProduct)
                 val metadataChanges = MetadataChanges(
                     // Even though the subscription keys are passed as new metadata here, the server will replace any
@@ -335,10 +335,10 @@ class ProductDetailRepository @Inject constructor(
         return wooResult.model?.map { it.toAppModel() } ?: emptyList()
     }
 
-    private fun getCachedWCProductModel(remoteProductId: Long) =
-        productStore.getProductByRemoteId(selectedSite.get(), remoteProductId)
+    private suspend fun getCachedWCProductModel(remoteProductId: Long) =
+        productStore.getProduct(selectedSite.get(), remoteProductId)
 
-    fun getProduct(remoteProductId: Long): Product? = getCachedWCProductModel(remoteProductId)?.toAppModel()
+    suspend fun getProduct(remoteProductId: Long): Product? = getCachedWCProductModel(remoteProductId)?.toAppModel()
 
     suspend fun getProductAsync(remoteProductId: Long): Product? = withContext(coroutineDispatchers.io) {
         getCachedWCProductModel(remoteProductId)?.toAppModel()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailRepository.kt
@@ -21,7 +21,6 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.ContinuationWrapper
 import com.woocommerce.android.util.ContinuationWrapper.ContinuationResult.Cancellation
 import com.woocommerce.android.util.ContinuationWrapper.ContinuationResult.Success
-import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T.PRODUCTS
 import com.woocommerce.android.util.suspendCoroutineWithTimeout
@@ -63,8 +62,7 @@ class ProductDetailRepository @Inject constructor(
     private val productStore: WCProductStore,
     private val globalAttributeStore: WCGlobalAttributeStore,
     private val selectedSite: SelectedSite,
-    private val taxStore: WCTaxStore,
-    private val coroutineDispatchers: CoroutineDispatchers
+    private val taxStore: WCTaxStore
 ) {
     private var continuationUpdateProduct: Continuation<Pair<Boolean, WCProductStore.ProductError?>>? = null
     private var continuationFetchProductPassword = ContinuationWrapper<String?>(PRODUCTS)
@@ -339,10 +337,6 @@ class ProductDetailRepository @Inject constructor(
         productStore.getProduct(selectedSite.get(), remoteProductId)
 
     suspend fun getProduct(remoteProductId: Long): Product? = getCachedWCProductModel(remoteProductId)?.toAppModel()
-
-    suspend fun getProductAsync(remoteProductId: Long): Product? = withContext(coroutineDispatchers.io) {
-        getCachedWCProductModel(remoteProductId)?.toAppModel()
-    }
 
     suspend fun getProductAggregate(remoteProductId: Long): ProductAggregate? {
         val product = getProduct(remoteProductId) ?: return null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailRepository.kt
@@ -344,7 +344,7 @@ class ProductDetailRepository @Inject constructor(
         return ProductAggregate(product, subscriptionDetails)
     }
 
-    fun isSkuAvailableLocally(sku: String) = runBlocking { !productStore.isProductExists(selectedSite.get(), sku) }
+    suspend fun isSkuAvailableLocally(sku: String) = !productStore.isProductExists(selectedSite.get(), sku)
 
     suspend fun getCachedVariationCount(remoteProductId: Long) =
         productStore.getVariationsForProduct(selectedSite.get(), remoteProductId).size

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailRepository.kt
@@ -18,7 +18,6 @@ import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.model.toDataModel
 import com.woocommerce.android.model.toMetaData
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.products.models.QuantityRules
 import com.woocommerce.android.util.ContinuationWrapper
 import com.woocommerce.android.util.ContinuationWrapper.ContinuationResult.Cancellation
 import com.woocommerce.android.util.ContinuationWrapper.ContinuationResult.Success
@@ -364,17 +363,6 @@ class ProductDetailRepository @Inject constructor(
      */
     suspend fun getProductShippingClassByRemoteId(remoteShippingClassId: Long) =
         productStore.getShippingClassByRemoteId(selectedSite.get(), remoteShippingClassId)?.toAppModel()
-
-    fun getQuantityRules(remoteProductId: Long): QuantityRules? {
-        val product = getCachedWCProductModel(remoteProductId)
-        return product?.let {
-            QuantityRules(
-                if (product.minAllowedQuantity > 0) product.minAllowedQuantity else null,
-                if (product.maxAllowedQuantity > 0) product.maxAllowedQuantity else null,
-                if (product.groupOfQuantity > 0) product.groupOfQuantity else null
-            )
-        }
-    }
 
     suspend fun getProductMetadata(remoteProductId: Long): List<WCMetaData> {
         return productStore.getProductMetaData(selectedSite.get(), remoteProductId)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailRepository.kt
@@ -26,7 +26,6 @@ import com.woocommerce.android.util.WooLog.T.PRODUCTS
 import com.woocommerce.android.util.suspendCoroutineWithTimeout
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode.MAIN
@@ -349,8 +348,8 @@ class ProductDetailRepository @Inject constructor(
     suspend fun getCachedVariationCount(remoteProductId: Long) =
         productStore.getVariationsForProduct(selectedSite.get(), remoteProductId).size
 
-    fun getTaxClassesForSite(): List<TaxClass> =
-        runBlocking { taxStore.getTaxClassListForSite(selectedSite.get()).map { it.toAppModel() } }
+    suspend fun getTaxClassesForSite(): List<TaxClass> =
+        taxStore.getTaxClassListForSite(selectedSite.get()).map { it.toAppModel() }
 
     /**
      * Returns the cached (SQLite) shipping class for the given [remoteShippingClassId]

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/price/ProductPricingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/price/ProductPricingViewModel.kt
@@ -84,7 +84,8 @@ class ProductPricingViewModel @Inject constructor(
 
         if (isProductPricing) {
             launch {
-                viewState = viewState.copy(taxClassList = productRepository.getTaxClassesForSite())
+                val taxClasses = productRepository.getTaxClassesForSite()
+                viewState = viewState.copy(taxClassList = taxClasses)
             }
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/price/ProductPricingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/price/ProductPricingViewModel.kt
@@ -24,6 +24,7 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.model.settings.CurrencyPosition
 import org.wordpress.android.fluxc.model.settings.CurrencyPosition.LEFT
@@ -78,9 +79,14 @@ class ProductPricingViewModel @Inject constructor(
             currency = parameters.currencySymbol,
             currencyPosition = parameters.currencyFormattingParameters?.currencyPosition,
             decimals = decimals,
-            taxClassList = if (isProductPricing) productRepository.getTaxClassesForSite() else null,
             isTaxSectionVisible = isProductPricing
         )
+
+        if (isProductPricing) {
+            launch {
+                viewState = viewState.copy(taxClassList = productRepository.getTaxClassesForSite())
+            }
+        }
 
         originalPricingData = navArgs.pricingData
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailViewModel.kt
@@ -118,7 +118,8 @@ class VariationDetailViewModel @Inject constructor(
 
     init {
         launch {
-            viewState = viewState.copy(parentProduct = productRepository.getProduct(navArgs.remoteProductId))
+            val parentProduct = productRepository.getProduct(navArgs.remoteProductId)
+            viewState = viewState.copy(parentProduct = parentProduct)
             originalVariation?.let {
                 showVariation(it.copy())
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailViewModel.kt
@@ -117,9 +117,11 @@ class VariationDetailViewModel @Inject constructor(
     }
 
     init {
-        viewState = viewState.copy(parentProduct = productRepository.getProduct(navArgs.remoteProductId))
-        originalVariation?.let {
-            showVariation(it.copy())
+        launch {
+            viewState = viewState.copy(parentProduct = productRepository.getProduct(navArgs.remoteProductId))
+            originalVariation?.let {
+                showVariation(it.copy())
+            }
         }
 
         observeImageUploadEvents()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListViewModel.kt
@@ -108,9 +108,11 @@ class VariationListViewModel @Inject constructor(
         get() = _variationList.value?.isEmpty() ?: true
 
     fun start() {
-        productRepository.getProduct(remoteProductId)?.let {
-            viewState = viewState.copy(parentProduct = it)
-            handleVariationLoading(remoteProductId)
+        launch {
+            productRepository.getProduct(remoteProductId)?.let {
+                viewState = viewState.copy(parentProduct = it)
+                handleVariationLoading(remoteProductId)
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/edit/EditVariationAttributesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/edit/EditVariationAttributesViewModel.kt
@@ -49,7 +49,9 @@ class EditVariationAttributesViewModel @Inject constructor(
         )
     }
 
-    private val parentProduct by lazy { productRepository.getProduct(viewState.parentProductID) }
+    private val parentProductDeferred = async(start = LAZY) {
+        productRepository.getProduct(viewState.parentProductID)
+    }
 
     private val hasChanges
         get() = editableVariationAttributeList.value?.toTypedArray()
@@ -85,7 +87,7 @@ class EditVariationAttributesViewModel @Inject constructor(
     private fun loadProductAttributes() =
         viewState.copy(isSkeletonShown = true).let { viewState = it }.also {
             launch(context = dispatchers.computation) {
-                parentProduct?.variationEnabledAttributes
+                parentProductDeferred.await()?.variationEnabledAttributes
                     ?.pairAttributeWithSelectedOption()
                     ?.pairAttributeWithUnselectedOption()
                     ?.mapToAttributeSelectionGroupList()
@@ -101,9 +103,9 @@ class EditVariationAttributesViewModel @Inject constructor(
                 ?.let { Pair(attribute, it) }
         }
 
-    private fun List<Pair<ProductAttribute, VariantOption>>.pairAttributeWithUnselectedOption() =
+    private suspend fun List<Pair<ProductAttribute, VariantOption>>.pairAttributeWithUnselectedOption() =
         map { it.first }.let { selectedAttributes ->
-            parentProduct?.variationEnabledAttributes
+            parentProductDeferred.await()?.variationEnabledAttributes
                 ?.filter { selectedAttributes.contains(it).not() }
                 ?.map { it to VariantOption.empty }
                 ?.let { toMutableList().apply { addAll(it) } }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationViewModelTest.kt
@@ -13,7 +13,9 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.stub
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
 import kotlin.test.Test
@@ -43,7 +45,9 @@ class BlazeCampaignCreationAdDestinationViewModelTest : BaseUnitTest() {
     fun setupTests() {
         whenever(product.permalink).thenReturn("https://woocommerce.com")
         whenever(selectedSite.get()).thenReturn(SiteModel().apply { url = "https://woo2.com" })
-        whenever(productDetailRepository.getProduct(any())).thenReturn(product)
+        productDetailRepository.stub {
+            on { getProduct(any()) } doReturn product
+        }
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/GetShipmentsTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/GetShipmentsTests.kt
@@ -53,7 +53,7 @@ class GetShipmentsTests : BaseUnitTest() {
         val items = result.first().items
 
         assertTrue(items.isEmpty())
-        verify(productDetailRepository, never()).getProductAsync(any())
+        verify(productDetailRepository, never()).getProduct(any())
     }
 
     @Test
@@ -64,7 +64,7 @@ class GetShipmentsTests : BaseUnitTest() {
             items = OrderTestUtils.generateTestOrderItems(count = itemsSize)
         )
         whenever(orderDetailRepository.getOrderRefunds(eq(order.id))) doReturn refunds
-        whenever(productDetailRepository.getProductAsync(any())).thenAnswer { invocation ->
+        whenever(productDetailRepository.getProduct(any())).thenAnswer { invocation ->
             val productId = invocation.arguments[0] as Long
             ProductTestUtils.generateProduct(productId = productId, productName = "Product $productId")
         }
@@ -87,7 +87,7 @@ class GetShipmentsTests : BaseUnitTest() {
         )
 
         whenever(orderDetailRepository.getOrderRefunds(eq(order.id))) doReturn refunds
-        whenever(productDetailRepository.getProductAsync(any())).thenAnswer { invocation ->
+        whenever(productDetailRepository.getProduct(any())).thenAnswer { invocation ->
             val id = invocation.arguments[0] as Long
             ProductTestUtils.generateProduct(productId = id, productName = "Product $id")
         }
@@ -109,7 +109,7 @@ class GetShipmentsTests : BaseUnitTest() {
         val order = OrderTestUtils.generateTestOrder().copy(items = orderItems)
 
         whenever(orderDetailRepository.getOrderRefunds(eq(order.id))) doReturn refunds
-        whenever(productDetailRepository.getProductAsync(any())).thenAnswer { invocation ->
+        whenever(productDetailRepository.getProduct(any())).thenAnswer { invocation ->
             val id = invocation.arguments[0] as Long
             val isVirtual = id == virtualProductId
             val isSample = id == sampleProductId
@@ -142,7 +142,7 @@ class GetShipmentsTests : BaseUnitTest() {
 
         val order = OrderTestUtils.generateTestOrder().copy(items = listOf(item))
         whenever(orderDetailRepository.getOrderRefunds(eq(order.id))) doReturn refunds
-        whenever(productDetailRepository.getProductAsync(any())).thenAnswer { invocation ->
+        whenever(productDetailRepository.getProduct(any())).thenAnswer { invocation ->
             val productId = invocation.arguments[0] as Long
             ProductTestUtils.generateProduct(productId = productId, productName = "Product $productId")
         }
@@ -192,7 +192,7 @@ class GetShipmentsTests : BaseUnitTest() {
         val labelId = 123L
 
         whenever(orderDetailRepository.getOrderRefunds(eq(order.id))) doReturn emptyList()
-        whenever(productDetailRepository.getProductAsync(any())).thenAnswer { invocation ->
+        whenever(productDetailRepository.getProduct(any())).thenAnswer { invocation ->
             val productId = invocation.arguments[0] as Long
             ProductTestUtils.generateProduct(productId = productId, productName = "Product $productId")
         }
@@ -239,7 +239,7 @@ class GetShipmentsTests : BaseUnitTest() {
         val labelId = 123L
 
         whenever(orderDetailRepository.getOrderRefunds(eq(order.id))) doReturn emptyList()
-        whenever(productDetailRepository.getProductAsync(any())).thenAnswer { invocation ->
+        whenever(productDetailRepository.getProduct(any())).thenAnswer { invocation ->
             val productId = invocation.arguments[0] as Long
             ProductTestUtils.generateProduct(productId = productId, productName = "Product $productId")
         }
@@ -286,7 +286,7 @@ class GetShipmentsTests : BaseUnitTest() {
         val labelId = 12L
 
         whenever(orderDetailRepository.getOrderRefunds(eq(order.id))) doReturn emptyList()
-        whenever(productDetailRepository.getProductAsync(any())).thenAnswer { invocation ->
+        whenever(productDetailRepository.getProduct(any())).thenAnswer { invocation ->
             val productId = invocation.arguments[0] as Long
             ProductTestUtils.generateProduct(productId = productId, productName = "Product $productId")
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/HasUnsupportedBundledProductsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/HasUnsupportedBundledProductsTest.kt
@@ -86,7 +86,7 @@ class HasUnsupportedBundledProductsTest : BaseUnitTest() {
         whenever(getBundledProducts.invoke(eq(BUNDLE_ID))).thenReturn(flowOf(children.toList()))
     }
 
-    private fun child(productId: Long, type: String, customStatus: String? = null): BundledProduct {
+    private suspend fun child(productId: Long, type: String, customStatus: String? = null): BundledProduct {
         val product = ProductTestUtils.generateProduct(
             productId = productId,
             productType = type,
@@ -97,7 +97,7 @@ class HasUnsupportedBundledProductsTest : BaseUnitTest() {
         return bundledProduct(productId, type)
     }
 
-    private fun unresolvedChild(productId: Long): BundledProduct {
+    private suspend fun unresolvedChild(productId: Long): BundledProduct {
         whenever(productDetailRepository.getProduct(productId)).thenReturn(null)
 
         return bundledProduct(productId, type = "")

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/VariationListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/VariationListViewModelTest.kt
@@ -58,7 +58,9 @@ class VariationListViewModelTest : BaseUnitTest() {
     @Before
     fun setup() {
         doReturn(true).whenever(networkStatus).isConnected()
-        whenever(productRepository.getProduct(productRemoteId)).thenReturn(product)
+        productRepository.stub {
+            on { getProduct(productRemoteId) } doReturn product
+        }
 
         variationRepository = mock {
             on { fetchProductVariations(any(), any()) } doReturn emptyList()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailRepositoryTest.kt
@@ -2,7 +2,6 @@ package com.woocommerce.android.ui.products.details
 
 import com.woocommerce.android.WooException
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
@@ -35,8 +34,7 @@ class ProductDetailRepositoryTest : BaseUnitTest() {
         productStore = productStore,
         globalAttributeStore = mock<WCGlobalAttributeStore>(),
         selectedSite = selectedSite,
-        taxStore = mock<WCTaxStore>(),
-        coroutineDispatchers = mock<CoroutineDispatchers>()
+        taxStore = mock<WCTaxStore>()
     )
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/price/ProductPricingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/price/ProductPricingViewModelTest.kt
@@ -26,6 +26,7 @@ import org.mockito.kotlin.clearInvocations
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.spy
+import org.mockito.kotlin.stub
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
@@ -98,7 +99,9 @@ class ProductPricingViewModelTest : BaseUnitTest() {
         )
         doReturn(SiteModel()).whenever(selectedSite).get()
         doReturn(siteSettings).whenever(wooCommerceStore).getSiteSettings(any())
-        doReturn(taxClasses).whenever(productRepository).getTaxClassesForSite()
+        productRepository.stub {
+            on { getTaxClassesForSite() } doReturn taxClasses
+        }
 
         viewModel = ProductPricingViewModel(
             savedState,


### PR DESCRIPTION
Fixes WOOMOB-994

### Description

`ProductDetailRepository` read from Room on the main thread in three places. `isSkuAvailableLocally` and `getTaxClassesForSite` wrapped suspend store calls in `runBlocking`, and `getProduct` called `WCProductStore.getProductByRemoteId`, which wraps `runBlocking` itself.

This PR makes those three suspend and points `getProduct` at the suspend `WCProductStore.getProduct`. Most callers were already in a coroutine, the rest now wrap the call in `launch`. Part of WOOMOB-983.

Three call sites needed more than a `launch`:

- `EditVariationAttributesViewModel` resolved the parent product with `by lazy`, now an `async(start = LAZY)` deferred, matching the variation lookup next to it.
- `GetChildrenProductInfo` resolved the product eagerly in `invoke`, now inside a `flow` builder, so the lookup happens on collection.
- `BlazeCampaignCreationAdDestinationViewModel` loads the product URL asynchronously, so the change check compares the destination parameters instead of the whole view state. The product URL is display only and never part of the result.

`getProductAsync` is removed as a duplicate of `getProduct`, and `getQuantityRules` is removed as it had no callers.

### Test Steps

#### Product price

1. Open the **Products** tab.
2. Open a simple product.
3. Tap the **Price** card.
4. Confirm the **Tax class** field shows a name and is not blank.
5. Tap the **Tax class** dropdown.
6. Confirm the store's tax classes are listed.
7. Tap back to the product.

#### Product inventory

1. Tap the **Inventory** card.
2. Replace the SKU with the SKU of another product.
3. Confirm the "SKU already in use by another product" error appears immediately, without waiting for a network call.
4. Add a few characters to the end of the SKU.
5. Confirm the error clears.
6. Tap back.
7. Tap back again and tap **DISCARD**.

#### Variations

1. Open a variable product.
2. Tap the **Variations** card.
3. Confirm every variation is listed.
4. Open a variation.
5. Confirm the first card shows the parent product name, not the variation's attributes.
6. Tap the **Attributes** card.
7. Confirm every attribute dropdown shows its selected value.
8. Tap one dropdown.
9. Confirm its terms are listed.

#### Bundle configuration

Needs a bundle product with two bundled items, one of them optional.

1. Open the **Orders** tab.
2. Tap the create order button.
3. Tap **Add products**.
4. Select the bundle product.
5. Confirm the configuration screen lists both bundled items with their names and images.
6. Tap the optional item to select it.
7. Tap **Save configuration**.
8. Confirm the selection.
9. Confirm the bundle and both bundled items are listed in the order.
10. Tap back and tap **DISCARD**.

#### Blaze ad destination

1. Open a product.
2. Tap **Promote with Blaze**.
3. Scroll to the **Ad destination** row and tap it.
4. Tap the **Destination URL** row.
5. Confirm **The product URL** shows the product permalink and is not blank.
6. Tap **Cancel**.
7. Tap the toolbar back arrow.

### Images/gif

N/A, no UI change.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.