### PR TITLE
[WOOMOB-3739] Simplify Product Detail row models

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/adapters/ProductPropertiesAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/adapters/ProductPropertiesAdapter.kt
@@ -86,20 +86,4 @@ class ProductPropertiesAdapter : Adapter<ProductPropertyViewHolder>() {
             is ButtonViewHolder -> holder.bind(item as Button)
         }
     }
-
-    override fun onBindViewHolder(
-        holder: ProductPropertyViewHolder,
-        position: Int,
-        payloads: MutableList<Any>,
-    ) {
-        val focusedEditable = items[position].withEditableFocus(payloads)
-        if (holder is EditableViewHolder && focusedEditable != null) {
-            holder.bind(focusedEditable)
-        } else {
-            super.onBindViewHolder(holder, position, payloads)
-        }
-    }
 }
-
-internal fun ProductProperty.withEditableFocus(payloads: List<Any>): Editable? =
-    (this as? Editable)?.takeIf { EditableFocusPayload in payloads }?.copy(shouldFocus = true)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/adapters/ProductPropertiesAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/adapters/ProductPropertiesAdapter.kt
@@ -86,4 +86,20 @@ class ProductPropertiesAdapter : Adapter<ProductPropertyViewHolder>() {
             is ButtonViewHolder -> holder.bind(item as Button)
         }
     }
+
+    override fun onBindViewHolder(
+        holder: ProductPropertyViewHolder,
+        position: Int,
+        payloads: MutableList<Any>,
+    ) {
+        val focusedEditable = items[position].withEditableFocus(payloads)
+        if (holder is EditableViewHolder && focusedEditable != null) {
+            holder.bind(focusedEditable)
+        } else {
+            super.onBindViewHolder(holder, position, payloads)
+        }
+    }
 }
+
+internal fun ProductProperty.withEditableFocus(payloads: List<Any>): Editable? =
+    (this as? Editable)?.takeIf { EditableFocusPayload in payloads }?.copy(shouldFocus = true)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/adapters/ProductPropertiesDiffCallback.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/adapters/ProductPropertiesDiffCallback.kt
@@ -4,6 +4,8 @@ import androidx.recyclerview.widget.DiffUtil.Callback
 import com.woocommerce.android.ui.products.models.ProductProperty
 import com.woocommerce.android.ui.products.models.ProductProperty.Editable
 
