### PR TITLE
[WOOMOB-3865] Normalize HTTP site URLs to HTTPS

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 
 25.6
 -----
+- [*] Stores configured with an HTTP address now connect securely over HTTPS, with guidance to update their WordPress address [https://github.com/woocommerce/woocommerce-android/pull/16456]
 - [*] Remote Tap to Pay keeps working on Android 17: the phone now asks for local network permission before it advertises itself, and the tablet asks before it connects to a phone reader
 - [*****] [Internal] Updated the app's target SDK to Android 17 (API 37) [https://github.com/woocommerce/woocommerce-android/pull/16413]
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -62,6 +62,8 @@ import java.util.Date
 @SuppressLint("StaticFieldLeak")
 @SuppressWarnings("LargeClass")
 object AppPrefs {
+    private const val HTTPS_CONFIGURATION_WARNING_DISMISSAL_PREFIX =
+        "HTTPS_CONFIGURATION_WARNING_DISMISSAL"
     interface PrefKey
 
     @JvmInline
@@ -544,6 +546,16 @@ object AppPrefs {
             selfHostedSiteId
         )
     )
+
+    fun getHttpsConfigurationWarningDismissedAt(localSiteId: Int): Long =
+        getLong(getHttpsConfigurationWarningDismissalKey(localSiteId))
+
+    fun setHttpsConfigurationWarningDismissedAt(localSiteId: Int, dismissedAt: Long) {
+        setLong(getHttpsConfigurationWarningDismissalKey(localSiteId), dismissedAt)
+    }
+
+    private fun getHttpsConfigurationWarningDismissalKey(localSiteId: Int) =
+        "$HTTPS_CONFIGURATION_WARNING_DISMISSAL_PREFIX:$localSiteId"
 
     private fun getCardReaderUpsellDismissedForeverKey(
         localSiteId: Int,
@@ -1424,7 +1436,10 @@ object AppPrefs {
     private fun removePreferencesWithDynamicKey(editor: Editor) {
         getPreferences()
             .all
-            .filter { it.key.contains(RECEIPT_PREFIX.toString(), ignoreCase = true) }
+            .filter {
+                it.key.contains(RECEIPT_PREFIX.toString(), ignoreCase = true) ||
+                    it.key.startsWith(HTTPS_CONFIGURATION_WARNING_DISMISSAL_PREFIX)
+            }
             .forEach {
                 editor.remove(it.key)
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -471,6 +471,7 @@ class AnalyticsTracker private constructor(
         const val KEY_REFUND_METHOD = "gateway"
         const val KEY_AMOUNT = "amount"
         const val KEY_AMOUNT_NORMALIZED = "amount_normalized"
+        const val KEY_URL_WAS_NORMALIZED_TO_HTTPS = "url_was_normalized_to_https"
         const val KEY_CURRENCY = "currency"
 
         const val KEY_PAYMENT_METHOD = "payment_method"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/SiteModelExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/SiteModelExt.kt
@@ -5,6 +5,7 @@ import com.woocommerce.android.ui.plans.domain.FREE_TRIAL_PLAN_ID
 import com.woocommerce.android.util.WooLog
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.SiteStore.SiteVisibility.PUBLIC
+import org.wordpress.android.fluxc.utils.HttpsUrlNormalizer
 import org.wordpress.android.fluxc.utils.SiteUtils.getNormalizedTimezone
 import org.wordpress.android.fluxc.utils.extensions.slashJoin
 import java.time.Clock
@@ -44,10 +45,14 @@ val SiteModel.isSimpleWPComSite
     get() = isWPCom
 
 val SiteModel.adminUrlOrDefault
-    get() = adminUrl ?: url.slashJoin("wp-admin")
+    get() = (adminUrl ?: url.slashJoin("wp-admin")).normalizedToHttps()
 
 val SiteModel.loginUrlOrDefault
-    get() = loginUrl ?: url.slashJoin("wp-login.php")
+    get() = (loginUrl ?: url.slashJoin("wp-login.php")).normalizedToHttps()
+
+private val httpsUrlNormalizer = HttpsUrlNormalizer()
+
+private fun String.normalizedToHttps() = httpsUrlNormalizer.normalize(this).normalizedUrl
 
 val SiteModel.clock: Clock
     @Suppress("TooGenericExceptionCaught")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -202,6 +202,7 @@ class LoginActivity :
     private lateinit var binding: ActivityLoginBinding
 
     private var connectSiteInfo: ConnectSiteInfo? = null
+    private var pendingSiteAddressWasNormalizedToHttps = false
 
     override fun androidInjector(): AndroidInjector<Any> = androidInjector
 
@@ -764,6 +765,7 @@ class LoginActivity :
         // in the login process.
         val siteAddressClean = inputSiteAddress.replaceFirst(PROTOCOL_REGEX, "")
         appPrefsWrapper.setLoginSiteAddress(siteAddressClean)
+        pendingSiteAddressWasNormalizedToHttps = result.wasUrlNormalizedToHttps
         if (result.hasJetpack || connectSiteInfo?.shouldUseWPComAuth == true) {
             showEmailLoginScreen(null)
         } else {
@@ -994,11 +996,13 @@ class LoginActivity :
             siteAddress = requireNotNull(siteAddress),
             isJetpackConnected = connectSiteInfo?.isJetpackConnected ?: false,
             username = inputUsername,
-            password = inputPassword
+            password = inputPassword,
+            wasUrlNormalizedToHttps = pendingSiteAddressWasNormalizedToHttps ||
+                siteAddress.startsWith("http://", ignoreCase = true),
         ),
         shouldAddToBackStack = true,
         tag = LoginSiteCredentialsFragment.TAG
-    )
+    ).also { pendingSiteAddressWasNormalizedToHttps = false }
 
     override fun onApplicationPasswordHelpRequired(
         verifiedLoginUrl: String?,
@@ -1070,6 +1074,7 @@ class LoginActivity :
     override fun handleSiteAddressError(siteInfo: ConnectSiteInfoPayload) {
         org.wordpress.android.util.ActivityUtils.hideKeyboard(this)
         if (siteInfo.error?.wpApiDiscovery?.wpApiBaseUrl != null) {
+            pendingSiteAddressWasNormalizedToHttps = siteInfo.wasUrlNormalizedToHttps
             LoginSiteInfoFallbackDialogFragment.newInstance(siteInfo.url)
                 .show(LoginSiteInfoFallbackDialogFragment.TAG)
         } else if (!siteInfo.isWordPress) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/WPApiSiteRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/WPApiSiteRepository.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.withTimeoutOrNull
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.SiteActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.INVALID_SSL_CERTIFICATE
 import org.wordpress.android.fluxc.network.rest.wpapi.CookieNonceAuthenticator
 import org.wordpress.android.fluxc.network.rest.wpapi.CookieNonceAuthenticator.CookieNonceAuthenticationResult.Error
 import org.wordpress.android.fluxc.network.rest.wpapi.CookieNonceAuthenticationEndpoints
@@ -88,14 +89,20 @@ class WPApiSiteRepository @Inject constructor(
         }
     }
 
-    suspend fun fetchSite(url: String, username: String? = null, password: String? = null): Result<SiteModel> {
+    suspend fun fetchSite(
+        url: String,
+        username: String? = null,
+        password: String? = null,
+        wasUrlNormalizedToHttps: Boolean = false,
+    ): Result<SiteModel> {
         WooLog.d(WooLog.T.LOGIN, "Fetching site using WP REST API")
 
         return siteStore.fetchWPAPISite(
             FetchWPAPISitePayload(
                 url = url,
                 username = username,
-                password = password
+                password = password,
+                wasUrlNormalizedToHttps = wasUrlNormalizedToHttps,
             )
         ).let { result ->
             when {
@@ -248,6 +255,8 @@ class WPApiSiteRepository @Inject constructor(
         type == CUSTOM_LOGIN_URL -> UiStringRes(string.login_site_credentials_custom_login_url)
         type == CUSTOM_ADMIN_URL -> UiStringRes(string.login_site_credentials_custom_admin_url)
         type == BASIC_AUTH_REQUIRED -> UiStringRes(string.login_site_credentials_http_basic_auth_error)
+        networkError?.type == INVALID_SSL_CERTIFICATE -> UiStringRes(string.error_site_url_remote_certificate)
+        networkError != null -> null
         else -> message?.takeIf { it.isNotEmpty() }?.let { UiStringText(it) }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsFragment.kt
@@ -30,13 +30,23 @@ import javax.inject.Inject
 class LoginSiteCredentialsFragment : Fragment() {
     companion object {
         const val TAG = "LoginSiteCredentialsFragment"
-        fun newInstance(siteAddress: String, isJetpackConnected: Boolean, username: String?, password: String?) =
+        fun newInstance(
+            siteAddress: String,
+            isJetpackConnected: Boolean,
+            username: String?,
+            password: String?,
+            wasUrlNormalizedToHttps: Boolean = false,
+        ) =
             LoginSiteCredentialsFragment().apply {
                 arguments = Bundle().apply {
                     putString(LoginSiteCredentialsViewModel.SITE_ADDRESS_KEY, siteAddress)
                     putBoolean(LoginSiteCredentialsViewModel.IS_JETPACK_CONNECTED_KEY, isJetpackConnected)
                     putString(LoginSiteCredentialsViewModel.USERNAME_KEY, username.orEmpty())
                     putString(LoginSiteCredentialsViewModel.PASSWORD_KEY, password.orEmpty())
+                    putBoolean(
+                        LoginSiteCredentialsViewModel.WAS_URL_NORMALIZED_TO_HTTPS_KEY,
+                        wasUrlNormalizedToHttps,
+                    )
                 }
             }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
@@ -51,6 +51,7 @@ import org.wordpress.android.fluxc.network.rest.wpapi.Nonce.CookieNonceErrorType
 import org.wordpress.android.fluxc.network.rest.wpapi.Nonce.CookieNonceErrorType.INVALID_RESPONSE
 import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordsConfiguration
 import org.wordpress.android.fluxc.store.SiteStore.SiteError
+import org.wordpress.android.fluxc.utils.HttpsUrlNormalizer
 import org.wordpress.android.login.LoginAnalyticsListener
 import org.wordpress.android.util.UrlUtils
 import java.net.URI
@@ -59,6 +60,7 @@ import javax.inject.Inject
 @HiltViewModel
 class LoginSiteCredentialsViewModel @Inject constructor(
     private val savedStateHandle: SavedStateHandle,
+    private val httpsUrlNormalizer: HttpsUrlNormalizer,
     private val wpApiSiteRepository: WPApiSiteRepository,
     private val selectedSite: SelectedSite,
     private val loginAnalyticsListener: LoginAnalyticsListener,
@@ -73,6 +75,7 @@ class LoginSiteCredentialsViewModel @Inject constructor(
         const val USERNAME_KEY = "username"
         const val PASSWORD_KEY = "password"
         const val IS_JETPACK_CONNECTED_KEY = "is-jetpack-connected"
+        const val WAS_URL_NORMALIZED_TO_HTTPS_KEY = "was-url-normalized-to-https"
         private const val REDIRECTION_URL = "woocommerce://login"
         private const val SUCCESS_PARAMETER = "success"
         private const val USERNAME_PARAMETER = "user_login"
@@ -82,10 +85,25 @@ class LoginSiteCredentialsViewModel @Inject constructor(
         private const val ADMIN_BASE_URL_KEY = "admin-base-url"
     }
 
+    private val wasSiteAddressNormalizedToHttps =
+        savedStateHandle[WAS_URL_NORMALIZED_TO_HTTPS_KEY]
+            ?: normalizeSiteAddress(requireNotNull(savedStateHandle.get<String>(SITE_ADDRESS_KEY)))?.wasUpgraded
+            ?: false
+
     private var siteAddress: String
-        get() = savedStateHandle[SITE_ADDRESS_KEY]!!
+        get() {
+            val rawUrl = requireNotNull(savedStateHandle.get<String>(SITE_ADDRESS_KEY))
+            return normalizeSiteAddress(rawUrl)?.normalizedUrl ?: rawUrl
+        }
         set(value) {
-            savedStateHandle[SITE_ADDRESS_KEY] = value
+            savedStateHandle[SITE_ADDRESS_KEY] = normalizeSiteAddress(value)?.normalizedUrl ?: value
+        }
+
+    private fun normalizeSiteAddress(rawUrl: String): HttpsUrlNormalizer.Result? =
+        try {
+            httpsUrlNormalizer.normalize(rawUrl, addHttpsSchemeIfMissing = true)
+        } catch (_: IllegalArgumentException) {
+            null
         }
 
     // The URL the WP.com `connect/site-info` endpoint reports as the canonical site URL is
@@ -404,7 +422,10 @@ class LoginSiteCredentialsViewModel @Inject constructor(
 
     private suspend fun fetchSiteForTutorial(detectedErrorMessage: UiString? = null) {
         loadingMessage.value = R.string.login_site_credentials_fetching_site
-        wpApiSiteRepository.fetchSite(url = siteAddress).fold(
+        wpApiSiteRepository.fetchSite(
+            url = siteAddress,
+            wasUrlNormalizedToHttps = wasSiteAddressNormalizedToHttps,
+        ).fold(
             onSuccess = { site ->
                 val canonicalUrl = site.url
                 if (!hasReconciledSiteUrl && !canonicalUrl.isNullOrEmpty() && canonicalUrl != siteAddress) {
@@ -454,7 +475,8 @@ class LoginSiteCredentialsViewModel @Inject constructor(
         wpApiSiteRepository.fetchSite(
             url = siteAddress,
             username = viewState?.username,
-            password = viewState?.password
+            password = viewState?.password,
+            wasUrlNormalizedToHttps = wasSiteAddressNormalizedToHttps,
         ).fold(
             onSuccess = { site ->
                 if (site.hasWooCommerce) {
@@ -573,7 +595,8 @@ class LoginSiteCredentialsViewModel @Inject constructor(
             LOGIN_SITE_CREDENTIALS_LOGIN_FAILED,
             mapOf(
                 AnalyticsTracker.KEY_STEP to step.name.lowercase(),
-                AnalyticsTracker.KEY_NETWORK_STATUS_CODE to statusCode?.toString().orEmpty()
+                AnalyticsTracker.KEY_NETWORK_STATUS_CODE to statusCode?.toString().orEmpty(),
+                AnalyticsTracker.KEY_URL_WAS_NORMALIZED_TO_HTTPS to wasSiteAddressNormalizedToHttps.toString(),
             ),
             errorContext = errorContext,
             errorType = errorType,
@@ -644,7 +667,10 @@ class LoginSiteCredentialsViewModel @Inject constructor(
 
     private suspend fun handleEndpointRecovery(type: EndpointType, isRetry: Boolean) {
         if (!isRetry && !hasReconciledSiteUrl) {
-            val canonicalUrl = wpApiSiteRepository.fetchSite(url = siteAddress).getOrNull()?.url
+            val canonicalUrl = wpApiSiteRepository.fetchSite(
+                url = siteAddress,
+                wasUrlNormalizedToHttps = wasSiteAddressNormalizedToHttps,
+            ).getOrNull()?.url
             val reconciledSiteAddress = canonicalUrl?.toSafeReconciledSiteAddress()
             if (reconciledSiteAddress != null) {
                 hasReconciledSiteUrl = true

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -23,8 +23,10 @@ import androidx.activity.viewModels
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.appcompat.widget.Toolbar
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.content.ContextCompat
@@ -37,8 +39,11 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentManager.FragmentLifecycleCallbacks
 import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.NavController
 import androidx.navigation.NavDestination
 import androidx.navigation.NavOptions
@@ -73,6 +78,10 @@ import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.TopLevelFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.common.InfoScreenFragment
+import com.woocommerce.android.ui.compose.designsystem.WooTheme as WooDesignSystem
+import com.woocommerce.android.ui.compose.designsystem.component.WooNoticeBanner
+import com.woocommerce.android.ui.compose.designsystem.component.WooNoticeBannerTone
+import com.woocommerce.android.ui.compose.designsystem.foundation.WooDesignSystemTheme
 import com.woocommerce.android.ui.compose.theme.WooTheme
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.dashboard.StoreConnectionErrorDialog
@@ -131,6 +140,7 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.widgets.AppRatingDialog
 import com.woocommerce.android.widgets.DisabledAppBarLayoutBehavior
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.login.LoginAnalyticsListener
 import org.wordpress.android.login.LoginMode
@@ -156,6 +166,8 @@ class MainActivity :
         private const val KEY_UNFILLED_ORDER_COUNT = "unfilled-order-count"
 
         private const val DIALOG_NAVIGATOR_NAME = "dialog"
+        private const val HTTPS_CONFIGURATION_LEARN_MORE_URL =
+            "https://developer.wordpress.org/advanced-administration/security/https/"
 
         // push notification-related constants
         const val FIELD_OPENED_FROM_PUSH = "opened-from-push-notification"
@@ -233,6 +245,8 @@ class MainActivity :
     // Drives the collapsing toolbar's elevation shadow from its own offset (see setupAppBarElevation).
     private var appBarVerticalOffset = 0
     private var appBarHasShadow = true
+    private var httpsConfigurationWarningRequired = false
+    private var httpsConfigurationWarningAllowedForDestination = false
 
     private val appBarOffsetListener by lazy {
         AppBarLayout.OnOffsetChangedListener { _, verticalOffset ->
@@ -307,6 +321,8 @@ class MainActivity :
 
             when (val appBarStatus = (f as? BaseFragment)?.activityAppBarStatus ?: AppBarStatus.Visible()) {
                 is AppBarStatus.Visible -> {
+                    httpsConfigurationWarningAllowedForDestination =
+                        f is TopLevelFragment && shouldShowBottomNavigation
                     showToolbar()
                     // re-expand the AppBar when returning to top level fragment,
                     // collapse it when entering a child fragment
@@ -332,11 +348,13 @@ class MainActivity :
                 }
 
                 AppBarStatus.Hidden -> {
+                    httpsConfigurationWarningAllowedForDestination = false
                     hideToolbar()
                     appBarHasShadow = false
                     updateAppBarElevation()
                 }
             }
+            updateHttpsConfigurationWarningVisibility()
         }
     }
 
@@ -371,6 +389,7 @@ class MainActivity :
         setContentView(binding.root)
 
         setupStoreConnectionErrorDialog()
+        setupHttpsConfigurationWarning()
 
         edgeToEdgeHelper.applyEdgeToEdgeSettings(binding)
 
@@ -916,6 +935,44 @@ class MainActivity :
                 }
             }
         }
+    }
+
+    private fun setupHttpsConfigurationWarning() {
+        binding.httpsConfigurationWarning.setViewCompositionStrategy(
+            ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed
+        )
+        binding.httpsConfigurationWarning.setContent {
+            WooDesignSystemTheme {
+                WooNoticeBanner(
+                    title = getString(R.string.https_configuration_warning_title),
+                    description = getString(R.string.https_configuration_warning_message),
+                    tone = WooNoticeBannerTone.Warning,
+                    actionLabel = getString(R.string.learn_more),
+                    onActionClick = {
+                        ChromeCustomTabUtils.launchUrl(this, HTTPS_CONFIGURATION_LEARN_MORE_URL)
+                    },
+                    dismissContentDescription = getString(R.string.https_configuration_warning_dismiss),
+                    onDismissClick = viewModel::onHttpsConfigurationWarningDismissed,
+                    modifier = Modifier.padding(
+                        horizontal = WooDesignSystem.padding.padding4,
+                        vertical = WooDesignSystem.padding.padding3,
+                    ),
+                )
+            }
+        }
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.httpsConfigurationWarningVisible.collect { isVisible ->
+                    httpsConfigurationWarningRequired = isVisible
+                    updateHttpsConfigurationWarningVisibility()
+                }
+            }
+        }
+    }
+
+    private fun updateHttpsConfigurationWarningVisibility() {
+        binding.httpsConfigurationWarning.isVisible =
+            httpsConfigurationWarningRequired && httpsConfigurationWarningAllowedForDestination
     }
 
     @Suppress("ComplexMethod")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
@@ -40,20 +40,35 @@ import com.woocommerce.android.util.BuildConfigWrapper
 import com.woocommerce.android.util.SystemVersionUtilsWrapper
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T
+import com.woocommerce.android.util.observeEvents
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged
+import org.wordpress.android.fluxc.utils.CurrentTimeProvider
 import javax.inject.Inject
 
 @HiltViewModel
 @Suppress("LongParameterList")
 class MainActivityViewModel @Inject constructor(
     savedState: SavedStateHandle,
+    private val dispatcher: Dispatcher,
     private val siteStore: SiteStore,
     private val selectedSite: SelectedSite,
     private val storeConnectionErrorMonitor: StoreConnectionErrorMonitor,
@@ -65,6 +80,7 @@ class MainActivityViewModel @Inject constructor(
     private val resolveAppLink: ResolveAppLink,
     private val privacyRepository: PrivacySettingsRepository,
     private val systemVersionUtilsWrapper: SystemVersionUtilsWrapper,
+    private val currentTimeProvider: CurrentTimeProvider,
     ageEligibilityChecker: AgeEligibilityChecker,
     moreMenuNewFeatureHandler: MoreMenuNewFeatureHandler,
     unseenReviewsCountHandler: UnseenReviewsCountHandler,
@@ -95,6 +111,14 @@ class MainActivityViewModel @Inject constructor(
     val trialStatusBarState = determineTrialStatusBarState(_bottomBarState).asLiveData()
 
     val isUserAgeRangeEligible = ageEligibilityChecker.ageEligibilityState.asLiveData()
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val httpsConfigurationWarningVisible = combine(
+        observeSelectedSiteUpdates(),
+        prefs.observePrefs().onStart { emit(Unit) },
+    ) { site, _ -> site }
+        .flatMapLatest(::httpsConfigurationWarningVisibility)
+        .toStateFlow(initialValue = false)
 
     // Snoozes the dialog when the merchant taps Dismiss. Reset when the app goes to the background
     // (see [onAppBackgrounded]) so a still-unreachable store reminds the merchant again next session.
@@ -130,6 +154,50 @@ class MainActivityViewModel @Inject constructor(
 
     fun onStoreConnectionErrorDismissed() {
         connectionErrorSnoozed.value = true
+    }
+
+    fun onHttpsConfigurationWarningDismissed() {
+        selectedSite.getOrNull()?.id?.takeIf { it > 0 }?.let { localSiteId ->
+            prefs.setHttpsConfigurationWarningDismissedAt(
+                localSiteId = localSiteId,
+                dismissedAt = currentTimeProvider.currentDate().time,
+            )
+        }
+    }
+
+    private fun observeSelectedSiteUpdates(): Flow<SiteModel?> = merge(
+        selectedSite.observe(),
+        dispatcher.observeEvents<OnSiteChanged>().map { event ->
+            val selectedLocalId = selectedSite.getOrNull()?.id ?: return@map null
+            event.updatedSites.firstOrNull { it.id == selectedLocalId }
+                ?: siteStore.getSiteByLocalId(selectedLocalId)
+                ?: selectedSite.getOrNull()
+        },
+    )
+
+    private fun httpsConfigurationWarningVisibility(site: SiteModel?): Flow<Boolean> = flow {
+        if (site == null || !site.requiresHttpsConfigurationWarning()) {
+            emit(false)
+            return@flow
+        }
+
+        val dismissedAt = prefs.getHttpsConfigurationWarningDismissedAt(site.id)
+        val elapsedSinceDismissal = currentTimeProvider.currentDate().time - dismissedAt
+        val remainingDismissal = HTTPS_WARNING_DISMISSAL_DURATION_MILLIS - elapsedSinceDismissal
+        if (dismissedAt > 0L && remainingDismissal > 0L) {
+            emit(false)
+            delay(remainingDismissal)
+        }
+        emit(true)
+        awaitCancellation()
+    }
+
+    private fun SiteModel.requiresHttpsConfigurationWarning(): Boolean = when (httpsConfigurationState) {
+        SiteModel.HTTPS_CONFIGURATION_REQUIRES_HTTPS -> true
+        SiteModel.HTTPS_CONFIGURATION_SECURE -> false
+        else -> sequenceOf(url, loginUrl, prefs.getLoginSiteAddress())
+            .filterNotNull()
+            .any { it.startsWith("http://", ignoreCase = true) }
     }
 
     fun onAppBackgrounded() {
@@ -440,5 +508,9 @@ class MainActivityViewModel @Inject constructor(
     sealed class BottomBarState : Event() {
         object Visible : BottomBarState()
         object Hidden : BottomBarState()
+    }
+
+    companion object {
+        private const val HTTPS_WARNING_DISMISSAL_DURATION_MILLIS = 24 * 60 * 60 * 1000L
     }
 }

--- a/WooCommerce/src/main/res/layout/activity_main.xml
+++ b/WooCommerce/src/main/res/layout/activity_main.xml
@@ -50,6 +50,12 @@
                 android:layout_gravity="bottom"
                 style="@style/Woo.Divider"
                 android:visibility="gone" />
+
+            <androidx.compose.ui.platform.ComposeView
+                android:id="@+id/https_configuration_warning"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:visibility="gone" />
         </com.google.android.material.appbar.AppBarLayout>
 
         <FrameLayout

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -54,6 +54,9 @@
     <string name="keep_editing">Keep editing</string>
     <string name="keep_changes">Keep changes</string>
     <string name="learn_more">Learn more</string>
+    <string name="https_configuration_warning_title">Secure your store with HTTPS</string>
+    <string name="https_configuration_warning_message">Your store supports HTTPS, but its address is configured to use HTTP. Update it to HTTPS to protect your store and prevent connection problems.</string>
+    <string name="https_configuration_warning_dismiss">Dismiss HTTPS security notice</string>
     <string name="set_up_now">Set up now</string>
     <string name="offline_message">Offline \u2014 using cached data</string>
     <string name="offline_error">Your network is unavailable. Check your data or wifi connection.</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/AppPrefsHttpsWarningTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/AppPrefsHttpsWarningTest.kt
@@ -1,0 +1,28 @@
+package com.woocommerce.android
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class AppPrefsHttpsWarningTest {
+    @Before
+    fun setUp() {
+        AppPrefs.init(RuntimeEnvironment.getApplication())
+        AppPrefs.getPreferences().edit().clear().apply()
+    }
+
+    @Test
+    fun `given per-site HTTPS warning dismissals, when logging out, then remove all dynamic keys`() {
+        AppPrefs.setHttpsConfigurationWarningDismissedAt(localSiteId = 1, dismissedAt = 100L)
+        AppPrefs.setHttpsConfigurationWarningDismissedAt(localSiteId = 2, dismissedAt = 200L)
+
+        AppPrefs.resetUserPreferences()
+
+        assertThat(AppPrefs.getHttpsConfigurationWarningDismissedAt(1)).isZero()
+        assertThat(AppPrefs.getHttpsConfigurationWarningDismissedAt(2)).isZero()
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/WPApiSiteRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/WPApiSiteRepositoryTest.kt
@@ -23,11 +23,14 @@ import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.action.SiteAction
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.INVALID_SSL_CERTIFICATE
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.NO_CONNECTION
 import org.wordpress.android.fluxc.network.rest.wpapi.CookieNonceAuthenticationEndpoints
 import org.wordpress.android.fluxc.network.rest.wpapi.CookieNonceAuthenticator
 import org.wordpress.android.fluxc.network.rest.wpapi.CookieNonceAuthenticator.CookieNonceAuthenticationResult.Error
 import org.wordpress.android.fluxc.network.rest.wpapi.CookieNonceAuthenticator.CookieNonceAuthenticationResult.Success
 import org.wordpress.android.fluxc.network.rest.wpapi.Nonce.CookieNonceErrorType.CUSTOM_LOGIN_URL
+import org.wordpress.android.fluxc.network.rest.wpapi.Nonce.CookieNonceErrorType.UNKNOWN
 import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordsStore
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged
@@ -94,6 +97,42 @@ class WPApiSiteRepositoryTest : BaseUnitTest() {
                 UiStringRes(R.string.login_site_credentials_http_error, listOf(UiStringText("404")))
             )
             assertThat(exception.loginEntryVerified).isTrue()
+        }
+
+    @Test
+    fun `given direct WPAPI certificate failure, when logging in, then show security certificate guidance`() =
+        testBlocking {
+            whenever(authenticator.authenticate(ENDPOINTS, USERNAME, PASSWORD)).thenReturn(
+                Error(
+                    type = UNKNOWN,
+                    message = "low-level TLS exception",
+                    networkError = BaseNetworkError(INVALID_SSL_CERTIFICATE)
+                )
+            )
+
+            val exception = repository.login(SITE_URL, USERNAME, PASSWORD, ENDPOINTS).exceptionOrNull()
+                as WPApiSiteRepository.CookieNonceAuthenticationException
+
+            assertThat(exception.errorMessage).isEqualTo(UiStringRes(R.string.error_site_url_remote_certificate))
+            assertThat(exception.message).isNull()
+        }
+
+    @Test
+    fun `given direct WPAPI offline failure, when logging in, then hide low-level details behind generic error`() =
+        testBlocking {
+            whenever(authenticator.authenticate(ENDPOINTS, USERNAME, PASSWORD)).thenReturn(
+                Error(
+                    type = UNKNOWN,
+                    message = "socket details",
+                    networkError = BaseNetworkError(NO_CONNECTION)
+                )
+            )
+
+            val exception = repository.login(SITE_URL, USERNAME, PASSWORD, ENDPOINTS).exceptionOrNull()
+                as WPApiSiteRepository.CookieNonceAuthenticationException
+
+            assertThat(exception.errorMessage).isEqualTo(UiStringRes(R.string.error_generic))
+            assertThat(exception.message).isNull()
         }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModelTest.kt
@@ -43,6 +43,7 @@ import org.wordpress.android.fluxc.network.rest.wpapi.Nonce
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetworkError
 import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordsConfiguration
 import org.wordpress.android.fluxc.store.SiteStore.SiteError
+import org.wordpress.android.fluxc.utils.HttpsUrlNormalizer
 import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType
 import org.wordpress.android.login.LoginAnalyticsListener
 
@@ -118,32 +119,30 @@ class LoginSiteCredentialsViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given scheme-less site, when recovering with full http or https login URL, then validate matching origin`() =
+    fun `given scheme-less site, when recovering with HTTPS login URL, then validate matching origin`() =
         testBlocking {
-            listOf("http", "https").forEach { scheme ->
-                val loginUrl = "$scheme://$SCHEMELESS_SITE/private-login"
-                val expectedEndpoints = CookieNonceAuthenticationEndpoints(
-                    siteUrl = "$scheme://$SCHEMELESS_SITE/",
-                    loginEntryUrl = loginUrl
-                )
-                val invalidCredentials = cookieNonceError(
-                    Nonce.CookieNonceErrorType.INVALID_CREDENTIALS,
-                    loginEntryVerified = true
-                )
-                whenever(repository.login(eq(SCHEMELESS_SITE), eq(USERNAME), eq(PASSWORD), any()))
-                    .thenReturn(Result.failure(invalidCredentials))
-                setup(recoveryState(EndpointType.LOGIN, loginUrl, SCHEMELESS_SITE))
+            val loginUrl = "https://$SCHEMELESS_SITE/private-login"
+            val expectedEndpoints = CookieNonceAuthenticationEndpoints(
+                siteUrl = "$SITE_URL/",
+                loginEntryUrl = loginUrl
+            )
+            val invalidCredentials = cookieNonceError(
+                Nonce.CookieNonceErrorType.INVALID_CREDENTIALS,
+                loginEntryVerified = true
+            )
+            whenever(repository.login(eq(SITE_URL), eq(USERNAME), eq(PASSWORD), any()))
+                .thenReturn(Result.failure(invalidCredentials))
+            setup(recoveryState(EndpointType.LOGIN, loginUrl, SCHEMELESS_SITE))
 
-                viewModel.viewState.observeForTesting {
-                    viewModel.onContinueClick()
-                    advanceUntilIdle()
-                }
-
-                assertThat(viewModel.viewState.value?.endpointRecovery).isNull()
-                assertThat(viewModel.viewState.value?.authenticationError?.errorMessage)
-                    .isEqualTo(invalidCredentials.errorMessage)
-                verify(repository).login(SCHEMELESS_SITE, USERNAME, PASSWORD, expectedEndpoints)
+            viewModel.viewState.observeForTesting {
+                viewModel.onContinueClick()
+                advanceUntilIdle()
             }
+
+            assertThat(viewModel.viewState.value?.endpointRecovery).isNull()
+            assertThat(viewModel.viewState.value?.authenticationError?.errorMessage)
+                .isEqualTo(invalidCredentials.errorMessage)
+            verify(repository).login(SITE_URL, USERNAME, PASSWORD, expectedEndpoints)
         }
 
     @Test
@@ -153,9 +152,9 @@ class LoginSiteCredentialsViewModelTest : BaseUnitTest() {
             url = SCHEMELESS_SITE
             hasWooCommerce = true
         }
-        whenever(repository.login(eq(SCHEMELESS_SITE), eq(USERNAME), eq(PASSWORD), any()))
+        whenever(repository.login(eq(SITE_URL), eq(USERNAME), eq(PASSWORD), any()))
             .thenReturn(Result.failure(cookieNonceError(Nonce.CookieNonceErrorType.CUSTOM_LOGIN_URL)))
-        whenever(repository.fetchSite(SCHEMELESS_SITE)).thenReturn(Result.success(schemeLessSite))
+        whenever(repository.fetchSite(SITE_URL)).thenReturn(Result.success(schemeLessSite))
         setup(siteAddress = SCHEMELESS_SITE)
 
         viewModel.viewState.observeForTesting {
@@ -169,7 +168,7 @@ class LoginSiteCredentialsViewModelTest : BaseUnitTest() {
                 "https://$SCHEMELESS_SITE/wp-login.php"
             )
         )
-        verify(repository).login(SCHEMELESS_SITE, USERNAME, PASSWORD, SCHEMELESS_ENDPOINTS)
+        verify(repository).login(SITE_URL, USERNAME, PASSWORD, DEFAULT_ENDPOINTS)
     }
 
     @Test
@@ -233,15 +232,12 @@ class LoginSiteCredentialsViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given discovery returns reconciled site URL, when native retry succeeds, then complete login`() =
+    fun `given HTTP input, when logging in, then authentication and fetch use only HTTPS`() =
         testBlocking {
             val originalSiteUrl = "http://site.example"
-            val originalEndpoints = CookieNonceAuthenticationEndpoints(originalSiteUrl)
-            whenever(repository.login(originalSiteUrl, USERNAME, PASSWORD, originalEndpoints))
-                .thenReturn(Result.failure(cookieNonceError(Nonce.CookieNonceErrorType.CUSTOM_LOGIN_URL)))
-            whenever(repository.fetchSite(originalSiteUrl)).thenReturn(Result.success(site))
             whenever(repository.login(SITE_URL, USERNAME, PASSWORD, DEFAULT_ENDPOINTS))
                 .thenReturn(Result.success(Unit))
+            whenever(repository.fetchSite(SITE_URL, USERNAME, PASSWORD, true)).thenReturn(Result.success(site))
             setup(siteAddress = originalSiteUrl)
 
             viewModel.viewState.observeForTesting {
@@ -249,8 +245,9 @@ class LoginSiteCredentialsViewModelTest : BaseUnitTest() {
                 advanceUntilIdle()
             }
 
-            verify(repository).login(originalSiteUrl, USERNAME, PASSWORD, originalEndpoints)
             verify(repository).login(SITE_URL, USERNAME, PASSWORD, DEFAULT_ENDPOINTS)
+            verify(repository).fetchSite(SITE_URL, USERNAME, PASSWORD, true)
+            verify(repository, never()).login(eq(originalSiteUrl), any(), any(), any())
             verify(repository).checkIfUserIsEligible(site)
             assertThat(viewModel.viewState.value?.endpointRecovery).isNull()
             assertThat(viewModel.event.value).isEqualTo(LoggedIn(0))
@@ -632,7 +629,8 @@ class LoginSiteCredentialsViewModelTest : BaseUnitTest() {
                 properties = mapOf(
                     AnalyticsTracker.KEY_STEP to
                         LoginSiteCredentialsViewModel.Step.ENDPOINT_PERSISTENCE.name.lowercase(),
-                    AnalyticsTracker.KEY_NETWORK_STATUS_CODE to ""
+                    AnalyticsTracker.KEY_NETWORK_STATUS_CODE to "",
+                    AnalyticsTracker.KEY_URL_WAS_NORMALIZED_TO_HTTPS to "false"
                 ),
                 errorContext = SiteError::class.java.simpleName,
                 errorType = SiteErrorType.GENERIC_ERROR.name,
@@ -821,6 +819,7 @@ class LoginSiteCredentialsViewModelTest : BaseUnitTest() {
         )
         viewModel = LoginSiteCredentialsViewModel(
             savedState,
+            HttpsUrlNormalizer(),
             repository,
             selectedSite,
             loginAnalytics,
@@ -915,7 +914,6 @@ class LoginSiteCredentialsViewModelTest : BaseUnitTest() {
         const val ADMIN_BASE_URL_STATE_KEY = "admin-base-url"
         const val WEB_SUCCESS_URL = "woocommerce://login?user_login=$USERNAME&password=$PASSWORD"
         val DEFAULT_ENDPOINTS = CookieNonceAuthenticationEndpoints(SITE_URL)
-        val SCHEMELESS_ENDPOINTS = CookieNonceAuthenticationEndpoints(SCHEMELESS_SITE)
         val LOGIN_ENDPOINTS = CookieNonceAuthenticationEndpoints("$SITE_URL/", loginEntryUrl = LOGIN_URL)
         val PENDING_LOGIN_ENDPOINTS = CookieNonceAuthenticationEndpoints(SITE_URL, loginEntryUrl = LOGIN_URL)
         val ADMIN_RETRY_ENDPOINTS = CookieNonceAuthenticationEndpoints(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.main
 
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.AppPrefs
+import com.woocommerce.android.FakeDispatcher
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsEvent.REVIEW_OPEN
@@ -37,12 +38,16 @@ import com.woocommerce.android.ui.moremenu.MoreMenuNewFeatureHandler
 import com.woocommerce.android.ui.whatsnew.FeatureAnnouncementRepository
 import com.woocommerce.android.util.BuildConfigWrapper
 import com.woocommerce.android.util.SystemVersionUtilsWrapper
+import com.woocommerce.android.util.advanceTimeAndRun
+import com.woocommerce.android.util.runAndCaptureValues
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -51,6 +56,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.atLeastOnce
 import org.mockito.kotlin.clearInvocations
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -59,6 +65,9 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged
+import org.wordpress.android.fluxc.utils.CurrentTimeProvider
+import java.util.Date
 
 @ExperimentalCoroutinesApi
 class MainActivityViewModelTest : BaseUnitTest() {
@@ -79,12 +88,16 @@ class MainActivityViewModelTest : BaseUnitTest() {
 
         private const val TEST_BLAZE_REMOTE_NOTE_ID = 5604993864
         private const val TEST_BLAZE_CAMPAIGN_ID_1 = 4418L
+        private const val NOW = 1_000_000L
+        private const val ONE_DAY_MILLIS = 24 * 60 * 60 * 1000L
     }
 
     private lateinit var viewModel: MainActivityViewModel
     private val savedStateHandle: SavedStateHandle = SavedStateHandle()
+    private val selectedSiteFlow = MutableStateFlow<SiteModel?>(null)
     private val selectedSite: SelectedSite = mock {
-        on { observe() } doReturn flowOf<SiteModel?>(null)
+        on { observe() } doReturn selectedSiteFlow
+        on { getOrNull() } doAnswer { selectedSiteFlow.value }
     }
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper = mock()
     private val invalidSignatureFlow = MutableStateFlow<Long?>(null)
@@ -135,7 +148,22 @@ class MainActivityViewModelTest : BaseUnitTest() {
 
     private val featureAnnouncementRepository: FeatureAnnouncementRepository = mock()
     private val buildConfigWrapper: BuildConfigWrapper = mock()
-    private val prefs: AppPrefs = mock()
+    private val prefsChanges = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+    private var httpsWarningDismissedAt = 0L
+    private val prefs: AppPrefs = mock {
+        on { observePrefs() } doReturn prefsChanges
+        on { getHttpsConfigurationWarningDismissedAt(any()) } doAnswer { httpsWarningDismissedAt }
+        on { setHttpsConfigurationWarningDismissedAt(any(), any()) } doAnswer { invocation ->
+            httpsWarningDismissedAt = invocation.getArgument(1)
+            prefsChanges.tryEmit(Unit)
+            Unit
+        }
+    }
+    private var currentTimeMillis = NOW
+    private val currentTimeProvider: CurrentTimeProvider = mock {
+        on { currentDate() } doAnswer { Date(currentTimeMillis) }
+    }
+    private val dispatcher = FakeDispatcher()
     private val systemVersionUtilsWrapper: SystemVersionUtilsWrapper = mock()
     private val moreMenuNewFeatureHandler: MoreMenuNewFeatureHandler = mock()
     private val unseenReviewsCountHandler: UnseenReviewsCountHandler = mock {
@@ -591,6 +619,120 @@ class MainActivityViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `given server requires HTTPS configuration, when observing warning, then show it`() = testBlocking {
+        selectedSiteFlow.value = httpsWarningSite(SiteModel.HTTPS_CONFIGURATION_REQUIRES_HTTPS)
+        createViewModel()
+
+        viewModel.httpsConfigurationWarningVisible.runAndCaptureValues { runCurrent() }
+
+        assertThat(viewModel.httpsConfigurationWarningVisible.value).isTrue()
+    }
+
+    @Test
+    fun `given server reports secure configuration, when selected URL was HTTP, then hide warning`() = testBlocking {
+        selectedSiteFlow.value = httpsWarningSite(SiteModel.HTTPS_CONFIGURATION_SECURE).apply {
+            url = "http://test.com"
+        }
+        createViewModel()
+
+        viewModel.httpsConfigurationWarningVisible.runAndCaptureValues { runCurrent() }
+
+        assertThat(viewModel.httpsConfigurationWarningVisible.value).isFalse()
+    }
+
+    @Test
+    fun `given unknown server state and HTTP selected address, when observing warning, then show fallback`() =
+        testBlocking {
+            selectedSiteFlow.value = httpsWarningSite(SiteModel.HTTPS_CONFIGURATION_UNKNOWN).apply {
+                url = "http://test.com"
+            }
+            createViewModel()
+
+            viewModel.httpsConfigurationWarningVisible.runAndCaptureValues { runCurrent() }
+
+            assertThat(viewModel.httpsConfigurationWarningVisible.value).isTrue()
+        }
+
+    @Test
+    fun `given unknown server state and stored HTTP login address, when observing warning, then show fallback`() =
+        testBlocking {
+            selectedSiteFlow.value = httpsWarningSite(SiteModel.HTTPS_CONFIGURATION_UNKNOWN)
+            whenever(prefs.getLoginSiteAddress()).thenReturn("http://test.com")
+            createViewModel()
+
+            viewModel.httpsConfigurationWarningVisible.runAndCaptureValues { runCurrent() }
+
+            assertThat(viewModel.httpsConfigurationWarningVisible.value).isTrue()
+        }
+
+    @Test
+    fun `given warning dismissed, when 24 hours elapse in foreground, then show at exact expiry`() = testBlocking {
+        selectedSiteFlow.value = httpsWarningSite(SiteModel.HTTPS_CONFIGURATION_REQUIRES_HTTPS)
+        createViewModel()
+
+        viewModel.httpsConfigurationWarningVisible.runAndCaptureValues {
+            runCurrent()
+            viewModel.onHttpsConfigurationWarningDismissed()
+            runCurrent()
+            assertThat(viewModel.httpsConfigurationWarningVisible.value).isFalse()
+
+            currentTimeMillis += ONE_DAY_MILLIS - 1
+            advanceTimeAndRun(ONE_DAY_MILLIS - 1)
+            assertThat(viewModel.httpsConfigurationWarningVisible.value).isFalse()
+
+            currentTimeMillis += 1
+            advanceTimeAndRun(1)
+            assertThat(viewModel.httpsConfigurationWarningVisible.value).isTrue()
+        }
+    }
+
+    @Test
+    fun `given visible warning, when switching to secure store, then hide it`() = testBlocking {
+        selectedSiteFlow.value = httpsWarningSite(SiteModel.HTTPS_CONFIGURATION_REQUIRES_HTTPS)
+        createViewModel()
+
+        viewModel.httpsConfigurationWarningVisible.runAndCaptureValues {
+            runCurrent()
+            selectedSiteFlow.value = httpsWarningSite(SiteModel.HTTPS_CONFIGURATION_SECURE).apply { id = 2 }
+            runCurrent()
+        }
+
+        assertThat(viewModel.httpsConfigurationWarningVisible.value).isFalse()
+    }
+
+    @Test
+    fun `given visible warning, when fresh FluxC update reports secure, then hide it`() = testBlocking {
+        selectedSiteFlow.value = httpsWarningSite(SiteModel.HTTPS_CONFIGURATION_REQUIRES_HTTPS)
+        createViewModel()
+
+        viewModel.httpsConfigurationWarningVisible.runAndCaptureValues {
+            runCurrent()
+            dispatcher.emitChange(
+                OnSiteChanged(updatedSites = listOf(httpsWarningSite(SiteModel.HTTPS_CONFIGURATION_SECURE)))
+            )
+            runCurrent()
+        }
+
+        assertThat(viewModel.httpsConfigurationWarningVisible.value).isFalse()
+    }
+
+    @Test
+    fun `given visible warning, when failed FluxC update has no fresh state, then retain it`() = testBlocking {
+        val selected = httpsWarningSite(SiteModel.HTTPS_CONFIGURATION_REQUIRES_HTTPS)
+        selectedSiteFlow.value = selected
+        whenever(siteStore.getSiteByLocalId(selected.id)).thenReturn(selected)
+        createViewModel()
+
+        viewModel.httpsConfigurationWarningVisible.runAndCaptureValues {
+            runCurrent()
+            dispatcher.emitChange(OnSiteChanged())
+            runCurrent()
+        }
+
+        assertThat(viewModel.httpsConfigurationWarningVisible.value).isTrue()
+    }
+
+    @Test
     fun `given image uris when app opened, then a product creation is triggered using the images`() = testBlocking {
         // GIVEN
         createViewModel()
@@ -818,6 +960,7 @@ class MainActivityViewModelTest : BaseUnitTest() {
         viewModel = spy(
             MainActivityViewModel(
                 savedState = savedStateHandle,
+                dispatcher = dispatcher,
                 siteStore = siteStore,
                 selectedSite = selectedSite,
                 storeConnectionErrorMonitor = storeConnectionErrorMonitor,
@@ -829,6 +972,7 @@ class MainActivityViewModelTest : BaseUnitTest() {
                 resolveAppLink = resolveAppLink,
                 privacyRepository = mock(),
                 systemVersionUtilsWrapper = systemVersionUtilsWrapper,
+                currentTimeProvider = currentTimeProvider,
                 moreMenuNewFeatureHandler = moreMenuNewFeatureHandler,
                 unseenReviewsCountHandler = unseenReviewsCountHandler,
                 determineTrialStatusBarState = mock {
@@ -837,6 +981,12 @@ class MainActivityViewModelTest : BaseUnitTest() {
                 ageEligibilityChecker = ageEligibilityChecker,
             )
         )
+    }
+
+    private fun httpsWarningSite(@SiteModel.HttpsConfigurationState state: Int) = SiteModel().apply {
+        id = 1
+        url = "https://test.com"
+        httpsConfigurationState = state
     }
 
     private fun applicationPasswordsSite() = SiteModel().apply {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
@@ -40,6 +40,16 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
     public static final int ORIGIN_XMLRPC = 2;
     public static final int ORIGIN_WPAPI = 3;
 
+    @Retention(SOURCE)
+    @IntDef({HTTPS_CONFIGURATION_UNKNOWN, HTTPS_CONFIGURATION_SECURE,
+            HTTPS_CONFIGURATION_REQUIRES_HTTPS})
+    public @interface HttpsConfigurationState {
+    }
+
+    public static final int HTTPS_CONFIGURATION_UNKNOWN = 0;
+    public static final int HTTPS_CONFIGURATION_SECURE = 1;
+    public static final int HTTPS_CONFIGURATION_REQUIRES_HTTPS = 2;
+
     public static final long VIP_PLAN_ID = 31337;
 
     @PrimaryKey
@@ -129,6 +139,8 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
     // Comma-separated list of active features in the site's plan
     @Column
     private String mPlanActiveFeatures;
+    @Column
+    private int mHttpsConfigurationState = HTTPS_CONFIGURATION_UNKNOWN;
 
     @Override
     public int getId() {
@@ -440,6 +452,15 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
         this.mPlanActiveFeatures = planActiveFeatures;
     }
 
+    @HttpsConfigurationState
+    public int getHttpsConfigurationState() {
+        return mHttpsConfigurationState;
+    }
+
+    public void setHttpsConfigurationState(@HttpsConfigurationState int httpsConfigurationState) {
+        mHttpsConfigurationState = httpsConfigurationState;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (!(o instanceof SiteModel)) return false;
@@ -459,6 +480,7 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
                 mIsPrivate == siteModel.mIsPrivate &&
                 mPlanId == siteModel.mPlanId &&
                 mHasCapabilityManageOptions == siteModel.mHasCapabilityManageOptions &&
+                mHttpsConfigurationState == siteModel.mHttpsConfigurationState &&
                 Objects.equals(mUrl, siteModel.mUrl) &&
                 Objects.equals(mAdminUrl, siteModel.mAdminUrl) &&
                 Objects.equals(mLoginUrl, siteModel.mLoginUrl) &&
@@ -515,6 +537,7 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
                 mJetpackModules,
                 mApplicationPasswordsAuthorizeUrl,
                 mCanBlaze,
-                mPlanActiveFeatures);
+                mPlanActiveFeatures,
+                mHttpsConfigurationState);
     }
 }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/CookieNonceAuthenticator.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/CookieNonceAuthenticator.kt
@@ -1,7 +1,5 @@
 package org.wordpress.android.fluxc.network.rest.wpapi
 
-import okhttp3.HttpUrl.Companion.toHttpUrl
-import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
@@ -12,15 +10,16 @@ import org.wordpress.android.fluxc.network.rest.wpapi.Nonce.Unknown
 import org.wordpress.android.fluxc.persistence.SiteStorePersistence
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.tools.CoroutineEngine
+import org.wordpress.android.fluxc.utils.HttpsUrlNormalizer
 import org.wordpress.android.util.AppLog
-import org.wordpress.android.util.UrlUtils
 import javax.inject.Inject
 
 class CookieNonceAuthenticator @Inject constructor(
     private val nonceRestClient: NonceRestClient,
     private val discoveryWPAPIRestClient: DiscoveryWPAPIRestClient,
     private val siteStore: SiteStore,
-    private val coroutineEngine: CoroutineEngine
+    private val coroutineEngine: CoroutineEngine,
+    private val httpsUrlNormalizer: HttpsUrlNormalizer,
 ) {
     suspend fun authenticate(
         siteUrl: String,
@@ -38,15 +37,7 @@ class CookieNonceAuthenticator @Inject constructor(
         password: String
     ): CookieNonceAuthenticationResult {
         return coroutineEngine.withDefaultContext(AppLog.T.API, this, "authenticate") {
-            val siteUrlWithScheme = if (endpoints.siteUrl.toHttpUrlOrNull() == null) {
-                // If the URL is missing a scheme, try inferring it from the API endpoint
-                val siteUrl = endpoints.siteUrl
-                val wpApiUrl = discoverApiEndpoint(UrlUtils.addUrlSchemeIfNeeded(siteUrl, false))
-                val scheme = wpApiUrl.toHttpUrl().scheme
-                UrlUtils.addUrlSchemeIfNeeded(UrlUtils.removeScheme(siteUrl), scheme == "https")
-            } else endpoints.siteUrl
-
-            val resolvedEndpoints = endpoints.copy(siteUrl = siteUrlWithScheme)
+            val resolvedEndpoints = endpoints.normalizedToHttps()
             when (val nonce = nonceRestClient.requestNonce(resolvedEndpoints, username, password)) {
                 is Available -> CookieNonceAuthenticationResult.Success
                 is FailedRequest -> {
@@ -72,7 +63,8 @@ class CookieNonceAuthenticator @Inject constructor(
     ): WPAPIResponse<T> {
         val usingSavedRestUrl = site.wpApiRestUrl != null
         if (!usingSavedRestUrl) {
-            site.wpApiRestUrl = discoverApiEndpoint(site.url)
+            val normalizedSiteUrl = httpsUrlNormalizer.normalize(site.url, addHttpsSchemeIfMissing = true).normalizedUrl
+            site.wpApiRestUrl = httpsUrlNormalizer.normalize(discoverApiEndpoint(normalizedSiteUrl)).normalizedUrl
             try {
                 siteStore.insertOrUpdateSite(site)
             } catch (e: SiteStorePersistence.DuplicateSiteException) {
@@ -119,14 +111,16 @@ class CookieNonceAuthenticator @Inject constructor(
         password: String,
         fetchMethod: suspend (wpApiUrl: String, nonce: Available) -> WPAPIResponse<T>
     ): WPAPIResponse<T> {
-        var nonce = nonceRestClient.getNonce(endpoints.siteUrl, username)
+        val normalizedEndpoints = endpoints.normalizedToHttps()
+        val normalizedWpApiUrl = httpsUrlNormalizer.normalize(wpApiUrl).normalizedUrl
+        var nonce = nonceRestClient.getNonce(normalizedEndpoints.siteUrl, username)
         val usingSavedNonce = nonce is Available
         if (nonce !is Available) {
-            nonce = nonceRestClient.requestNonce(endpoints, username, password)
+            nonce = nonceRestClient.requestNonce(normalizedEndpoints, username, password)
         }
         if (nonce !is Available) return nonce.toErrorResponse()
 
-        val response = fetchMethod(wpApiUrl, nonce)
+        val response = fetchMethod(normalizedWpApiUrl, nonce)
 
         if (response is WPAPIResponse.Success<*>) return response
 
@@ -139,12 +133,12 @@ class CookieNonceAuthenticator @Inject constructor(
                 if (usingSavedNonce) {
                     // Call with saved nonce failed, so try getting a new one
                     val previousNonce = nonce
-                    val newNonce = nonceRestClient.requestNonce(endpoints, username, password)
+                    val newNonce = nonceRestClient.requestNonce(normalizedEndpoints, username, password)
 
                     // Try original call again if we have a new nonce
                     when {
                         newNonce !is Available -> newNonce.toErrorResponse()
-                        newNonce != previousNonce -> fetchMethod(wpApiUrl, newNonce)
+                        newNonce != previousNonce -> fetchMethod(normalizedWpApiUrl, newNonce)
                         else -> response
                     }
                 } else {
@@ -162,6 +156,12 @@ class CookieNonceAuthenticator @Inject constructor(
         return discoveryWPAPIRestClient.discoverWPAPIBaseURL(url) // discover rest api endpoint
             ?: WPAPIDiscoveryUtils.buildDefaultRESTBaseUrl(url)
     }
+
+    private fun CookieNonceAuthenticationEndpoints.normalizedToHttps() = copy(
+        siteUrl = httpsUrlNormalizer.normalize(siteUrl, addHttpsSchemeIfMissing = true).normalizedUrl,
+        loginEntryUrl = loginEntryUrl?.let { httpsUrlNormalizer.normalize(it).normalizedUrl },
+        adminBaseUrl = adminBaseUrl?.let { httpsUrlNormalizer.normalize(it).normalizedUrl },
+    )
 
     private fun <T> Nonce.toErrorResponse(): WPAPIResponse.Error<T> {
         val (genericErrorType, message) = when (this) {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/WPAPIEncodedBodyRequestBuilder.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/WPAPIEncodedBodyRequestBuilder.kt
@@ -6,10 +6,13 @@ import kotlinx.coroutines.suspendCancellableCoroutine
 import org.wordpress.android.fluxc.network.BaseRequest
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse.Error
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse.Success
+import org.wordpress.android.fluxc.utils.HttpsUrlNormalizer
 import javax.inject.Inject
 import kotlin.coroutines.resume
 
-class WPAPIEncodedBodyRequestBuilder @Inject constructor() {
+class WPAPIEncodedBodyRequestBuilder @Inject constructor(
+    private val httpsUrlNormalizer: HttpsUrlNormalizer,
+) {
     suspend fun syncGetRequest(
         restClient: BaseWPAPIRestClient,
         url: String,
@@ -46,7 +49,8 @@ class WPAPIEncodedBodyRequestBuilder @Inject constructor() {
         nonce: String?,
         restClient: BaseWPAPIRestClient
     ) {
-        val request = WPAPIEncodedBodyRequest(method, url, params, body, { response, headers ->
+        val normalizedUrl = httpsUrlNormalizer.normalize(url).normalizedUrl
+        val request = WPAPIEncodedBodyRequest(method, normalizedUrl, params, body, { response, headers ->
             cont.resume(Success(response, headers))
         }, { error ->
             cont.resume(Error(error))

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/WPAPIGsonRequestBuilder.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/WPAPIGsonRequestBuilder.kt
@@ -6,11 +6,14 @@ import kotlinx.coroutines.suspendCancellableCoroutine
 import org.wordpress.android.fluxc.network.BaseRequest
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse.Error
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse.Success
+import org.wordpress.android.fluxc.utils.HttpsUrlNormalizer
 import java.lang.reflect.Type
 import javax.inject.Inject
 import kotlin.coroutines.resume
 
-class WPAPIGsonRequestBuilder @Inject constructor() {
+class WPAPIGsonRequestBuilder @Inject constructor(
+    private val httpsUrlNormalizer: HttpsUrlNormalizer,
+) {
     suspend fun <T> syncGetRequest(
         restClient: BaseWPAPIRestClient,
         url: String,
@@ -80,7 +83,8 @@ class WPAPIGsonRequestBuilder @Inject constructor() {
         nonce: String?,
         restClient: BaseWPAPIRestClient
     ) {
-        val request = WPAPIGsonRequest(method, url, params, body, clazz, { responseData, headers ->
+        val normalizedUrl = httpsUrlNormalizer.normalize(url).normalizedUrl
+        val request = WPAPIGsonRequest(method, normalizedUrl, params, body, clazz, { responseData, headers ->
             cont.resume(Success(responseData, headers))
         }, { error ->
             cont.resume(Error(error))
@@ -114,7 +118,8 @@ class WPAPIGsonRequestBuilder @Inject constructor() {
         nonce: String?,
         restClient: BaseWPAPIRestClient
     ) {
-        val request = WPAPIGsonRequest<T>(method, url, params, body, type, { responseData, headers ->
+        val normalizedUrl = httpsUrlNormalizer.normalize(url).normalizedUrl
+        val request = WPAPIGsonRequest<T>(method, normalizedUrl, params, body, type, { responseData, headers ->
             cont.resume(Success(responseData, headers))
         }, { error ->
             cont.resume(Error(error))

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsNetwork.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsNetwork.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetworkError
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
 import org.wordpress.android.fluxc.network.toVolleyMethod
+import org.wordpress.android.fluxc.utils.HttpsUrlNormalizer
 import org.wordpress.android.fluxc.utils.extensions.slashJoin
 import org.wordpress.android.util.AppLog
 import java.util.Optional
@@ -31,7 +32,8 @@ private const val UNAUTHORIZED = 401
 class ApplicationPasswordsNetwork @Inject constructor(
     @Named("no-cookies") private val requestQueue: RequestQueue,
     private val userAgent: UserAgent,
-    private val listener: Optional<ApplicationPasswordsListener>
+    private val listener: Optional<ApplicationPasswordsListener>,
+    private val httpsUrlNormalizer: HttpsUrlNormalizer,
 ) : WPAPINetwork {
     // We can't use construction injection for this variable, as its class is internal
     @Inject
@@ -58,7 +60,9 @@ class ApplicationPasswordsNetwork @Inject constructor(
         ): WPAPIGsonRequest<T> {
             val request = WPAPIGsonRequest(
                 method.toVolleyMethod(),
-                (site.wpApiRestUrl ?: site.url.slashJoin("wp-json")).slashJoin(path),
+                httpsUrlNormalizer.normalize(
+                    (site.wpApiRestUrl ?: site.url.slashJoin("wp-json")).slashJoin(path)
+                ).normalizedUrl,
                 params,
                 body,
                 clazz,

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/WPApiApplicationPasswordsRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/WPApiApplicationPasswordsRestClient.kt
@@ -16,6 +16,7 @@ import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIGsonRequest
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetworkError
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
+import org.wordpress.android.fluxc.utils.HttpsUrlNormalizer
 import org.wordpress.android.fluxc.utils.extensions.slashJoin
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
@@ -28,6 +29,7 @@ import kotlin.coroutines.resume
 internal class WPApiApplicationPasswordsRestClient @Inject constructor(
     private val wpApiGsonRequestBuilder: WPAPIGsonRequestBuilder,
     private val cookieNonceAuthenticator: CookieNonceAuthenticator,
+    private val httpsUrlNormalizer: HttpsUrlNormalizer,
     @Named("no-cookies") private val noCookieRequestQueue: RequestQueue,
     @Named("regular") requestQueue: RequestQueue,
     dispatcher: Dispatcher,
@@ -226,6 +228,6 @@ internal class WPApiApplicationPasswordsRestClient @Inject constructor(
 
     private fun SiteModel.buildUrl(path: String): String {
         val baseUrl = wpApiRestUrl ?: url.slashJoin("/wp-json")
-        return baseUrl.slashJoin(path)
+        return httpsUrlNormalizer.normalize(baseUrl.slashJoin(path)).normalizedUrl
     }
 }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/site/SiteWPAPIRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/site/SiteWPAPIRestClient.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.fluxc.network.rest.wpapi.site
 
 import com.android.volley.RequestQueue
-import okhttp3.HttpUrl.Companion.toHttpUrl
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
@@ -16,7 +15,7 @@ import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse.Error
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse.Success
 import org.wordpress.android.fluxc.store.SiteStore.FetchWPAPISitePayload
-import org.wordpress.android.util.UrlUtils
+import org.wordpress.android.fluxc.utils.HttpsUrlNormalizer
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -25,6 +24,7 @@ import javax.inject.Singleton
 class SiteWPAPIRestClient @Inject constructor(
     private val wpapiGsonRequestBuilder: WPAPIGsonRequestBuilder,
     private val discoveryWPAPIRestClient: DiscoveryWPAPIRestClient,
+    private val httpsUrlNormalizer: HttpsUrlNormalizer,
     dispatcher: Dispatcher,
     @Named("custom-ssl") requestQueue: RequestQueue,
     userAgent: UserAgent
@@ -39,12 +39,17 @@ class SiteWPAPIRestClient @Inject constructor(
     suspend fun fetchWPAPISite(
         payload: FetchWPAPISitePayload
     ): SiteModel {
-        val cleanedUrl = UrlUtils.addUrlSchemeIfNeeded(payload.url, false).let { urlWithScheme ->
-            DiscoveryUtils.stripKnownPaths(urlWithScheme)
+        val inputUrl = try {
+            httpsUrlNormalizer.normalize(payload.url, addHttpsSchemeIfMissing = true)
+        } catch (e: IllegalArgumentException) {
+            return SiteModel().apply { error = BaseNetworkError(INVALID_RESPONSE) }
         }
-
-        val discoveredWpApiUrl = discoverApiEndpoint(cleanedUrl)
-        val urlScheme = discoveredWpApiUrl.toHttpUrl().scheme
+        val cleanedUrl = DiscoveryUtils.stripKnownPaths(inputUrl.normalizedUrl)
+        val discoveredWpApiUrl = try {
+            httpsUrlNormalizer.normalize(discoverApiEndpoint(cleanedUrl)).normalizedUrl
+        } catch (e: IllegalArgumentException) {
+            return SiteModel().apply { error = BaseNetworkError(INVALID_RESPONSE) }
+        }
 
         val result = wpapiGsonRequestBuilder.syncGetRequest(
             restClient = this,
@@ -61,21 +66,31 @@ class SiteWPAPIRestClient @Inject constructor(
                         error = BaseNetworkError(INVALID_RESPONSE)
                     }
                 }
+                val serverUrl = try {
+                    response.url?.let(httpsUrlNormalizer::normalize)
+                } catch (e: IllegalArgumentException) {
+                    return SiteModel().apply { error = BaseNetworkError(INVALID_RESPONSE) }
+                }
 
                 SiteModel().apply {
                     name = response.name
                     timezone = response.gmtOffset
                     origin = SiteModel.ORIGIN_WPAPI
+                    httpsConfigurationState = configurationState(
+                        serverUrl,
+                        inputUrl.wasUpgraded || payload.wasUrlNormalizedToHttps,
+                    )
                     hasWooCommerce = response.namespaces.any {
                         it.startsWith(WOO_API_NAMESPACE_PREFIX)
                     }
 
                     applicationPasswordsAuthorizeUrl = response.authentication?.applicationPasswords
                         ?.endpoints?.authorization
+                        ?.normalizeOptionalUrl()
                     adminUrl = inferAdminBaseUrl(applicationPasswordsAuthorizeUrl)
 
                     wpApiRestUrl = discoveredWpApiUrl
-                    this.url = cleanedUrl.replaceBefore("://", urlScheme)
+                    this.url = serverUrl?.normalizedUrl ?: cleanedUrl
                     this.username = payload.username
                     this.password = payload.password
                 }
@@ -97,17 +112,37 @@ class SiteWPAPIRestClient @Inject constructor(
                 url = site.url,
                 username = site.username,
                 password = site.password,
+                wasUrlNormalizedToHttps = site.url.startsWith("http://", ignoreCase = true),
             )
         ).also { refreshedSite ->
             if (!refreshedSite.isError) {
-                site.loginUrl?.takeUnless(String::isBlank)?.let { refreshedSite.loginUrl = it }
+                refreshedSite.id = site.id
+                if (refreshedSite.httpsConfigurationState == SiteModel.HTTPS_CONFIGURATION_UNKNOWN) {
+                    refreshedSite.httpsConfigurationState = site.httpsConfigurationState
+                }
+                site.loginUrl?.takeUnless(String::isBlank)?.normalizeOptionalUrl()
+                    ?.let { refreshedSite.loginUrl = it }
                 site.adminUrl
                     ?.takeUnless(String::isBlank)
                     ?.takeUnless { it.matchesAdminBaseInferredFrom(site.applicationPasswordsAuthorizeUrl) }
+                    ?.normalizeOptionalUrl()
                     ?.let { refreshedSite.adminUrl = it }
             }
         }
     }
+
+    @SiteModel.HttpsConfigurationState
+    private fun configurationState(serverUrl: HttpsUrlNormalizer.Result?, inputWasUpgraded: Boolean): Int {
+        return when {
+            serverUrl?.wasUpgraded == true -> SiteModel.HTTPS_CONFIGURATION_REQUIRES_HTTPS
+            serverUrl != null -> SiteModel.HTTPS_CONFIGURATION_SECURE
+            inputWasUpgraded -> SiteModel.HTTPS_CONFIGURATION_REQUIRES_HTTPS
+            else -> SiteModel.HTTPS_CONFIGURATION_UNKNOWN
+        }
+    }
+
+    private fun String.normalizeOptionalUrl(): String? =
+        runCatching { httpsUrlNormalizer.normalize(this).normalizedUrl }.getOrNull()
 
     private fun inferAdminBaseUrl(applicationPasswordsAuthorizeUrl: String?): String? =
         applicationPasswordsAuthorizeUrl

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -54,9 +54,8 @@ import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainsResponsePayload
 import org.wordpress.android.fluxc.store.SiteStore.WPAPIDiscoveryResult
 import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.fluxc.utils.ErrorUtils.OnUnexpectedError
+import org.wordpress.android.fluxc.utils.HttpsUrlNormalizer
 import org.wordpress.android.util.AppLog
-import org.wordpress.android.util.UrlUtils
-import java.net.URI
 import java.security.cert.CertificateException
 import java.security.cert.CertificateExpiredException
 import java.security.cert.CertificateNotYetValidException
@@ -80,6 +79,7 @@ class SiteRestClient @Inject constructor(
     private val jetpackTunnelGsonRequestBuilder: JetpackTunnelGsonRequestBuilder,
     private val coroutineEngine: CoroutineEngine,
     private val discoveryWPAPIRestClient: DiscoveryWPAPIRestClient,
+    private val httpsUrlNormalizer: HttpsUrlNormalizer,
     accessToken: AccessToken?,
     userAgent: UserAgent?
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
@@ -216,6 +216,9 @@ class SiteRestClient @Inject constructor(
                 if (site.id > 0) {
                     newSite.id = site.id
                 }
+                if (newSite.httpsConfigurationState == SiteModel.HTTPS_CONFIGURATION_UNKNOWN) {
+                    newSite.httpsConfigurationState = site.httpsConfigurationState
+                }
                 newSite
             }
 
@@ -238,16 +241,29 @@ class SiteRestClient @Inject constructor(
 
         return when {
             result is JetpackResponse.JetpackSuccess && result.data != null -> {
+                val serverUrl = try {
+                    result.data.url?.let(httpsUrlNormalizer::normalize)
+                } catch (e: IllegalArgumentException) {
+                    return SiteModel().apply { error = BaseNetworkError(GenericErrorType.INVALID_RESPONSE) }
+                }
                 // Keep existing fields, and update only fields fetched from the root endpoint
                 site.apply {
                     name = result.data.name
                     timezone = result.data.gmtOffset
+                    serverUrl?.let {
+                        url = it.normalizedUrl
+                        httpsConfigurationState = if (it.wasUpgraded) {
+                            SiteModel.HTTPS_CONFIGURATION_REQUIRES_HTTPS
+                        } else {
+                            SiteModel.HTTPS_CONFIGURATION_SECURE
+                        }
+                    }
                     hasWooCommerce = result.data.namespaces?.any {
                         it.startsWith(WOO_API_NAMESPACE_PREFIX)
                     } ?: false
 
                     applicationPasswordsAuthorizeUrl = result.data.authentication?.applicationPasswords
-                        ?.endpoints?.authorization
+                        ?.endpoints?.authorization?.normalizeOptionalUrl()
                 }
             }
 
@@ -270,7 +286,9 @@ class SiteRestClient @Inject constructor(
         )
 
         return (result as? JetpackResponse.JetpackSuccess)?.let {
-            Result.success(it.data?.authentication?.applicationPasswords?.endpoints?.authorization)
+            Result.success(
+                it.data?.authentication?.applicationPasswords?.endpoints?.authorization?.normalizeOptionalUrl()
+            )
         } ?: Result.failure(Exception((result as? JetpackResponse.JetpackError)?.error?.message ?: "Unknown error"))
     }
 
@@ -380,7 +398,13 @@ class SiteRestClient @Inject constructor(
         siteUrl: String,
         discoverWPAPIOnFailure: Boolean = false
     ): ConnectSiteInfoPayload {
-        fun ConnectSiteInfoResponse.toConnectSiteInfoPayload(url: String): ConnectSiteInfoPayload {
+        fun ConnectSiteInfoResponse.toConnectSiteInfoPayload(
+            url: String,
+            inputWasUpgraded: Boolean,
+        ): ConnectSiteInfoPayload {
+            val redirectResult = urlAfterRedirects?.let {
+                runCatching { httpsUrlNormalizer.normalize(it) }.getOrNull()
+            }
             return ConnectSiteInfoPayload(
                 url,
                 exists,
@@ -389,20 +413,20 @@ class SiteRestClient @Inject constructor(
                 isJetpackActive,
                 isJetpackConnected,
                 isWordPressDotCom, // CHECKSTYLE IGNORE
-                urlAfterRedirects
+                redirectResult?.normalizedUrl,
+                inputWasUpgraded || redirectResult?.wasUpgraded == true,
             )
         }
 
-        // Get a proper URI to reliably retrieve the scheme.
-        val uri: URI = try {
-            URI.create(UrlUtils.addUrlSchemeIfNeeded(siteUrl, false))
+        val normalizedSiteUrl = try {
+            httpsUrlNormalizer.normalize(siteUrl, addHttpsSchemeIfMissing = true)
         } catch (e: IllegalArgumentException) {
             val siteError = SiteError(INVALID_SITE)
             return ConnectSiteInfoPayload(siteUrl, siteError)
         }
 
         val params = mutableMapOf<String, String>()
-        params["url"] = uri.toString()
+        params["url"] = normalizedSiteUrl.normalizedUrl
 
         // Make the call.
         val url = WPCOMREST.connect.site_info.urlV1_1
@@ -419,15 +443,24 @@ class SiteRestClient @Inject constructor(
                 val discovery = siteError.wpApiDiscovery
                 if (discovery != null) {
                     val wpApiBaseUrl = withContext(Dispatchers.IO) {
-                        discoveryWPAPIRestClient.discoverWPAPIBaseURL(uri.toString())
+                        discoveryWPAPIRestClient.discoverWPAPIBaseURL(normalizedSiteUrl.normalizedUrl)
+                            ?.let { runCatching { httpsUrlNormalizer.normalize(it).normalizedUrl }.getOrNull() }
                             ?.let { discoveryWPAPIRestClient.verifyWPAPIV2Support(it) }
                     }
                     siteError = siteError.copy(wpApiDiscovery = discovery.copy(wpApiBaseUrl = wpApiBaseUrl))
                 }
-                ConnectSiteInfoPayload(siteUrl, siteError)
+                ConnectSiteInfoPayload(
+                    url = normalizedSiteUrl.normalizedUrl,
+                    wasUrlNormalizedToHttps = normalizedSiteUrl.wasUpgraded,
+                ).apply {
+                    error = siteError
+                }
             }
             is Success -> {
-                response.data.toConnectSiteInfoPayload(siteUrl)
+                response.data.toConnectSiteInfoPayload(
+                    normalizedSiteUrl.normalizedUrl,
+                    normalizedSiteUrl.wasUpgraded,
+                )
             }
         }
     }
@@ -597,9 +630,15 @@ class SiteRestClient @Inject constructor(
 
     @Suppress("LongMethod", "ComplexMethod")
     private fun siteResponseToSiteModelOrThrow(from: SiteWPComRestResponse): SiteModel {
+        val normalizedSiteUrl = httpsUrlNormalizer.normalize(from.URL, addHttpsSchemeIfMissing = true)
         val site = SiteModel()
         site.siteId = from.ID
-        site.url = from.URL
+        site.url = normalizedSiteUrl.normalizedUrl
+        site.httpsConfigurationState = when {
+            normalizedSiteUrl.wasUpgraded -> SiteModel.HTTPS_CONFIGURATION_REQUIRES_HTTPS
+            from.URL.startsWith("https://", ignoreCase = true) -> SiteModel.HTTPS_CONFIGURATION_SECURE
+            else -> SiteModel.HTTPS_CONFIGURATION_UNKNOWN
+        }
         site.name = StringEscapeUtils.unescapeHtml4(from.name)
         site.setIsJetpackConnected(from.jetpack && from.jetpack_connection)
         site.setIsJetpackInstalled(from.jetpack)
@@ -610,8 +649,8 @@ class SiteRestClient @Inject constructor(
             site.setIsWpComStore(from.options.is_wpcom_store)
             site.publishedStatus = from.options.blog_public
             site.hasWooCommerce = from.options.woocommerce_is_active
-            site.adminUrl = from.options.admin_url
-            site.loginUrl = from.options.login_url
+            site.adminUrl = from.options.admin_url?.normalizeOptionalUrl()
+            site.loginUrl = from.options.login_url?.normalizeOptionalUrl()
             site.timezone = from.options.gmt_offset
             site.jetpackVersion = from.options.jetpack_version
             site.setIsWPComAtomic(from.options.is_wpcom_atomic)
@@ -648,11 +687,14 @@ class SiteRestClient @Inject constructor(
         return site
     }
 
+    private fun String.normalizeOptionalUrl(): String? =
+        runCatching { httpsUrlNormalizer.normalize(this).normalizedUrl }.getOrNull()
+
     companion object {
         @VisibleForTesting
         const val SITE_FIELDS = "ID,URL,name,jetpack,jetpack_connection,is_private," +
             "options,plan,capabilities,meta,jetpack_modules"
-        private const val ROOT_ENDPOINT_FIELDS = "name,gmt_offset,namespaces,authentication"
+        private const val ROOT_ENDPOINT_FIELDS = "name,gmt_offset,url,namespaces,authentication"
         private const val WOO_API_NAMESPACE_PREFIX = "wc/"
         private const val FIELDS = "fields"
         private const val FILTERS = "filters"

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -40,7 +40,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 243
+        return 245
     }
 
     override fun getDbName(): String {
@@ -2312,6 +2312,12 @@ open class WellSqlConfig : DefaultWellConfig {
 
                 243 -> migrate(version) {
                     db.execSQL("DROP TABLE IF EXISTS AccountModel")
+                }
+
+                244 -> migrate(version) {
+                    db.execSQL(
+                        "ALTER TABLE SiteModel ADD HTTPS_CONFIGURATION_STATE INTEGER NOT NULL DEFAULT 0"
+                    )
                 }
             }
         }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -85,6 +85,7 @@ open class SiteStore @Inject constructor(
         val url: String,
         val username: String? = null,
         val password: String? = null,
+        val wasUrlNormalizedToHttps: Boolean = false,
     ) : Payload<BaseNetworkError>()
 
     data class FetchSitesPayload @JvmOverloads constructor(
@@ -134,7 +135,8 @@ open class SiteStore @Inject constructor(
         @JvmField val isJetpackActive: Boolean = false,
         @JvmField val isJetpackConnected: Boolean = false,
         @JvmField val isWPCom: Boolean = false,
-        @JvmField val urlAfterRedirects: String? = null
+        @JvmField val urlAfterRedirects: String? = null,
+        @JvmField val wasUrlNormalizedToHttps: Boolean = false,
     ) : Payload<SiteError>() {
         constructor(url: String, error: SiteError?) : this(url) {
             this.error = error

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/utils/HttpsUrlNormalizer.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/utils/HttpsUrlNormalizer.kt
@@ -1,0 +1,62 @@
+package org.wordpress.android.fluxc.utils
+
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import java.util.Locale
+import javax.inject.Inject
+
+class HttpsUrlNormalizer @Inject constructor() {
+    data class Result(
+        val normalizedUrl: String,
+        val wasUpgraded: Boolean,
+    )
+
+    @JvmOverloads
+    fun normalize(rawUrl: String, addHttpsSchemeIfMissing: Boolean = false): Result {
+        val trimmedUrl = rawUrl.trim()
+        val scheme = SCHEME_REGEX.find(trimmedUrl)?.groupValues?.get(1)?.lowercase(Locale.ROOT)
+        val urlWithScheme = when {
+            scheme == null && addHttpsSchemeIfMissing -> "https://$trimmedUrl"
+            scheme == null -> throw IllegalArgumentException("URL has no scheme")
+            scheme == HTTP_SCHEME || scheme == HTTPS_SCHEME -> trimmedUrl
+            else -> throw IllegalArgumentException("Unsupported URL scheme")
+        }
+        val parsedUrl = requireNotNull(urlWithScheme.toHttpUrlOrNull()) { "Malformed URL" }
+        val hadEmptyPath = urlWithScheme.hasEmptyPath()
+        val wasUpgraded = parsedUrl.scheme == HTTP_SCHEME
+        val normalizedUrlWithPath = if (wasUpgraded) {
+            parsedUrl.newBuilder().scheme(HTTPS_SCHEME).build().toString()
+        } else {
+            parsedUrl.toString()
+        }
+        val normalizedUrl = if (hadEmptyPath) {
+            normalizedUrlWithPath.withoutSyntheticRootPath()
+        } else {
+            normalizedUrlWithPath
+        }
+        return Result(normalizedUrl, wasUpgraded)
+    }
+
+    private fun String.hasEmptyPath(): Boolean {
+        val authorityStart = indexOf("://") + 3
+        val authorityEnd = listOf(indexOf('?', authorityStart), indexOf('#', authorityStart), length)
+            .filter { it >= 0 }
+            .min()
+        val pathStart = indexOf('/', authorityStart)
+        return pathStart == -1 || pathStart >= authorityEnd
+    }
+
+    private fun String.withoutSyntheticRootPath(): String {
+        val authorityEnd = indexOf('/', startIndex = indexOf("://") + 3)
+        return if (authorityEnd >= 0 && getOrNull(authorityEnd + 1) in listOf(null, '?', '#')) {
+            removeRange(authorityEnd, authorityEnd + 1)
+        } else {
+            this
+        }
+    }
+
+    companion object {
+        private val SCHEME_REGEX = Regex("^([A-Za-z][A-Za-z0-9+.-]*):")
+        private const val HTTP_SCHEME = "http"
+        private const val HTTPS_SCHEME = "https"
+    }
+}

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/model/SiteModelTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/model/SiteModelTest.kt
@@ -1,0 +1,22 @@
+package org.wordpress.android.fluxc.model
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class SiteModelTest {
+    @Test
+    fun `given otherwise equal sites, when HTTPS configuration differs, then equality and hash code differ`() {
+        val unknown = SiteModel().apply {
+            id = 1
+            url = "https://test.com"
+        }
+        val requiresConfiguration = SiteModel().apply {
+            id = 1
+            url = "https://test.com"
+            httpsConfigurationState = SiteModel.HTTPS_CONFIGURATION_REQUIRES_HTTPS
+        }
+
+        assertThat(unknown).isNotEqualTo(requiresConfiguration)
+        assertThat(unknown.hashCode()).isNotEqualTo(requiresConfiguration.hashCode())
+    }
+}

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/WPAPIRequestBuilderTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/WPAPIRequestBuilderTest.kt
@@ -1,0 +1,69 @@
+package org.wordpress.android.fluxc.network.rest.wpapi
+
+import com.android.volley.RequestQueue
+import com.android.volley.VolleyError
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.utils.HttpsUrlNormalizer
+import javax.net.ssl.SSLHandshakeException
+
+@RunWith(RobolectricTestRunner::class)
+class WPAPIRequestBuilderTest {
+    private val requestQueue: RequestQueue = mock()
+    private val userAgent: UserAgent = mock {
+        on { apiUserAgent } doReturn "test-user-agent"
+    }
+    private val restClient = object : BaseWPAPIRestClient(mock<Dispatcher>(), requestQueue, userAgent) {}
+    private val normalizer = HttpsUrlNormalizer()
+
+    @Test
+    fun `given HTTP Gson request and TLS failure, when sending, then use HTTPS once without downgrade`() = runTest {
+        lateinit var sentRequest: WPAPIGsonRequest<String>
+        whenever(requestQueue.add(any<WPAPIGsonRequest<String>>())).thenAnswer { invocation ->
+            sentRequest = invocation.getArgument(0)
+            sentRequest.deliverError(VolleyError(SSLHandshakeException("certificate failure")))
+            sentRequest
+        }
+
+        val response = WPAPIGsonRequestBuilder(normalizer).syncGetRequest(
+            restClient = restClient,
+            url = "http://example.com/wp-json/wc/v3/orders",
+            clazz = String::class.java,
+        )
+
+        assertThat(sentRequest.url).isEqualTo("https://example.com/wp-json/wc/v3/orders")
+        assertThat(response).isInstanceOf(WPAPIResponse.Error::class.java)
+        verify(requestQueue, times(1)).add(any<WPAPIGsonRequest<String>>())
+    }
+
+    @Test
+    fun `given HTTP encoded-body request and TLS failure, when sending, then use HTTPS once without downgrade`() =
+        runTest {
+            lateinit var sentRequest: WPAPIEncodedBodyRequest
+            whenever(requestQueue.add(any<WPAPIEncodedBodyRequest>())).thenAnswer { invocation ->
+                sentRequest = invocation.getArgument(0)
+                sentRequest.deliverError(VolleyError(SSLHandshakeException("certificate failure")))
+                sentRequest
+            }
+
+            val response = WPAPIEncodedBodyRequestBuilder(normalizer).syncPostRequest(
+                restClient = restClient,
+                url = "http://example.com/wp-login.php",
+            )
+
+            assertThat(sentRequest.url).isEqualTo("https://example.com/wp-login.php")
+            assertThat(response).isInstanceOf(WPAPIResponse.Error::class.java)
+            verify(requestQueue, times(1)).add(any<WPAPIEncodedBodyRequest>())
+        }
+}

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsNetworkTests.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsNetworkTests.kt
@@ -22,6 +22,7 @@ import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.ResponseWithHeaders
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIGsonRequest
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
+import org.wordpress.android.fluxc.utils.HttpsUrlNormalizer
 import java.util.Optional
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -42,6 +43,7 @@ class ApplicationPasswordsNetworkTests {
     private val userAgent: UserAgent = mock()
     private val listener: ApplicationPasswordsListener = mock()
     private val mApplicationPasswordsManager: ApplicationPasswordsManager = mock()
+    private var lastRequestUrl: String? = null
     private lateinit var network: ApplicationPasswordsNetwork
 
     @Before
@@ -49,7 +51,8 @@ class ApplicationPasswordsNetworkTests {
         network = ApplicationPasswordsNetwork(
             requestQueue = requestQueue,
             userAgent = userAgent,
-            listener = Optional.of(listener)
+            listener = Optional.of(listener),
+            httpsUrlNormalizer = HttpsUrlNormalizer(),
         ).apply {
             mApplicationPasswordsManager = this@ApplicationPasswordsNetworkTests.mApplicationPasswordsManager
         }
@@ -64,6 +67,17 @@ class ApplicationPasswordsNetworkTests {
         network.executeGetGsonRequest(testSite, "path", TestResponse::class.java)
 
         verify(mApplicationPasswordsManager).getApplicationCredentials(testSite)
+    }
+
+    @Test
+    fun `given HTTP site, when sending request, then use HTTPS`() = runTest {
+        givenSuccessResponse()
+        whenever(mApplicationPasswordsManager.getApplicationCredentials(testSite))
+            .thenReturn(ApplicationPasswordCreationResult.Existing(testCredentials))
+
+        network.executeGetGsonRequest(testSite, "path", TestResponse::class.java)
+
+        assertEquals("https://test-site.com/wp-json/path", lastRequestUrl)
     }
 
     @Test
@@ -148,6 +162,7 @@ class ApplicationPasswordsNetworkTests {
     private fun givenSuccessResponse(response: TestResponse = TestResponse("")) {
         whenever(requestQueue.add(any<WPAPIGsonRequest<TestResponse>>())).thenAnswer { invocation ->
             val request = (invocation.arguments.first() as WPAPIGsonRequest<TestResponse>)
+            lastRequestUrl = request.url
 
             val deliverMethod = Request::class.java.getDeclaredMethod("deliverResponse", Any::class.java)
             deliverMethod.isAccessible = true
@@ -161,6 +176,7 @@ class ApplicationPasswordsNetworkTests {
     private fun givenErrorResponse(error: VolleyError) {
         whenever(requestQueue.add(any<WPAPIGsonRequest<TestResponse>>())).thenAnswer { invocation ->
             val request = (invocation.arguments.first() as WPAPIGsonRequest<TestResponse>)
+            lastRequestUrl = request.url
             request.deliverError(error)
 
             return@thenAnswer request

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/site/SiteWPAPIRestClientTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/site/SiteWPAPIRestClientTest.kt
@@ -18,6 +18,7 @@ import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
 import org.wordpress.android.fluxc.store.SiteStore.FetchWPAPISitePayload
 import org.wordpress.android.fluxc.test
+import org.wordpress.android.fluxc.utils.HttpsUrlNormalizer
 
 @Suppress("UnitTestNamingRule")
 @RunWith(RobolectricTestRunner::class)
@@ -27,6 +28,7 @@ class SiteWPAPIRestClientTest {
     private val subject = SiteWPAPIRestClient(
         wpapiGsonRequestBuilder = requestBuilder,
         discoveryWPAPIRestClient = discoveryClient,
+        httpsUrlNormalizer = HttpsUrlNormalizer(),
         dispatcher = mock<Dispatcher>(),
         requestQueue = mock<RequestQueue>(),
         userAgent = mock<UserAgent>()
@@ -95,6 +97,86 @@ class SiteWPAPIRestClientTest {
         val refreshedSite = subject.fetchWPAPISite(existingSite)
 
         assertThat(refreshedSite.adminUrl).isEqualTo(REST_ADMIN_URL)
+    }
+
+    @Test
+    fun `given server advertises HTTP, when fetching a WPAPI site, then normalize fields and require configuration`() =
+        test {
+            givenSiteResponse(
+                RootWPAPIRestResponse(
+                    url = HTTP_SITE_URL,
+                    authentication = RootWPAPIRestResponse.Authentication(
+                        applicationPasswords = RootWPAPIRestResponse.Authentication.ApplicationPasswords(
+                            endpoints = RootWPAPIRestResponse.Authentication.ApplicationPasswords.Endpoints(
+                                authorization = HTTP_REST_ADMIN_AUTHORIZATION_URL
+                            )
+                        )
+                    ),
+                    namespaces = listOf("wc/v3")
+                )
+            )
+
+            val site = subject.fetchWPAPISite(FetchWPAPISitePayload(HTTP_SITE_URL))
+
+            assertThat(site.url).isEqualTo(SITE_URL)
+            assertThat(site.wpApiRestUrl).isEqualTo(WP_API_URL)
+            assertThat(site.adminUrl).isEqualTo(REST_ADMIN_URL)
+            assertThat(site.applicationPasswordsAuthorizeUrl).isEqualTo(REST_ADMIN_AUTHORIZATION_URL)
+            assertThat(site.httpsConfigurationState)
+                .isEqualTo(SiteModel.HTTPS_CONFIGURATION_REQUIRES_HTTPS)
+        }
+
+    @Test
+    fun `given HTTP input and server advertises HTTPS, when fetching site, then server state is secure`() = test {
+        givenSiteResponse(
+            RootWPAPIRestResponse(
+                url = SITE_URL,
+                namespaces = listOf("wc/v3"),
+            )
+        )
+
+        val site = subject.fetchWPAPISite(FetchWPAPISitePayload(HTTP_SITE_URL))
+
+        assertThat(site.url).isEqualTo(SITE_URL)
+        assertThat(site.httpsConfigurationState).isEqualTo(SiteModel.HTTPS_CONFIGURATION_SECURE)
+    }
+
+    @Test
+    fun `given existing application-password site, when refreshing, then retain its local ID`() = test {
+        val existingSite = existingSite().apply { id = 42 }
+        givenSiteResponse(REST_ADMIN_AUTHORIZATION_URL)
+
+        val refreshedSite = subject.fetchWPAPISite(existingSite)
+
+        assertThat(refreshedSite.id).isEqualTo(42)
+    }
+
+    @Test
+    fun `given refresh omits server URL, when prior state requires configuration, then retain prior state`() = test {
+        val existingSite = existingSite().apply {
+            httpsConfigurationState = SiteModel.HTTPS_CONFIGURATION_REQUIRES_HTTPS
+        }
+        givenSiteResponse(REST_ADMIN_AUTHORIZATION_URL)
+
+        val refreshedSite = subject.fetchWPAPISite(existingSite)
+
+        assertThat(refreshedSite.httpsConfigurationState)
+            .isEqualTo(SiteModel.HTTPS_CONFIGURATION_REQUIRES_HTTPS)
+    }
+
+    @Test
+    fun `given server URL has unsupported scheme, when fetching site, then return invalid response`() = test {
+        givenSiteResponse(
+            RootWPAPIRestResponse(
+                url = "ftp://site.example",
+                namespaces = listOf("wc/v3"),
+            )
+        )
+
+        val site = subject.fetchWPAPISite(FetchWPAPISitePayload(SITE_URL))
+
+        assertThat(site.isError).isTrue()
+        assertThat(site.error.type).isEqualTo(INVALID_RESPONSE)
     }
 
     @Test
@@ -175,6 +257,7 @@ class SiteWPAPIRestClientTest {
 
     private companion object {
         const val SITE_URL = "https://site.example"
+        const val HTTP_SITE_URL = "http://site.example"
         const val WP_API_URL = "$SITE_URL/wp-json/"
         const val USERNAME = "merchant"
         const val PASSWORD = "password"
@@ -184,6 +267,8 @@ class SiteWPAPIRestClientTest {
         const val STALE_REST_ADMIN_AUTHORIZATION_URL = "${STALE_REST_ADMIN_URL}authorize-application.php"
         const val REST_ADMIN_URL = "$SITE_URL/wp-admin/"
         const val REST_ADMIN_AUTHORIZATION_URL = "${REST_ADMIN_URL}authorize-application.php"
+        const val HTTP_REST_ADMIN_AUTHORIZATION_URL =
+            "http://site.example/wp-admin/authorize-application.php"
         const val FETCH_API_CALL_FIELDS =
             "name,description,gmt_offset,url,authentication,namespaces"
     }

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
@@ -39,6 +39,7 @@ import org.wordpress.android.fluxc.store.SiteStore.SiteFilter.WPCOM
 import org.wordpress.android.fluxc.test
 import org.wordpress.android.fluxc.tools.initCoroutineEngine
 import org.wordpress.android.fluxc.utils.ErrorUtils.OnUnexpectedError
+import org.wordpress.android.fluxc.utils.HttpsUrlNormalizer
 import org.wordpress.android.util.UrlUtils
 import java.security.cert.CertificateException
 import java.security.cert.CertificateExpiredException
@@ -85,6 +86,7 @@ class SiteRestClientTest {
             jetpackTunnelGsonRequestBuilder = jetpackTunnelGsonRequestBuilder,
             coroutineEngine = initCoroutineEngine(),
             discoveryWPAPIRestClient = discoveryWPAPIRestClient,
+            httpsUrlNormalizer = HttpsUrlNormalizer(),
             accessToken = accessToken,
             userAgent = userAgent
         )
@@ -107,6 +109,29 @@ class SiteRestClientTest {
             .isEqualTo("https://public-api.wordpress.com/rest/v1.1/sites/12")
         assertThat(paramsCaptor.lastValue).isEqualTo(mapOf("fields" to SiteRestClient.SITE_FIELDS))
     }
+
+    @Test
+    fun `given WPCom response advertises HTTP, when fetching site, then normalize fields and require configuration`() =
+        test {
+            val response = SiteWPComRestResponse().apply {
+                ID = siteId
+                name = "Store"
+                URL = "http://site.example/store"
+                options = SiteWPComRestResponse.Options().apply {
+                    admin_url = "http://site.example/store/wp-admin/"
+                    login_url = "http://site.example/store/wp-login.php"
+                }
+            }
+            initSiteResponse(response)
+
+            val responseModel = restClient.fetchSite(site)
+
+            assertThat(responseModel.url).isEqualTo("https://site.example/store")
+            assertThat(responseModel.adminUrl).isEqualTo("https://site.example/store/wp-admin/")
+            assertThat(responseModel.loginUrl).isEqualTo("https://site.example/store/wp-login.php")
+            assertThat(responseModel.httpsConfigurationState)
+                .isEqualTo(SiteModel.HTTPS_CONFIGURATION_REQUIRES_HTTPS)
+        }
 
     @Test
     fun `fetchSite returns error when API call fails`() = test {
@@ -297,6 +322,25 @@ class SiteRestClientTest {
     }
 
     @Test
+    fun `given HTTP login address, when fetching site info, then send and return only HTTPS`() = test {
+        initGetResponse(
+            ConnectSiteInfoResponse::class.java,
+            ConnectSiteInfoResponse().apply {
+                exists = true
+                isWordPress = true
+                urlAfterRedirects = "http://test.com/redirected"
+            }
+        )
+
+        val result = restClient.fetchConnectSiteInfoSync("http://test.com")
+
+        assertThat(paramsCaptor.lastValue["url"]).isEqualTo("https://test.com")
+        assertThat(result.url).isEqualTo("https://test.com")
+        assertThat(result.urlAfterRedirects).isEqualTo("https://test.com/redirected")
+        assertThat(result.wasUrlNormalizedToHttps).isTrue()
+    }
+
+    @Test
     fun `given ordinary site info error, when fetching site info, then WP API discovery state is attached`() = test {
         val urlUtilsMock = mockStatic(UrlUtils::class.java)
         try {
@@ -382,42 +426,58 @@ class SiteRestClientTest {
     fun `given eligible site info error and successful probe, when fetching site info, then WP API base URL is attached`() =
         test {
             val error = WPComGsonNetworkError(BaseNetworkError(GenericErrorType.INVALID_RESPONSE, "origin failed"))
-            whenever(discoveryWPAPIRestClient.discoverWPAPIBaseURL("test.com")).thenReturn("https://test.com/wp-json/")
+            whenever(discoveryWPAPIRestClient.discoverWPAPIBaseURL("https://test.com"))
+                .thenReturn("https://test.com/wp-json/")
             whenever(discoveryWPAPIRestClient.verifyWPAPIV2Support("https://test.com/wp-json/"))
                 .thenReturn("https://test.com/wp-json/")
 
             val result = fetchConnectSiteInfoWithError(error, discoverWPAPIOnFailure = true)
 
             assertThat(result.error!!.wpApiDiscovery!!.wpApiBaseUrl).isEqualTo("https://test.com/wp-json/")
-            verify(discoveryWPAPIRestClient).discoverWPAPIBaseURL("test.com")
+            verify(discoveryWPAPIRestClient).discoverWPAPIBaseURL("https://test.com")
             verify(discoveryWPAPIRestClient).verifyWPAPIV2Support("https://test.com/wp-json/")
         }
+
+    @Test
+    fun `given discovery advertises HTTP API root, when verifying fallback, then upgrade it to HTTPS`() = test {
+        val error = WPComGsonNetworkError(BaseNetworkError(GenericErrorType.INVALID_RESPONSE, "origin failed"))
+        whenever(discoveryWPAPIRestClient.discoverWPAPIBaseURL("https://test.com"))
+            .thenReturn("http://test.com/wp-json/")
+        whenever(discoveryWPAPIRestClient.verifyWPAPIV2Support("https://test.com/wp-json/"))
+            .thenReturn("https://test.com/wp-json/")
+
+        val result = fetchConnectSiteInfoWithError(error, discoverWPAPIOnFailure = true)
+
+        assertThat(result.error?.wpApiDiscovery?.wpApiBaseUrl).isEqualTo("https://test.com/wp-json/")
+        verify(discoveryWPAPIRestClient).verifyWPAPIV2Support("https://test.com/wp-json/")
+    }
 
     @Test
     fun `given eligible site info error and missing link header, when fetching site info, then WP API base URL is null`() =
         test {
             val error = WPComGsonNetworkError(BaseNetworkError(GenericErrorType.INVALID_RESPONSE, "origin failed"))
-            whenever(discoveryWPAPIRestClient.discoverWPAPIBaseURL("test.com")).thenReturn(null)
+            whenever(discoveryWPAPIRestClient.discoverWPAPIBaseURL("https://test.com")).thenReturn(null)
 
             val result = fetchConnectSiteInfoWithError(error, discoverWPAPIOnFailure = true)
 
             assertThat(result.error!!.wpApiDiscovery).isNotNull
             assertThat(result.error!!.wpApiDiscovery!!.wpApiBaseUrl).isNull()
-            verify(discoveryWPAPIRestClient).discoverWPAPIBaseURL("test.com")
+            verify(discoveryWPAPIRestClient).discoverWPAPIBaseURL("https://test.com")
         }
 
     @Test
     fun `given eligible site info error and unsupported WP API, when fetching site info, then WP API base URL is null`() =
         test {
             val error = WPComGsonNetworkError(BaseNetworkError(GenericErrorType.INVALID_RESPONSE, "origin failed"))
-            whenever(discoveryWPAPIRestClient.discoverWPAPIBaseURL("test.com")).thenReturn("https://test.com/wp-json/")
+            whenever(discoveryWPAPIRestClient.discoverWPAPIBaseURL("https://test.com"))
+                .thenReturn("https://test.com/wp-json/")
             whenever(discoveryWPAPIRestClient.verifyWPAPIV2Support("https://test.com/wp-json/")).thenReturn(null)
 
             val result = fetchConnectSiteInfoWithError(error, discoverWPAPIOnFailure = true)
 
             assertThat(result.error!!.wpApiDiscovery).isNotNull
             assertThat(result.error!!.wpApiDiscovery!!.wpApiBaseUrl).isNull()
-            verify(discoveryWPAPIRestClient).discoverWPAPIBaseURL("test.com")
+            verify(discoveryWPAPIRestClient).discoverWPAPIBaseURL("https://test.com")
             verify(discoveryWPAPIRestClient).verifyWPAPIV2Support("https://test.com/wp-json/")
         }
 
@@ -648,6 +708,50 @@ class SiteRestClientTest {
     }
 
     @Test
+    fun `given root endpoint advertises HTTP, when fetching site, then normalize and require configuration`() = test {
+        val jetpackCPSite = SiteModel().apply { setIsJetpackConnected(false) }
+        initRootEndpointResponse(
+            RootWPAPIRestResponse(
+                url = "http://test.com",
+                namespaces = listOf("wc/v3"),
+                authentication = RootWPAPIRestResponse.Authentication(
+                    applicationPasswords = RootWPAPIRestResponse.Authentication.ApplicationPasswords(
+                        endpoints = RootWPAPIRestResponse.Authentication.ApplicationPasswords.Endpoints(
+                            authorization = "http://test.com/application-passwords"
+                        )
+                    )
+                ),
+            )
+        )
+
+        val result = restClient.fetchSite(jetpackCPSite)
+
+        assertThat(result.url).isEqualTo("https://test.com")
+        assertThat(result.applicationPasswordsAuthorizeUrl).isEqualTo("https://test.com/application-passwords")
+        assertThat(result.httpsConfigurationState)
+            .isEqualTo(SiteModel.HTTPS_CONFIGURATION_REQUIRES_HTTPS)
+    }
+
+    @Test
+    fun `given root endpoint server URL is invalid, when fetching site, then fail without changing stored state`() = test {
+        val jetpackCPSite = SiteModel().apply {
+            url = "https://test.com"
+            name = "Original"
+            httpsConfigurationState = SiteModel.HTTPS_CONFIGURATION_REQUIRES_HTTPS
+            setIsJetpackConnected(false)
+        }
+        initRootEndpointResponse(RootWPAPIRestResponse(name = "Updated", url = "ftp://test.com"))
+
+        val result = restClient.fetchSite(jetpackCPSite)
+
+        assertThat(result.isError).isTrue()
+        assertThat(result.error.type).isEqualTo(GenericErrorType.INVALID_RESPONSE)
+        assertThat(jetpackCPSite.name).isEqualTo("Original")
+        assertThat(jetpackCPSite.httpsConfigurationState)
+            .isEqualTo(SiteModel.HTTPS_CONFIGURATION_REQUIRES_HTTPS)
+    }
+
+    @Test
     fun `given Jetpack CP sites, when fetching sites, then use root endpoint for additional data`() = test {
         val wpComSiteResponse = SiteWPComRestResponse()
         wpComSiteResponse.ID = siteId
@@ -791,7 +895,8 @@ class SiteRestClientTest {
 
     private suspend fun assertOptedInConnectivityErrorDiscoversWPAPI(type: GenericErrorType) {
         val error = WPComGsonNetworkError(BaseNetworkError(type, VolleyError("Android connectivity failure")))
-        whenever(discoveryWPAPIRestClient.discoverWPAPIBaseURL("test.com")).thenReturn("https://test.com/wp-json/")
+        whenever(discoveryWPAPIRestClient.discoverWPAPIBaseURL("https://test.com"))
+            .thenReturn("https://test.com/wp-json/")
         whenever(discoveryWPAPIRestClient.verifyWPAPIV2Support("https://test.com/wp-json/"))
             .thenReturn("https://test.com/wp-json/")
 
@@ -802,7 +907,7 @@ class SiteRestClientTest {
         assertThat(result.error!!.wpApiDiscovery).isNotNull
         assertThat(result.error!!.wpApiDiscovery!!.connectSiteInfoApiError).isEqualTo(error.apiError)
         assertThat(result.error!!.wpApiDiscovery!!.wpApiBaseUrl).isEqualTo("https://test.com/wp-json/")
-        verify(discoveryWPAPIRestClient).discoverWPAPIBaseURL("test.com")
+        verify(discoveryWPAPIRestClient).discoverWPAPIBaseURL("https://test.com")
         verify(discoveryWPAPIRestClient).verifyWPAPIV2Support("https://test.com/wp-json/")
     }
 

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/persistence/SiteStorePersistenceTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/persistence/SiteStorePersistenceTest.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.fluxc.persistence
 import androidx.test.core.app.ApplicationProvider
 import com.yarolegovich.wellsql.WellSql
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -55,6 +56,40 @@ class SiteStorePersistenceTest {
     }
 
     // endregion
+
+    @Test
+    fun `given application-password site local ID, when URL is normalized, then update the existing row`() {
+        val site = SiteModel().apply {
+            url = "http://test.com"
+            origin = SiteModel.ORIGIN_WPAPI
+        }
+        sut.insertOrUpdateSite(site)
+        val originalLocalId = site.id
+
+        site.url = "https://test.com"
+        val result = sut.insertOrUpdateSite(site)
+
+        assertThat(result).isEqualTo(1)
+        assertThat(site.id).isEqualTo(originalLocalId)
+        assertThat(siteSqlUtils.getSites()).singleElement().extracting(SiteModel::getUrl)
+            .isEqualTo("https://test.com")
+    }
+
+    @Test
+    fun `given HTTP and HTTPS rows collide, when normalizing by local ID, then preserve both and fail`() {
+        val httpSite = SiteModel().apply { url = "http://test.com" }
+        val httpsSite = SiteModel().apply { url = "https://test.com" }
+        sut.insertOrUpdateSite(httpSite)
+        sut.insertOrUpdateSite(httpsSite)
+
+        httpSite.url = "https://test.com"
+
+        assertThatThrownBy { sut.insertOrUpdateSite(httpSite) }
+            .isInstanceOf(SiteStorePersistence.DuplicateSiteException::class.java)
+        assertThat(siteSqlUtils.getSites()).hasSize(2)
+        assertThat(siteSqlUtils.getSites().map(SiteModel::getUrl))
+            .containsExactlyInAnyOrder("http://test.com", "https://test.com")
+    }
 
     // region insert (case 4)
 

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/persistence/WellSqlConfigMigrationTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/persistence/WellSqlConfigMigrationTest.kt
@@ -1,0 +1,40 @@
+package org.wordpress.android.fluxc.persistence
+
+import android.database.sqlite.SQLiteDatabase
+import androidx.test.core.app.ApplicationProvider
+import com.yarolegovich.wellsql.WellTableManager
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.robolectric.RobolectricTestRunner
+import org.wordpress.android.fluxc.model.SiteModel
+
+@RunWith(RobolectricTestRunner::class)
+class WellSqlConfigMigrationTest {
+    @Test
+    fun `given existing site row, when upgrading from 243, then preserve it with unknown HTTPS state`() {
+        val database = SQLiteDatabase.create(null).apply {
+            execSQL("CREATE TABLE SiteModel (_id INTEGER PRIMARY KEY AUTOINCREMENT, URL TEXT)")
+            execSQL("INSERT INTO SiteModel (URL) VALUES ('http://test.com')")
+        }
+        val config = WellSqlConfig(ApplicationProvider.getApplicationContext())
+
+        config.onUpgrade(database, mock<WellTableManager>(), 243, 245)
+
+        database.query(
+            "SiteModel",
+            arrayOf("URL", "HTTPS_CONFIGURATION_STATE"),
+            null,
+            null,
+            null,
+            null,
+            null,
+        ).use { cursor ->
+            assertThat(cursor.moveToFirst()).isTrue()
+            assertThat(cursor.getString(0)).isEqualTo("http://test.com")
+            assertThat(cursor.getInt(1)).isEqualTo(SiteModel.HTTPS_CONFIGURATION_UNKNOWN)
+        }
+        assertThat(config.dbVersion).isEqualTo(245)
+    }
+}

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/utils/HttpsUrlNormalizerTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/utils/HttpsUrlNormalizerTest.kt
@@ -1,0 +1,69 @@
+package org.wordpress.android.fluxc.utils
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
+import org.junit.Test
+
+class HttpsUrlNormalizerTest {
+    private val normalizer = HttpsUrlNormalizer()
+
+    @Test
+    fun `given HTTP URL, when normalizing, then upgrade only its transport`() {
+        val result = normalizer.normalize("http://example.com/store%2Fpath?q=a%2Fb#section")
+
+        assertThat(result.normalizedUrl).isEqualTo("https://example.com/store%2Fpath?q=a%2Fb#section")
+        assertThat(result.wasUpgraded).isTrue()
+    }
+
+    @Test
+    fun `given uppercase HTTP scheme, when normalizing, then upgrade to HTTPS`() {
+        val result = normalizer.normalize("HTTP://example.com/path")
+
+        assertThat(result.normalizedUrl).isEqualTo("https://example.com/path")
+        assertThat(result.wasUpgraded).isTrue()
+    }
+
+    @Test
+    fun `given HTTPS URL, when normalizing, then keep it secure`() {
+        val result = normalizer.normalize("https://example.com/path")
+
+        assertThat(result.normalizedUrl).isEqualTo("https://example.com/path")
+        assertThat(result.wasUpgraded).isFalse()
+    }
+
+    @Test
+    fun `given URL has query and fragment without path, when normalizing, then avoid adding a path`() {
+        val result = normalizer.normalize("http://example.com?q=a%2Fb#section")
+
+        assertThat(result.normalizedUrl).isEqualTo("https://example.com?q=a%2Fb#section")
+    }
+
+    @Test
+    fun `given scheme-less login input, when adding a scheme, then default to HTTPS`() {
+        val result = normalizer.normalize("example.com/store", addHttpsSchemeIfMissing = true)
+
+        assertThat(result.normalizedUrl).isEqualTo("https://example.com/store")
+        assertThat(result.wasUpgraded).isFalse()
+    }
+
+    @Test
+    fun `given HTTP default port, when normalizing, then use HTTPS default port`() {
+        val result = normalizer.normalize("http://example.com:80/path")
+
+        assertThat(result.normalizedUrl).isEqualTo("https://example.com/path")
+    }
+
+    @Test
+    fun `given HTTP custom port, when normalizing, then preserve the port`() {
+        val result = normalizer.normalize("http://example.com:8080/path")
+
+        assertThat(result.normalizedUrl).isEqualTo("https://example.com:8080/path")
+    }
+
+    @Test
+    fun `given unsupported or malformed URL, when normalizing, then reject it`() {
+        listOf("ftp://example.com", "not a url", "https://").forEach { url ->
+            assertThatIllegalArgumentException().isThrownBy { normalizer.normalize(url) }
+        }
+    }
+}

--- a/libs/login/src/main/java/org/wordpress/android/login/ConnectSiteInfoResult.kt
+++ b/libs/login/src/main/java/org/wordpress/android/login/ConnectSiteInfoResult.kt
@@ -8,4 +8,5 @@ data class ConnectSiteInfoResult @JvmOverloads constructor(
      * Whether the site is suspended on WordPress.com and can't be connected using Jetpack
      */
     val isWPComSuspended: Boolean = false,
+    val wasUrlNormalizedToHttps: Boolean = false,
 )

--- a/libs/login/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
+++ b/libs/login/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
@@ -35,6 +35,7 @@ import org.wordpress.android.fluxc.store.SiteStore.FetchConnectSiteInfoPayload;
 import org.wordpress.android.fluxc.store.SiteStore.OnConnectSiteInfoChecked;
 import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType;
 import org.wordpress.android.fluxc.store.SiteStore.WPAPIDiscoveryResult;
+import org.wordpress.android.fluxc.utils.HttpsUrlNormalizer;
 import org.wordpress.android.login.util.SiteUtils;
 import org.wordpress.android.login.widgets.WPLoginInputRow;
 import org.wordpress.android.login.widgets.WPLoginInputRow.OnEditorCommitListener;
@@ -83,6 +84,7 @@ public class LoginSiteAddressFragment extends LoginBaseDiscoveryFragment impleme
     @Inject Dispatcher mDispatcher;
     @Inject HTTPAuthManager mHTTPAuthManager;
     @Inject MemorizingTrustManager mMemorizingTrustManager;
+    @Inject HttpsUrlNormalizer mHttpsUrlNormalizer;
 
     @Override
     protected @LayoutRes int getContentLayout() {
@@ -223,6 +225,14 @@ public class LoginSiteAddressFragment extends LoginBaseDiscoveryFragment impleme
         mRequestedSiteAddress = mLoginSiteAddressValidator.getCleanedSiteAddress();
 
         String cleanedUrl = stripKnownPaths(mRequestedSiteAddress);
+        if (mLoginListener.getLoginMode() == LoginMode.WOO_LOGIN_MODE) {
+            try {
+                cleanedUrl = mHttpsUrlNormalizer.normalize(cleanedUrl, true).getNormalizedUrl();
+            } catch (IllegalArgumentException exception) {
+                showError(R.string.invalid_site_url_message);
+                return;
+            }
+        }
 
         mAnalyticsListener.trackConnectedSiteInfoRequested(cleanedUrl);
         mDispatcher.dispatch(SiteActionBuilder.newFetchConnectSiteInfoAction(
@@ -403,7 +413,8 @@ public class LoginSiteAddressFragment extends LoginBaseDiscoveryFragment impleme
                                 mRequestedSiteAddress,
                                 null,
                                 mConnectSiteInfoCalculatedHasJetpack,
-                                true
+                                true,
+                                event.info.wasUrlNormalizedToHttps
                         )
                 );
             } else {
@@ -470,7 +481,9 @@ public class LoginSiteAddressFragment extends LoginBaseDiscoveryFragment impleme
                     new ConnectSiteInfoResult(
                             mConnectSiteInfoUrl,
                             mConnectSiteInfoUrlRedirect,
-                            mConnectSiteInfoCalculatedHasJetpack
+                            mConnectSiteInfoCalculatedHasJetpack,
+                            false,
+                            siteInfo.wasUrlNormalizedToHttps
                     )
             );
         }

--- a/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooNoticeBanner.kt
+++ b/libs/store-design-system/src/main/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooNoticeBanner.kt
@@ -9,10 +9,14 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
@@ -25,6 +29,7 @@ import com.woocommerce.android.ui.compose.designsystem.icons.Bolt
 import com.woocommerce.android.ui.compose.designsystem.icons.CircleInfo
 import com.woocommerce.android.ui.compose.designsystem.icons.CirclePlus
 import com.woocommerce.android.ui.compose.designsystem.icons.WooIcons
+import com.woocommerce.android.ui.compose.designsystem.icons.Xmark
 
 @Composable
 fun WooNoticeBanner(
@@ -33,7 +38,21 @@ fun WooNoticeBanner(
     description: String? = null,
     tone: WooNoticeBannerTone = WooNoticeBannerTone.Neutral,
     leadingIcon: (@Composable () -> Unit)? = null,
+    actionLabel: String? = null,
+    onActionClick: (() -> Unit)? = null,
+    dismissContentDescription: String? = null,
+    onDismissClick: (() -> Unit)? = null,
 ) {
+    require((actionLabel == null) == (onActionClick == null)) {
+        "WooNoticeBanner action label and callback must be provided together"
+    }
+    require((dismissContentDescription == null) == (onDismissClick == null)) {
+        "WooNoticeBanner dismiss label and callback must be provided together"
+    }
+    require(actionLabel == null || actionLabel.isNotBlank()) { "WooNoticeBanner action label must not be blank" }
+    require(dismissContentDescription == null || dismissContentDescription.isNotBlank()) {
+        "WooNoticeBanner dismiss content description must not be blank"
+    }
     val colors = tone.toNoticeBannerColors()
 
     Surface(
@@ -46,7 +65,7 @@ fun WooNoticeBanner(
         Row(
             modifier = Modifier.padding(WooTheme.padding.padding4),
             horizontalArrangement = Arrangement.spacedBy(WooTheme.spacing.space3),
-            verticalAlignment = Alignment.CenterVertically,
+            verticalAlignment = Alignment.Top,
         ) {
             if (leadingIcon != null) {
                 CompositionLocalProvider(LocalContentColor provides colors.contentColor) {
@@ -58,7 +77,10 @@ fun WooNoticeBanner(
                     }
                 }
             }
-            Column(verticalArrangement = Arrangement.spacedBy(WooTheme.spacing.space1)) {
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(WooTheme.spacing.space1),
+            ) {
                 Text(
                     text = title,
                     style = WooTheme.text.titleMedium.emphasized,
@@ -67,6 +89,29 @@ fun WooNoticeBanner(
                     Text(
                         text = description,
                         style = WooTheme.text.bodyMedium.regular,
+                    )
+                }
+                if (actionLabel != null && onActionClick != null) {
+                    TextButton(
+                        onClick = onActionClick,
+                        colors = ButtonDefaults.textButtonColors(contentColor = colors.contentColor),
+                    ) {
+                        Text(
+                            text = actionLabel,
+                            style = WooTheme.text.labelLarge.emphasized,
+                        )
+                    }
+                }
+            }
+            if (dismissContentDescription != null && onDismissClick != null) {
+                IconButton(
+                    onClick = onDismissClick,
+                    colors = IconButtonDefaults.iconButtonColors(contentColor = colors.contentColor),
+                ) {
+                    Icon(
+                        imageVector = WooIcons.Regular.Xmark,
+                        contentDescription = dismissContentDescription,
+                        modifier = Modifier.size(WooTheme.iconSize.size24),
                     )
                 }
             }

--- a/libs/store-design-system/src/test/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooNoticeBannerTest.kt
+++ b/libs/store-design-system/src/test/kotlin/com/woocommerce/android/ui/compose/designsystem/component/WooNoticeBannerTest.kt
@@ -1,0 +1,68 @@
+package com.woocommerce.android.ui.compose.designsystem.component
+
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.unit.Density
+import com.woocommerce.android.ui.compose.designsystem.foundation.WooDesignSystemTheme
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class WooNoticeBannerTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun `given action and dismiss affordances, when tapped, then expose semantics and invoke callbacks`() {
+        var actionClicked = false
+        var dismissClicked = false
+        composeRule.setContent {
+            WooDesignSystemTheme {
+                WooNoticeBanner(
+                    title = "Secure your store with HTTPS",
+                    description = "Update the configured address.",
+                    actionLabel = "Learn more",
+                    onActionClick = { actionClicked = true },
+                    dismissContentDescription = "Dismiss HTTPS security notice",
+                    onDismissClick = { dismissClicked = true },
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("Learn more").performClick()
+        composeRule.onNodeWithContentDescription("Dismiss HTTPS security notice").performClick()
+
+        assertThat(actionClicked).isTrue()
+        assertThat(dismissClicked).isTrue()
+    }
+
+    @Test
+    fun `given dark theme and large text, when rendering action banner, then keep all content visible`() {
+        composeRule.setContent {
+            CompositionLocalProvider(LocalDensity provides Density(density = 1f, fontScale = 2f)) {
+                WooDesignSystemTheme(useDarkTheme = true) {
+                    WooNoticeBanner(
+                        title = "Secure your store with HTTPS",
+                        description = "Update the configured address.",
+                        actionLabel = "Learn more",
+                        onActionClick = {},
+                        dismissContentDescription = "Dismiss HTTPS security notice",
+                        onDismissClick = {},
+                    )
+                }
+            }
+        }
+
+        composeRule.onNodeWithText("Secure your store with HTTPS").assertIsDisplayed()
+        composeRule.onNodeWithText("Learn more").assertIsDisplayed()
+        composeRule.onNodeWithContentDescription("Dismiss HTTPS security notice").assertIsDisplayed()
+    }
+}


### PR DESCRIPTION
### Description

Fixes WOOMOB-3865

Normalizes site-bound HTTP URLs to HTTPS before login discovery, authentication, and WPAPI request construction. Server-provided site and authorization URLs are normalized before persistence, and TLS failures never retry the original HTTP URL.

The app also persists whether WordPress still advertises HTTP. Affected stores show a per-store, dismissible warning on the main top-level tabs until a fresh sync reports HTTPS; dismissal lasts 24 hours. Existing application-password sites retain their local ID during migration, and POS catalog URLs remain unchanged.

### Test Steps

#### HTTP-configured store with working HTTPS

1. Use a test store that is reachable over HTTPS but whose **WordPress Address** or **Site Address** is configured as `http://…`.
2. Enter the HTTP address in the site-credentials login flow and complete authentication.
3. Confirm login succeeds and the expected store is selected. If using a network inspector, confirm site-bound discovery/authentication requests use HTTPS and no HTTP retry occurs.
4. Open **My Store**, **Orders**, **Products**, and **More**. Confirm the “Secure your store with HTTPS” warning is pinned below the shared toolbar.
5. Open a nested destination and confirm the warning is hidden when the shared toolbar is hidden.
6. Tap **Learn more** and confirm the WordPress HTTPS documentation opens.
7. Dismiss the warning and confirm it stays hidden while switching tabs and keeping the app foregrounded.
8. Advance the device clock by 24 hours and confirm the warning becomes eligible to appear again.
9. Update both WordPress URLs to HTTPS, refresh/sync the site, and confirm the warning disappears.

#### Existing store migration

1. With a previous app build, sign in to the HTTP-configured test store.
2. Install this branch over that build and trigger a site refresh.
3. Confirm requests continue over HTTPS, the existing store remains selected, and no duplicate store is added.

#### Secure and failure cases

1. Sign in to a store whose server-reported address is HTTPS and confirm no warning appears, even if the initial typed address used HTTP.
2. Try an HTTP-only store and confirm login fails with secure-connection guidance, without selecting a site or falling back to HTTP.
3. Try a store with an invalid or expired certificate and confirm the certificate-specific guidance is preserved.
4. Open POS and confirm this warning is not shown and catalog-download behavior is unchanged.

### Images/gif

Not included; the UI change is the text warning described above.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.