### PR TITLE
Fix browser fallback for custom login challenges

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -1000,9 +1000,17 @@ class LoginActivity :
         tag = LoginSiteCredentialsFragment.TAG
     )
 
-    override fun onApplicationPasswordHelpRequired(url: String, errorMessage: String) {
+    override fun onApplicationPasswordHelpRequired(
+        verifiedLoginUrl: String?,
+        applicationPasswordAuthorizationUrl: String,
+        errorMessage: String
+    ) {
         changeFragment(
-            fragment = ApplicationPasswordTutorialFragment.newInstance(url, errorMessage),
+            fragment = ApplicationPasswordTutorialFragment.newInstance(
+                verifiedLoginUrl = verifiedLoginUrl,
+                applicationPasswordAuthorizationUrl = applicationPasswordAuthorizationUrl,
+                errorMessage = errorMessage
+            ),
             shouldAddToBackStack = true,
             tag = ApplicationPasswordTutorialFragment.TAG
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsFragment.kt
@@ -83,7 +83,11 @@ class LoginSiteCredentialsFragment : Fragment() {
                 is ShowHelpScreen -> loginListener.helpUsernamePassword(it.siteAddress, it.username, false)
                 is ShowSnackbar -> uiMessageResolver.showSnack(it.message)
                 is ShowApplicationPasswordTutorialScreen ->
-                    passwordTutorialListener?.onApplicationPasswordHelpRequired(it.url, it.errorMessage)
+                    passwordTutorialListener?.onApplicationPasswordHelpRequired(
+                        verifiedLoginUrl = it.verifiedLoginUrl,
+                        applicationPasswordAuthorizationUrl = it.applicationPasswordAuthorizationUrl,
+                        errorMessage = it.errorMessage
+                    )
                 is ShowUiStringSnackbar -> uiMessageResolver.showSnack(it.message)
                 is Exit -> requireActivity().onBackPressedDispatcher.onBackPressed()
             }
@@ -109,7 +113,7 @@ class LoginSiteCredentialsFragment : Fragment() {
             ApplicationPasswordTutorialFragment.WEB_NAVIGATION_RESULT,
             viewLifecycleOwner
         ) { _, result ->
-            result.getString(ApplicationPasswordTutorialFragment.URL_KEY)
+            result.getString(ApplicationPasswordTutorialFragment.WEB_NAVIGATION_RESULT_URL_KEY)
                 ?.takeIf { it.isNotEmpty() }
                 ?.let { viewModel.onWebAuthorizationUrlLoaded(it) }
                 ?: viewModel.onPasswordTutorialAborted()
@@ -117,6 +121,10 @@ class LoginSiteCredentialsFragment : Fragment() {
     }
 
     interface Listener {
-        fun onApplicationPasswordHelpRequired(url: String, errorMessage: String)
+        fun onApplicationPasswordHelpRequired(
+            verifiedLoginUrl: String?,
+            applicationPasswordAuthorizationUrl: String,
+            errorMessage: String
+        )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
@@ -356,7 +356,7 @@ class LoginSiteCredentialsViewModel @Inject constructor(
 
             INVALID_CREDENTIALS -> authError.value = AuthenticationError(
                 errorMessage = authenticationError.errorMessage,
-                showWpAdminFallbackOption = endpoints.loginEntryUrl == null
+                showWpAdminFallbackOption = true
             )
 
             BASIC_AUTH_REQUIRED -> showNativeAuthenticationError(authenticationError.errorMessage)
@@ -376,8 +376,9 @@ class LoginSiteCredentialsViewModel @Inject constructor(
         hasVerifiedCustomLoginEntry: Boolean
     ) {
         when {
-            hasVerifiedCustomLoginEntry -> showNativeAuthenticationError(
-                requireNotNull(authenticationError).errorMessage
+            hasVerifiedCustomLoginEntry -> authError.value = AuthenticationError(
+                errorMessage = requireNotNull(authenticationError).errorMessage,
+                showWpAdminFallbackOption = authenticationError.errorType == INVALID_RESPONSE
             )
 
             authenticationError?.errorType == INVALID_RESPONSE && endpoints.loginEntryUrl != null -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
@@ -17,7 +17,6 @@ import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.applicationpasswords.ApplicationPasswordGenerationException
 import com.woocommerce.android.applicationpasswords.ApplicationPasswordsNotifier
 import com.woocommerce.android.extensions.combine
-import com.woocommerce.android.extensions.isNotNullOrEmpty
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.model.UiString.UiStringRes
 import com.woocommerce.android.model.UiString.UiStringText
@@ -115,7 +114,7 @@ class LoginSiteCredentialsViewModel @Inject constructor(
         key = "endpoint-recovery"
     )
 
-    private val SiteModel?.fullAuthorizationUrl: String?
+    private val SiteModel?.applicationPasswordAuthorizationUrl: String?
         get() = this?.applicationPasswordsAuthorizeUrl
             ?.let { url ->
                 "$url?app_name=${applicationPasswordsConfiguration.applicationName}&success_url=$REDIRECTION_URL"
@@ -420,10 +419,12 @@ class LoginSiteCredentialsViewModel @Inject constructor(
                     val errorMessage = detectedErrorMessage
                         ?.toPresentableString()
                         ?: resourceProvider.getString(R.string.error_generic)
-                    if (site.fullAuthorizationUrl.isNotNullOrEmpty()) {
+                    val applicationPasswordAuthorizationUrl = site.applicationPasswordAuthorizationUrl
+                    if (!applicationPasswordAuthorizationUrl.isNullOrEmpty()) {
                         triggerEvent(
                             ShowApplicationPasswordTutorialScreen(
-                                url = site.fullAuthorizationUrl!!,
+                                verifiedLoginUrl = savedStateHandle.get<String>(LOGIN_ENTRY_URL_KEY),
+                                applicationPasswordAuthorizationUrl = applicationPasswordAuthorizationUrl,
                                 errorMessage = errorMessage
                             )
                         )
@@ -757,7 +758,8 @@ class LoginSiteCredentialsViewModel @Inject constructor(
     ) : MultiLiveEvent.Event()
 
     data class ShowApplicationPasswordTutorialScreen(
-        val url: String,
+        val verifiedLoginUrl: String?,
+        val applicationPasswordAuthorizationUrl: String,
         val errorMessage: String
     ) : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/applicationpassword/ApplicationPasswordTutorialFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/applicationpassword/ApplicationPasswordTutorialFragment.kt
@@ -26,7 +26,12 @@ import dagger.hilt.android.AndroidEntryPoint
 class ApplicationPasswordTutorialFragment : BaseFragment() {
     val viewModel: ApplicationPasswordTutorialViewModel by viewModels()
 
-    private val url: String by lazy { requireArguments().getString(URL_KEY, "") }
+    private val verifiedLoginUrl: String? by lazy {
+        requireArguments().getString(VERIFIED_LOGIN_URL_KEY)
+    }
+    private val applicationPasswordAuthorizationUrl: String by lazy {
+        requireArguments().getString(APPLICATION_PASSWORD_AUTHORIZATION_URL_KEY, "")
+    }
     private val errorMessage: String? by lazy {
         requireArguments()
             .getString(ERROR_MESSAGE_KEY, "")
@@ -58,7 +63,8 @@ class ApplicationPasswordTutorialFragment : BaseFragment() {
     override fun onAttach(context: Context) {
         super.onAttach(context)
         viewModel.onWebViewDataAvailable(
-            authorizationUrl = url,
+            verifiedLoginUrl = verifiedLoginUrl,
+            applicationPasswordAuthorizationUrl = applicationPasswordAuthorizationUrl,
             errorMessage = errorMessage
         )
     }
@@ -80,7 +86,7 @@ class ApplicationPasswordTutorialFragment : BaseFragment() {
 
         setFragmentResult(
             requestKey = WEB_NAVIGATION_RESULT,
-            result = Bundle().apply { putString(URL_KEY, url) }
+            result = Bundle().apply { putString(WEB_NAVIGATION_RESULT_URL_KEY, url) }
         )
         parentFragmentManager.popBackStack()
     }
@@ -95,13 +101,20 @@ class ApplicationPasswordTutorialFragment : BaseFragment() {
 
     companion object {
         const val TAG = "ApplicationPasswordTutorialFragment"
-        const val URL_KEY = "url"
+        const val WEB_NAVIGATION_RESULT_URL_KEY = "url"
+        private const val VERIFIED_LOGIN_URL_KEY = "verified_login_url"
+        private const val APPLICATION_PASSWORD_AUTHORIZATION_URL_KEY = "application_password_authorization_url"
         const val ERROR_MESSAGE_KEY = "error_message"
         const val WEB_NAVIGATION_RESULT = "web_navigation_result"
-        fun newInstance(url: String, errorMessage: String) =
+        fun newInstance(
+            verifiedLoginUrl: String?,
+            applicationPasswordAuthorizationUrl: String,
+            errorMessage: String
+        ) =
             ApplicationPasswordTutorialFragment().apply {
                 arguments = Bundle().apply {
-                    putString(URL_KEY, url)
+                    putString(VERIFIED_LOGIN_URL_KEY, verifiedLoginUrl)
+                    putString(APPLICATION_PASSWORD_AUTHORIZATION_URL_KEY, applicationPasswordAuthorizationUrl)
                     putString(ERROR_MESSAGE_KEY, errorMessage)
                 }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/applicationpassword/ApplicationPasswordTutorialScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/applicationpassword/ApplicationPasswordTutorialScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -33,6 +34,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.web.WCWebView
+import com.woocommerce.android.ui.compose.component.web.WCWebViewClient
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import org.wordpress.android.fluxc.network.UserAgent
 
@@ -41,11 +43,15 @@ fun ApplicationPasswordTutorialScreen(viewModel: ApplicationPasswordTutorialView
     BackHandler { viewModel.onNavigationButtonClicked() }
 
     val viewState = viewModel.viewState.observeAsState()
+    val webViewClient = remember(viewModel) {
+        ApplicationPasswordWebViewClient(viewModel::onWebNavigationRequested)
+    }
     ApplicationPasswordTutorialScreen(
         authorizationStarted = viewState.value?.authorizationStarted ?: false,
         errorMessage = viewState.value?.errorMessage,
-        webViewUrl = viewState.value?.authorizationUrl.orEmpty(),
+        webViewUrl = viewState.value?.webViewUrl.orEmpty(),
         webViewUserAgent = viewModel.userAgent,
+        webViewClient = webViewClient,
         onContinueClicked = viewModel::onContinueClicked,
         onContactSupportClicked = viewModel::onContactSupportClicked,
         onPageLoaded = viewModel::onWebPageLoaded,
@@ -59,6 +65,7 @@ fun ApplicationPasswordTutorialScreen(
     authorizationStarted: Boolean,
     webViewUrl: String,
     webViewUserAgent: UserAgent?,
+    webViewClient: WCWebViewClient = remember { WCWebViewClient() },
     errorMessage: String?,
     onPageLoaded: (String) -> Unit,
     onContinueClicked: () -> Unit,
@@ -80,6 +87,7 @@ fun ApplicationPasswordTutorialScreen(
                 url = webViewUrl,
                 userAgent = webViewUserAgent,
                 onPageFinished = onPageLoaded,
+                webViewClient = webViewClient,
                 modifier = modifier
             )
         } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/applicationpassword/ApplicationPasswordTutorialViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/applicationpassword/ApplicationPasswordTutorialViewModel.kt
@@ -13,6 +13,8 @@ import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.update
 import kotlinx.parcelize.Parcelize
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import org.wordpress.android.fluxc.network.UserAgent
 import javax.inject.Inject
 
@@ -42,7 +44,14 @@ class ApplicationPasswordTutorialViewModel @Inject constructor(
         analyticsTracker.track(AnalyticsEvent.APPLICATION_PASSWORDS_AUTHORIZATION_WEB_VIEW_SHOWN)
         if (url.startsWith(REDIRECTION_URL)) {
             triggerEvent(ExitWithResult(url))
+            return
         }
+
+        recoverAuthorizationIfNeeded(url)
+    }
+
+    fun onWebNavigationRequested(url: String): Boolean {
+        return recoverAuthorizationIfNeeded(url)
     }
 
     fun onNavigationButtonClicked() {
@@ -61,15 +70,77 @@ class ApplicationPasswordTutorialViewModel @Inject constructor(
     }
 
     fun onWebViewDataAvailable(
-        authorizationUrl: String?,
+        verifiedLoginUrl: String?,
+        applicationPasswordAuthorizationUrl: String,
         errorMessage: String?
     ) {
+        _viewState.update { state ->
+            if (state.webViewUrl != null) {
+                state
+            } else {
+                state.copy(
+                    webViewUrl = buildWebViewUrl(
+                        verifiedLoginUrl = verifiedLoginUrl,
+                        applicationPasswordAuthorizationUrl = applicationPasswordAuthorizationUrl
+                    ),
+                    applicationPasswordAuthorizationUrl = applicationPasswordAuthorizationUrl,
+                    errorMessage = errorMessage
+                )
+            }
+        }
+    }
+
+    private fun buildWebViewUrl(
+        verifiedLoginUrl: String?,
+        applicationPasswordAuthorizationUrl: String
+    ): String {
+        val loginUrl = verifiedLoginUrl?.toHttpUrlOrNull() ?: return applicationPasswordAuthorizationUrl
+        return loginUrl.newBuilder()
+            .setQueryParameter("redirect_to", applicationPasswordAuthorizationUrl)
+            .build()
+            .toString()
+    }
+
+    private fun ViewState.shouldRecoverAuthorization(loadedUrl: String): Boolean {
+        val authorizationPageUrl = applicationPasswordAuthorizationUrl?.toHttpUrlOrNull()
+        val startUrl = webViewUrl?.toHttpUrlOrNull()
+        val currentUrl = loadedUrl.toHttpUrlOrNull()
+        return !authorizationRecoveryAttempted &&
+            webViewUrl != applicationPasswordAuthorizationUrl &&
+            authorizationPageUrl != null &&
+            startUrl != null &&
+            currentUrl != null &&
+            currentUrl.isAuthorizationRecoveryLanding(authorizationPageUrl, startUrl)
+    }
+
+    private fun HttpUrl.isAuthorizationRecoveryLanding(
+        authorizationPageUrl: HttpUrl,
+        startUrl: HttpUrl
+    ) = hasSameOrigin(authorizationPageUrl) &&
+        isWithinAdminDirectory(authorizationPageUrl) &&
+        encodedPath != authorizationPageUrl.encodedPath &&
+        encodedPath != startUrl.encodedPath
+
+    private fun HttpUrl.hasSameOrigin(other: HttpUrl) =
+        scheme == other.scheme && host == other.host && port == other.port
+
+    private fun HttpUrl.isWithinAdminDirectory(authorizationPageUrl: HttpUrl): Boolean {
+        val adminDirectorySegments = authorizationPageUrl.encodedPathSegments.dropLast(1)
+        return adminDirectorySegments.isNotEmpty() &&
+            encodedPathSegments.size >= adminDirectorySegments.size &&
+            encodedPathSegments.take(adminDirectorySegments.size) == adminDirectorySegments
+    }
+
+    private fun recoverAuthorizationIfNeeded(url: String): Boolean {
+        if (!_viewState.value.shouldRecoverAuthorization(url)) return false
+
         _viewState.update {
             it.copy(
-                authorizationUrl = authorizationUrl,
-                errorMessage = errorMessage
+                webViewUrl = it.applicationPasswordAuthorizationUrl,
+                authorizationRecoveryAttempted = true
             )
         }
+        return true
     }
 
     object OnContactSupport : Event()
@@ -78,7 +149,9 @@ class ApplicationPasswordTutorialViewModel @Inject constructor(
     @Parcelize
     data class ViewState(
         val authorizationStarted: Boolean = false,
-        val authorizationUrl: String? = null,
+        val webViewUrl: String? = null,
+        val applicationPasswordAuthorizationUrl: String? = null,
+        val authorizationRecoveryAttempted: Boolean = false,
         val errorMessage: String? = null,
     ) : Parcelable
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/applicationpassword/ApplicationPasswordWebViewClient.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/applicationpassword/ApplicationPasswordWebViewClient.kt
@@ -1,0 +1,20 @@
+package com.woocommerce.android.ui.login.sitecredentials.applicationpassword
+
+import android.webkit.WebResourceRequest
+import android.webkit.WebView
+import com.woocommerce.android.ui.compose.component.web.WCWebViewClient
+
+internal class ApplicationPasswordWebViewClient(
+    private val onMainFrameNavigationRequested: (String) -> Boolean
+) : WCWebViewClient() {
+    override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean {
+        if (super.shouldOverrideUrlLoading(view, request)) return true
+
+        return request
+            ?.takeIf { it.isForMainFrame }
+            ?.url
+            ?.toString()
+            ?.let(onMainFrameNavigationRequested)
+            ?: false
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModelTest.kt
@@ -319,7 +319,7 @@ class LoginSiteCredentialsViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given verified custom login, when post response fails, then retain it and show the actual error`() =
+    fun `given verified custom login, when post response fails, then retain it and offer browser fallback`() =
         testBlocking {
             val responseError = cookieNonceError(
                 Nonce.CookieNonceErrorType.INVALID_RESPONSE,
@@ -342,9 +342,13 @@ class LoginSiteCredentialsViewModelTest : BaseUnitTest() {
             }
 
             val state = viewModel.viewState.value
+            assertThat(state?.username).isEqualTo(USERNAME)
+            assertThat(state?.password).isEqualTo(PASSWORD)
             assertThat(state?.endpointRecovery).isNull()
             assertThat(state?.authenticationError?.errorMessage).isEqualTo(responseError.errorMessage)
-            assertThat(state?.authenticationError?.showWpAdminFallbackOption).isFalse()
+            assertThat(state?.authenticationError?.showWpAdminFallbackOption).isTrue()
+            assertThat(savedState.get<String>(LOGIN_ENTRY_URL_STATE_KEY)).isEqualTo(LOGIN_URL)
+            assertThat(viewModel.event.value).isNull()
             verify(repository, never()).saveAuthenticationEndpoints(any(), any())
 
             viewModel.viewState.observeForTesting {
@@ -470,7 +474,7 @@ class LoginSiteCredentialsViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given custom login invalid credentials, when retrying and recreating, then retain it until native success`() =
+    fun `given custom login invalid credentials, when retrying and recreating, then retain it with browser fallback`() =
         testBlocking {
             val invalidCredentials = cookieNonceError(
                 Nonce.CookieNonceErrorType.INVALID_CREDENTIALS,
@@ -495,7 +499,8 @@ class LoginSiteCredentialsViewModelTest : BaseUnitTest() {
             assertThat(firstFailureState?.endpointRecovery).isNull()
             assertThat(firstFailureState?.authenticationError?.errorMessage)
                 .isEqualTo(invalidCredentials.errorMessage)
-            assertThat(firstFailureState?.authenticationError?.showWpAdminFallbackOption).isFalse()
+            assertThat(firstFailureState?.authenticationError?.showWpAdminFallbackOption).isTrue()
+            assertThat(viewModel.event.value).isNull()
             verify(repository, never()).saveAuthenticationEndpoints(any(), any())
             verify(selectedSite, never()).set(any())
 
@@ -512,14 +517,14 @@ class LoginSiteCredentialsViewModelTest : BaseUnitTest() {
             assertThat(repeatedFailureState?.endpointRecovery).isNull()
             assertThat(repeatedFailureState?.authenticationError?.errorMessage)
                 .isEqualTo(invalidCredentials.errorMessage)
-            assertThat(repeatedFailureState?.authenticationError?.showWpAdminFallbackOption).isFalse()
+            assertThat(repeatedFailureState?.authenticationError?.showWpAdminFallbackOption).isTrue()
             verify(repository).login(SITE_URL, USERNAME, STILL_WRONG_PASSWORD, PENDING_LOGIN_ENDPOINTS)
 
             val restoredState = SavedStateHandle(savedState.keys().associateWith { savedState.get<Any?>(it) })
             setup(restoredState)
             val recreatedState = viewModel.viewState.getOrAwaitValue()
             assertThat(recreatedState.endpointRecovery).isNull()
-            assertThat(recreatedState.authenticationError?.showWpAdminFallbackOption).isFalse()
+            assertThat(recreatedState.authenticationError?.showWpAdminFallbackOption).isTrue()
 
             viewModel.viewState.observeForTesting {
                 viewModel.onErrorDialogDismissed()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModelTest.kt
@@ -500,7 +500,6 @@ class LoginSiteCredentialsViewModelTest : BaseUnitTest() {
             assertThat(firstFailureState?.authenticationError?.errorMessage)
                 .isEqualTo(invalidCredentials.errorMessage)
             assertThat(firstFailureState?.authenticationError?.showWpAdminFallbackOption).isTrue()
-            assertThat(viewModel.event.value).isNull()
             verify(repository, never()).saveAuthenticationEndpoints(any(), any())
             verify(selectedSite, never()).set(any())
 
@@ -725,7 +724,8 @@ class LoginSiteCredentialsViewModelTest : BaseUnitTest() {
                 assertThat(viewModel.viewState.value?.endpointRecovery?.type).isEqualTo(type)
                 assertThat(viewModel.event.value).isEqualTo(
                     ShowApplicationPasswordTutorialScreen(
-                        url = "$SITE_URL/wp-admin/authorize-application.php" +
+                        verifiedLoginUrl = null,
+                        applicationPasswordAuthorizationUrl = "$SITE_URL/wp-admin/authorize-application.php" +
                             "?app_name=woo_android&success_url=woocommerce://login",
                         errorMessage = "error"
                     )
@@ -734,6 +734,36 @@ class LoginSiteCredentialsViewModelTest : BaseUnitTest() {
 
             verify(repository, never()).saveAuthenticationEndpoints(any(), any())
             verify(repository, times(2)).fetchSite(SITE_URL)
+        }
+
+    @Test
+    fun `given verified login and advertised authorization URLs, when fallback is selected, then pass both unchanged`() =
+        testBlocking {
+            val loginUrl = "$LOGIN_URL?security_token=abc&redirect_to=stale"
+            val customAuthorizationUrl = "$SITE_URL/private-admin/authorize-application.php"
+            val fetchedSite = SiteModel().apply {
+                id = SITE_ID
+                url = SITE_URL
+                hasWooCommerce = true
+                applicationPasswordsAuthorizeUrl = customAuthorizationUrl
+            }
+            whenever(repository.fetchSite(SITE_URL)).thenReturn(Result.success(fetchedSite))
+            setup(
+                credentialsState().apply {
+                    this[LOGIN_ENTRY_URL_STATE_KEY] = loginUrl
+                }
+            )
+
+            viewModel.viewState.observeForTesting {
+                viewModel.onStartWebAuthorizationClick()
+                advanceUntilIdle()
+            }
+
+            val event = viewModel.event.value as ShowApplicationPasswordTutorialScreen
+            assertThat(event.verifiedLoginUrl).isEqualTo(loginUrl)
+            assertThat(event.applicationPasswordAuthorizationUrl).isEqualTo(
+                "$customAuthorizationUrl?app_name=woo_android&success_url=woocommerce://login"
+            )
         }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/sitecredentials/applicationpassword/ApplicationPasswordTutorialViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/sitecredentials/applicationpassword/ApplicationPasswordTutorialViewModelTest.kt
@@ -1,0 +1,278 @@
+package com.woocommerce.android.ui.login.sitecredentials.applicationpassword
+
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.util.getOrAwaitValue
+import com.woocommerce.android.util.runAndCaptureValues
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.wordpress.android.fluxc.network.UserAgent
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ApplicationPasswordTutorialViewModelTest : BaseUnitTest() {
+    private val analyticsTracker: AnalyticsTrackerWrapper = mock()
+    private val userAgent: UserAgent = mock()
+
+    private lateinit var viewModel: ApplicationPasswordTutorialViewModel
+
+    @Test
+    fun `given verified login URL with query, when data is delivered, then initialize login first flow`() =
+        testBlocking {
+            setup()
+            val verifiedLoginUrl = "$VERIFIED_LOGIN_URL?security_token=abc&redirect_to=stale"
+
+            // WHEN
+            givenWebViewData(verifiedLoginUrl = verifiedLoginUrl)
+
+            // THEN
+            val webViewUrl = requireNotNull(viewModel.currentState.webViewUrl).toHttpUrl()
+            assertThat(webViewUrl.encodedPath).isEqualTo("/private-login/")
+            assertThat(webViewUrl.queryParameter("security_token")).isEqualTo("abc")
+            assertThat(webViewUrl.queryParameterValues("redirect_to"))
+                .containsExactly(APPLICATION_PASSWORD_AUTHORIZATION_URL)
+            assertThat(viewModel.currentState.applicationPasswordAuthorizationUrl)
+                .isEqualTo(APPLICATION_PASSWORD_AUTHORIZATION_URL)
+            assertThat(viewModel.currentState.authorizationRecoveryAttempted).isFalse()
+            assertThat(viewModel.currentState.errorMessage).isEqualTo(ERROR_MESSAGE)
+        }
+
+    @Test
+    fun `given no verified login URL, when web view data is delivered, then start at authorization page`() =
+        testBlocking {
+            setup()
+
+            // WHEN
+            givenWebViewData(verifiedLoginUrl = null)
+
+            // THEN
+            assertThat(viewModel.currentState.webViewUrl).isEqualTo(APPLICATION_PASSWORD_AUTHORIZATION_URL)
+        }
+
+    @Test
+    fun `given custom login flow, when admin navigation repeats, then recover only once`() =
+        testBlocking {
+            setup()
+            givenWebViewData()
+
+            // WHEN
+            val firstNavigationIntercepted = viewModel.onWebNavigationRequested(SITE_ADMIN_URL)
+            val secondNavigationIntercepted = viewModel.onWebNavigationRequested("${SITE_ADMIN_URL}profile.php")
+
+            // THEN
+            assertThat(firstNavigationIntercepted).isTrue()
+            assertThat(secondNavigationIntercepted).isFalse()
+            assertThat(viewModel.currentState.webViewUrl).isEqualTo(APPLICATION_PASSWORD_AUTHORIZATION_URL)
+            assertThat(viewModel.currentState.authorizationRecoveryAttempted).isTrue()
+        }
+
+    @Test
+    fun `given custom login flow, when unrelated navigation is requested, then allow navigation`() =
+        testBlocking {
+            setup()
+            givenWebViewData()
+            val startUrl = viewModel.currentState.webViewUrl
+
+            // WHEN
+            val intercepted = viewModel.onWebNavigationRequested("$SITE_URL/shop/")
+
+            // THEN
+            assertThat(intercepted).isFalse()
+            assertThat(viewModel.currentState.webViewUrl).isEqualTo(startUrl)
+            assertThat(viewModel.currentState.authorizationRecoveryAttempted).isFalse()
+        }
+
+    @Test
+    fun `given rewritten authorization page, when rewritten admin loads, then open authorization page`() =
+        testBlocking {
+            setup()
+            givenWebViewData(
+                applicationPasswordAuthorizationUrl = REWRITTEN_APPLICATION_PASSWORD_AUTHORIZATION_URL
+            )
+
+            // WHEN
+            viewModel.onWebPageLoaded(REWRITTEN_ADMIN_URL)
+
+            // THEN
+            assertThat(viewModel.currentState.webViewUrl)
+                .isEqualTo(REWRITTEN_APPLICATION_PASSWORD_AUTHORIZATION_URL)
+            assertThat(viewModel.currentState.authorizationRecoveryAttempted).isTrue()
+        }
+
+    @Test
+    fun `given custom login flow, when a page in the admin directory loads, then open authorization page`() =
+        testBlocking {
+            listOf(
+                SITE_ADMIN_URL,
+                "${SITE_ADMIN_URL}index.php?welcome=1",
+                "${SITE_ADMIN_URL}admin.php?page=wc-admin",
+                "${SITE_ADMIN_URL}profile.php"
+            ).forEach { adminPageUrl ->
+                setup()
+                givenWebViewData()
+
+                // WHEN
+                viewModel.onWebPageLoaded(adminPageUrl)
+
+                // THEN
+                assertThat(viewModel.currentState.webViewUrl).isEqualTo(APPLICATION_PASSWORD_AUTHORIZATION_URL)
+                assertThat(viewModel.currentState.authorizationRecoveryAttempted).isTrue()
+            }
+        }
+
+    @Test
+    fun `given login page in admin directory, when that page loads, then do not recover`() = testBlocking {
+        setup()
+        givenWebViewData(
+            verifiedLoginUrl = REWRITTEN_LOGIN_URL,
+            applicationPasswordAuthorizationUrl = REWRITTEN_APPLICATION_PASSWORD_AUTHORIZATION_URL
+        )
+        val startUrl = viewModel.currentState.webViewUrl
+
+        // WHEN
+        viewModel.onWebPageLoaded("$REWRITTEN_LOGIN_URL?loggedout=true")
+
+        // THEN
+        assertThat(viewModel.currentState.webViewUrl).isEqualTo(startUrl)
+        assertThat(viewModel.currentState.authorizationRecoveryAttempted).isFalse()
+    }
+
+    @Test
+    fun `given custom login flow, when landing is ineligible, then keep the flow start URL`() = testBlocking {
+        listOf(
+            "$SITE_URL/wp-adminsomething/" to APPLICATION_PASSWORD_AUTHORIZATION_URL,
+            APPLICATION_PASSWORD_AUTHORIZATION_URL to APPLICATION_PASSWORD_AUTHORIZATION_URL,
+            "https://other.example/wp-admin/" to APPLICATION_PASSWORD_AUTHORIZATION_URL,
+            "http://site.example/wp-admin/" to APPLICATION_PASSWORD_AUTHORIZATION_URL,
+            "https://site.example:8443/wp-admin/" to APPLICATION_PASSWORD_AUTHORIZATION_URL,
+            SITE_ADMIN_URL to "not a URL",
+            SITE_URL to "$SITE_URL/authorize-application.php"
+        ).forEach { (loadedUrl, authorizationUrl) ->
+            setup()
+            givenWebViewData(applicationPasswordAuthorizationUrl = authorizationUrl)
+            val startUrl = viewModel.currentState.webViewUrl
+
+            // WHEN
+            viewModel.onWebPageLoaded(loadedUrl)
+
+            // THEN
+            assertThat(viewModel.currentState.webViewUrl).isEqualTo(startUrl)
+            assertThat(viewModel.currentState.authorizationRecoveryAttempted).isFalse()
+        }
+    }
+
+    @Test
+    fun `given direct authorization flow, when admin loads, then do not recover`() = testBlocking {
+        setup()
+        givenWebViewData(verifiedLoginUrl = null)
+
+        // WHEN
+        viewModel.onWebPageLoaded(SITE_ADMIN_URL)
+
+        // THEN
+        assertThat(viewModel.currentState.webViewUrl).isEqualTo(APPLICATION_PASSWORD_AUTHORIZATION_URL)
+        assertThat(viewModel.currentState.authorizationRecoveryAttempted).isFalse()
+    }
+
+    @Test
+    fun `given recovery was used, when fragment data is delivered again, then retain recovered state`() =
+        testBlocking {
+            setup()
+            givenWebViewData()
+            viewModel.onWebPageLoaded(SITE_ADMIN_URL)
+
+            // WHEN
+            viewModel.onWebViewDataAvailable(
+                verifiedLoginUrl = "$SITE_URL/another-login/",
+                applicationPasswordAuthorizationUrl = REWRITTEN_APPLICATION_PASSWORD_AUTHORIZATION_URL,
+                errorMessage = "another error"
+            )
+
+            // THEN
+            assertThat(viewModel.currentState.webViewUrl).isEqualTo(APPLICATION_PASSWORD_AUTHORIZATION_URL)
+            assertThat(viewModel.currentState.applicationPasswordAuthorizationUrl)
+                .isEqualTo(APPLICATION_PASSWORD_AUTHORIZATION_URL)
+            assertThat(viewModel.currentState.authorizationRecoveryAttempted).isTrue()
+            assertThat(viewModel.currentState.errorMessage).isEqualTo(ERROR_MESSAGE)
+        }
+
+    @Test
+    fun `given recovered saved state, when recreated and data is redelivered, then retain recovered state`() =
+        testBlocking {
+            val savedState = SavedStateHandle()
+            setup(savedState)
+            givenWebViewData()
+            viewModel.onWebPageLoaded(SITE_ADMIN_URL)
+            advanceUntilIdle()
+            val restoredState = SavedStateHandle(savedState.keys().associateWith { savedState.get<Any?>(it) })
+
+            // WHEN
+            setup(restoredState)
+            givenWebViewData()
+
+            // THEN
+            assertThat(viewModel.currentState.webViewUrl).isEqualTo(APPLICATION_PASSWORD_AUTHORIZATION_URL)
+            assertThat(viewModel.currentState.applicationPasswordAuthorizationUrl)
+                .isEqualTo(APPLICATION_PASSWORD_AUTHORIZATION_URL)
+            assertThat(viewModel.currentState.authorizationRecoveryAttempted).isTrue()
+        }
+
+    @Test
+    fun `given authorization success, when callback loads, then exit with the callback URL`() = testBlocking {
+        setup()
+        givenWebViewData()
+        val startUrl = viewModel.currentState.webViewUrl
+
+        // WHEN
+        val event = viewModel.event.runAndCaptureValues {
+            viewModel.onWebPageLoaded(SUCCESS_URL)
+        }.last()
+
+        // THEN
+        assertThat(event).isEqualTo(ExitWithResult(SUCCESS_URL))
+        assertThat(viewModel.currentState.webViewUrl).isEqualTo(startUrl)
+        assertThat(viewModel.currentState.authorizationRecoveryAttempted).isFalse()
+    }
+
+    private fun setup(savedStateHandle: SavedStateHandle = SavedStateHandle()) {
+        viewModel = ApplicationPasswordTutorialViewModel(
+            analyticsTracker = analyticsTracker,
+            userAgent = userAgent,
+            savedState = savedStateHandle
+        )
+    }
+
+    private fun givenWebViewData(
+        verifiedLoginUrl: String? = VERIFIED_LOGIN_URL,
+        applicationPasswordAuthorizationUrl: String = APPLICATION_PASSWORD_AUTHORIZATION_URL
+    ) {
+        viewModel.onWebViewDataAvailable(
+            verifiedLoginUrl = verifiedLoginUrl,
+            applicationPasswordAuthorizationUrl = applicationPasswordAuthorizationUrl,
+            errorMessage = ERROR_MESSAGE
+        )
+    }
+
+    private val ApplicationPasswordTutorialViewModel.currentState
+        get() = viewState.getOrAwaitValue()
+
+    private companion object {
+        const val SITE_URL = "https://site.example"
+        const val SITE_ADMIN_URL = "$SITE_URL/wp-admin/"
+        const val VERIFIED_LOGIN_URL = "$SITE_URL/private-login/"
+        const val APPLICATION_PASSWORD_AUTHORIZATION_URL = "${SITE_ADMIN_URL}authorize-application.php" +
+            "?app_name=woo_android&success_url=woocommerce://login"
+        const val REWRITTEN_ADMIN_URL = "$SITE_URL/private-admin/"
+        const val REWRITTEN_LOGIN_URL = "${REWRITTEN_ADMIN_URL}login.php"
+        const val REWRITTEN_APPLICATION_PASSWORD_AUTHORIZATION_URL =
+            "${REWRITTEN_ADMIN_URL}authorize-application.php" +
+                "?app_name=woo_android&success_url=woocommerce://login"
+        const val SUCCESS_URL = "woocommerce://login?user_login=merchant&password=application-password"
+        const val ERROR_MESSAGE = "Native authentication failed"
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/sitecredentials/applicationpassword/ApplicationPasswordWebViewClientTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/sitecredentials/applicationpassword/ApplicationPasswordWebViewClientTest.kt
@@ -1,0 +1,85 @@
+package com.woocommerce.android.ui.login.sitecredentials.applicationpassword
+
+import android.net.Uri
+import android.webkit.WebResourceRequest
+import com.woocommerce.android.ui.common.webview.WebViewAuthenticator
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class ApplicationPasswordWebViewClientTest {
+    @Test
+    fun `given main frame navigation, when URL is requested, then delegate URL and result`() {
+        listOf(true, false).forEach { recoveryHandled ->
+            var requestedUrl: String? = null
+            val client = ApplicationPasswordWebViewClient {
+                requestedUrl = it
+                recoveryHandled
+            }
+
+            // WHEN
+            val intercepted = client.shouldOverrideUrlLoading(
+                view = null,
+                request = givenRequest(ADMIN_URL, isForMainFrame = true)
+            )
+
+            // THEN
+            assertThat(intercepted).isEqualTo(recoveryHandled)
+            assertThat(requestedUrl).isEqualTo(ADMIN_URL)
+        }
+    }
+
+    @Test
+    fun `given subframe navigation, when URL is requested, then do not invoke recovery`() {
+        var recoveryInvoked = false
+        val client = ApplicationPasswordWebViewClient {
+            recoveryInvoked = true
+            true
+        }
+
+        // WHEN
+        val intercepted = client.shouldOverrideUrlLoading(
+            view = null,
+            request = givenRequest(ADMIN_URL, isForMainFrame = false)
+        )
+
+        // THEN
+        assertThat(intercepted).isFalse()
+        assertThat(recoveryInvoked).isFalse()
+    }
+
+    @Test
+    fun `given Jetpack temporary redirect, when URL is requested, then retain shared client handling`() {
+        var recoveryInvoked = false
+        val client = ApplicationPasswordWebViewClient {
+            recoveryInvoked = true
+            false
+        }
+
+        // WHEN
+        val intercepted = client.shouldOverrideUrlLoading(
+            view = null,
+            request = givenRequest(
+                WebViewAuthenticator.JETPACK_SSO_TEMP_REDIRECT_URL,
+                isForMainFrame = true
+            )
+        )
+
+        // THEN
+        assertThat(intercepted).isTrue()
+        assertThat(recoveryInvoked).isFalse()
+    }
+
+    private fun givenRequest(url: String, isForMainFrame: Boolean): WebResourceRequest = mock {
+        on { this.url } doReturn Uri.parse(url)
+        on { this.isForMainFrame } doReturn isForMainFrame
+    }
+
+    private companion object {
+        const val ADMIN_URL = "https://site.example/wp-admin/"
+    }
+}


### PR DESCRIPTION
### Description

Follow-up to WOOMOB-3799 and #16398, which added recovery and retention for custom WordPress login and admin URLs.

That work correctly retains a custom login URL after it has been verified, but its new error routing also hid the existing browser/Application Password fallback when the subsequent native credential submission failed. A verified login form only proves that the endpoint is correct; CAPTCHA, 2FA, and other interactive security layers can still prevent native authentication. Invalid-credentials and invalid-response failures now return to the credentials form with the verified endpoint and credentials retained, expose the existing browser fallback, and never launch it until the merchant taps it.

Sites using WPS Hide Login need two additional safeguards. While logged out, opening the site-advertised Application Password URL directly can return 404, so the fallback starts at the verified custom login URL with a redirect to the advertised authorization target. If the WebView is already authenticated, WPS can ignore that redirect and attempt to navigate to the admin dashboard instead; the app now intercepts that same-origin main-frame navigation before the dashboard loads and performs a one-shot navigation to the advertised target in the same WebView, preserving its authenticated cookies. The existing page-finished check remains as a fallback. The admin directory is derived from the advertised URL, so rewritten/custom authorization paths remain supported.

The change reuses the existing failure classifications and authorization flow instead of relying on CAPTCHA- or plugin-specific strings. Pending, unverified recovery endpoints are neither used for browser routing nor persisted.

### Test Steps

Run the fixture script below from the WordPress root of a disposable test site. It installs the same WPS Hide Login and Simple Login Captcha versions used by the test fixture, configures `/private-login/`, and leaves existing users and credentials unchanged.

<details>
<summary>WP-CLI fixture setup script</summary>

```bash
#!/usr/bin/env bash

set -euo pipefail

LOGIN_SLUG="${1:-private-login}"

if ! command -v wp >/dev/null 2>&1; then
    echo "Error: wp-cli is not available." >&2
    exit 1
fi

if [[ ! "$LOGIN_SLUG" =~ ^[a-z0-9][a-z0-9_-]*$ ]]; then
    echo "Usage: $0 [login-slug]" >&2
    exit 1
fi

wp core is-installed

install_plugin() {
    local plugin="$1"
    local version="${2:-}"

    if ! wp plugin is-installed "$plugin"; then
        if [[ -n "$version" ]]; then
            wp plugin install "$plugin" --version="$version"
        else
            wp plugin install "$plugin"
        fi
    elif [[ -n "$version" && "$(wp plugin get "$plugin" --field=version)" != "$version" ]]; then
        wp plugin install "$plugin" --version="$version" --force
    fi
}

install_plugin woocommerce
wp plugin activate woocommerce

install_plugin simple-login-captcha 1.3.6
install_plugin wps-hide-login 1.9.19

wp option update whl_page "$LOGIN_SLUG"
wp option update whl_redirect_admin 404
wp plugin activate simple-login-captcha wps-hide-login
wp rewrite flush

site_url="$(wp option get home)"
authorization_url="$(wp eval 'echo admin_url("authorize-application.php");')"

printf '\nFixture ready.\n'
printf 'Custom login URL: %s/%s/\n' "${site_url%/}" "$LOGIN_SLUG"
printf 'Application Password URL: %s\n' "$authorization_url"
printf 'Use an existing administrator account; no credentials were changed.\n'
printf 'Recovery: wp plugin deactivate wps-hide-login simple-login-captcha && wp rewrite flush\n'

if ! wp eval 'exit(function_exists("wp_is_application_passwords_available") && wp_is_application_passwords_available() ? 0 : 1);'; then
    printf 'Warning: Application Passwords are not available on this site. Check that it uses HTTPS.\n' >&2
fi
```

</details>

An AI agent with approved access can provision a disposable Jurassic Ninja site and run the same WP-CLI setup automatically.

Use a real Android device for these steps. Emulator WebViews may be classified as automated traffic by Atomic/WP Cloud edge protections, causing the Application Password creation POST to return an HTML 429 response even when the app flow is correct.

1. Start site-credentials login, submit valid credentials, and provide the generated custom login URL when prompted.
2. Verify the native CAPTCHA failure returns to the credentials form with the endpoint and credentials retained.
3. Verify the browser/Application Password action is visible and that nothing opens automatically.
4. With the WebView logged out, tap the browser action, complete the browser login challenge, and verify the site-advertised Application Password authorization page opens.
5. Approve the connection and verify authentication completes in the app.
6. Repeat with an already-authenticated WebView session. Verify that the attempted WPS redirect to the dashboard is intercepted and the Application Password authorization page opens without rendering the dashboard first.
7. Rotate the device after reaching the authorization page and verify it remains there instead of restarting from the hidden login URL.
8. If the site advertises a rewritten/custom admin authorization path, verify that exact path is used.

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
