### PR TITLE
[WOOMOB-1027] Apply gift card when editing an order

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 
 25.5
 -----
+- [*] You can now apply a gift card when editing an order [https://github.com/woocommerce/woocommerce-android/pull/16445]
 - [WEAR][*] Order and stats dates on the watch now follow the language's date order [https://github.com/woocommerce/woocommerce-android/pull/16429]
 - [Internal] Fixed duplicated device registration API calls fired concurrently during login [https://github.com/woocommerce/woocommerce-android/pull/16354]
 - [*] The Pay In Person toggle on the Payments screen no longer looks turned off when its status could not be loaded

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -136,7 +136,6 @@ import org.wordpress.android.login.LoginAnalyticsListener
 import org.wordpress.android.login.LoginMode
 import org.wordpress.android.util.NetworkUtils
 import java.lang.ref.WeakReference
-import java.math.BigDecimal
 import java.util.Locale
 import javax.inject.Inject
 import kotlin.math.abs
@@ -1299,14 +1298,10 @@ class MainActivity :
 
     fun showOrderCreation(
         mode: OrderCreateEditViewModel.Mode,
-        giftCardCode: String?,
-        giftCardAmount: BigDecimal?,
         orderCurrency: String? = null,
     ) {
         NavGraphMainDirections.actionGlobalToOrderCreationFragment(
             mode = mode,
-            giftCardCode = giftCardCode,
-            giftCardAmount = giftCardAmount,
             orderCurrency = orderCurrency
         ).apply {
             navController.navigateSafely(this)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigationTarget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigationTarget.kt
@@ -4,7 +4,6 @@ import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.orders.shippinglabels.ShippingLabelPaperSizeSelectorDialog.ShippingLabelPaperSize
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
-import java.math.BigDecimal
 
 sealed class OrderNavigationTarget : Event() {
     data class ViewOrderStatusSelector(
@@ -74,8 +73,6 @@ sealed class OrderNavigationTarget : Event() {
         OrderNavigationTarget()
     data class EditOrder(
         val orderId: Long,
-        val giftCard: String? = null,
-        val appliedDiscount: BigDecimal? = null,
         val orderCurrency: String? = null,
     ) : OrderNavigationTarget()
     data class ShowOrder(val orderId: Long, val allOrderIds: LongArray) : OrderNavigationTarget()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigator.kt
@@ -202,8 +202,6 @@ class OrderNavigator @Inject constructor() {
             is EditOrder -> {
                 (fragment.activity as? MainActivity)?.showOrderCreation(
                     OrderCreateEditViewModel.Mode.Edit(target.orderId),
-                    target.giftCard,
-                    target.appliedDiscount,
                     target.orderCurrency
                 )
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/CreateUpdateOrder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/CreateUpdateOrder.kt
@@ -23,7 +23,11 @@ class CreateUpdateOrder @Inject constructor(
 
     private fun createOrUpdateOrder(order: Order) = flow {
         emit(OrderUpdateStatus.Ongoing)
-        orderCreateEditRepository.createOrUpdateOrder(order, source = OrderCreationSource.STORE_MANAGEMENT)
+        orderCreateEditRepository.createOrUpdateOrder(
+            order,
+            source = OrderCreationSource.STORE_MANAGEMENT,
+            giftCard = order.selectedGiftCard.orEmpty()
+        )
             .fold(
                 onSuccess = { emit(OrderUpdateStatus.Succeeded(it)) },
                 onFailure = { emit(OrderUpdateStatus.Failed(it)) }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -829,15 +829,6 @@ class OrderCreateEditFormFragment :
     }
 
     private fun OrderCreationAdditionalInfoCollectionSectionBinding.bindGiftCardSubSection(newOrderData: Order) {
-        when (viewModel.mode) {
-            is Creation -> bindGiftCardForOrderCreation(newOrderData)
-            is Edit -> addGiftCardButtonGroup.isVisible = false
-        }
-    }
-
-    private fun OrderCreationAdditionalInfoCollectionSectionBinding.bindGiftCardForOrderCreation(
-        newOrderData: Order
-    ) {
         if (newOrderData.selectedGiftCard.isNullOrEmpty()) {
             addGiftCardButtonGroup.isVisible = viewModel.isGiftCardExtensionEnabled
             addGiftCardButton.setOnClickListener { viewModel.onAddGiftCardButtonClicked() }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -257,10 +257,10 @@ class OrderCreateEditViewModel @Inject constructor(
         get() = pluginsInformation.value[WOO_GIFT_CARDS.pluginName]
             ?.isOperational ?: false
 
-    private val _selectedGiftCard = savedState.getStateFlow(
+    private val _giftCardToApply = savedState.getStateFlow(
         scope = viewModelScope,
         initialValue = "",
-        key = "selected_gift_card"
+        key = "gift_card_to_apply"
     )
 
     private val _orderDraft = savedState.getStateFlow(
@@ -272,10 +272,10 @@ class OrderCreateEditViewModel @Inject constructor(
     )
 
     val orderDraft = _orderDraft
-        .combine(_selectedGiftCard) { order, giftCard ->
+        .combine(_giftCardToApply) { order, giftCardToApply ->
             val appliedGiftCard = order.giftCards.firstOrNull()
             order.copy(
-                selectedGiftCard = appliedGiftCard?.code ?: giftCard,
+                selectedGiftCard = appliedGiftCard?.code ?: giftCardToApply,
                 giftCardDiscountedAmount = appliedGiftCard?.used
             )
         }.asLiveData()
@@ -292,10 +292,10 @@ class OrderCreateEditViewModel @Inject constructor(
     val totalsData: LiveData<TotalsSectionsState> =
         viewStateData.liveData.combineWith(
             _orderDraft.asLiveData(),
-            _selectedGiftCard.asLiveData()
-        ) { viewState, order, selectedGiftCard ->
+            _giftCardToApply.asLiveData()
+        ) { viewState, order, giftCardToApply ->
             val appliedGiftCard = order!!.giftCards.firstOrNull()
-            val displayedGiftCard = appliedGiftCard?.code ?: selectedGiftCard
+            val displayedGiftCard = appliedGiftCard?.code ?: giftCardToApply
             totalsHelper.mapToPaymentTotalsState(
                 order = order.copy(
                     selectedGiftCard = displayedGiftCard,
@@ -866,7 +866,7 @@ class OrderCreateEditViewModel @Inject constructor(
     }
 
     private fun updateAddGiftCardButtonVisibility(order: Order) {
-        val hasGiftCard = order.giftCards.isNotEmpty() || _selectedGiftCard.value.isNotEmpty()
+        val hasGiftCard = order.giftCards.isNotEmpty() || _giftCardToApply.value.isNotEmpty()
         val shouldEnableAddGiftCardButton = order.hasProducts() &&
             order.isEditable &&
             !hasGiftCard
@@ -1248,9 +1248,9 @@ class OrderCreateEditViewModel @Inject constructor(
     }
 
     fun onGiftCardSelected(selectedGiftCard: String) {
-        val giftCardWasRemoved = selectedGiftCard.isEmpty() && _selectedGiftCard.value.isNotEmpty()
+        val giftCardWasRemoved = selectedGiftCard.isEmpty() && _giftCardToApply.value.isNotEmpty()
         trackGiftCardSet(giftCardWasRemoved)
-        _selectedGiftCard.update { selectedGiftCard }
+        _giftCardToApply.update { selectedGiftCard }
     }
 
     /**
@@ -1259,8 +1259,8 @@ class OrderCreateEditViewModel @Inject constructor(
      * used or invalid card comes back with no applied gift cards — they are notified.
      */
     private fun reconcileGiftCardWithSyncedOrder(syncedOrder: Order) {
-        val attemptedGiftCard = _selectedGiftCard.value
-        _selectedGiftCard.update { "" }
+        val attemptedGiftCard = _giftCardToApply.value
+        _giftCardToApply.update { "" }
         val appliedGiftCard = syncedOrder.giftCards.firstOrNull()?.code.orEmpty()
         if (attemptedGiftCard.isNotEmpty() && appliedGiftCard != attemptedGiftCard) {
             triggerEvent(ShowSnackbar(string.order_creation_gift_card_not_applied))
@@ -1394,11 +1394,11 @@ class OrderCreateEditViewModel @Inject constructor(
     private fun createOrder(order: Order, onSuccess: (Order) -> Unit) {
         launch {
             viewState = viewState.copy(isProgressDialogShown = true)
-            val giftCard = _selectedGiftCard.value
+            val giftCardToApply = _giftCardToApply.value
             orderCreateEditRepository.createOrUpdateOrder(
                 order,
                 source = OrderCreationSource.STORE_MANAGEMENT,
-                giftCard
+                giftCardToApply
             ).fold(
                 onSuccess = {
                     trackOrderCreationSuccess()
@@ -1450,8 +1450,8 @@ class OrderCreateEditViewModel @Inject constructor(
             val changes =
                 if (mode is Mode.Edit) {
                     // Gift cards are only redeemed against a real order status, so sync them in edit mode only.
-                    combine(_orderDraft, _selectedGiftCard) { order, giftCard ->
-                        order.copy(selectedGiftCard = giftCard)
+                    combine(_orderDraft, _giftCardToApply) { order, giftCardToApply ->
+                        order.copy(selectedGiftCard = giftCardToApply)
                     }.drop(1)
                 } else {
                     // When we are in the order creation flow, we need to keep the order status as auto-draft.

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -259,7 +259,8 @@ class OrderCreateEditViewModel @Inject constructor(
 
     private val _selectedGiftCard = savedState.getStateFlow(
         scope = viewModelScope,
-        initialValue = args.giftCardCode.orEmpty()
+        initialValue = "",
+        key = "selected_gift_card"
     )
 
     private val _orderDraft = savedState.getStateFlow(
@@ -272,9 +273,10 @@ class OrderCreateEditViewModel @Inject constructor(
 
     val orderDraft = _orderDraft
         .combine(_selectedGiftCard) { order, giftCard ->
+            val appliedGiftCard = order.giftCards.firstOrNull()
             order.copy(
-                selectedGiftCard = giftCard,
-                giftCardDiscountedAmount = order.giftCards.firstOrNull()?.used
+                selectedGiftCard = appliedGiftCard?.code ?: giftCard,
+                giftCardDiscountedAmount = appliedGiftCard?.used
             )
         }.asLiveData()
 
@@ -292,14 +294,16 @@ class OrderCreateEditViewModel @Inject constructor(
             _orderDraft.asLiveData(),
             _selectedGiftCard.asLiveData()
         ) { viewState, order, selectedGiftCard ->
+            val appliedGiftCard = order!!.giftCards.firstOrNull()
+            val displayedGiftCard = appliedGiftCard?.code ?: selectedGiftCard
             totalsHelper.mapToPaymentTotalsState(
-                order = order!!.copy(
-                    selectedGiftCard = selectedGiftCard,
-                    giftCardDiscountedAmount = order.giftCards.firstOrNull()?.used
+                order = order.copy(
+                    selectedGiftCard = displayedGiftCard,
+                    giftCardDiscountedAmount = appliedGiftCard?.used
                 ),
                 mode = mode,
                 viewState = viewState!!,
-                onGiftClicked = { onEditGiftCardButtonClicked(selectedGiftCard) },
+                onGiftClicked = { onEditGiftCardButtonClicked(displayedGiftCard) },
                 onTaxesLearnMore = { onTaxHelpButtonClicked() },
                 onMainButtonClicked = { onTotalsSectionPrimaryButtonClicked() },
                 onRecalculateButtonClicked = { onTotalsSectionRecalculateButtonClicked() },
@@ -862,9 +866,10 @@ class OrderCreateEditViewModel @Inject constructor(
     }
 
     private fun updateAddGiftCardButtonVisibility(order: Order) {
+        val hasGiftCard = order.giftCards.isNotEmpty() || _selectedGiftCard.value.isNotEmpty()
         val shouldEnableAddGiftCardButton = order.hasProducts() &&
             order.isEditable &&
-            _selectedGiftCard.value.isEmpty()
+            !hasGiftCard
 
         viewState = viewState.copy(isAddGiftCardButtonEnabled = shouldEnableAddGiftCardButton)
 
@@ -1249,13 +1254,14 @@ class OrderCreateEditViewModel @Inject constructor(
     }
 
     /**
-     * Reconciles the selected gift card with what the store actually redeemed after a sync. A used or invalid card
-     * comes back with no applied gift cards, so it is cleared (stops showing as applied) and the merchant is notified.
+     * Once a sync completes, the applied gift card is reflected by the synced order's [Order.giftCards], so the pending
+     * selection is cleared (it is only sent once). If the store did not redeem the card the merchant just entered — a
+     * used or invalid card comes back with no applied gift cards — they are notified.
      */
     private fun reconcileGiftCardWithSyncedOrder(syncedOrder: Order) {
         val attemptedGiftCard = _selectedGiftCard.value
+        _selectedGiftCard.update { "" }
         val appliedGiftCard = syncedOrder.giftCards.firstOrNull()?.code.orEmpty()
-        _selectedGiftCard.value = appliedGiftCard
         if (attemptedGiftCard.isNotEmpty() && appliedGiftCard != attemptedGiftCard) {
             triggerEvent(ShowSnackbar(string.order_creation_gift_card_not_applied))
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -1248,6 +1248,19 @@ class OrderCreateEditViewModel @Inject constructor(
         _selectedGiftCard.update { selectedGiftCard }
     }
 
+    /**
+     * Reconciles the selected gift card with what the store actually redeemed after a sync. A used or invalid card
+     * comes back with no applied gift cards, so it is cleared (stops showing as applied) and the merchant is notified.
+     */
+    private fun reconcileGiftCardWithSyncedOrder(syncedOrder: Order) {
+        val attemptedGiftCard = _selectedGiftCard.value
+        val appliedGiftCard = syncedOrder.giftCards.firstOrNull()?.code.orEmpty()
+        _selectedGiftCard.value = appliedGiftCard
+        if (attemptedGiftCard.isNotEmpty() && appliedGiftCard != attemptedGiftCard) {
+            triggerEvent(ShowSnackbar(string.order_creation_gift_card_not_applied))
+        }
+    }
+
     fun onAddOrEditShippingClicked(itemId: Long? = null) {
         tracker.track(AnalyticsEvent.ORDER_ADD_SHIPPING_TAPPED)
         val shippingLine = itemId?.let { id -> currentDraft.shippingLines.firstOrNull { it.itemId == id } }
@@ -1491,6 +1504,9 @@ class OrderCreateEditViewModel @Inject constructor(
                                         updateStatus.order
                                     }
                                 }.also {
+                                    if (mode is Mode.Edit) {
+                                        reconcileGiftCardWithSyncedOrder(it)
+                                    }
                                     updateCouponAndDiscountButtonsState(it)
                                     updateAddShippingButtonVisibility(it)
                                     updateAddGiftCardButtonVisibility(it)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -274,7 +274,7 @@ class OrderCreateEditViewModel @Inject constructor(
         .combine(_selectedGiftCard) { order, giftCard ->
             order.copy(
                 selectedGiftCard = giftCard,
-                giftCardDiscountedAmount = args.giftCardAmount
+                giftCardDiscountedAmount = order.giftCards.firstOrNull()?.used
             )
         }.asLiveData()
 
@@ -295,7 +295,7 @@ class OrderCreateEditViewModel @Inject constructor(
             totalsHelper.mapToPaymentTotalsState(
                 order = order!!.copy(
                     selectedGiftCard = selectedGiftCard,
-                    giftCardDiscountedAmount = args.giftCardAmount
+                    giftCardDiscountedAmount = order.giftCards.firstOrNull()?.used
                 ),
                 mode = mode,
                 viewState = viewState!!,
@@ -1430,7 +1430,10 @@ class OrderCreateEditViewModel @Inject constructor(
             var ignoreIfOrderJustUpdatedFromRemote = false
             val changes =
                 if (mode is Mode.Edit) {
-                    _orderDraft.drop(1)
+                    // Gift cards are only redeemed against a real order status, so sync them in edit mode only.
+                    combine(_orderDraft, _selectedGiftCard) { order, giftCard ->
+                        order.copy(selectedGiftCard = giftCard)
+                    }.drop(1)
                 } else {
                     // When we are in the order creation flow, we need to keep the order status as auto-draft.
                     // In this way, when the draft of the created order needs to synchronize the price modifiers,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/totals/OrderCreateEditTotalsHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/totals/OrderCreateEditTotalsHelper.kt
@@ -47,7 +47,9 @@ class OrderCreateEditTotalsHelper @Inject constructor(
                     order.toShippingSection(bigDecimalFormatter),
                     order.toCouponsSection(bigDecimalFormatter),
                     order.toGiftSection(
-                        enabled = viewState.isAddGiftCardButtonEnabled && viewState.isIdle,
+                        // Editable while the card is still pending (giftCards empty); a card the store has already
+                        // redeemed can't be edited or removed yet, so it stays locked.
+                        enabled = order.isEditable && viewState.isIdle && order.giftCards.isEmpty(),
                         bigDecimalFormatter,
                         onClick = onGiftClicked
                     ),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -397,12 +397,9 @@ class OrderDetailViewModel @Inject constructor(
         launch {
             val order = awaitOrder()
             tracker.trackEditButtonTapped(order.feesLines.size, order.shippingLines.size)
-            val firstGiftCard = order.giftCards.firstOrNull()
             triggerEvent(
                 EditOrder(
                     orderId = order.id,
-                    giftCard = firstGiftCard?.code,
-                    appliedDiscount = firstGiftCard?.used,
                     orderCurrency = order.currency
                 )
             )

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -386,16 +386,6 @@
             app:argType="com.woocommerce.android.ui.orders.creation.coupon.edit.OrderCreateCouponDetailsViewModel$CouponEditResult"
             app:nullable="true" />
         <argument
-            android:name="giftCardCode"
-            android:defaultValue="@null"
-            app:argType="string"
-            app:nullable="true" />
-        <argument
-            android:name="giftCardAmount"
-            android:defaultValue="@null"
-            app:argType="java.math.BigDecimal"
-            app:nullable="true" />
-        <argument
             android:name="orderCurrency"
             android:defaultValue="@null"
             app:argType="string"

--- a/WooCommerce/src/main/res/navigation/nav_graph_order_creations.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_order_creations.xml
@@ -145,16 +145,6 @@
             app:argType="com.woocommerce.android.ui.orders.creation.coupon.edit.OrderCreateCouponDetailsViewModel$CouponEditResult"
             app:nullable="true" />
         <argument
-            android:name="giftCardCode"
-            android:defaultValue="@null"
-            app:argType="string"
-            app:nullable="true" />
-        <argument
-            android:name="giftCardAmount"
-            android:defaultValue="@null"
-            app:argType="java.math.BigDecimal"
-            app:nullable="true" />
-        <argument
             android:name="orderCurrency"
             android:defaultValue="@null"
             app:argType="string"

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -277,14 +277,6 @@
                 android:name="barcodeFormat"
                 app:argType="com.woocommerce.android.ui.orders.creation.GoogleBarcodeFormatMapper$BarcodeFormat"
                 app:nullable="true" />
-            <argument
-                android:name="giftCardCode"
-                app:argType="string"
-                app:nullable="true" />
-            <argument
-                android:name="giftCardAmount"
-                app:argType="java.math.BigDecimal"
-                app:nullable="true" />
         </action>
 
         <action

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -812,6 +812,7 @@
     <string name="order_creation_collapse_expand_product_card_content_description">Collapse/expand product card</string>
     <string name="order_creation_gift_card_text_field_hint">Enter code</string>
     <string name="order_creation_gift_card_text_error">The code should be in XXXX-XXXX-XXXX-XXXX format</string>
+    <string name="order_creation_gift_card_not_applied">This gift card couldn\'t be applied</string>
     <string name="order_creation_collect_payment_button">Collect Payment</string>
     <string name="order_creation_recalculate_button">Recalculate</string>
     <string name="order_creation_expand_collapse_order_totals">Expand collapse order totals</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CreateUpdateOrderTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CreateUpdateOrderTests.kt
@@ -18,6 +18,7 @@ import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.times
@@ -65,6 +66,20 @@ class CreateUpdateOrderTests : BaseUnitTest() {
                     ).getOrThrow()
                 )
         }
+
+        job.cancel()
+    }
+
+    @Test
+    fun `given an order with a gift card, when updating, then send the gift card to the repository`() = testBlocking {
+        val giftCardCode = "1234-5678-9012-3456"
+        orderDraftChanges.update { it.copy(selectedGiftCard = giftCardCode) }
+        val job = sut(orderDraftChanges, retryTrigger)
+            .launchIn(this)
+
+        advanceUntilIdle()
+
+        verify(orderCreateEditRepository).createOrUpdateOrder(any(), any(), eq(giftCardCode))
 
         job.cancel()
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CreationFocusedOrderCreateEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CreationFocusedOrderCreateEditViewModelTest.kt
@@ -2408,4 +2408,19 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
         verify(tracker).track(ORDER_CREATION_REMOVE_CUSTOM_AMOUNT_TAPPED, mapOf(KEY_HORIZONTAL_SIZE_CLASS to "compact"))
     }
     //endregion
+
+    @Test
+    fun `given creation, when a gift card is applied, then show the code but no discount amount`() = testBlocking {
+        initMocksForAnalyticsWithOrder(defaultOrderValue)
+        createSut()
+        var orderDraft: Order? = null
+        sut.orderDraft.observeForever { orderDraft = it }
+
+        sut.onGiftCardSelected("1234-5678-9012-3456")
+
+        // The store can't redeem a gift card against an auto-draft order, so nothing is synced during creation:
+        // the code is shown for the user, but the discount only materializes once the order is created.
+        assertThat(orderDraft?.selectedGiftCard).isEqualTo("1234-5678-9012-3456")
+        assertThat(orderDraft?.giftCardDiscountedAmount).isNull()
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/EditFocusedOrderCreateEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/EditFocusedOrderCreateEditViewModelTest.kt
@@ -880,4 +880,51 @@ class EditFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTest() 
             assertThat(orderDraft?.giftCardDiscountedAmount).isNull()
             assertThat(lastEvent).isEqualTo(Event.ShowSnackbar(R.string.order_creation_gift_card_not_applied))
         }
+
+    @Test
+    fun `given an order with an applied gift card, when loaded, then show it from the synced order`() = testBlocking {
+        val giftCard = GiftCardSummary(id = 1L, code = "1234-5678-9012-3456", used = BigDecimal("10.00"))
+        val order = defaultOrderValue.copy(isEditable = true, giftCards = listOf(giftCard))
+        orderDetailRepository.stub {
+            on { getOrderById(defaultOrderValue.id) }.doReturn(order)
+        }
+        createUpdateOrderUseCase = mock {
+            on { invoke(any(), any()) } doReturn flowOf(Succeeded(order))
+        }
+        createSut()
+        var orderDraft: Order? = null
+        sut.orderDraft.observeForever { orderDraft = it }
+
+        // The card is shown from the loaded order's giftCards, without any nav argument or user selection.
+        assertThat(orderDraft?.selectedGiftCard).isEqualTo("1234-5678-9012-3456")
+        assertThat(orderDraft?.giftCardDiscountedAmount).isEqualTo(BigDecimal("10.00"))
+    }
+
+    @Test
+    fun `given an applied gift card, when a later sync still returns it, then keep it and show no snackbar`() =
+        testBlocking {
+            val giftCard = GiftCardSummary(id = 1L, code = "1234-5678-9012-3456", used = BigDecimal("10.00"))
+            val order = defaultOrderValue.copy(isEditable = true)
+            val orderWithGiftCard = order.copy(giftCards = listOf(giftCard))
+            val syncResult = MutableSharedFlow<CreateUpdateOrder.OrderUpdateStatus>(replay = 1)
+            orderDetailRepository.stub {
+                on { getOrderById(defaultOrderValue.id) }.doReturn(order)
+            }
+            createUpdateOrderUseCase = mock {
+                on { invoke(any(), any()) } doReturn syncResult
+            }
+            createSut()
+            var orderDraft: Order? = null
+            sut.orderDraft.observeForever { orderDraft = it }
+            var lastEvent: Event? = null
+            sut.event.observeForever { lastEvent = it }
+
+            sut.onGiftCardSelected("1234-5678-9012-3456")
+            syncResult.emit(Succeeded(orderWithGiftCard))
+            // A later unrelated change syncs and the store still returns the applied card.
+            syncResult.emit(Succeeded(orderWithGiftCard))
+
+            assertThat(orderDraft?.selectedGiftCard).isEqualTo("1234-5678-9012-3456")
+            assertThat(lastEvent).isNotEqualTo(Event.ShowSnackbar(R.string.order_creation_gift_card_not_applied))
+        }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/EditFocusedOrderCreateEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/EditFocusedOrderCreateEditViewModelTest.kt
@@ -5,6 +5,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_DEVICE_TYPE_COMPACT
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_DEVICE_TYPE_REGULAR
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_FLOW_EDITING
+import com.woocommerce.android.model.GiftCardSummary
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.orders.CurrencyMatchResult
 import com.woocommerce.android.ui.orders.creation.CreateUpdateOrder.OrderUpdateStatus.Succeeded
@@ -826,5 +827,29 @@ class EditFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTest() 
         assertThat(lastReceivedEvent).isInstanceOf(OrderCreateEditNavigationTarget.SelectItems::class.java)
         val event = lastReceivedEvent as OrderCreateEditNavigationTarget.SelectItems
         assertThat(event.orderCurrency).isNull()
+    }
+
+    @Test
+    fun `given editable order, when a gift card is applied, then reflect the synced total and discount`() = testBlocking {
+        val order = defaultOrderValue.copy(isEditable = true)
+        val discountedOrder = order.copy(
+            total = BigDecimal("5.00"),
+            giftCards = listOf(GiftCardSummary(id = 1L, code = "1234-5678-9012-3456", used = BigDecimal("10.00")))
+        )
+        orderDetailRepository.stub {
+            on { getOrderById(defaultOrderValue.id) }.doReturn(order)
+        }
+        createUpdateOrderUseCase = mock {
+            on { invoke(any(), any()) } doReturn flowOf(Succeeded(discountedOrder))
+        }
+        createSut()
+        var orderDraft: Order? = null
+        sut.orderDraft.observeForever { orderDraft = it }
+
+        sut.onGiftCardSelected("1234-5678-9012-3456")
+
+        assertThat(orderDraft?.selectedGiftCard).isEqualTo("1234-5678-9012-3456")
+        assertThat(orderDraft?.giftCardDiscountedAmount).isEqualTo(BigDecimal("10.00"))
+        assertThat(orderDraft?.total).isEqualTo(BigDecimal("5.00"))
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/EditFocusedOrderCreateEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/EditFocusedOrderCreateEditViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.orders.creation
 
+import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_DEVICE_TYPE_COMPACT
@@ -23,6 +24,7 @@ import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.flowOf
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
@@ -852,4 +854,30 @@ class EditFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTest() 
         assertThat(orderDraft?.giftCardDiscountedAmount).isEqualTo(BigDecimal("10.00"))
         assertThat(orderDraft?.total).isEqualTo(BigDecimal("5.00"))
     }
+
+    @Test
+    fun `given editable order, when the store rejects a used gift card, then clear it and notify the merchant`() =
+        testBlocking {
+            val order = defaultOrderValue.copy(isEditable = true)
+            val syncResult = MutableSharedFlow<CreateUpdateOrder.OrderUpdateStatus>(replay = 1)
+            orderDetailRepository.stub {
+                on { getOrderById(defaultOrderValue.id) }.doReturn(order)
+            }
+            createUpdateOrderUseCase = mock {
+                on { invoke(any(), any()) } doReturn syncResult
+            }
+            createSut()
+            var orderDraft: Order? = null
+            sut.orderDraft.observeForever { orderDraft = it }
+            var lastEvent: Event? = null
+            sut.event.observeForever { lastEvent = it }
+
+            sut.onGiftCardSelected("9999-9999-9999-9999")
+            // The store accepts the request but applies no gift card (used/invalid): giftCards stays empty.
+            syncResult.emit(Succeeded(order))
+
+            assertThat(orderDraft?.selectedGiftCard).isEmpty()
+            assertThat(orderDraft?.giftCardDiscountedAmount).isNull()
+            assertThat(lastEvent).isEqualTo(Event.ShowSnackbar(R.string.order_creation_gift_card_not_applied))
+        }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
@@ -613,6 +613,18 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
             )
         }
 
+    @Test
+    fun `when a gift card is selected, then the order draft carries the gift card code`() = testBlocking {
+        initMocksForAnalyticsWithOrder(defaultOrderValue)
+        createSut()
+        var orderDraft: Order? = null
+        sut.orderDraft.observeForever { orderDraft = it }
+
+        sut.onGiftCardSelected("1234-5678-9012-3456")
+
+        assertThat(orderDraft?.selectedGiftCard).isEqualTo("1234-5678-9012-3456")
+    }
+
     // region Scanned and Deliver
     @Test
     fun `when scan succeeds, then set isUpdatingOrderDraft to true`() {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/totals/OrderCreateEditTotalsHelperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/totals/OrderCreateEditTotalsHelperTest.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.orders.creation.totals
 
 import com.woocommerce.android.R
+import com.woocommerce.android.model.GiftCardSummary
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.orders.creation.OrderCreateEditViewModel
 import com.woocommerce.android.util.CurrencyFormatter
@@ -166,7 +167,7 @@ class OrderCreateEditTotalsHelperTest {
 
         assertThat((actual.lines[4] as TotalsSectionsState.Line.Button).text).isEqualTo("Gift Cards")
         assertThat((actual.lines[4] as TotalsSectionsState.Line.Button).value).isEqualTo("-15.00$")
-        assertThat((actual.lines[4] as TotalsSectionsState.Line.Button).enabled).isFalse()
+        assertThat((actual.lines[4] as TotalsSectionsState.Line.Button).enabled).isTrue()
         assertThat((actual.lines[4] as TotalsSectionsState.Line.Button).extraValue).isEqualTo("21OFF")
         assertThat((actual.lines[4] as TotalsSectionsState.Line.Button).onClick == onGiftClicked).isTrue()
 
@@ -281,7 +282,71 @@ class OrderCreateEditTotalsHelperTest {
 
         assertThat((actual.lines[1] as TotalsSectionsState.Line.Button).text).isEqualTo("Gift Cards")
         assertThat((actual.lines[1] as TotalsSectionsState.Line.Button).value).isEqualTo("")
-        assertThat((actual.lines[1] as TotalsSectionsState.Line.Button).enabled).isFalse()
+        assertThat((actual.lines[1] as TotalsSectionsState.Line.Button).enabled).isTrue()
         assertThat((actual.lines[1] as TotalsSectionsState.Line.Button).extraValue).isEqualTo("21OFF")
+    }
+
+    @Test
+    fun `given a gift card on a non-editable order, when mapToPaymentTotalsState, then the gift card row is disabled`() {
+        val item = mock<Order.Item> {
+            on { total }.thenReturn(BigDecimal(11))
+        }
+        val localOrder = order.copy(
+            items = listOf(item),
+            isEditable = false,
+            selectedGiftCard = "21OFF",
+            giftCardDiscountedAmount = BigDecimal(15),
+        )
+        whenever(resourceProvider.getString(R.string.order_gift_card)).thenReturn("Gift Cards")
+
+        val actual = helper.mapToPaymentTotalsState(
+            localOrder,
+            OrderCreateEditViewModel.Mode.Creation,
+            OrderCreateEditViewModel.ViewState(),
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+        )
+
+        actual as TotalsSectionsState.Full
+        val giftLine = actual.lines
+            .filterIsInstance<TotalsSectionsState.Line.Button>()
+            .first { it.text == "Gift Cards" }
+        assertThat(giftLine.enabled).isFalse()
+    }
+
+    @Test
+    fun `given a gift card already redeemed by the store, when mapToPaymentTotalsState, then the row is disabled`() {
+        val item = mock<Order.Item> {
+            on { total }.thenReturn(BigDecimal(11))
+        }
+        val localOrder = order.copy(
+            items = listOf(item),
+            selectedGiftCard = "21OFF",
+            giftCardDiscountedAmount = BigDecimal(15),
+            giftCards = listOf(GiftCardSummary(id = 1L, code = "21OFF", used = BigDecimal(15))),
+        )
+        whenever(resourceProvider.getString(R.string.order_gift_card)).thenReturn("Gift Cards")
+
+        val actual = helper.mapToPaymentTotalsState(
+            localOrder,
+            OrderCreateEditViewModel.Mode.Edit(1L),
+            OrderCreateEditViewModel.ViewState(),
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+        )
+
+        actual as TotalsSectionsState.Full
+        val giftLine = actual.lines
+            .filterIsInstance<TotalsSectionsState.Line.Button>()
+            .first { it.text == "Gift Cards" }
+        assertThat(giftLine.enabled).isFalse()
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/totals/OrderCreateEditTotalsHelperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/totals/OrderCreateEditTotalsHelperTest.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.orders.creation.totals
 import com.woocommerce.android.R
 import com.woocommerce.android.model.GiftCardSummary
 import com.woocommerce.android.model.Order
+import com.woocommerce.android.ui.orders.OrderTestUtils
 import com.woocommerce.android.ui.orders.creation.OrderCreateEditViewModel
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.viewmodel.ResourceProvider
@@ -288,11 +289,8 @@ class OrderCreateEditTotalsHelperTest {
 
     @Test
     fun `given a gift card on a non-editable order, when mapToPaymentTotalsState, then the gift card row is disabled`() {
-        val item = mock<Order.Item> {
-            on { total }.thenReturn(BigDecimal(11))
-        }
         val localOrder = order.copy(
-            items = listOf(item),
+            items = OrderTestUtils.generateTestOrderItems(),
             isEditable = false,
             selectedGiftCard = "21OFF",
             giftCardDiscountedAmount = BigDecimal(15),
@@ -320,11 +318,8 @@ class OrderCreateEditTotalsHelperTest {
 
     @Test
     fun `given a gift card already redeemed by the store, when mapToPaymentTotalsState, then the row is disabled`() {
-        val item = mock<Order.Item> {
-            on { total }.thenReturn(BigDecimal(11))
-        }
         val localOrder = order.copy(
-            items = listOf(item),
+            items = OrderTestUtils.generateTestOrderItems(),
             selectedGiftCard = "21OFF",
             giftCardDiscountedAmount = BigDecimal(15),
             giftCards = listOf(GiftCardSummary(id = 1L, code = "21OFF", used = BigDecimal(15))),


### PR DESCRIPTION
### Description

Fixes WOOMOB-1027

The "Apply gift card" button was hidden when editing an order, so a gift card could only be added during creation (it's available in edit mode on iOS and the web). 

The first commit in this PR makes this button visible in EDIT mode. This alone was not enough to make it work properly, as the applied gift card would not be sent to the server. You can see this in the first recording at the bottom.

Commit number 2 fixes that by wiring the newly applied gift card to the server request. 

Additionally, I noticed a bug when applying a gift card that was already used. The server silently ignores this, so the app would show the gift card as applied (without the option to change it) but with the amount unchanged. That is fixed in the last commit by removing the selected gift card from the UI and showing an additional snack to the user.

Another bug in the creation flow was fixed in https://github.com/woocommerce/woocommerce-android/pull/16445/changes/2baa9700c16a64dfe78e3b27a4dfa37ee68ffbab - the applied gift card would become uneditable after adding more products. See video below.

A small note about order creation flow:

The gift card is synced only in edit mode. The store won't redeem it against the auto-draft order used while creating one, so (as on iOS) it's still applied at the Create step. 

### Test Steps

Requires a store with the Gift Cards extension active and at least one valid gift card code with a balance.

1. Create an order, add a product, and tap Create.
2. Open the order's detail screen and tap Edit — confirm the **Add gift card** button is now visible.
3. Apply a valid gift card — confirm the gift card discount and the order total update.
4. Apply a used/invalid gift card — confirm it is **not** shown as applied, the button returns, and a "This gift card couldn't be applied" snackbar appears.
5. Edit an order that already has a gift card — confirm it still shows the applied gift card and its discount.
6. Start a new order, add a product, apply a gift card, then add another product — confirm the gift card stays editable (tap it in the totals sheet to change it) instead of getting locked.

### Images/gif

| State after commit 1 | Without commit 3 | With commit 3 | Last bug fixed (step 6) |
|---|---|---|---|
| <video src="https://github.com/user-attachments/assets/3cfca363-1416-445e-8b77-90d6c06716aa" /> | <video src="https://github.com/user-attachments/assets/67247dd0-ad4b-4035-bfda-93acc04446f4" /> | <video src="https://github.com/user-attachments/assets/979e1442-71eb-4ad6-831c-812a564722ec" /> | <video src="https://github.com/user-attachments/assets/fef9d26f-ee63-4558-97dc-7af2abbf991c"/> |

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
