### PR TITLE
Minify the Wear app's release builds

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 
 25.5
 -----
+- [WEAR][*****] The watch app's release builds are now shrunk with R8, cutting the APK from 18.1 to 6.5 MB [https://github.com/woocommerce/woocommerce-android/pull/16443]
 - [WEAR][*] Order and stats dates on the watch now follow the language's date order [https://github.com/woocommerce/woocommerce-android/pull/16429]
 - [Internal] [WEAR] Wear stack traces in Sentry now carry source context: the source bundle uploads to the `woocommerce-wear` project rather than the phone app's [https://github.com/woocommerce/woocommerce-android/pull/16427]
 - [Internal] Fixed duplicated device registration API calls fired concurrently during login [https://github.com/woocommerce/woocommerce-android/pull/16354]

--- a/WooCommerce-Wear/build.gradle
+++ b/WooCommerce-Wear/build.gradle
@@ -1,6 +1,3 @@
-import io.sentry.android.gradle.extensions.InstrumentationFeature
-import io.sentry.android.gradle.tasks.SentryCliExecTask
-
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.compose)
@@ -11,44 +8,8 @@ plugins {
     alias(libs.plugins.dependency.analysis)
 }
 
-def sentryAuthToken = providers.environmentVariable("SENTRY_AUTH_TOKEN").orNull?.trim() ?: null
-def shouldUploadToSentry = gradle.ext.isCi
-        && !providers.gradleProperty("skipSentryUpload").orNull?.toBoolean()
-
 sentry {
-    org = "a8c"
     projectName = "woocommerce-wear"
-    authToken = sentryAuthToken
-
-    includeProguardMapping = shouldUploadToSentry
-    includeSourceContext = shouldUploadToSentry
-    autoUploadSourceContext = true
-    tracingInstrumentation {
-        enabled = true
-        features = [InstrumentationFeature.DATABASE]
-        logcat {
-            enabled = false
-        }
-    }
-    autoInstallation {
-        enabled = false
-    }
-    includeDependenciesReport = false
-    /* Sentry won't send source context or add performance instrumentations for debug builds
-    so we can save build times. Sending events will still work in debug builds
-    (if enabled in WCCrashLoggingDataProvider).
-    */
-    ignoredBuildTypes = ["debug"]
-}
-
-tasks.withType(SentryCliExecTask).configureEach {
-    doFirst {
-        if (sentryAuthToken == null) {
-            throw new GradleException("SENTRY_AUTH_TOKEN is not set (or is blank). " +
-                    "Export it to upload debug files to Sentry, " +
-                    "or pass -PskipSentryUpload=true to skip the upload.")
-        }
-    }
 }
 
 def versionProperties = loadPropertiesFromFile(file("${rootDir}/version.properties"))

--- a/WooCommerce-Wear/build.gradle
+++ b/WooCommerce-Wear/build.gradle
@@ -72,7 +72,7 @@ android {
 
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled = true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -1,5 +1,3 @@
-import io.sentry.android.gradle.extensions.InstrumentationFeature
-import io.sentry.android.gradle.tasks.SentryCliExecTask
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -64,34 +62,8 @@ fladle {
     ]
 }
 
