### PR TITLE
[WOOMOB-3794] Format the product discount screen values

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,9 +2,12 @@
 *** Use [*****] to indicate smoke tests of all critical flows should be run on the final APK before release (e.g. major library or targetSdk updates).
 *** For entries which are touching the Android Wear app's, start entry with `[WEAR]` too.
 
-25.5
+25.6
 -----
 - [*] Order creation: the discount screen now formats the product line and totals like the rest of the app, and "Price after discount" shows the full price until a discount is entered
+
+25.5
+-----
 - [Internal] Woo POS analytics: replaced the catch-all "other" reason on the POS ineligible screen with specific reasons, and added the missing orders_list_loaded event [https://github.com/woocommerce/woocommerce-android/pull/16439]
 - [WEAR][*] Order and stats dates on the watch now follow the language's date order [https://github.com/woocommerce/woocommerce-android/pull/16429]
 - [Internal] Fixed duplicated device registration API calls fired concurrently during login [https://github.com/woocommerce/woocommerce-android/pull/16354]

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 
 25.5
 -----
+- [*] Order creation: the discount screen now formats the product line and totals like the rest of the app, and "Price after discount" shows the full price until a discount is entered
 - [Internal] Woo POS analytics: replaced the catch-all "other" reason on the POS ineligible screen with specific reasons, and added the missing orders_list_loaded event [https://github.com/woocommerce/woocommerce-android/pull/16439]
 - [WEAR][*] Order and stats dates on the watch now follow the language's date order [https://github.com/woocommerce/woocommerce-android/pull/16429]
 - [Internal] Fixed duplicated device registration API calls fired concurrently during login [https://github.com/woocommerce/woocommerce-android/pull/16354]

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/product/discount/OrderCreateEditProductDiscountScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/product/discount/OrderCreateEditProductDiscountScreen.kt
@@ -61,6 +61,7 @@ import com.woocommerce.android.ui.orders.creation.product.discount.OrderCreateEd
 import com.woocommerce.android.ui.orders.creation.product.discount.OrderCreateEditProductDiscountViewModel.DiscountType.Amount
 import com.woocommerce.android.ui.orders.creation.product.discount.OrderCreateEditProductDiscountViewModel.DiscountType.Percentage
 import com.woocommerce.android.ui.orders.creation.product.discount.OrderCreateEditProductDiscountViewModel.ViewState
+import com.woocommerce.android.ui.orders.creation.views.getQuantityWithTotalText
 import com.woocommerce.android.ui.products.ProductStockStatus
 import com.woocommerce.android.ui.products.ProductType
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -98,10 +99,8 @@ fun OrderCreateEditProductDiscountScreen(
                 ProductCard(
                     imageUrl = viewState.value.productDetailsState?.imageUrl,
                     productName = productItem.value.item.name,
-                    productPrice = productItem.value.item.pricePreDiscount,
-                    productQuantity = productItem.value.item.quantity,
-                    subTotalPerProduct = productItem.value.item.subtotal,
-                    state = state.value
+                    quantityWithPrice = getQuantityWithTotalText(productItem.value),
+                    subTotalPerProduct = productItem.value.productInfo.priceSubtotal,
                 )
 
                 Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.minor_100)))
@@ -202,10 +201,8 @@ private fun Toolbar(
 private fun ProductCard(
     imageUrl: String?,
     productName: String,
-    productPrice: BigDecimal,
-    productQuantity: Float,
-    subTotalPerProduct: BigDecimal,
-    state: ViewState
+    quantityWithPrice: String,
+    subTotalPerProduct: String,
 ) {
     ConstraintLayout(
         modifier = Modifier
@@ -257,7 +254,7 @@ private fun ProductCard(
         )
 
         Text(
-            text = "$productQuantity x ${state.currency}$productPrice",
+            text = quantityWithPrice,
             style = MaterialTheme.typography.body2,
             color = colorResource(id = R.color.woo_gray_40),
             modifier = Modifier
@@ -273,7 +270,7 @@ private fun ProductCard(
         )
 
         Text(
-            text = "${state.currency}$subTotalPerProduct",
+            text = subTotalPerProduct,
             modifier = Modifier
                 .constrainAs(totalText) {
                     end.linkTo(parent.end)
@@ -330,11 +327,6 @@ data class DiscountInputFieldConfig(
 fun CalculatedAmount(
     state: ViewState,
 ) {
-    val discountAmount = when (state.discountType) {
-        is Percentage -> "${state.currency}${state.calculatedPriceAfterDiscount}"
-        is Amount -> "${state.calculatedPriceAfterDiscount}%"
-    }
-
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -355,7 +347,7 @@ fun CalculatedAmount(
             color = colorResource(id = R.color.woo_gray_40)
         )
         Text(
-            text = discountAmount,
+            text = state.calculatedAmount,
             style = MaterialTheme.typography.body2,
             color = colorResource(id = R.color.woo_gray_40)
         )
@@ -383,7 +375,7 @@ private fun PriceAfterDiscount(
             style = MaterialTheme.typography.body1,
         )
         Text(
-            text = "${state.currency}${state.priceAfterDiscount}",
+            text = state.priceAfterDiscount,
             style = MaterialTheme.typography.body1,
             color = colorResource(id = R.color.woo_gray_40)
         )
@@ -460,13 +452,7 @@ fun ProductCardPreview() {
     ProductCard(
         imageUrl = "",
         productName = "Product Name",
-        productPrice = BigDecimal.ZERO,
-        productQuantity = 1f,
-        subTotalPerProduct = BigDecimal.ZERO,
-        state = ViewState(
-            "$",
-            BigDecimal.ZERO,
-            isRemoveButtonVisible = true,
-        )
+        quantityWithPrice = "1 × $10.00",
+        subTotalPerProduct = "$10.00",
     )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/product/discount/OrderCreateEditProductDiscountViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/product/discount/OrderCreateEditProductDiscountViewModel.kt
@@ -11,6 +11,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_ORDER_
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.ui.orders.creation.OrderCreationProduct
 import com.woocommerce.android.ui.products.ParameterRepository
+import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.ResourceProvider
@@ -37,10 +38,12 @@ class OrderCreateEditProductDiscountViewModel @Inject constructor(
     private val tracker: AnalyticsTrackerWrapper,
     siteParamsRepo: ParameterRepository,
     currencySymbolFinder: CurrencySymbolFinder,
+    currencyFormatter: CurrencyFormatter,
 ) : ScopedViewModel(savedStateHandle) {
     private val args =
         OrderCreateEditProductDiscountFragmentArgs.fromSavedStateHandle(savedStateHandle)
     private val currency = currencySymbolFinder.findCurrencySymbol(args.currency)
+    private val formatCurrency = currencyFormatter.buildBigDecimalFormatter(args.currency)
     val productItem: MutableStateFlow<OrderCreationProduct> =
         savedStateHandle.getStateFlow(
             scope = this,
@@ -81,8 +84,8 @@ class OrderCreateEditProductDiscountViewModel @Inject constructor(
                 discountValidationState = checkDiscountValidationState(discount, type),
                 isRemoveButtonVisible = getRemoveButtonVisibility(),
                 discountType = type,
-                priceAfterDiscount = getPriceAfterDiscount(),
-                calculatedPriceAfterDiscount = getCalculatedPriceAfterDiscount(),
+                priceAfterDiscount = formatCurrency(getPriceAfterDiscount()),
+                calculatedAmount = getCalculatedAmountText(),
                 productDetailsState = ProductDetailsState(
                     imageUrl = productItem.value.productInfo.imageUrl
                 )
@@ -208,28 +211,20 @@ class OrderCreateEditProductDiscountViewModel @Inject constructor(
         }
     }
 
-    private fun getPriceAfterDiscount(): BigDecimal {
-        return if (discount.value == null) {
-            BigDecimal.ZERO
-        } else {
-            productItem.value.item.subtotal - getDiscountAmount()
-                .setScale(2, RoundingMode.HALF_UP)
-        }
-    }
+    private fun getPriceAfterDiscount(): BigDecimal =
+        productItem.value.item.subtotal - getDiscountAmount().setScale(2, RoundingMode.HALF_UP)
 
-    private fun getCalculatedPriceAfterDiscount(): BigDecimal {
-        return if (discount.value == null) {
-            BigDecimal.ZERO
-        } else if (discountType.value == DiscountType.Percentage) {
-            discount.value?.let {
-                calculateDiscountAmount(it)
-                    .setScale(2, RoundingMode.HALF_UP)
-            } ?: BigDecimal.ZERO
-        } else {
-            discount.value?.let {
-                calculateDiscountPercentage(it)
-                    .setScale(2, RoundingMode.HALF_UP)
-            } ?: BigDecimal.ZERO
+    private fun getCalculatedAmountText(): String {
+        val enteredDiscount = discount.value
+        return when (discountType.value) {
+            DiscountType.Percentage -> formatCurrency(
+                enteredDiscount?.let { calculateDiscountAmount(it) } ?: BigDecimal.ZERO
+            )
+
+            is DiscountType.Amount -> {
+                val percentage = enteredDiscount?.let { calculateDiscountPercentage(it) } ?: BigDecimal.ZERO
+                "${percentage.setScale(2, RoundingMode.HALF_UP)}$PERCENTAGE_SYMBOL"
+            }
         }
     }
 
@@ -244,8 +239,8 @@ class OrderCreateEditProductDiscountViewModel @Inject constructor(
         val isDoneButtonEnabled: Boolean = discountValidationState is DiscountAmountValidationState.Valid,
         val isRemoveButtonVisible: Boolean = false,
         val discountType: DiscountType = DiscountType.Amount(currency),
-        val priceAfterDiscount: BigDecimal = BigDecimal.ZERO,
-        val calculatedPriceAfterDiscount: BigDecimal = BigDecimal.ZERO,
+        val priceAfterDiscount: String = "",
+        val calculatedAmount: String = "",
         val productDetailsState: ProductDetailsState? = null,
     )
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/product/discount/OrderCreateEditProductDiscountViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/product/discount/OrderCreateEditProductDiscountViewModelTest.kt
@@ -19,6 +19,7 @@ import com.woocommerce.android.ui.products.ProductStockStatus
 import com.woocommerce.android.ui.products.ProductType
 import com.woocommerce.android.ui.products.models.CurrencyFormattingParameters
 import com.woocommerce.android.ui.products.models.SiteParameters
+import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ResourceProvider
@@ -31,6 +32,8 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.wordpress.android.fluxc.model.settings.CurrencyPosition
+import java.math.BigDecimal
+import java.math.RoundingMode
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 
@@ -74,6 +77,12 @@ class OrderCreateEditProductDiscountViewModelTest : BaseUnitTest() {
     }
 
     private val tracker: AnalyticsTrackerWrapper = mock()
+
+    private val currencyFormatter: CurrencyFormatter = mock {
+        on { buildBigDecimalFormatter(anyString()) } doReturn { amount: BigDecimal ->
+            "$" + amount.setScale(2, RoundingMode.HALF_UP).toPlainString()
+        }
+    }
 
     @Test
     fun `given discount bigger than item's total price, when done clicked, then should return Invalid state`() =
@@ -221,7 +230,7 @@ class OrderCreateEditProductDiscountViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given discount amount selected, when amount provided, then calculatedPriceAfterDiscount should return discount percentage`() =
+    fun `given discount amount selected, when amount provided, then calculatedAmount should return discount percentage`() =
         testBlocking {
             val item = Order.Item.EMPTY.copy(
                 quantity = 1F,
@@ -236,12 +245,12 @@ class OrderCreateEditProductDiscountViewModelTest : BaseUnitTest() {
             sut.onDiscountAmountChange(4.29.toBigDecimal())
             sut.viewState.test {
                 val viewState = awaitItem()
-                assertThat(viewState.calculatedPriceAfterDiscount).isEqualTo("13.00")
+                assertThat(viewState.calculatedAmount).isEqualTo("13.00%")
             }
         }
 
     @Test
-    fun `given discount percentage selected, when discount provided, the calculatedPriceAfterDiscount should return discount amount`() =
+    fun `given discount percentage selected, when discount provided, then calculatedAmount should return discount amount`() =
         testBlocking {
             val item = Order.Item.EMPTY.copy(
                 quantity = 1F,
@@ -257,9 +266,31 @@ class OrderCreateEditProductDiscountViewModelTest : BaseUnitTest() {
             sut.onDiscountAmountChange(13.toBigDecimal())
             sut.viewState.test {
                 val viewState = awaitItem()
-                assertThat(viewState.calculatedPriceAfterDiscount).isEqualTo("4.29")
+                assertThat(viewState.calculatedAmount).isEqualTo("$4.29")
             }
         }
+
+    @Test
+    fun `given no discount entered, when the screen opens, then price after discount shows the subtotal`() = testBlocking {
+        // GIVEN
+        val item = Order.Item.EMPTY.copy(
+            quantity = 2F,
+            subtotal = 36.toBigDecimal(),
+            total = 36.toBigDecimal(),
+        )
+        val savedStateHandle: SavedStateHandle = OrderCreateEditProductDiscountFragmentArgs(
+            createProductItem(item),
+            "usd"
+        ).toSavedStateHandle()
+
+        // WHEN
+        val sut = createSut(savedStateHandle)
+
+        // THEN
+        sut.viewState.test {
+            assertThat(awaitItem().priceAfterDiscount).isEqualTo("$36.00")
+        }
+    }
 
     @Test
     fun `given discount amount provided, then show correct price after discount`() = testBlocking {
@@ -276,7 +307,7 @@ class OrderCreateEditProductDiscountViewModelTest : BaseUnitTest() {
         sut.onDiscountAmountChange(4.29.toBigDecimal())
         sut.viewState.test {
             val viewState = awaitItem()
-            assertThat(viewState.priceAfterDiscount).isEqualTo("28.71")
+            assertThat(viewState.priceAfterDiscount).isEqualTo("$28.71")
         }
     }
 
@@ -384,6 +415,7 @@ class OrderCreateEditProductDiscountViewModelTest : BaseUnitTest() {
             tracker,
             parameterRepository,
             currencySymbolFinder,
+            currencyFormatter,
         )
     }
 


### PR DESCRIPTION
Fixes WOOMOB-3794

### Description

The discount screen built its text by hand, `"$productQuantity x ${state.currency}$productPrice"`, so it printed a raw `Float` and a raw `BigDecimal` and you got `2.0 x €18.00000000`. The product line now comes from `getQuantityWithTotalText()`, the same one the order card uses, and totals go through `CurrencyFormatter`. Also `getPriceAfterDiscount()` returned `ZERO` when no discount was entered, so the row showed `€0` instead of the full price. That branch is gone.

Not visible in the diff: switching Amount to Percentage puts a rounded value in the input while the internal one stays precise, so Calculated Amount can read `US$200.00` instead of `US$199.94`. Old behaviour, I did not touch it.

### Test Steps

1. Orders, create order, add a product, set quantity to 2
2. Expand the card and tap **Add discount**
3. Line reads `2 × US$913.90` and the total `US$1,827.80`
4. With the amount field empty, **Price after discount** shows the full price, not `US$0`

### Images/gif

| No discount entered | Discount of 200 |
| -- | -- |
| <img src="https://pressable-kidinov.mystagingwebsite.com/wp-content/uploads/2026/08/woomob-3794-after-full-scaled.png" width="300" /> | <img src="https://pressable-kidinov.mystagingwebsite.com/wp-content/uploads/2026/08/woomob-3794-after-discount-scaled.png" width="300" /> |

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
