### PR TITLE
[WOOMOB-986] Avoid the blocking virtual products check in the order screens

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -398,7 +398,7 @@ class OrderDetailFragment :
     private fun setupObservers(viewModel: OrderDetailViewModel) {
         viewModel.viewStateData.observe(viewLifecycleOwner) { old, new ->
             new.orderInfo?.takeIfNotEqualTo(old?.orderInfo) {
-                showOrderDetail(it.order!!, it.receiptButtonStatus)
+                showOrderDetail(it.order!!, it.isVirtualOrder, it.receiptButtonStatus)
                 if (requireContext().isTwoPanesShouldBeUsed) {
                     orderEditingViewModel.setOrderId(it.order.id)
                 }
@@ -645,12 +645,13 @@ class OrderDetailFragment :
 
     private fun showOrderDetail(
         order: Order,
+        isVirtualOrder: Boolean,
         receiptButtonStatus: OrderDetailViewState.ReceiptButtonStatus
     ) {
         binding.orderDetailOrderStatus.updateOrder(order)
         binding.orderDetailCustomerInfo.updateCustomerInfo(
             order = order,
-            isVirtualOrder = viewModel.hasVirtualProductsOnly(),
+            isVirtualOrder = isVirtualOrder,
             isReadOnly = false,
             viewOrdersButtonVissible = shouldShowViewCustomerOrdersButton()
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -90,7 +90,6 @@ import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.withIndex
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import org.wordpress.android.fluxc.model.OrderAttributionInfo
 import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderResult.OptimisticUpdateResult
 import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderResult.RemoteUpdateResult
@@ -268,9 +267,10 @@ class OrderDetailViewModel @Inject constructor(
     fun hasOrder() = viewState.orderInfo?.order != null
 
     private suspend fun displayOrderDetails() {
-        updateOrderState()
+        val isVirtualOrder = hasVirtualProductsOnly(awaitOrder())
+        updateOrderState(isVirtualOrder)
         loadOrderNotes()
-        displayProductAndShippingDetails()
+        displayProductAndShippingDetails(isVirtualOrder)
         displayCustomAmounts()
         trackGiftCardShownIfNeeded()
     }
@@ -339,17 +339,12 @@ class OrderDetailViewModel @Inject constructor(
         launch { fetchOrder(false) }
     }
 
-    fun hasVirtualProductsOnly(): Boolean {
-        return runBlocking {
-            val orderFetched = awaitOrder()
-            if (orderFetched.items.isNotEmpty()) {
-                val remoteProductIds = orderFetched.getProductIds()
-                orderDetailRepository.hasVirtualProductsOnly(remoteProductIds)
-            } else {
-                false
-            }
+    private suspend fun hasVirtualProductsOnly(order: Order): Boolean =
+        if (order.items.isNotEmpty()) {
+            orderDetailRepository.hasVirtualProductsOnly(order.getProductIds())
+        } else {
+            false
         }
-    }
 
     fun onEditOrderStatusSelected() {
         viewState.orderStatus?.let { orderStatus ->
@@ -774,12 +769,13 @@ class OrderDetailViewModel @Inject constructor(
         )
     }
 
-    private suspend fun updateOrderState() {
+    private suspend fun updateOrderState(isVirtualOrder: Boolean) {
         val order = awaitOrder()
         val orderStatus = orderDetailRepository.getOrderStatus(order.status.value)
         viewState = viewState.copy(
             orderInfo = OrderDetailViewState.OrderInfo(
                 order = order,
+                isVirtualOrder = isVirtualOrder,
                 isPaymentCollectableWithCardReader = isPaymentCollectableWithCardReader(order),
                 receiptButtonStatus = if (paymentReceiptHelper.isReceiptAvailable(order.id) && order.isOrderPaid) {
                     OrderDetailViewState.ReceiptButtonStatus.Visible
@@ -864,9 +860,12 @@ class OrderDetailViewModel @Inject constructor(
         orderDetailsTransactionLauncher.onPackageCreationEligibleFetched()
     }
 
-    private fun loadShipmentTracking(shippingLabels: ListInfo<ShippingLabelModel>): ListInfo<OrderShipmentTracking> {
+    private fun loadShipmentTracking(
+        shippingLabels: ListInfo<ShippingLabelModel>,
+        isVirtualOrder: Boolean
+    ): ListInfo<OrderShipmentTracking> {
         val trackingList = orderDetailRepository.getOrderShipmentTrackings(navArgs.orderId)
-        return if (!appPrefs.isTrackingExtensionAvailable() || shippingLabels.isVisible || hasVirtualProductsOnly()) {
+        return if (!appPrefs.isTrackingExtensionAvailable() || shippingLabels.isVisible || isVirtualOrder) {
             ListInfo(isVisible = false)
         } else {
             ListInfo(list = trackingList)
@@ -936,10 +935,10 @@ class OrderDetailViewModel @Inject constructor(
         return ListInfo(isVisible = false)
     }
 
-    private suspend fun displayProductAndShippingDetails() {
+    private suspend fun displayProductAndShippingDetails(isVirtualOrder: Boolean) {
         val wooShippingShipments = loadWooShippingShipments()
         val shippingLabels = loadOrderShippingLabels()
-        val shipmentTracking = loadShipmentTracking(shippingLabels)
+        val shipmentTracking = loadShipmentTracking(shippingLabels, isVirtualOrder)
         val orderRefunds = loadOrderRefunds()
         val orderProducts = loadOrderProducts(orderRefunds)
 
@@ -1010,13 +1009,16 @@ class OrderDetailViewModel @Inject constructor(
         launch {
             _order.collect { newOrder ->
                 newOrder?.let {
+                    val isVirtualOrder = hasVirtualProductsOnly(it)
                     viewState = viewState.copy(
                         orderInfo = viewState.orderInfo?.copy(
                             order = it,
+                            isVirtualOrder = isVirtualOrder,
                             isPaymentCollectableWithCardReader = viewState.orderInfo?.isPaymentCollectableWithCardReader
                                 ?: false
                         ) ?: OrderDetailViewState.OrderInfo(
                             it,
+                            isVirtualOrder = isVirtualOrder,
                             isPaymentCollectableWithCardReader = false
                         )
                     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewState.kt
@@ -32,6 +32,7 @@ data class OrderDetailViewState(
     @Parcelize
     data class OrderInfo(
         val order: Order? = null,
+        val isVirtualOrder: Boolean = false,
         val isPaymentCollectableWithCardReader: Boolean = false,
         val receiptButtonStatus: ReceiptButtonStatus = ReceiptButtonStatus.Hidden,
     ) : Parcelable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/fulfill/OrderFulfillFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/fulfill/OrderFulfillFragment.kt
@@ -99,7 +99,7 @@ class OrderFulfillFragment :
     private fun setupObservers(binding: FragmentOrderFulfillBinding) {
         viewModel.viewStateData.observe(viewLifecycleOwner) { old, new ->
             new.order?.takeIfNotEqualTo(old?.order) {
-                showOrderDetail(it, binding)
+                showOrderDetail(it, new.isVirtualOrder, binding)
             }
             new.toolbarTitle?.takeIfNotEqualTo(old?.toolbarTitle) { screenTitle = it }
             new.isShipmentTrackingAvailable?.takeIfNotEqualTo(old?.isShipmentTrackingAvailable) {
@@ -131,10 +131,10 @@ class OrderFulfillFragment :
         }
     }
 
-    private fun showOrderDetail(order: Order, binding: FragmentOrderFulfillBinding) {
+    private fun showOrderDetail(order: Order, isVirtualOrder: Boolean, binding: FragmentOrderFulfillBinding) {
         binding.orderDetailCustomerInfo.updateCustomerInfo(
             order = order,
-            isVirtualOrder = viewModel.hasVirtualProductsOnly(),
+            isVirtualOrder = isVirtualOrder,
             isReadOnly = true
         )
         binding.buttonMarkOrderCompete.setOnClickListener {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/fulfill/OrderFulfillViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/fulfill/OrderFulfillViewModel.kt
@@ -32,7 +32,6 @@ import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderChanged
 import javax.inject.Inject
@@ -89,16 +88,18 @@ class OrderFulfillViewModel @Inject constructor(
         launch {
             val order = repository.getOrderById(navArgs.orderId)
             order?.let {
-                displayOrderDetails(it)
+                val isVirtualOrder = hasVirtualProductsOnly(it)
+                displayOrderDetails(it, isVirtualOrder)
                 displayOrderProducts(it)
-                displayShipmentTrackings()
+                displayShipmentTrackings(isVirtualOrder)
             }
         }
     }
 
-    private fun displayOrderDetails(order: Order) {
+    private fun displayOrderDetails(order: Order, isVirtualOrder: Boolean) {
         viewState = viewState.copy(
             order = order,
+            isVirtualOrder = isVirtualOrder,
             toolbarTitle = resourceProvider.getString(R.string.order_fulfill_title)
         )
     }
@@ -108,26 +109,22 @@ class OrderFulfillViewModel @Inject constructor(
         _productList.value = products
     }
 
-    private fun displayShipmentTrackings() {
+    private fun displayShipmentTrackings(isVirtualOrder: Boolean) {
         val isShippingLabelAvailable = repository.getOrderShippingLabels(navArgs.orderId).isNotEmpty()
         val trackingAvailable = appPrefs.isTrackingExtensionAvailable() &&
-            !hasVirtualProductsOnly() && !isShippingLabelAvailable
+            !isVirtualOrder && !isShippingLabelAvailable
         viewState = viewState.copy(isShipmentTrackingAvailable = trackingAvailable)
         if (trackingAvailable) {
             _shipmentTrackings.value = repository.getOrderShipmentTrackings(navArgs.orderId)
         }
     }
 
-    fun hasVirtualProductsOnly(): Boolean {
-        return runBlocking {
-            if (order.items.isNotEmpty()) {
-                val remoteProductIds = order.getProductIds()
-                repository.hasVirtualProductsOnly(remoteProductIds)
-            } else {
-                false
-            }
+    private suspend fun hasVirtualProductsOnly(order: Order): Boolean =
+        if (order.items.isNotEmpty()) {
+            repository.hasVirtualProductsOnly(order.getProductIds())
+        } else {
+            false
         }
-    }
 
     fun onMarkOrderCompleteButtonClicked() {
         if (networkStatus.isConnected()) {
@@ -244,6 +241,7 @@ class OrderFulfillViewModel @Inject constructor(
     @Parcelize
     data class ViewState(
         val order: Order? = null,
+        val isVirtualOrder: Boolean = false,
         val toolbarTitle: String? = null,
         val isShipmentTrackingAvailable: Boolean? = null,
         val shouldRefreshShipmentTracking: Boolean = false

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -453,7 +453,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `hasVirtualProductsOnly returns false if there are no products for the order`() =
+    fun `given an order with no products, when the screen loads, then the order is not marked as virtual`() =
         testBlocking {
             val order = order.copy(items = emptyList())
             doReturn(order).whenever(orderDetailRepository).getOrderById(any())
@@ -467,11 +467,12 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             doReturn(emptyList<ShippingLabel>()).whenever(orderDetailRepository).fetchOrderShippingLabels(any(), any())
 
             viewModel.start()
-            assertThat(viewModel.hasVirtualProductsOnly()).isEqualTo(false)
+
+            assertThat(currentViewStateValue!!.orderInfo!!.isVirtualOrder).isFalse()
         }
 
     @Test
-    fun `hasVirtualProductsOnly returns true if and only if there are no physical products for the order`() =
+    fun `given an order with only virtual products, when the screen loads, then the order is marked as virtual`() =
         testBlocking {
             val item = OrderTestUtils.generateTestOrder().items.first().copy(productId = 1)
             val virtualItems = listOf(item.copy(productId = 3), item.copy(productId = 4))
@@ -487,11 +488,11 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
             viewModel.start()
 
-            assertThat(viewModel.hasVirtualProductsOnly()).isEqualTo(true)
+            assertThat(currentViewStateValue!!.orderInfo!!.isVirtualOrder).isTrue()
         }
 
     @Test
-    fun `hasVirtualProductsOnly returns false if there are both virtual and physical products for the order`() =
+    fun `given an order with virtual and physical products, when the screen loads, then the order is not marked as virtual`() =
         testBlocking {
             val item = OrderTestUtils.generateTestOrder().items.first().copy(productId = 1)
             val mixedItems = listOf(item, item.copy(productId = 2))
@@ -510,7 +511,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
             viewModel.start()
 
-            assertThat(viewModel.hasVirtualProductsOnly()).isEqualTo(false)
+            assertThat(currentViewStateValue!!.orderInfo!!.isVirtualOrder).isFalse()
         }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderFullfillViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderFullfillViewModelTest.kt
@@ -134,18 +134,22 @@ class OrderFullfillViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `hasVirtualProductsOnly returns false if there are no products for the order`() =
+    fun `given an order with no products, when the screen loads, then the order is not marked as virtual`() =
         testBlocking {
             val order = order.copy(items = emptyList())
             doReturn(order).whenever(repository).getOrderById(any())
             doReturn(testOrderShipmentTrackings).whenever(repository).getOrderShipmentTrackings(any())
 
+            var orderData: ViewState? = null
+            viewModel.viewStateData.observeForever { _, new -> orderData = new }
+
             viewModel.start()
-            assertThat(viewModel.hasVirtualProductsOnly()).isEqualTo(false)
+
+            assertThat(orderData?.isVirtualOrder).isEqualTo(false)
         }
 
     @Test
-    fun `hasVirtualProductsOnly returns true if and only if there are no physical products for the order`() =
+    fun `given an order with only virtual products, when the screen loads, then the order is marked as virtual`() =
         testBlocking {
             val item = OrderTestUtils.generateTestOrder().items.first().copy(productId = 1)
             val virtualItems = listOf(item.copy(productId = 3), item.copy(productId = 4))
@@ -154,13 +158,16 @@ class OrderFullfillViewModelTest : BaseUnitTest() {
             doReturn(true).whenever(repository).hasVirtualProductsOnly(listOf(3, 4))
             doReturn(virtualOrder).whenever(repository).getOrderById(any())
 
+            var orderData: ViewState? = null
+            viewModel.viewStateData.observeForever { _, new -> orderData = new }
+
             viewModel.start()
 
-            assertThat(viewModel.hasVirtualProductsOnly()).isEqualTo(true)
+            assertThat(orderData?.isVirtualOrder).isEqualTo(true)
         }
 
     @Test
-    fun `hasVirtualProductsOnly returns false if there are both virtual and physical products for the order`() =
+    fun `given an order with virtual and physical products, when the screen loads, then the order is not marked as virtual`() =
         testBlocking {
             val item = OrderTestUtils.generateTestOrder().items.first().copy(productId = 1)
             val mixedItems = listOf(item, item.copy(productId = 2))
@@ -170,9 +177,12 @@ class OrderFullfillViewModelTest : BaseUnitTest() {
             doReturn(mixedOrder).whenever(repository).getOrderById(any())
             doReturn(testOrderShipmentTrackings).whenever(repository).getOrderShipmentTrackings(any())
 
+            var orderData: ViewState? = null
+            viewModel.viewStateData.observeForever { _, new -> orderData = new }
+
             viewModel.start()
 
-            assertThat(viewModel.hasVirtualProductsOnly()).isEqualTo(false)
+            assertThat(orderData?.isVirtualOrder).isEqualTo(false)
         }
 
     @Test


### PR DESCRIPTION
Fixes WOOMOB-986

### Description

`OrderDetailViewModel` and `OrderFulfillViewModel` exposed `hasVirtualProductsOnly()` as a blocking function, wrapping the repository call in `runBlocking`. Both fragments called it from their view state observer while binding the customer card, so opening an order blocked the main thread on a DB read. `OrderDetailViewModel` also called it while building the shipment tracking list.

Each ViewModel now resolves the flag in the coroutine that loads the order and keeps it in the view state, as `OrderInfo.isVirtualOrder` and `ViewState.isVirtualOrder`. The fragments read it from the state they already observe. Part of [WOOMOB-983](https://linear.app/a8c/issue/WOOMOB-983/move-db-operations-to-background-thread-room-only).

### Test Steps

Needs a store with the Shipment Tracking extension active, and two paid orders in processing status: one containing only virtual products, one containing a physical product.

#### 1. Virtual order

1. Open the virtual order from the **Orders** tab.
2. Confirm the customer card shows no shipping address, including while the screen is loading.
3. Confirm there is no shipment tracking section.
4. Tap **Mark Order Complete**.
5. Confirm the customer card on the **Review order** screen shows no shipping address.
6. Confirm there is no **Add tracking** section.

#### 2. Physical order

1. Open the physical order from the **Orders** tab.
2. Confirm the customer card shows the shipping address.
3. Confirm the shipment tracking section is shown.
4. Tap **Mark Order Complete**.
5. Confirm the customer card on the **Review order** screen shows the shipping address.
6. Confirm the **Add tracking** section is shown.

### Images/gif

N/A, no UI change.

- [x] I have considered if this change warrants release notes. This is an internal threading fix with no user-visible change, so none were added.