### PR TITLE
[WOOMOB-3877] Hide the add product button when the search term is cleared

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,9 +2,12 @@
 *** Use [*****] to indicate smoke tests of all critical flows should be run on the final APK before release (e.g. major library or targetSdk updates).
 *** For entries which are touching the Android Wear app's, start entry with `[WEAR]` too.
 
-25.5
+25.6
 -----
 - [*] Fixed the add product button staying on screen after clearing the product search term [https://github.com/woocommerce/woocommerce-android/pull/16451]
+
+25.5
+-----
 - [Internal] Woo POS Scan to Pay: picking an offline method such as Pay in Person on the QR page no longer reports the order as paid, and a detected payment now shows the fullscreen success screen [https://github.com/woocommerce/woocommerce-android/pull/16363]
 - [*] Woo POS: Retrying a failed connection to a phone card reader now works without having to close and reopen the reader dialog [https://github.com/woocommerce/woocommerce-android/pull/16371]
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 
 25.5
 -----
+- [*] Fixed the add product button staying on screen after clearing the product search term
 - [Internal] Woo POS Scan to Pay: picking an offline method such as Pay in Person on the QR page no longer reports the order as paid, and a detected payment now shows the fullscreen success screen [https://github.com/woocommerce/woocommerce-android/pull/16363]
 - [*] Woo POS: Retrying a failed connection to a phone card reader now works without having to close and reopen the reader dialog [https://github.com/woocommerce/woocommerce-android/pull/16371]
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,7 +4,7 @@
 
 25.5
 -----
-- [*] Fixed the add product button staying on screen after clearing the product search term
+- [*] Fixed the add product button staying on screen after clearing the product search term [https://github.com/woocommerce/woocommerce-android/pull/16451]
 - [Internal] Woo POS Scan to Pay: picking an offline method such as Pay in Person on the QR page no longer reports the order as paid, and a detected payment now shows the fullscreen success screen [https://github.com/woocommerce/woocommerce-android/pull/16363]
 - [*] Woo POS: Retrying a failed connection to a phone card reader now works without having to close and reopen the reader dialog [https://github.com/woocommerce/woocommerce-android/pull/16371]
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/list/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/list/ProductListViewModel.kt
@@ -149,7 +149,7 @@ class ProductListViewModel @Inject constructor(
                 updateProductList(emptyList())
                 viewState = viewState.copy(
                     isEmptyViewVisible = false,
-                    isAddProductButtonVisible = shouldShowAddProductButton()
+                    isAddProductButtonVisible = false
                 )
             }
         }
@@ -426,8 +426,6 @@ class ProductListViewModel @Inject constructor(
         )
     }
 
-    // A blank search query means no search has been run yet, so there is nothing to add a product from.
-    // A query that returned nothing keeps the button, because that empty state has no add button of its own.
     private fun shouldShowAddProductButton(): Boolean =
         if (_productList.value.isNullOrEmpty()) {
             !viewState.query.isNullOrEmpty() || productFilterOptions.isNotEmpty()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/list/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/list/ProductListViewModel.kt
@@ -147,7 +147,10 @@ class ProductListViewModel @Inject constructor(
                 searchJob?.cancelAndJoin()
 
                 updateProductList(emptyList())
-                viewState = viewState.copy(isEmptyViewVisible = false)
+                viewState = viewState.copy(
+                    isEmptyViewVisible = false,
+                    isAddProductButtonVisible = shouldShowAddProductButton()
+                )
             }
         }
     }
@@ -423,9 +426,11 @@ class ProductListViewModel @Inject constructor(
         )
     }
 
+    // A blank search query means no search has been run yet, so there is nothing to add a product from.
+    // A query that returned nothing keeps the button, because that empty state has no add button of its own.
     private fun shouldShowAddProductButton(): Boolean =
         if (_productList.value.isNullOrEmpty()) {
-            viewState.query != null || productFilterOptions.isNotEmpty()
+            !viewState.query.isNullOrEmpty() || productFilterOptions.isNotEmpty()
         } else {
             !isSearching()
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/list/ProductListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/list/ProductListViewModelTest.kt
@@ -272,6 +272,63 @@ class ProductListViewModelTest : BaseUnitTest() {
         }
 
     @Test
+    fun `given search is open, when a query too short to search is typed, then the add product button is hidden`() =
+        testBlocking {
+            // GIVEN
+            doReturn(Result.success(productList)).whenever(productRepository).fetchProductList()
+
+            createViewModel()
+
+            val isAddProductButtonVisible = ArrayList<Boolean>()
+            viewModel.viewStateLiveData.observeForever { old, new ->
+                new.isAddProductButtonVisible?.takeIfNotEqualTo(old?.isAddProductButtonVisible) {
+                    isAddProductButtonVisible.add(it)
+                }
+            }
+
+            // WHEN
+            viewModel.loadProducts()
+            advanceUntilIdle()
+            viewModel.onSearchOpened()
+            viewModel.onSearchQueryChanged("no")
+            advanceUntilIdle()
+
+            // THEN
+            assertThat(isAddProductButtonVisible.last()).isFalse()
+        }
+
+    @Test
+    fun `given a filter is set, when the term is cleared after a search with no results, then the button is hidden`() =
+        testBlocking {
+            // GIVEN
+            productRepository.stub {
+                on { fetchProductList(any(), any(), any(), anyOrNull(), any()) } doReturn Result.success(productList)
+                on { searchProductList(any(), any(), any(), anyOrNull(), any()) } doReturn emptyList()
+            }
+
+            createViewModel()
+
+            val isAddProductButtonVisible = ArrayList<Boolean>()
+            viewModel.viewStateLiveData.observeForever { old, new ->
+                new.isAddProductButtonVisible?.takeIfNotEqualTo(old?.isAddProductButtonVisible) {
+                    isAddProductButtonVisible.add(it)
+                }
+            }
+
+            // WHEN
+            viewModel.onFiltersChanged("instock", null, null, null, null)
+            advanceUntilIdle()
+            viewModel.onSearchOpened()
+            viewModel.onSearchQueryChanged("nomatch")
+            advanceUntilIdle()
+            viewModel.onSearchQueryChanged("")
+            advanceUntilIdle()
+
+            // THEN
+            assertThat(isAddProductButtonVisible.last()).isFalse()
+        }
+
+    @Test
     fun `given cached products, when search closes during refresh, then add product button remains visible`() =
         testBlocking {
             // GIVEN

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/list/ProductListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/list/ProductListViewModelTest.kt
@@ -212,6 +212,66 @@ class ProductListViewModelTest : BaseUnitTest() {
         }
 
     @Test
+    fun `given search is open, when the search returns no results, then the add product button is shown`() =
+        testBlocking {
+            // GIVEN
+            doReturn(Result.success(productList)).whenever(productRepository).fetchProductList()
+            productRepository.stub {
+                on { searchProductList(any(), any(), any(), anyOrNull(), any()) } doReturn emptyList()
+            }
+
+            createViewModel()
+
+            val isAddProductButtonVisible = ArrayList<Boolean>()
+            viewModel.viewStateLiveData.observeForever { old, new ->
+                new.isAddProductButtonVisible?.takeIfNotEqualTo(old?.isAddProductButtonVisible) {
+                    isAddProductButtonVisible.add(it)
+                }
+            }
+
+            // WHEN
+            viewModel.loadProducts()
+            advanceUntilIdle()
+            viewModel.onSearchOpened()
+            viewModel.onSearchQueryChanged("nomatch")
+            advanceUntilIdle()
+
+            // THEN
+            assertThat(isAddProductButtonVisible.last()).isTrue()
+        }
+
+    @Test
+    fun `given a search returned no results, when the term is cleared, then the add product button is hidden`() =
+        testBlocking {
+            // GIVEN
+            doReturn(Result.success(productList)).whenever(productRepository).fetchProductList()
+            productRepository.stub {
+                on { searchProductList(any(), any(), any(), anyOrNull(), any()) } doReturn emptyList()
+            }
+
+            createViewModel()
+
+            val isAddProductButtonVisible = ArrayList<Boolean>()
+            viewModel.viewStateLiveData.observeForever { old, new ->
+                new.isAddProductButtonVisible?.takeIfNotEqualTo(old?.isAddProductButtonVisible) {
+                    isAddProductButtonVisible.add(it)
+                }
+            }
+
+            // WHEN
+            viewModel.loadProducts()
+            advanceUntilIdle()
+            viewModel.onSearchOpened()
+            viewModel.onSearchQueryChanged("nomatch")
+            advanceUntilIdle()
+            viewModel.onSearchQueryChanged("")
+            advanceUntilIdle()
+
+            // THEN
+            assertThat(isAddProductButtonVisible.last()).isFalse()
+        }
+
+    @Test
     fun `given cached products, when search closes during refresh, then add product button remains visible`() =
         testBlocking {
             // GIVEN

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/list/ProductListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/list/ProductListViewModelTest.kt
@@ -237,7 +237,7 @@ class ProductListViewModelTest : BaseUnitTest() {
             advanceUntilIdle()
 
             // THEN
-            assertThat(isAddProductButtonVisible.last()).isTrue()
+            assertThat(isAddProductButtonVisible).containsExactly(true, false, true)
         }
 
     @Test
@@ -268,7 +268,7 @@ class ProductListViewModelTest : BaseUnitTest() {
             advanceUntilIdle()
 
             // THEN
-            assertThat(isAddProductButtonVisible.last()).isFalse()
+            assertThat(isAddProductButtonVisible).containsExactly(true, false, true, false)
         }
 
     @Test
@@ -294,7 +294,7 @@ class ProductListViewModelTest : BaseUnitTest() {
             advanceUntilIdle()
 
             // THEN
-            assertThat(isAddProductButtonVisible.last()).isFalse()
+            assertThat(isAddProductButtonVisible).containsExactly(true, false)
         }
 
     @Test
@@ -325,7 +325,7 @@ class ProductListViewModelTest : BaseUnitTest() {
             advanceUntilIdle()
 
             // THEN
-            assertThat(isAddProductButtonVisible.last()).isFalse()
+            assertThat(isAddProductButtonVisible).containsExactly(true, false, true, false)
         }
 
     @Test


### PR DESCRIPTION
WOOMOB-3877

### Description

On the Products screen the add product button is hidden while search is open, except on a zero result search, where it is deliberately kept because that empty state has no add button of its own. Clearing the search term left it on screen, so you end up with a floating plus over a blank search screen.

Two things caused it. `onSearchQueryChanged` never recomputed the button visibility on the short query path, and `shouldShowAddProductButton` tested `query != null`, which stays true for the empty string the field holds after clearing.

I kept the button visible on a zero result search instead of hiding it for the whole search session as the issue asks. Hiding it there takes away the only way to add a product without leaving search, which the issue itself flags as worth a design call first.

This targets `feature/store-design-system-migration` rather than trunk, as requested on the issue.

### Test Steps

1. Open the Products tab.
2. Tap the search icon.
3. Type a term of at least 3 characters that matches no products, for example `zzzqqq`.
4. Wait for the no results message. The add product button should still be visible.
5. Clear the search term using the X in the search field, leaving search open.
6. The add product button should now be gone, leaving an empty search screen.
7. Type a term that does match products. The add product button stays hidden while results are shown.

### Images/gif
Before
<img width="300" alt="woomob3877-before-cleared" src="https://github.com/user-attachments/assets/3f156bb8-c743-44d5-b851-074b21c002de" />

After
<img width="300" alt="woomob3877-after-cleared" src="https://github.com/user-attachments/assets/406f5d9e-cf82-453f-8ad7-66ce5e1d046d" />
<img width="300" alt="woomob3877-after-no-results" src="https://github.com/user-attachments/assets/65a03730-5532-4ef5-bc74-637c148bd163" />




- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.