-def sentryAuthToken = providers.environmentVariable("SENTRY_AUTH_TOKEN").orNull?.trim() ?: null
-def shouldUploadToSentry = gradle.ext.isCi
-        && !providers.gradleProperty("skipSentryUpload").orNull?.toBoolean()
-
 sentry {
-    org = "a8c"
     projectName = "woocommerce-android"
-    authToken = sentryAuthToken
-
-    includeProguardMapping = shouldUploadToSentry
-    includeSourceContext = shouldUploadToSentry
-    autoUploadSourceContext = true
-    tracingInstrumentation {
-        enabled = true
-        features = [InstrumentationFeature.DATABASE]
-        logcat {
-            enabled = false
-        }
-    }
-    autoInstallation {
-        enabled = false
-    }
-    includeDependenciesReport = false
-    /* Sentry won't send source context or add performance instrumentations for debug builds
-    so we can save build times. Sending events will still work in debug builds
-    (if enabled in WCCrashLoggingDataProvider).
-    */
-    ignoredBuildTypes = ["debug"]
 
     /* Additional source directories to be included in the source context. For now, manually:
     https://github.com/getsentry/sentry-android-gradle-plugin/issues/685
@@ -99,16 +71,6 @@ sentry {
     additionalSourceDirsForSourceContext = [
             '../libs/cardreader/src/main/java',
     ]
-}
-
-tasks.withType(SentryCliExecTask).configureEach {
-    doFirst {
-        if (sentryAuthToken == null) {
-            throw new GradleException("SENTRY_AUTH_TOKEN is not set (or is blank). " +
-                    "Export it to upload debug files to Sentry, " +
-                    "or pass -PskipSentryUpload=true to skip the upload.")
-        }
-    }
 }
 
 def versionProperties = loadPropertiesFromFile(file("${rootDir}/version.properties"))

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,8 @@ import com.automattic.android.measure.reporters.InternalA8cCiReporter
 import com.automattic.android.measure.reporters.RemoteBuildCacheMetricsReporter
 import com.automattic.android.measure.reporters.SlowSlowTasksMetricsReporter
 import io.gitlab.arturbosch.detekt.Detekt
+import io.sentry.android.gradle.extensions.InstrumentationFeature
+import io.sentry.android.gradle.tasks.SentryCliExecTask
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -20,6 +22,7 @@ plugins {
     alias(libs.plugins.androidx.navigation.safeargs) apply false
     alias(libs.plugins.google.services) apply false
     alias(libs.plugins.ksp) apply false
+    alias(libs.plugins.sentry) apply false
     alias(libs.plugins.room) apply false
 }
 
@@ -75,6 +78,46 @@ subprojects {
         dependencies {
             lintChecks(libs.wordpress.lint)
             lintChecks(libs.android.security.lint)
+        }
+    }
+    plugins.withId(libs.plugins.sentry.get().pluginId) {
+        def sentryAuthToken = providers.environmentVariable("SENTRY_AUTH_TOKEN").orNull?.trim() ?: null
+        def shouldUploadToSentry = gradle.ext.isCi
+                && !providers.gradleProperty("skipSentryUpload").orNull?.toBoolean()
+
+        sentry {
+            org = "a8c"
+            authToken = sentryAuthToken
+
+            includeProguardMapping = shouldUploadToSentry
+            includeSourceContext = shouldUploadToSentry
+            autoUploadSourceContext = true
+            tracingInstrumentation {
+                enabled = true
+                features = [InstrumentationFeature.DATABASE]
+                logcat {
+                    enabled = false
+                }
+            }
+            autoInstallation {
+                enabled = false
+            }
+            includeDependenciesReport = false
+            /* Sentry won't send source context or add performance instrumentations for debug builds
+            so we can save build times. Sending events will still work in debug builds
+            (if enabled in WCCrashLoggingDataProvider).
+            */
+            ignoredBuildTypes = ["debug"]
+        }
+
+        tasks.withType(SentryCliExecTask).configureEach {
+            doFirst {
+                if (sentryAuthToken == null) {
+                    throw new GradleException("SENTRY_AUTH_TOKEN is not set (or is blank). " +
+                            "Export it to upload debug files to Sentry, " +
+                            "or pass -PskipSentryUpload=true to skip the upload.")
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Stacked on #16427.

### Description

While reviewing #16427, @AliSoftware asked whether `minifyEnabled false` on the Wear app was intentional. It isn't: it came verbatim from the Android Studio Wear OS module template in the module's scaffolding commit and was never revisited. Two weeks later the module's `proguard-rules.pro` was replaced with a copy of the phone app's — 161 lines that R8 has never read, and that someone has since maintained.

Nothing about Wear OS prevents shrinking. The Wear app is a real shipped artifact, built and uploaded by the release pipeline with its own AAB and GitHub release, so it has been going to watches unshrunk this whole time. On `vanillaRelease` that is **18,996,193 → 6,839,159 bytes**, on the platform with the tightest storage budget of the two.

It also makes #16427's `includeProguardMapping` meaningful for Wear: with minification off, no `uploadSentryProguardMappings*` task exists on that module at all.

The second commit removes the copy-paste this whole thread came from. The two `sentry {}` blocks were identical, and they had already drifted — before #16427 the Wear one was missing `includeProguardMapping` and hardcoded `includeSourceContext = true`. There is now one copy in the root build file, and each module declares only its own Sentry project (plus, for the phone app, the `cardreader` source dir the Wear app has no dependency on).

### Intentional tradeoffs

The shared block sits in the root `build.gradle` rather than a `config/gradle/sentry.gradle` script. A script applied with `apply from:` gets its own classloader scope and cannot resolve `InstrumentationFeature` or `SentryCliExecTask`; the root script can, which is the same mechanism the `AppPlugin`/`LibraryPlugin` blocks beside it already use.

`proguard-rules.pro` is left alone. Most of it — Zendesk, Glide, Picasso, photoview — names dependencies the Wear module doesn't have, but trimming it belongs in its own PR now that the file is finally live.

### Gotchas

**R8 building cleanly is not the same as the watch app working.** The copied rules carry `-dontobfuscate` and `-keep class com.woocommerce.** { *; }`, so no app class is renamed or removed and this is shrinking over library code only — but tiles, complications and other manifest-only entry points are the classic Wear R8 casualties and only a device can prove them. Hence the `[*****]` release note.

### Test Steps

Nothing in the PR pipeline exercises a Wear release build — prototype builds are `JalapenoDebug`, and only the API-triggered release pipeline assembles Release. So a green CI run here proves nothing about either change. #16444 is a throwaway stacked PR that runs the real upload tasks; read it for the CI-side evidence.

Locally, against this branch:

1. `./gradlew :WooCommerce-Wear:assembleVanillaRelease` — R8 runs, `lintVital` passes, APK is 6,839,159 bytes against 18,996,193 on `trunk`.
2. `CI=true ./gradlew :WooCommerce-Wear:tasks --all | grep uploadSentryProguardMappings` — present here, absent on #16427's head.
3. `CI=true ./gradlew :WooCommerce-Wear:assembleVanillaRelease --dry-run` lists the upload tasks; without `CI` it lists none.
4. `SENTRY_AUTH_TOKEN= CI=true ./gradlew :WooCommerce-Wear:uploadSentryProguardMappingsVanillaRelease` fails through the guard with `SENTRY_AUTH_TOKEN is not set`, proving the shared `tasks.withType(SentryCliExecTask)` block still wires up per module.
5. For the refactor, every `sentry` extension property was dumped for both modules before and after via an init script: identical, the only difference being the Wear tasks from (2).

### Images/gif

N/A.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