+internal data object EditableFocusPayload
+
 class ProductPropertiesDiffCallback(
     private val oldList: List<ProductProperty>,
     private val newList: List<ProductProperty>
@@ -32,7 +34,7 @@ class ProductPropertiesDiffCallback(
         val newItem = newList[newItemPosition]
         val oldItem = oldList[oldItemPosition]
         return if (oldItem is Editable && newItem is Editable && newItem.text != oldItem.text) {
-            newItem.shouldFocus = true
+            EditableFocusPayload
         } else {
             null
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/adapters/ProductPropertiesDiffCallback.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/adapters/ProductPropertiesDiffCallback.kt
@@ -4,8 +4,6 @@ import androidx.recyclerview.widget.DiffUtil.Callback
 import com.woocommerce.android.ui.products.models.ProductProperty
 import com.woocommerce.android.ui.products.models.ProductProperty.Editable
 
-internal data object EditableFocusPayload
-
 class ProductPropertiesDiffCallback(
     private val oldList: List<ProductProperty>,
     private val newList: List<ProductProperty>
@@ -27,16 +25,6 @@ class ProductPropertiesDiffCallback(
             true
         } else {
             oldItem == newItem
-        }
-    }
-
-    override fun getChangePayload(oldItemPosition: Int, newItemPosition: Int): Any? {
-        val newItem = newList[newItemPosition]
-        val oldItem = oldList[oldItemPosition]
-        return if (oldItem is Editable && newItem is Editable && newItem.text != oldItem.text) {
-            EditableFocusPayload
-        } else {
-            null
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailPreviewData.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailPreviewData.kt
@@ -1,75 +1,69 @@
 package com.woocommerce.android.ui.products.details
 
 import com.woocommerce.android.R
+import com.woocommerce.android.ui.products.models.ProductProperty
 
 internal object ProductDetailPreviewData {
     private val addRows = listOf(
-        ProductDetailRowUiModel.Editable(
+        ProductDetailRow(
             key = "title",
-            hint = R.string.product_detail_title_hint,
-            text = "",
-            shouldFocus = false,
-            isReadOnly = false,
-            badgeText = null,
-            badgeTone = null,
-            onTextChanged = {},
+            property = ProductProperty.Editable(
+                hint = R.string.product_detail_title_hint,
+                onTextChanged = {},
+            ),
         ),
-        ProductDetailRowUiModel.ComplexProperty(
+        ProductDetailRow(
             key = "description",
-            title = R.string.product_description,
-            value = "Describe your product",
-            icon = null,
-            showTitle = false,
-            maxLines = 1,
-            showDivider = false,
-            onClick = {},
-        ),
-        ProductDetailRowUiModel.Button(
-            key = "write_with_ai",
-            text = R.string.product_sharing_write_with_ai,
-            icon = R.drawable.ic_ai,
-            showDivider = true,
-            tooltip = null,
-            link = ProductDetailButtonLinkUiModel(
-                text = R.string.ai_product_description_learn_more_link,
+            property = ProductProperty.ComplexProperty(
+                title = R.string.product_description,
+                value = "Describe your product",
+                showTitle = false,
+                isDividerVisible = false,
                 onClick = {},
             ),
-            onClick = {},
+        ),
+        ProductDetailRow(
+            key = "write_with_ai",
+            property = ProductProperty.Button(
+                text = R.string.product_sharing_write_with_ai,
+                icon = R.drawable.ic_ai,
+                link = ProductProperty.Button.Link(
+                    text = R.string.ai_product_description_learn_more_link,
+                    onClick = {},
+                ),
+                onClick = {},
+            ),
         ),
     )
 
     private val addDetails = listOf(
-        ProductDetailRowUiModel.PropertyGroup(
+        ProductDetailRow(
             key = "price",
-            title = R.string.product_price,
-            properties = listOf(ProductDetailPropertyValueUiModel("", "Add price")),
-            icon = R.drawable.ic_gridicons_money,
-            showTitle = false,
-            showDivider = true,
-            isHighlighted = false,
-            propertyFormat = R.string.product_property_default_formatter,
-            onClick = {},
+            property = ProductProperty.PropertyGroup(
+                title = R.string.product_price,
+                properties = mapOf("" to "Add price"),
+                icon = R.drawable.ic_gridicons_money,
+                showTitle = false,
+                onClick = {},
+            ),
         ),
-        ProductDetailRowUiModel.PropertyGroup(
+        ProductDetailRow(
             key = "inventory",
-            title = R.string.product_inventory,
-            properties = listOf(ProductDetailPropertyValueUiModel("Stock status", "In stock")),
-            icon = R.drawable.ic_gridicons_list_checkmark,
-            showTitle = true,
-            showDivider = true,
-            isHighlighted = false,
-            propertyFormat = R.string.product_property_default_formatter,
-            onClick = {},
+            property = ProductProperty.PropertyGroup(
+                title = R.string.product_inventory,
+                properties = mapOf("Stock status" to "In stock"),
+                icon = R.drawable.ic_gridicons_list_checkmark,
+                onClick = {},
+            ),
         ),
-        ProductDetailRowUiModel.ComplexProperty(
+        ProductDetailRow(
             key = "type",
-            title = R.string.product_type,
-            value = "Physical product",
-            icon = R.drawable.ic_gridicons_product,
-            showTitle = true,
-            maxLines = 1,
-            showDivider = false,
-            onClick = null,
+            property = ProductProperty.ComplexProperty(
+                title = R.string.product_type,
+                value = "Physical product",
+                icon = R.drawable.ic_gridicons_product,
+                isDividerVisible = false,
+            ),
         ),
     )
 
@@ -89,11 +83,17 @@ internal object ProductDetailPreviewData {
                 style = ProductDetailCardStyle.PRIMARY,
                 caption = "",
                 rows = listOf(
-                    addRows.first().let { (it as ProductDetailRowUiModel.Editable).copy(text = "Beanie") },
-                    (addRows[1] as ProductDetailRowUiModel.ComplexProperty).copy(
-                        value = "A warm beanie for every season.",
-                        showTitle = true,
-                    ),
+                    addRows.first().let { row ->
+                        row.copy(property = (row.property as ProductProperty.Editable).copy(text = "Beanie"))
+                    },
+                    addRows[1].let { row ->
+                        row.copy(
+                            property = (row.property as ProductProperty.ComplexProperty).copy(
+                                value = "A warm beanie for every season.",
+                                showTitle = true,
+                            ),
+                        )
+                    },
                     addRows[2],
                 ),
             ),
@@ -101,14 +101,16 @@ internal object ProductDetailPreviewData {
                 key = "details",
                 style = ProductDetailCardStyle.SECONDARY,
                 caption = "",
-                rows = addDetails + ProductDetailRowUiModel.Rating(
+                rows = addDetails + ProductDetailRow(
                     key = "reviews",
-                    title = R.string.product_reviews,
-                    value = "6 approved reviews",
-                    rating = 4.5f,
-                    icon = R.drawable.ic_reviews,
+                    property = ProductProperty.RatingBar(
+                        title = R.string.product_reviews,
+                        value = "6 approved reviews",
+                        rating = 4.5f,
+                        icon = R.drawable.ic_reviews,
+                        onClick = {},
+                    ),
                     showDivider = true,
-                    onClick = {},
                 ),
             ),
         ),
@@ -123,16 +125,19 @@ internal object ProductDetailPreviewData {
                 style = ProductDetailCardStyle.SECONDARY,
                 caption = "",
                 rows = listOf(
-                    ProductDetailRowUiModel.Warning("warning", "Some variations are missing a price."),
-                    ProductDetailRowUiModel.ComplexProperty(
+                    ProductDetailRow(
+                        key = "warning",
+                        property = ProductProperty.Warning("Some variations are missing a price."),
+                    ),
+                    ProductDetailRow(
                         key = "variations",
-                        title = R.string.product_variations,
-                        value = "3 variations",
-                        icon = R.drawable.ic_gridicons_types,
-                        showTitle = true,
-                        maxLines = 1,
-                        showDivider = false,
-                        onClick = {},
+                        property = ProductProperty.ComplexProperty(
+                            title = R.string.product_variations,
+                            value = "3 variations",
+                            icon = R.drawable.ic_gridicons_types,
+                            isDividerVisible = false,
+                            onClick = {},
+                        ),
                     ),
                 ),
             ),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailRows.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailRows.kt
@@ -250,7 +250,7 @@ private fun ProductDetailEditableField(
     var restoreFocus by rememberSaveable(key) { mutableStateOf(false) }
     var hasEditedWhileFocused by rememberSaveable(key) { mutableStateOf(false) }
     var value by rememberSaveable(key, stateSaver = TextFieldValue.Saver) {
-        mutableStateOf(titleFieldValue(property.text, moveCursorToEnd = property.shouldFocus))
+        mutableStateOf(titleFieldValue(property.text, moveCursorToEnd = false))
     }
     val shouldRestoreFocus = restoreFocus
 
@@ -258,7 +258,6 @@ private fun ProductDetailEditableField(
         val synchronizedState = synchronizeTitleFieldState(
             externalText = property.text,
             isFocused = isFocused,
-            shouldFocus = property.shouldFocus,
             currentState = ProductDetailTitleFieldState(
                 value = value,
                 restoreFocus = restoreFocus,
@@ -268,9 +267,6 @@ private fun ProductDetailEditableField(
         value = synchronizedState.value
         restoreFocus = synchronizedState.restoreFocus
         hasEditedWhileFocused = synchronizedState.hasEditedWhileFocused
-    }
-    LaunchedEffect(property.shouldFocus, property.isReadOnly) {
-        if (property.shouldFocus && !property.isReadOnly) focusRequester.requestFocus()
     }
     LaunchedEffect(Unit) {
         if (shouldRestoreFocus && !property.isReadOnly) focusRequester.requestFocus()
@@ -651,7 +647,6 @@ private fun synchronizeTitleFieldValue(
 internal fun synchronizeTitleFieldState(
     externalText: String,
     isFocused: Boolean,
-    shouldFocus: Boolean,
     currentState: ProductDetailTitleFieldState,
 ): ProductDetailTitleFieldState {
     val matchesExternalText = externalText == currentState.value.text
@@ -662,7 +657,7 @@ internal fun synchronizeTitleFieldState(
             currentValue = currentState.value,
             preserveCurrentValue = currentState.hasEditedWhileFocused &&
                 (isFocused || currentState.restoreFocus),
-            moveCursorToEnd = isFocused || shouldFocus,
+            moveCursorToEnd = isFocused,
         ),
         restoreFocus = currentState.restoreFocus && !shouldClearEditing,
         hasEditedWhileFocused = currentState.hasEditedWhileFocused && !shouldClearEditing,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailRows.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailRows.kt
@@ -80,22 +80,48 @@ import com.woocommerce.android.ui.compose.designsystem.component.WooSwitch
 import com.woocommerce.android.ui.compose.designsystem.icons.AngleRight
 import com.woocommerce.android.ui.compose.designsystem.icons.Star
 import com.woocommerce.android.ui.compose.designsystem.icons.WooIcons
+import com.woocommerce.android.ui.products.models.ProductProperty
 
 @Composable
-internal fun ProductDetailRow(row: ProductDetailRowUiModel) {
+internal fun ProductDetailRow(row: ProductDetailRow) {
     val modifier = Modifier.testTag(ProductDetailTestTags.row(row.key))
-    when (row) {
-        is ProductDetailRowUiModel.Divider -> WooDivider(modifier)
-        is ProductDetailRowUiModel.Property -> ProductDetailPropertyRow(row, modifier)
-        is ProductDetailRowUiModel.ComplexProperty -> ProductDetailComplexPropertyRow(row, modifier)
-        is ProductDetailRowUiModel.Rating -> ProductDetailRatingRow(row, modifier)
-        is ProductDetailRowUiModel.Editable -> ProductDetailEditableRow(row, modifier)
-        is ProductDetailRowUiModel.PropertyGroup -> ProductDetailPropertyGroupRow(row, modifier)
-        is ProductDetailRowUiModel.Link -> ProductDetailLinkRow(row, modifier)
-        is ProductDetailRowUiModel.Button -> ProductDetailButtonRow(row, modifier)
-        is ProductDetailRowUiModel.Switch -> ProductDetailSwitchRow(row, modifier)
-        is ProductDetailRowUiModel.Warning -> WooNoticeBanner(
-            title = row.content,
+    when (val property = row.property) {
+        ProductProperty.Divider -> WooDivider(modifier)
+        is ProductProperty.Property -> ProductDetailPropertyRow(
+            property = property,
+            showDivider = row.showDivider ?: property.isDividerVisible,
+            modifier = modifier,
+        )
+        is ProductProperty.ComplexProperty -> ProductDetailComplexPropertyRow(
+            property = property,
+            showDivider = row.showDivider ?: property.isDividerVisible,
+            modifier = modifier,
+        )
+        is ProductProperty.RatingBar -> ProductDetailRatingRow(
+            property = property,
+            showDivider = row.showDivider ?: false,
+            modifier = modifier,
+        )
+        is ProductProperty.Editable -> ProductDetailEditableRow(property, row.key, modifier)
+        is ProductProperty.PropertyGroup -> ProductDetailPropertyGroupRow(
+            property = property,
+            showDivider = row.showDivider ?: property.isDividerVisible,
+            modifier = modifier,
+        )
+        is ProductProperty.Link -> ProductDetailLinkRow(
+            property = property,
+            showDivider = row.showDivider ?: property.isDividerVisible,
+            modifier = modifier,
+        )
+        is ProductProperty.Button -> ProductDetailButtonRow(
+            property = property,
+            key = row.key,
+            showDivider = row.showDivider ?: property.isDividerVisible,
+            modifier = modifier,
+        )
+        is ProductProperty.Switch -> ProductDetailSwitchRow(property, modifier)
+        is ProductProperty.Warning -> WooNoticeBanner(
+            title = property.content,
             tone = WooNoticeBannerTone.Warning,
             modifier = modifier.padding(WooTheme.padding.padding5),
         )
@@ -104,7 +130,8 @@ internal fun ProductDetailRow(row: ProductDetailRowUiModel) {
 
 @Composable
 private fun ProductDetailPropertyRow(
-    row: ProductDetailRowUiModel.Property,
+    property: ProductProperty.Property,
+    showDivider: Boolean,
     modifier: Modifier,
 ) {
     Column(modifier = modifier) {
@@ -117,67 +144,69 @@ private fun ProductDetailPropertyRow(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(
-                text = stringResource(row.title),
+                text = stringResource(property.title),
                 color = WooTheme.colors.surface.onDefault,
                 style = WooTheme.text.bodyLarge.emphasized,
                 modifier = Modifier.weight(1f),
             )
             Text(
-                text = row.value,
+                text = property.value,
                 color = WooTheme.colors.surface.onVariant,
                 style = WooTheme.text.bodyLarge.regular,
             )
         }
         ProductDetailOptionalDivider(
-            show = row.showDivider,
+            show = showDivider,
         )
     }
 }
 
 @Composable
 private fun ProductDetailComplexPropertyRow(
-    row: ProductDetailRowUiModel.ComplexProperty,
+    property: ProductProperty.ComplexProperty,
+    showDivider: Boolean,
     modifier: Modifier,
 ) {
-    val title = row.title?.let { stringResource(it) }.orEmpty()
-    val value = AnnotatedString.fromHtml(row.value)
+    val title = property.title?.let { stringResource(it) }.orEmpty()
+    val value = AnnotatedString.fromHtml(property.value)
     Column {
         ProductDetailPropertyCell(
-            title = if (row.showTitle && row.title != null) title else value.text,
-            description = value.takeIf { row.showTitle && row.title != null },
-            icon = row.icon,
-            maxLines = row.maxLines,
-            onClick = row.onClick,
+            title = if (property.showTitle && property.title != null) title else value.text,
+            description = value.takeIf { property.showTitle && property.title != null },
+            icon = property.icon,
+            maxLines = property.maxLines,
+            onClick = property.onClick,
             modifier = modifier,
         )
         ProductDetailOptionalDivider(
-            show = row.showDivider,
-            hasLeadingIcon = row.icon != null,
+            show = showDivider,
+            hasLeadingIcon = property.icon != null,
         )
     }
 }
 
 @Composable
 private fun ProductDetailRatingRow(
-    row: ProductDetailRowUiModel.Rating,
+    property: ProductProperty.RatingBar,
+    showDivider: Boolean,
     modifier: Modifier,
 ) {
     Column {
         ProductDetailPropertyCell(
-            title = stringResource(row.title),
+            title = stringResource(property.title),
             description = null,
-            icon = row.icon,
-            onClick = row.onClick,
+            icon = property.icon,
+            onClick = property.onClick,
             modifier = modifier,
             additionalContent = {
                 ProductDetailRatingSummary(
-                    rating = row.rating,
-                    reviewCount = row.value,
+                    rating = property.rating,
+                    reviewCount = property.value,
                 )
             },
         )
         ProductDetailOptionalDivider(
-            show = row.showDivider,
+            show = showDivider,
             hasLeadingIcon = true,
         )
     }
@@ -185,7 +214,8 @@ private fun ProductDetailRatingRow(
 
 @Composable
 private fun ProductDetailEditableRow(
-    row: ProductDetailRowUiModel.Editable,
+    property: ProductProperty.Editable,
+    key: String,
     modifier: Modifier,
 ) {
     Column {
@@ -197,8 +227,8 @@ private fun ProductDetailEditableRow(
             horizontalArrangement = Arrangement.spacedBy(WooTheme.spacing.space3),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            ProductDetailEditableField(row, Modifier.weight(1f))
-            ProductDetailEditableBadge(row)
+            ProductDetailEditableField(property, key, Modifier.weight(1f))
+            ProductDetailEditableBadge(property)
         }
         WooDivider()
     }
@@ -206,26 +236,27 @@ private fun ProductDetailEditableRow(
 
 @Composable
 private fun ProductDetailEditableField(
-    row: ProductDetailRowUiModel.Editable,
+    property: ProductProperty.Editable,
+    key: String,
     modifier: Modifier,
 ) {
-    val callback by rememberUpdatedState(row.onTextChanged)
-    val focusRequester = remember(row.key) { FocusRequester() }
+    val callback by rememberUpdatedState(property.onTextChanged)
+    val focusRequester = remember(key) { FocusRequester() }
     val focusManager = LocalFocusManager.current
     val keyboardController = LocalSoftwareKeyboardController.current
-    var isFocused by remember(row.key) { mutableStateOf(false) }
-    var restoreFocus by rememberSaveable(row.key) { mutableStateOf(false) }
-    var hasEditedWhileFocused by rememberSaveable(row.key) { mutableStateOf(false) }
-    var value by rememberSaveable(row.key, stateSaver = TextFieldValue.Saver) {
-        mutableStateOf(titleFieldValue(row.text, moveCursorToEnd = row.shouldFocus))
+    var isFocused by remember(key) { mutableStateOf(false) }
+    var restoreFocus by rememberSaveable(key) { mutableStateOf(false) }
+    var hasEditedWhileFocused by rememberSaveable(key) { mutableStateOf(false) }
+    var value by rememberSaveable(key, stateSaver = TextFieldValue.Saver) {
+        mutableStateOf(titleFieldValue(property.text, moveCursorToEnd = property.shouldFocus))
     }
     val shouldRestoreFocus = restoreFocus
 
-    LaunchedEffect(row.text, isFocused, restoreFocus, hasEditedWhileFocused) {
+    LaunchedEffect(property.text, isFocused, restoreFocus, hasEditedWhileFocused) {
         val synchronizedState = synchronizeTitleFieldState(
-            externalText = row.text,
+            externalText = property.text,
             isFocused = isFocused,
-            shouldFocus = row.shouldFocus,
+            shouldFocus = property.shouldFocus,
             currentState = ProductDetailTitleFieldState(
                 value = value,
                 restoreFocus = restoreFocus,
@@ -236,11 +267,11 @@ private fun ProductDetailEditableField(
         restoreFocus = synchronizedState.restoreFocus
         hasEditedWhileFocused = synchronizedState.hasEditedWhileFocused
     }
-    LaunchedEffect(row.shouldFocus, row.isReadOnly) {
-        if (row.shouldFocus && !row.isReadOnly) focusRequester.requestFocus()
+    LaunchedEffect(property.shouldFocus, property.isReadOnly) {
+        if (property.shouldFocus && !property.isReadOnly) focusRequester.requestFocus()
     }
     LaunchedEffect(Unit) {
-        if (shouldRestoreFocus && !row.isReadOnly) focusRequester.requestFocus()
+        if (shouldRestoreFocus && !property.isReadOnly) focusRequester.requestFocus()
     }
 
     fun finishEditing() {
@@ -277,7 +308,7 @@ private fun ProductDetailEditableField(
                 }
             }
             .testTag(ProductDetailTestTags.TITLE),
-        enabled = !row.isReadOnly,
+        enabled = !property.isReadOnly,
         singleLine = true,
         textStyle = WooTheme.text.titleLarge.regular.copy(color = WooTheme.colors.surface.onDefault),
         cursorBrush = SolidColor(WooTheme.colors.primary),
@@ -287,7 +318,7 @@ private fun ProductDetailEditableField(
             Box(contentAlignment = Alignment.CenterStart) {
                 if (value.text.isEmpty()) {
                     Text(
-                        text = stringResource(row.hint),
+                        text = stringResource(property.hint),
                         color = WooTheme.colors.surface.onVariant,
                         style = WooTheme.text.titleLarge.regular,
                     )
@@ -299,13 +330,14 @@ private fun ProductDetailEditableField(
 }
 
 @Composable
-private fun ProductDetailEditableBadge(row: ProductDetailRowUiModel.Editable) {
-    if (row.badgeText != null && row.badgeTone != null) {
+private fun ProductDetailEditableBadge(property: ProductProperty.Editable) {
+    if (property.badgeText != null && property.badgeColor != null) {
         WooBadge(
-            text = stringResource(row.badgeText),
-            tone = when (row.badgeTone) {
-                ProductDetailBadgeTone.NEUTRAL -> WooBadgeTone.Neutral
-                ProductDetailBadgeTone.WARNING -> WooBadgeTone.Warning
+            text = stringResource(property.badgeText),
+            tone = if (property.badgeColor == R.color.product_status_badge_pending) {
+                WooBadgeTone.Warning
+            } else {
+                WooBadgeTone.Neutral
             },
         )
     }
@@ -313,66 +345,70 @@ private fun ProductDetailEditableBadge(row: ProductDetailRowUiModel.Editable) {
 
 @Composable
 private fun ProductDetailPropertyGroupRow(
-    row: ProductDetailRowUiModel.PropertyGroup,
+    property: ProductProperty.PropertyGroup,
+    showDivider: Boolean,
     modifier: Modifier,
 ) {
     val propertyValue = buildString {
-        row.properties.forEach { property ->
+        property.properties.forEach { (label, value) ->
             when {
-                property.label.isEmpty() -> append(property.value)
-                property.value.isNotEmpty() -> {
+                label.isEmpty() -> append(value)
+                value.isNotEmpty() -> {
                     if (isNotEmpty()) append('\n')
-                    append(stringResource(row.propertyFormat, property.label, property.value))
+                    append(stringResource(property.propertyFormat, label, value))
                 }
             }
         }
     }
-    val isSingleUntitledValue = row.properties.size == 1 && !row.showTitle
+    val isSingleUntitledValue = property.properties.size == 1 && !property.showTitle
     Column {
         ProductDetailPropertyCell(
-            title = if (isSingleUntitledValue) propertyValue else stringResource(row.title),
+            title = if (isSingleUntitledValue) propertyValue else stringResource(property.title),
             description = propertyValue.takeUnless { isSingleUntitledValue }?.let(::AnnotatedString),
-            icon = row.icon,
-            onClick = row.onClick,
-            isHighlighted = row.isHighlighted,
+            icon = property.icon,
+            onClick = property.onClick,
+            isHighlighted = property.isHighlighted,
             modifier = modifier,
         )
         ProductDetailOptionalDivider(
-            show = row.showDivider,
-            hasLeadingIcon = row.icon != null,
+            show = showDivider,
+            hasLeadingIcon = property.icon != null,
         )
     }
 }
 
 @Composable
 private fun ProductDetailLinkRow(
-    row: ProductDetailRowUiModel.Link,
+    property: ProductProperty.Link,
+    showDivider: Boolean,
     modifier: Modifier,
 ) {
     Column {
         WooCell(
-            title = stringResource(row.title),
-            onClick = row.onClick,
-            enabled = row.onClick != null,
-            modifier = modifier.disabledWhen(row.onClick == null),
-            leadingContent = row.icon?.let { icon -> { ProductDetailIcon(icon) } },
-            trailingContent = row.onClick?.let { { WooCellTrailingAffordance() } },
+            title = stringResource(property.title),
+            onClick = property.onClick,
+            enabled = property.onClick != null,
+            modifier = modifier.disabledWhen(property.onClick == null),
+            leadingContent = property.icon?.let { icon -> { ProductDetailIcon(icon) } },
+            trailingContent = property.onClick?.let { { WooCellTrailingAffordance() } },
         )
         ProductDetailOptionalDivider(
-            show = row.showDivider,
-            hasLeadingIcon = row.icon != null,
+            show = showDivider,
+            hasLeadingIcon = property.icon != null,
         )
     }
 }
 
 @Composable
 private fun ProductDetailButtonRow(
-    row: ProductDetailRowUiModel.Button,
+    property: ProductProperty.Button,
+    key: String,
+    showDivider: Boolean,
     modifier: Modifier,
 ) {
-    var showTooltip by rememberSaveable(row.key) { mutableStateOf(row.tooltip != null) }
-    val onClick by rememberUpdatedState(row.onClick)
-    val onTooltipDismiss by rememberUpdatedState(row.tooltip?.onDismiss)
+    var showTooltip by rememberSaveable(key) { mutableStateOf(property.tooltip != null) }
+    val onClick by rememberUpdatedState(property.onClick)
+    val onTooltipDismiss by rememberUpdatedState(property.tooltip?.onDismiss)
 
     Column {
         Column(
@@ -385,13 +421,13 @@ private fun ProductDetailButtonRow(
         ) {
             Box {
                 WooFilledTonalButton(
-                    text = stringResource(row.text),
+                    text = stringResource(property.text),
                     onClick = onClick,
                     size = WooButtonSize.Small,
-                    leadingIcon = row.icon?.let { icon -> { ProductDetailIcon(icon) } },
+                    leadingIcon = property.icon?.let { icon -> { ProductDetailIcon(icon) } },
                 )
                 DropdownMenu(
-                    expanded = showTooltip && row.tooltip != null,
+                    expanded = showTooltip && property.tooltip != null,
                     onDismissRequest = { showTooltip = false },
                     shadowElevation = 4.dp,
                     shape = MaterialTheme.shapes.medium,
@@ -399,7 +435,7 @@ private fun ProductDetailButtonRow(
                         .width(TOOLTIP_WIDTH)
                         .background(WooTheme.colors.surface.surfaceContainerHighest),
                 ) {
-                    row.tooltip?.let { tooltip ->
+                    property.tooltip?.let { tooltip ->
                         Column(
                             modifier = Modifier
                                 .fillMaxWidth()
@@ -427,7 +463,7 @@ private fun ProductDetailButtonRow(
                     }
                 }
             }
-            row.link?.let { link ->
+            property.link?.let { link ->
                 Spacer(modifier = Modifier.size(WooTheme.spacing.space3))
                 Text(
                     text = productDetailAiAttributionText(
@@ -441,28 +477,28 @@ private fun ProductDetailButtonRow(
             }
         }
         ProductDetailOptionalDivider(
-            show = row.showDivider,
+            show = showDivider,
         )
     }
 }
 
 @Composable
 private fun ProductDetailSwitchRow(
-    row: ProductDetailRowUiModel.Switch,
+    property: ProductProperty.Switch,
     modifier: Modifier,
 ) {
-    val onStateChanged by rememberUpdatedState(row.onStateChanged)
+    val onStateChanged by rememberUpdatedState(property.onStateChanged)
     WooCell(
-        title = stringResource(row.title),
-        enabled = row.onStateChanged != null,
-        onClick = row.onStateChanged?.let { { onStateChanged?.invoke(!row.isOn) } },
-        modifier = modifier.disabledWhen(row.onStateChanged == null),
-        leadingContent = row.icon?.let { icon -> { ProductDetailIcon(icon) } },
+        title = stringResource(property.title),
+        enabled = property.onStateChanged != null,
+        onClick = property.onStateChanged?.let { { onStateChanged?.invoke(!property.isOn) } },
+        modifier = modifier.disabledWhen(property.onStateChanged == null),
+        leadingContent = property.icon?.let { icon -> { ProductDetailIcon(icon) } },
         trailingContent = {
             WooSwitch(
-                checked = row.isOn,
+                checked = property.isOn,
                 onCheckedChange = null,
-                enabled = row.onStateChanged != null,
+                enabled = property.onStateChanged != null,
             )
         },
     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailRows.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailRows.kt
@@ -89,34 +89,34 @@ internal fun ProductDetailRow(row: ProductDetailRow) {
         ProductProperty.Divider -> WooDivider(modifier)
         is ProductProperty.Property -> ProductDetailPropertyRow(
             property = property,
-            showDivider = row.showDivider ?: property.isDividerVisible,
+            showDivider = row.dividerVisibility(property.isDividerVisible),
             modifier = modifier,
         )
         is ProductProperty.ComplexProperty -> ProductDetailComplexPropertyRow(
             property = property,
-            showDivider = row.showDivider ?: property.isDividerVisible,
+            showDivider = row.dividerVisibility(property.isDividerVisible),
             modifier = modifier,
         )
         is ProductProperty.RatingBar -> ProductDetailRatingRow(
             property = property,
-            showDivider = row.showDivider ?: false,
+            showDivider = row.dividerVisibility(default = false),
             modifier = modifier,
         )
         is ProductProperty.Editable -> ProductDetailEditableRow(property, row.key, modifier)
         is ProductProperty.PropertyGroup -> ProductDetailPropertyGroupRow(
             property = property,
-            showDivider = row.showDivider ?: property.isDividerVisible,
+            showDivider = row.dividerVisibility(property.isDividerVisible),
             modifier = modifier,
         )
         is ProductProperty.Link -> ProductDetailLinkRow(
             property = property,
-            showDivider = row.showDivider ?: property.isDividerVisible,
+            showDivider = row.dividerVisibility(property.isDividerVisible),
             modifier = modifier,
         )
         is ProductProperty.Button -> ProductDetailButtonRow(
             property = property,
             key = row.key,
-            showDivider = row.showDivider ?: property.isDividerVisible,
+            showDivider = row.dividerVisibility(property.isDividerVisible),
             modifier = modifier,
         )
         is ProductProperty.Switch -> ProductDetailSwitchRow(property, modifier)
@@ -127,6 +127,8 @@ internal fun ProductDetailRow(row: ProductDetailRow) {
         )
     }
 }
+
+private fun ProductDetailRow.dividerVisibility(default: Boolean) = showDivider ?: default
 
 @Composable
 private fun ProductDetailPropertyRow(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailUiMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailUiMapper.kt
@@ -59,130 +59,17 @@ class ProductDetailUiMapper {
         }
     }
 
-    private fun mapRows(properties: List<ProductProperty>): List<ProductDetailRowUiModel> {
+    private fun mapRows(properties: List<ProductProperty>): List<ProductDetailRow> {
         val keyOccurrences = mutableMapOf<String, Int>()
         return properties.mapIndexed { index, property ->
             val key = property.semanticKey().withOccurrence(keyOccurrences)
-            property.toUiModel(key).let { row ->
-                if (row is ProductDetailRowUiModel.Rating) {
-                    row.copy(showDivider = index != properties.lastIndex)
-                } else {
-                    row
-                }
-            }
+            ProductDetailRow(
+                key = key,
+                property = property,
+                showDivider = (index != properties.lastIndex).takeIf { property is ProductProperty.RatingBar },
+            )
         }
     }
-
-    private fun ProductProperty.toUiModel(key: String): ProductDetailRowUiModel = when (this) {
-        ProductProperty.Divider -> ProductDetailRowUiModel.Divider(key)
-        is ProductProperty.Property -> toPropertyUiModel(key)
-        is ProductProperty.ComplexProperty -> toComplexPropertyUiModel(key)
-        is ProductProperty.RatingBar -> toRatingUiModel(key)
-        is ProductProperty.Editable -> toEditableUiModel(key)
-        is ProductProperty.PropertyGroup -> toPropertyGroupUiModel(key)
-        is ProductProperty.Link -> toLinkUiModel(key)
-        is ProductProperty.Button -> toButtonUiModel(key)
-        is ProductProperty.Switch -> toSwitchUiModel(key)
-        is ProductProperty.Warning -> ProductDetailRowUiModel.Warning(key, content)
-    }
-
-    private fun ProductProperty.Property.toPropertyUiModel(key: String) =
-        ProductDetailRowUiModel.Property(
-            key = key,
-            title = title,
-            value = value,
-            showDivider = isDividerVisible,
-        )
-
-    private fun ProductProperty.ComplexProperty.toComplexPropertyUiModel(key: String) =
-        ProductDetailRowUiModel.ComplexProperty(
-            key = key,
-            title = title,
-            value = value,
-            icon = icon,
-            showTitle = showTitle,
-            maxLines = maxLines,
-            showDivider = isDividerVisible,
-            onClick = onClick,
-        )
-
-    private fun ProductProperty.RatingBar.toRatingUiModel(key: String) =
-        ProductDetailRowUiModel.Rating(
-            key = key,
-            title = title,
-            value = value,
-            rating = rating,
-            icon = icon,
-            showDivider = false,
-            onClick = onClick,
-        )
-
-    private fun ProductProperty.Editable.toEditableUiModel(key: String) =
-        ProductDetailRowUiModel.Editable(
-            key = key,
-            hint = hint,
-            text = text,
-            shouldFocus = shouldFocus,
-            isReadOnly = isReadOnly,
-            badgeText = badgeText,
-            badgeTone = badgeColor?.let {
-                if (it == R.color.product_status_badge_pending) {
-                    ProductDetailBadgeTone.WARNING
-                } else {
-                    ProductDetailBadgeTone.NEUTRAL
-                }
-            },
-            onTextChanged = onTextChanged,
-        )
-
-    private fun ProductProperty.PropertyGroup.toPropertyGroupUiModel(key: String) =
-        ProductDetailRowUiModel.PropertyGroup(
-            key = key,
-            title = title,
-            properties = properties.entries.map { ProductDetailPropertyValueUiModel(it.key, it.value) },
-            icon = icon,
-            showTitle = showTitle,
-            showDivider = isDividerVisible,
-            isHighlighted = isHighlighted,
-            propertyFormat = propertyFormat,
-            onClick = onClick,
-        )
-
-    private fun ProductProperty.Link.toLinkUiModel(key: String) =
-        ProductDetailRowUiModel.Link(
-            key = key,
-            title = title,
-            icon = icon,
-            showDivider = isDividerVisible,
-            onClick = onClick,
-        )
-
-    private fun ProductProperty.Button.toButtonUiModel(key: String) =
-        ProductDetailRowUiModel.Button(
-            key = key,
-            text = text,
-            icon = icon,
-            showDivider = isDividerVisible,
-            tooltip = tooltip?.let {
-                ProductDetailTooltipUiModel(
-                    title = it.title,
-                    text = it.text,
-                    dismissButtonText = it.dismissButtonText,
-                    onDismiss = it.onDismiss,
-                )
-            },
-            link = link?.let { ProductDetailButtonLinkUiModel(it.text, it.onClick) },
-            onClick = onClick,
-        )
-
-    private fun ProductProperty.Switch.toSwitchUiModel(key: String) =
-        ProductDetailRowUiModel.Switch(
-            key = key,
-            title = title,
-            isOn = isOn,
-            icon = icon,
-            onStateChanged = onStateChanged,
-        )
 
     private fun ProductProperty.semanticKey(): String = when (this) {
         ProductProperty.Divider -> "divider"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailUiModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailUiModel.kt
@@ -1,10 +1,9 @@
 package com.woocommerce.android.ui.products.details
 
-import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.compose.runtime.Immutable
+import com.woocommerce.android.ui.products.models.ProductProperty
 
-@Immutable
 sealed interface ProductDetailScreenState {
     data object Loading : ProductDetailScreenState
 
@@ -28,12 +27,11 @@ sealed interface ProductDetailImageUiState {
     data object Hidden : ProductDetailImageUiState
 }
 
-@Immutable
 data class ProductDetailCardUiModel(
     val key: String,
     val style: ProductDetailCardStyle,
     val caption: String,
-    val rows: List<ProductDetailRowUiModel>,
+    val rows: List<ProductDetailRow>,
 )
 
 enum class ProductDetailCardStyle {
@@ -41,118 +39,8 @@ enum class ProductDetailCardStyle {
     SECONDARY,
 }
 
-enum class ProductDetailBadgeTone {
-    NEUTRAL,
-    WARNING,
-}
-
-@Immutable
-sealed interface ProductDetailRowUiModel {
-    val key: String
-
-    data class Divider(
-        override val key: String,
-    ) : ProductDetailRowUiModel
-
-    data class Property(
-        override val key: String,
-        @StringRes val title: Int,
-        val value: String,
-        val showDivider: Boolean,
-    ) : ProductDetailRowUiModel
-
-    data class ComplexProperty(
-        override val key: String,
-        @StringRes val title: Int?,
-        val value: String,
-        @DrawableRes val icon: Int?,
-        val showTitle: Boolean,
-        val maxLines: Int,
-        val showDivider: Boolean,
-        val onClick: (() -> Unit)?,
-    ) : ProductDetailRowUiModel
-
-    data class Rating(
-        override val key: String,
-        @StringRes val title: Int,
-        val value: String,
-        val rating: Float,
-        @DrawableRes val icon: Int,
-        val showDivider: Boolean,
-        val onClick: (() -> Unit)?,
-    ) : ProductDetailRowUiModel
-
-    data class Editable(
-        override val key: String,
-        @StringRes val hint: Int,
-        val text: String,
-        val shouldFocus: Boolean,
-        val isReadOnly: Boolean,
-        @StringRes val badgeText: Int?,
-        val badgeTone: ProductDetailBadgeTone?,
-        val onTextChanged: ((String) -> Unit)?,
-    ) : ProductDetailRowUiModel
-
-    data class PropertyGroup(
-        override val key: String,
-        @StringRes val title: Int,
-        val properties: List<ProductDetailPropertyValueUiModel>,
-        @DrawableRes val icon: Int?,
-        val showTitle: Boolean,
-        val showDivider: Boolean,
-        val isHighlighted: Boolean,
-        @StringRes val propertyFormat: Int,
-        val onClick: (() -> Unit)?,
-    ) : ProductDetailRowUiModel
-
-    data class Link(
-        override val key: String,
-        @StringRes val title: Int,
-        @DrawableRes val icon: Int?,
-        val showDivider: Boolean,
-        val onClick: (() -> Unit)?,
-    ) : ProductDetailRowUiModel
-
-    data class Button(
-        override val key: String,
-        @StringRes val text: Int,
-        @DrawableRes val icon: Int?,
-        val showDivider: Boolean,
-        val tooltip: ProductDetailTooltipUiModel?,
-        val link: ProductDetailButtonLinkUiModel?,
-        val onClick: () -> Unit,
-    ) : ProductDetailRowUiModel
-
-    data class Switch(
-        override val key: String,
-        @StringRes val title: Int,
-        val isOn: Boolean,
-        @DrawableRes val icon: Int?,
-        val onStateChanged: ((Boolean) -> Unit)?,
-    ) : ProductDetailRowUiModel
-
-    data class Warning(
-        override val key: String,
-        val content: String,
-    ) : ProductDetailRowUiModel
-}
-
-@Immutable
-data class ProductDetailPropertyValueUiModel(
-    val label: String,
-    val value: String,
-)
-
-@Immutable
-data class ProductDetailTooltipUiModel(
-    @StringRes val title: Int,
-    @StringRes val text: Int,
-    @StringRes val dismissButtonText: Int,
-    val onDismiss: () -> Unit,
-)
-
-@Immutable
-data class ProductDetailButtonLinkUiModel(
-    @StringRes val text: Int,
-    val onClick: () -> Unit,
+data class ProductDetailRow(
+    val key: String,
+    val property: ProductProperty,
+    val showDivider: Boolean? = null,
 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/models/ProductProperty.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/models/ProductProperty.kt
@@ -77,7 +77,6 @@ sealed class ProductProperty(val type: Type) {
     data class Editable(
         @StringRes val hint: Int,
         val text: String = "",
-        val shouldFocus: Boolean = false,
         val isReadOnly: Boolean = false,
         @StringRes val badgeText: Int? = null,
         @ColorRes val badgeColor: Int? = null,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/models/ProductProperty.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/models/ProductProperty.kt
@@ -77,8 +77,8 @@ sealed class ProductProperty(val type: Type) {
     data class Editable(
         @StringRes val hint: Int,
         val text: String = "",
-        var shouldFocus: Boolean = false,
-        var isReadOnly: Boolean = false,
+        val shouldFocus: Boolean = false,
+        val isReadOnly: Boolean = false,
         @StringRes val badgeText: Int? = null,
         @ColorRes val badgeColor: Int? = null,
         val onTextChanged: ((String) -> Unit)? = null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/propertyviews/WCProductPropertyEditableView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/propertyviews/WCProductPropertyEditableView.kt
@@ -23,7 +23,7 @@ class WCProductPropertyEditableView @JvmOverloads constructor(
     // Flag to check if [EditText] already has a [EditText.doAfterTextChanged] defined to avoid multiple callbacks
     private var isTextChangeListenerActive: Boolean = false
 
-    fun show(hint: String, detail: String?, isFocused: Boolean, isReadOnly: Boolean) {
+    fun show(hint: String, detail: String?, isReadOnly: Boolean) {
         editableText.hint = hint
 
         if (!detail.isNullOrEmpty() && detail != editableText.text.toString()) {
@@ -32,10 +32,6 @@ class WCProductPropertyEditableView @JvmOverloads constructor(
         }
 
         editableText.isEnabled = !isReadOnly
-
-        if (isFocused) {
-            editableText.requestFocus()
-        }
     }
 
     fun showBadge(badgeTextRes: Int, badgeColorRes: Int) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/viewholders/EditableViewHolder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/viewholders/EditableViewHolder.kt
@@ -18,7 +18,7 @@ class EditableViewHolder(parent: ViewGroup) : ProductPropertyViewHolder(
             editableView.setOnTextChangedListener { text -> onTextChanged(text.toString()) }
         }
 
-        editableView.show(hint, item.text, item.shouldFocus, item.isReadOnly)
+        editableView.show(hint, item.text, item.isReadOnly)
 
         if (item.badgeText != null && item.badgeColor != null) {
             editableView.showBadge(item.badgeText, item.badgeColor)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/adapters/ProductPropertiesDiffCallbackTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/adapters/ProductPropertiesDiffCallbackTest.kt
@@ -1,0 +1,46 @@
+package com.woocommerce.android.ui.products.adapters
+
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.products.models.ProductProperty
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class ProductPropertiesDiffCallbackTest {
+    @Test
+    fun `given an empty editable, when text arrives, then immutable focus payload is returned`() {
+        // GIVEN
+        val oldItem = editable(text = "")
+        val newItem = editable(text = "Title")
+        val callback = ProductPropertiesDiffCallback(listOf(oldItem), listOf(newItem))
+
+        // WHEN
+        val payload = callback.getChangePayload(0, 0)
+        val focusedItem = newItem.withEditableFocus(listOf(EditableFocusPayload))
+
+        // THEN
+        assertThat(callback.areContentsTheSame(0, 0)).isFalse()
+        assertThat(payload).isSameAs(EditableFocusPayload)
+        assertThat(newItem.shouldFocus).isFalse()
+        assertThat(focusedItem).isEqualTo(newItem.copy(shouldFocus = true))
+    }
+
+    @Test
+    fun `given an editable in progress, when persisted text arrives, then rebinding remains suppressed`() {
+        // GIVEN
+        val callback = ProductPropertiesDiffCallback(
+            oldList = listOf(editable(text = "Local edit")),
+            newList = listOf(editable(text = "Persisted edit")),
+        )
+
+        // WHEN
+        val contentsAreTheSame = callback.areContentsTheSame(0, 0)
+
+        // THEN
+        assertThat(contentsAreTheSame).isTrue()
+    }
+
+    private fun editable(text: String) = ProductProperty.Editable(
+        hint = R.string.product_detail_title_hint,
+        text = text,
+    )
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/adapters/ProductPropertiesDiffCallbackTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/adapters/ProductPropertiesDiffCallbackTest.kt
@@ -7,21 +7,19 @@ import org.junit.Test
 
 class ProductPropertiesDiffCallbackTest {
     @Test
-    fun `given an empty editable, when text arrives, then immutable focus payload is returned`() {
+    fun `given an empty editable, when text arrives, then rebinding is requested`() {
         // GIVEN
         val oldItem = editable(text = "")
-        val newItem = editable(text = "Title")
-        val callback = ProductPropertiesDiffCallback(listOf(oldItem), listOf(newItem))
+        val callback = ProductPropertiesDiffCallback(
+            oldList = listOf(oldItem),
+            newList = listOf(editable(text = "Title")),
+        )
 
         // WHEN
-        val payload = callback.getChangePayload(0, 0)
-        val focusedItem = newItem.withEditableFocus(listOf(EditableFocusPayload))
+        val contentsAreTheSame = callback.areContentsTheSame(0, 0)
 
         // THEN
-        assertThat(callback.areContentsTheSame(0, 0)).isFalse()
-        assertThat(payload).isSameAs(EditableFocusPayload)
-        assertThat(newItem.shouldFocus).isFalse()
-        assertThat(focusedItem).isEqualTo(newItem.copy(shouldFocus = true))
+        assertThat(contentsAreTheSame).isFalse()
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailTitleFieldStateTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailTitleFieldStateTest.kt
@@ -15,7 +15,6 @@ class ProductDetailTitleFieldStateTest {
         val result = synchronizeTitleFieldState(
             externalText = UPDATED_TITLE,
             isFocused = false,
-            shouldFocus = false,
             currentState = currentState,
         )
 
@@ -37,7 +36,6 @@ class ProductDetailTitleFieldStateTest {
         val result = synchronizeTitleFieldState(
             externalText = UPDATED_TITLE,
             isFocused = true,
-            shouldFocus = false,
             currentState = currentState,
         )
 
@@ -59,7 +57,6 @@ class ProductDetailTitleFieldStateTest {
         val result = synchronizeTitleFieldState(
             externalText = UPDATED_TITLE,
             isFocused = false,
-            shouldFocus = false,
             currentState = currentState,
         )
 
@@ -68,15 +65,14 @@ class ProductDetailTitleFieldStateTest {
     }
 
     @Test
-    fun `given the title should focus, when the external text changes, then the cursor moves to the end`() {
+    fun `given the title is focused, when the external text changes, then the cursor moves to the end`() {
         // GIVEN
         val currentState = givenTitleFieldState(text = ORIGINAL_TITLE)
 
         // WHEN
         val result = synchronizeTitleFieldState(
             externalText = UPDATED_TITLE,
-            isFocused = false,
-            shouldFocus = true,
+            isFocused = true,
             currentState = currentState,
         )
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailUiMapperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailUiMapperTest.kt
@@ -107,7 +107,7 @@ class ProductDetailUiMapperTest {
     }
 
     @Test
-    fun `when an editable is mapped, then the thin row reuses it`() {
+    fun `when an immutable editable is mapped, then the thin row reuses it safely`() {
         val editable = ProductProperty.Editable(
             hint = R.string.product_detail_title_hint,
             shouldFocus = true,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailUiMapperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailUiMapperTest.kt
@@ -80,7 +80,6 @@ class ProductDetailUiMapperTest {
             "Second" to "2",
         )
         val editable = rows.singleProperty<ProductProperty.Editable>()
-        assertThat(editable.shouldFocus).isTrue()
         assertThat(editable.isReadOnly).isTrue()
         editable.onTextChanged?.invoke("updated")
         rows.singleProperty<ProductProperty.ComplexProperty>().onClick?.invoke()
@@ -110,14 +109,12 @@ class ProductDetailUiMapperTest {
     fun `when an immutable editable is mapped, then the thin row reuses it safely`() {
         val editable = ProductProperty.Editable(
             hint = R.string.product_detail_title_hint,
-            shouldFocus = true,
             isReadOnly = true,
         )
 
         val mapped = mapSingleProperty(editable) as ProductProperty.Editable
 
         assertThat(mapped).isSameAs(editable)
-        assertThat(mapped.shouldFocus).isTrue()
         assertThat(mapped.isReadOnly).isTrue()
     }
 
@@ -222,7 +219,6 @@ class ProductDetailUiMapperTest {
         ProductProperty.Editable(
             hint = R.string.product_detail_title_hint,
             text = "Title",
-            shouldFocus = true,
             isReadOnly = true,
             badgeText = R.string.product_status_private,
             badgeColor = R.color.product_status_badge_pending,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailUiMapperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailUiMapperTest.kt
@@ -47,46 +47,50 @@ class ProductDetailUiMapperTest {
             ProductDetailCardStyle.SECONDARY,
         )
         assertThat(result[1].caption).isEqualTo("Details")
-        assertThat(result[1].rows.map { it::class.java }).containsExactly(
-            ProductDetailRowUiModel.Divider::class.java,
-            ProductDetailRowUiModel.Property::class.java,
-            ProductDetailRowUiModel.ComplexProperty::class.java,
-            ProductDetailRowUiModel.Rating::class.java,
-            ProductDetailRowUiModel.Editable::class.java,
-            ProductDetailRowUiModel.PropertyGroup::class.java,
-            ProductDetailRowUiModel.Link::class.java,
-            ProductDetailRowUiModel.Button::class.java,
-            ProductDetailRowUiModel.Switch::class.java,
-            ProductDetailRowUiModel.Warning::class.java,
+        assertThat(result[1].rows.map { it.property::class.java }).containsExactly(
+            ProductProperty.Divider::class.java,
+            ProductProperty.Property::class.java,
+            ProductProperty.ComplexProperty::class.java,
+            ProductProperty.RatingBar::class.java,
+            ProductProperty.Editable::class.java,
+            ProductProperty.PropertyGroup::class.java,
+            ProductProperty.Link::class.java,
+            ProductProperty.Button::class.java,
+            ProductProperty.Switch::class.java,
+            ProductProperty.Warning::class.java,
         )
     }
 
     @Test
     fun `when properties are mapped, then values callbacks and ordered groups are preserved`() {
         val callbackResults = mutableListOf<String>()
-        val properties = allPropertyVariants(onCallback = callbackResults::add)
 
         val rows = mapper.map(
-            listOf(ProductPropertyCard(ProductPropertyCard.Type.SECONDARY, properties = properties))
+            listOf(
+                ProductPropertyCard(
+                    ProductPropertyCard.Type.SECONDARY,
+                    properties = allPropertyVariants(callbackResults::add),
+                )
+            )
         ).single().rows
 
-        val group = rows.filterIsInstance<ProductDetailRowUiModel.PropertyGroup>().single()
-        assertThat(group.properties).containsExactly(
-            ProductDetailPropertyValueUiModel("First", "1"),
-            ProductDetailPropertyValueUiModel("Second", "2"),
+        val group = rows.singleProperty<ProductProperty.PropertyGroup>()
+        assertThat(group.properties.entries.map { it.key to it.value }).containsExactly(
+            "First" to "1",
+            "Second" to "2",
         )
-        val editable = rows.filterIsInstance<ProductDetailRowUiModel.Editable>().single()
+        val editable = rows.singleProperty<ProductProperty.Editable>()
         assertThat(editable.shouldFocus).isTrue()
         assertThat(editable.isReadOnly).isTrue()
         editable.onTextChanged?.invoke("updated")
-        rows.filterIsInstance<ProductDetailRowUiModel.ComplexProperty>().single().onClick?.invoke()
-        rows.filterIsInstance<ProductDetailRowUiModel.Rating>().single().onClick?.invoke()
+        rows.singleProperty<ProductProperty.ComplexProperty>().onClick?.invoke()
+        rows.singleProperty<ProductProperty.RatingBar>().onClick?.invoke()
         group.onClick?.invoke()
-        rows.filterIsInstance<ProductDetailRowUiModel.Link>().single().onClick?.invoke()
-        val button = rows.filterIsInstance<ProductDetailRowUiModel.Button>().single()
+        rows.singleProperty<ProductProperty.Link>().onClick?.invoke()
+        val button = rows.singleProperty<ProductProperty.Button>()
         button.tooltip?.onDismiss?.invoke()
         button.link?.onClick?.invoke()
-        rows.filterIsInstance<ProductDetailRowUiModel.Switch>().single().onStateChanged?.invoke(false)
+        rows.singleProperty<ProductProperty.Switch>().onStateChanged?.invoke(false)
         button.onClick()
 
         assertThat(callbackResults).containsExactly(
@@ -103,30 +107,22 @@ class ProductDetailUiMapperTest {
     }
 
     @Test
-    fun `when mutable editable flags change after mapping, then mapped values remain a snapshot`() {
+    fun `when an editable is mapped, then the thin row reuses it`() {
         val editable = ProductProperty.Editable(
             hint = R.string.product_detail_title_hint,
             shouldFocus = true,
             isReadOnly = true,
         )
 
-        val mapped = mapper.map(
-            listOf(
-                ProductPropertyCard(
-                    ProductPropertyCard.Type.PRIMARY,
-                    properties = listOf(editable),
-                )
-            )
-        ).single().rows.single() as ProductDetailRowUiModel.Editable
-        editable.shouldFocus = false
-        editable.isReadOnly = false
+        val mapped = mapSingleProperty(editable) as ProductProperty.Editable
 
+        assertThat(mapped).isSameAs(editable)
         assertThat(mapped.shouldFocus).isTrue()
         assertThat(mapped.isReadOnly).isTrue()
     }
 
     @Test
-    fun `when rating position is mapped, then its legacy divider is hidden only at the end of a card`() {
+    fun `when rating position is mapped, then divider override is hidden only at the end of a card`() {
         val rating = ProductProperty.RatingBar(
             title = R.string.product_reviews,
             value = "4 reviews",
@@ -140,71 +136,70 @@ class ProductDetailUiMapperTest {
                     properties = listOf(rating, ProductProperty.Warning("Warning")),
                 )
             )
-        ).single().rows.first() as ProductDetailRowUiModel.Rating
+        ).single().rows.first()
         val finalRating = mapper.map(
             listOf(ProductPropertyCard(ProductPropertyCard.Type.SECONDARY, properties = listOf(rating)))
-        ).single().rows.single() as ProductDetailRowUiModel.Rating
+        ).single().rows.single()
 
         assertThat(followedRating.showDivider).isTrue()
         assertThat(finalRating.showDivider).isFalse()
     }
 
     @Test
-    fun `when semantic rows repeat, then keys are stable and unique without list indexes`() {
-        val properties = listOf(
-            ProductProperty.Property(R.string.product_price, "10"),
-            ProductProperty.Property(R.string.product_price, "20"),
+    fun `when semantic cards and rows repeat, then keys use stable occurrence suffixes`() {
+        val card = ProductPropertyCard(
+            ProductPropertyCard.Type.SECONDARY,
+            properties = listOf(
+                ProductProperty.Property(R.string.product_price, "10"),
+                ProductProperty.Property(R.string.product_price, "20"),
+            ),
         )
 
-        val first = mapper.map(
-            listOf(ProductPropertyCard(ProductPropertyCard.Type.SECONDARY, properties = properties))
-        )
-        val second = mapper.map(
-            listOf(ProductPropertyCard(ProductPropertyCard.Type.SECONDARY, properties = properties))
-        )
+        val first = mapper.map(listOf(card, card))
+        val second = mapper.map(listOf(card, card))
 
-        assertThat(first.single().rows.map { it.key }).containsExactly(
+        assertThat(first.map { it.key }).containsExactly("secondary", "secondary_1")
+        assertThat(first.first().rows.map { it.key }).containsExactly(
             "property_${R.string.product_price}",
             "property_${R.string.product_price}_1",
         )
-        assertThat(second.single().rows.map { it.key }).isEqualTo(first.single().rows.map { it.key })
+        assertThat(second.map { it.key }).isEqualTo(first.map { it.key })
+        assertThat(second.first().rows.map { it.key }).isEqualTo(first.first().rows.map { it.key })
     }
 
     @Test
-    fun `given Add is persisted, when cards are remapped, then semantic keys stay stable and callbacks are current`() {
+    fun `given Add is persisted, when cards are remapped, then keys stay stable and callbacks are current`() {
         var callback = ""
-        val initialCards = listOf(
-            ProductPropertyCard(
-                ProductPropertyCard.Type.PRIMARY,
-                properties = listOf(
-                    ProductProperty.Editable(
-                        hint = R.string.product_detail_title_hint,
-                        onTextChanged = { callback = "initial:$it" },
-                    )
-                ),
-            )
-        )
-        val persistedCards = listOf(
-            ProductPropertyCard(
-                ProductPropertyCard.Type.PRIMARY,
-                properties = listOf(
-                    ProductProperty.Editable(
-                        hint = R.string.product_detail_title_hint,
-                        onTextChanged = { callback = "persisted:$it" },
-                    )
-                ),
-            )
-        )
+        val initial = mapEditable { callback = "initial:$it" }
+        val persisted = mapEditable { callback = "persisted:$it" }
 
-        val initial = mapper.map(initialCards)
-        val persisted = mapper.map(persistedCards)
-        val editable = persisted.single().rows.single() as ProductDetailRowUiModel.Editable
-        editable.onTextChanged?.invoke("Title")
+        (persisted.single().rows.single().property as ProductProperty.Editable).onTextChanged?.invoke("Title")
 
         assertThat(persisted.map { it.key }).isEqualTo(initial.map { it.key })
         assertThat(persisted.single().rows.map { it.key }).isEqualTo(initial.single().rows.map { it.key })
         assertThat(callback).isEqualTo("persisted:Title")
     }
+
+    private fun mapSingleProperty(property: ProductProperty): ProductProperty = mapper.map(
+        listOf(ProductPropertyCard(ProductPropertyCard.Type.PRIMARY, properties = listOf(property)))
+    ).single().rows.single().property
+
+    private fun mapEditable(onTextChanged: (String) -> Unit) = mapper.map(
+        listOf(
+            ProductPropertyCard(
+                ProductPropertyCard.Type.PRIMARY,
+                properties = listOf(
+                    ProductProperty.Editable(
+                        hint = R.string.product_detail_title_hint,
+                        onTextChanged = onTextChanged,
+                    )
+                ),
+            )
+        )
+    )
+
+    private inline fun <reified T : ProductProperty> List<ProductDetailRow>.singleProperty() =
+        map { it.property }.filterIsInstance<T>().single()
 
     private fun allPropertyVariants(
         onCallback: (String) -> Unit = {},

--- a/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooDesignSystemToolbar.kt
+++ b/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooDesignSystemToolbar.kt
@@ -51,6 +51,7 @@ class WooDesignSystemToolbar @JvmOverloads constructor(
         // ActionMenuItemView centers icon-only items from the current icon bounds during measure.
         decorateNavigationButton()
         decorateRenderedMenuActions()
+        applyToolbarControlEdgeMargins()
         super.onMeasure(widthMeasureSpec, heightMeasureSpec)
         if (decorateTitle() || decorateNavigationButton() || decorateRenderedMenuActions()) {
             super.onMeasure(widthMeasureSpec, heightMeasureSpec)
@@ -58,10 +59,11 @@ class WooDesignSystemToolbar @JvmOverloads constructor(
     }
 
     override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
+        applyToolbarControlEdgeMargins()
         super.onLayout(changed, left, top, right, bottom)
         decorateNavigationButton()
         decorateRenderedMenuActions()
-        applyToolbarControlEdgeInsets()
+        centerToolbarControlsVertically()
     }
 
     private fun applyStaticChrome() {
@@ -189,64 +191,33 @@ class WooDesignSystemToolbar @JvmOverloads constructor(
     private fun View.isIconOnlyAction(): Boolean =
         this !is TextView || text.isNullOrEmpty()
 
-    private fun applyToolbarControlEdgeInsets() {
+    private fun applyToolbarControlEdgeMargins() {
         val controlEdgeInset = (
             resources.getDimension(R.dimen.woo_ds_toolbar_edge_padding) -
                 resources.getDimension(R.dimen.woo_ds_toolbar_icon_border_inset)
             ).roundToInt()
-        val isRtl = layoutDirection == View.LAYOUT_DIRECTION_RTL
-        val toolbarWidth = width
+        val navigationLayoutParams = children.filterIsInstance<AppCompatImageButton>()
+            .firstOrNull()?.layoutParams as? ViewGroup.MarginLayoutParams
+        val actionMenuLayoutParams = children.filterIsInstance<ActionMenuView>()
+            .firstOrNull()?.layoutParams as? ViewGroup.MarginLayoutParams
+
+        navigationLayoutParams?.marginStart = controlEdgeInset
+        actionMenuLayoutParams?.marginEnd = controlEdgeInset
+    }
+
+    private fun centerToolbarControlsVertically() {
         val toolbarHeight = height
-
-        children.filterIsInstance<AppCompatImageButton>().firstOrNull()?.layoutWithStartInset(
-            edgeInset = controlEdgeInset,
-            toolbarWidth = toolbarWidth,
-            toolbarHeight = toolbarHeight,
-            isRtl = isRtl,
-        )
-
+        children.filterIsInstance<AppCompatImageButton>().firstOrNull()?.centerVertically(toolbarHeight)
         children.filterIsInstance<ActionMenuView>().firstOrNull()?.let { actionMenuView ->
-            actionMenuView.layoutWithEndInset(
-                edgeInset = controlEdgeInset,
-                toolbarWidth = toolbarWidth,
-                toolbarHeight = toolbarHeight,
-                isRtl = isRtl,
-            )
+            actionMenuView.centerVertically(toolbarHeight)
             actionMenuView.centerOutlinedActionsVertically(toolbarHeight)
         }
     }
 }
 
-private fun View.layoutWithStartInset(
-    edgeInset: Int,
-    toolbarWidth: Int,
-    toolbarHeight: Int,
-    isRtl: Boolean,
-) {
-    val childWidth = measuredWidth
+private fun View.centerVertically(toolbarHeight: Int) {
     val childTop = ((toolbarHeight - measuredHeight) / 2f).roundToInt()
-    val childLeft = if (isRtl) {
-        toolbarWidth - edgeInset - childWidth
-    } else {
-        edgeInset
-    }
-    layout(childLeft, childTop, childLeft + childWidth, childTop + measuredHeight)
-}
-
-private fun View.layoutWithEndInset(
-    edgeInset: Int,
-    toolbarWidth: Int,
-    toolbarHeight: Int,
-    isRtl: Boolean,
-) {
-    val childWidth = measuredWidth
-    val childTop = ((toolbarHeight - measuredHeight) / 2f).roundToInt()
-    val childLeft = if (isRtl) {
-        edgeInset
-    } else {
-        toolbarWidth - edgeInset - childWidth
-    }
-    layout(childLeft, childTop, childLeft + childWidth, childTop + measuredHeight)
+    layout(left, childTop, right, childTop + measuredHeight)
 }
 
 private fun ActionMenuView.centerOutlinedActionsVertically(toolbarHeight: Int) {

--- a/libs/store-design-system/src/test/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooDesignSystemToolbarTest.kt
+++ b/libs/store-design-system/src/test/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooDesignSystemToolbarTest.kt
@@ -115,6 +115,33 @@ class WooDesignSystemToolbarTest {
     }
 
     @Test
+    fun `given long title with icon and overflow actions, when laid out, then title keeps spacing from actions`() {
+        // GIVEN
+        val toolbar = WooDesignSystemToolbar(toolbarContext()).apply {
+            title = "Beanie with Logo - Enormous Leather Company Limited ".repeat(10).trim()
+            navigationIcon = AppCompatResources.getDrawable(
+                context,
+                R.drawable.woo_ds_ic_regular_angle_left_24dp,
+            )
+            navigationContentDescription = "Back"
+            addIconAction(title = "Share")
+            addOverflowAction()
+        }
+        val controlSpacing = toolbar.resources.getDimensionPixelSize(
+            R.dimen.woo_ds_toolbar_title_control_spacing,
+        )
+
+        // WHEN
+        toolbar.layoutToolbar(widthDp = 480)
+
+        // THEN
+        val titleView = toolbar.titleTextView(toolbar.title.toString())
+        val action = toolbar.actionChild(ACTION_ID)
+        val actionLeft = toolbar.actionMenuView().left + action.left
+        assertThat(actionLeft - (titleView.right - titleView.paddingEnd)).isGreaterThanOrEqualTo(controlSpacing)
+    }
+
+    @Test
     fun `given toolbar xml attributes, when inflated, then title navigation and menu are applied`() {
         val toolbar = LayoutInflater.from(toolbarContext())
             .inflate(R.layout.woo_design_system_toolbar_test, null) as WooDesignSystemToolbar


### PR DESCRIPTION
### Description

Fixes WOOMOB-3739

During the Product Detail Compose migration, we introduced the separate `ProductDetailRowUiModel` hierarchy so the new renderer could consume UI-specific row state without changing the existing `ProductProperty` model. Once the migration was complete, it became clear that each row variant mirrored a `ProductProperty` variant almost field-for-field, leaving a large mapping layer without a meaningful separate abstraction.

This follow-up simplifies that design: each Product Detail row now contains a stable semantic key, the existing `ProductProperty`, and the one Product Detail-specific concern—an optional divider override. `Editable` is made immutable, and Product Detail no longer claims an `@Immutable` contract that the wrapped model cannot guarantee. This preserves ordering, duplicate-key handling, current callbacks, divider behavior, and visuals while removing the duplicated hierarchy and conversion boilerplate.

Making `Editable` immutable also removes `shouldFocus`. That flag was introduced in 2020 as a DiffUtil mutation workaround to keep the legacy Product Detail `EditText` focused when title updates rebuilt the list. Product Detail now owns focus, cursor position, and restoration in Compose, while the only remaining legacy adapter consumer is Variation Detail and its title is read-only. There is therefore no active editable legacy consumer for the flag, so this removes it together with the payload mutation and legacy `requestFocus()` path.

### Test Steps

1. Open Products and select an editable product with reviews.
2. Verify the Product Detail rows retain their expected order and dividers, including the divider after Reviews when another row follows.
3. Edit the title and verify the toolbar updates while the field retains focus and subsequent input is appended at the cursor.
4. Rotate the device and verify the title text, focus, and cursor behavior are restored; navigate back and discard the draft.
5. Open a variable product, navigate to Variations, and open a variation.
6. Verify Variation Detail renders normally and its product title remains read-only.

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
