### PR TITLE
Keep POS card reader onboarding in portrait on phones

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 
 25.5
 -----
+- [*] Woo POS on phones: the "Install WooCommerce Payments" prompt no longer rotates the screen to landscape
 - [WEAR][*] Order and stats dates on the watch now follow the language's date order [https://github.com/woocommerce/woocommerce-android/pull/16429]
 - [Internal] Fixed duplicated device registration API calls fired concurrently during login [https://github.com/woocommerce/woocommerce-android/pull/16354]
 - [*] The Pay In Person toggle on the Payments screen no longer looks turned off when its status could not be loaded

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,7 +4,7 @@
 
 25.5
 -----
-- [*] Woo POS on phones: the "Install WooCommerce Payments" prompt no longer rotates the screen to landscape
+- [*] Woo POS on phones: the "Install WooCommerce Payments" prompt no longer rotates the screen to landscape [https://github.com/woocommerce/woocommerce-android/pull/16447]
 - [WEAR][*] Order and stats dates on the watch now follow the language's date order [https://github.com/woocommerce/woocommerce-android/pull/16429]
 - [Internal] Fixed duplicated device registration API calls fired concurrently during login [https://github.com/woocommerce/woocommerce-android/pull/16354]
 - [*] The Pay In Person toggle on the Payments screen no longer looks turned off when its status could not be loaded

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/WooPosCardReaderOnboardingActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/WooPosCardReaderOnboardingActivity.kt
@@ -3,7 +3,6 @@ package com.woocommerce.android.ui.woopos.cardreader
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
-import android.content.pm.ActivityInfo
 import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
@@ -20,6 +19,7 @@ import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboa
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboardingState
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderType
 import com.woocommerce.android.ui.woopos.util.ext.isGestureNavigation
+import com.woocommerce.android.ui.woopos.util.ext.lockWooPosOrientation
 import com.woocommerce.android.util.parcelable
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -29,7 +29,7 @@ class WooPosCardReaderOnboardingActivity : AppCompatActivity(R.layout.activity_w
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setupTopAndBottomInsets()
-        requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
+        lockWooPosOrientation()
 
         val navHostFragment = supportFragmentManager.findFragmentById(
             R.id.woopos_card_reader_onboarding_nav_host_fragment


### PR DESCRIPTION
WOOMOB-3832

### Description

On a phone, opening a full-screen card reader onboarding prompt from POS rotated the device into landscape. `WooPosCardReaderOnboardingActivity` hard-coded `SCREEN_ORIENTATION_LANDSCAPE` instead of using the shared `lockWooPosOrientation()` helper, which picks portrait on phones and landscape on tablets. The activity predates phone POS, so it was never migrated - `WooPosActivity` and `WooPosCouponCreationActivity` already call the helper.

This affects every onboarding state that `WooPosOnboardingErrorMapper` maps to `FullScreenRequired`, not just "Install WooCommerce Payments": `WcpayNotActivated`, `SetupNotCompleted`, `StripeAccountOverdueRequirement`, `ChoosePaymentGatewayProvider` and `CashOnDeliveryDisabled` all go through the same activity. The states that render as an in-POS dialog were never affected.

Tablet behaviour is unchanged.

### Test Steps

Needs a phone (or a phone-sized emulator) and a store where WooPayments is not installed.

1. Open POS on a phone.
2. Go to Settings > Hardware > Card Readers.
3. Tap "Connect your card reader".
4. When the "Install WooCommerce Payments" screen appears, it stays in portrait. Before this change the device rotated to landscape.
5. Go back and confirm POS is still in portrait.
6. On a tablet, repeat and confirm the onboarding screen is still landscape.

### Images/gif

Pixel 9 emulator (411dp wide), phone POS, WooPayments not installed.

| Before | After |
|---|---|
| <img src="https://pressable-kidinov.mystagingwebsite.com/wp-content/uploads/2026/08/woomob-3832-before.png" width="420"> | <img src="https://pressable-kidinov.mystagingwebsite.com/wp-content/uploads/2026/08/woomob-3832-after.png" width="190"> |

### Testing that has already taken place

Verified on the Pixel 9 emulator by forcing the onboarding check to return `WcpayNotInstalled`, then reading the activity's orientation back from `dumpsys`:

| Form factor | `requestedOrientation` | Display |
|---|---|---|
| Phone (411 x 923dp) | `SCREEN_ORIENTATION_PORTRAIT` | `ROTATION_0` |
| Tablet (1067 x 1707dp, via `wm size`) | `SCREEN_ORIENTATION_LANDSCAPE` | unchanged |

Before the change the same phone run reported `ROTATION_90`. Also confirmed that backing out of the onboarding screen returns to POS still in portrait.

`detektAll` passes.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary.
