### PR TITLE
[DO NOT MERGE] Validate Wear minification for #16443

### DIFF
--- a/.buildkite/commands/validate-wear-minification.sh
+++ b/.buildkite/commands/validate-wear-minification.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+"$(dirname "${BASH_SOURCE[0]}")/restore-cache.sh"
+
+echo "--- :rubygems: Setting up Gems"
+install_gems
+
+echo "--- :closed_lock_with_key: Installing Secrets"
+bundle exec fastlane run configure_apply
+
+echo "+++ :sentry: Upload the Wear ProGuard mapping"
+./gradlew :WooCommerce-Wear:uploadSentryProguardMappingsVanillaRelease
+
+echo "--- :sentry: The shared config still serves both apps"
+./gradlew :WooCommerce:uploadSentryProguardMappingsVanillaRelease
+./gradlew :WooCommerce-Wear:sentryUploadSourceBundleVanillaRelease
+
+echo "--- :sentry: Guard fires when the token is missing"
+set +e
+output=$(SENTRY_AUTH_TOKEN= ./gradlew :WooCommerce-Wear:uploadSentryProguardMappingsVanillaRelease --rerun-tasks 2>&1)
+status=$?
+set -e
+
+printf '%s\n' "$output" | tail -30
+
+if [[ "$status" -eq 0 ]]; then
+  echo "FAIL: expected a non-zero exit without SENTRY_AUTH_TOKEN, got success."
+  exit 1
+fi
+
+if ! printf '%s' "$output" | grep -q 'SENTRY_AUTH_TOKEN is not set'; then
+  echo "FAIL: build failed without SENTRY_AUTH_TOKEN, but not through the guard."
+  exit 1
+fi
+
+echo "Guard fired as expected."
+
+echo "--- :watch: Build an installable minified Wear APK for smoke testing"
+./gradlew :WooCommerce-Wear:assembleJalapenoRelease
+
+ls -l WooCommerce-Wear/build/outputs/apk/jalapeno/release/

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -20,6 +20,12 @@ steps:
   # Wait for Gradle Wrapper to be validated before running any other jobs
   - wait
 
+  - label: ":watch: Validate Wear Minification"
+    command: .buildkite/commands/validate-wear-minification.sh
+    plugins: [$CI_TOOLKIT]
+    artifact_paths:
+      - "WooCommerce-Wear/build/outputs/apk/jalapeno/release/*.apk"
+
   ########################################
   - group: "🕵️ Linters"
     steps:


### PR DESCRIPTION
**Validation only — do not merge.** Stacked on #16443, which is stacked on #16427.

### Description

#16443 turns on R8 for the Wear app's release builds, and rehomes the Sentry config both apps share. Nothing in the ordinary pipeline touches either: prototype builds are `JalapenoDebug`, `debug` is in `ignoredBuildTypes`, and only the API-triggered release pipeline assembles a Release variant. So #16443 can go green while the Wear release build is broken, and a code freeze would be the first real test.

This adds one throwaway Buildkite step that builds the Wear release variant for real and runs the upload tasks against the code in #16443.

### Test Steps

Read the `:watch: Validate Wear Minification` job. All steps are expected to **pass** — there are no intentional failures here.

It proves four things:

1. `:WooCommerce-Wear:uploadSentryProguardMappingsVanillaRelease` runs at all — this task does not exist without minification — and lands in the `woocommerce-wear` project.
2. The phone app's mapping upload still lands in `woocommerce-android`, so moving the shared config to the root build file didn't break it.
3. With `SENTRY_AUTH_TOKEN` blank the build fails through the guard with `SENTRY_AUTH_TOKEN is not set`, so the guard is still wired up per module from its new home.
4. R8 completes on the Wear app, and the resulting `JalapenoRelease` APK is attached as an artifact.

Then download that APK and smoke test it on a watch. **That is the part CI cannot answer**: R8 building cleanly says nothing about tiles, complications, or other manifest-only entry points surviving. Confirm afterwards that the two mappings landed in their respective Sentry projects.

### Images/gif

N/A.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
