### PR TITLE
Pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/dependabot-constraintlayout-check.yml
+++ b/.github/workflows/dependabot-constraintlayout-check.yml
@@ -13,7 +13,7 @@ jobs:
       # Check if PR contains the constraintlayout dependency
       - name: Check for ConstraintLayout Compose dependency
         id: check-dependency
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const title = context.payload.pull_request.title;
@@ -31,7 +31,7 @@ jobs:
       # Add comment if dependency is found
       - name: Comment on PR
         if: steps.check-dependency.outputs.result == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             // Check if comment already exists to avoid duplicates

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -10,13 +10,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v4
         with:
           distribution: 'temurin'
           java-version: '17'
       - name: Setup Gradle to generate and submit dependency graphs
-        uses: gradle/actions/dependency-submission@v5
+        uses: gradle/actions/dependency-submission@0723195856401067f7a2779048b490ace7a47d7c # v5
         with:
           dependency-graph-include-projects: '^:(WooCommerce|WooCommerce-Wear)$'
           dependency-graph-include-configurations: 'vanillaReleaseRuntimeClasspath'

--- a/.github/workflows/dependabot_automerge.yml
+++ b/.github/workflows/dependabot_automerge.yml
@@ -16,11 +16,11 @@ jobs:
       PR_URL: ${{ github.event.pull_request.html_url }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -6,5 +6,5 @@ jobs:
     name: "Validation"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: gradle/actions/wrapper-validation@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: gradle/actions/wrapper-validation@ed408507eac070d1f99cc633dbcf757c94c7933a # v4


### PR DESCRIPTION
### Changes proposed in this Pull Request

The WooCommerce GitHub organization intends to enforce full-commit-SHA pinning for GitHub Actions. This change replaces every mutable external Action tag or branch used by this repository with the current 40-character commit SHA and preserves the original human-readable ref in a trailing comment.

Immutable pins reduce supply-chain compromise risk if an upstream tag or branch is moved or an Action repository is compromised. Local actions and reusable workflows remain unchanged.

### Verification

- [x] Re-audited the current default branch and pinned every mutable external Action reference.
- [x] Independently re-resolved each distinct tag or branch and confirmed it matches the pinned SHA.
- [x] Confirmed the post-change scan reports zero mutable external Action references.
- [x] Parsed every changed workflow and composite-action YAML file successfully.
- [x] Ran git diff --check.
- [x] Confirmed the diff contains only intended uses: reference changes.

### Backward compatibility impact

No backward-compatibility impact. This changes CI and automation configuration only.

### Changelog

No changelog entry is needed because this is a workflow-only configuration change with no product or runtime behavior change.

### Test steps

1. Inspect each changed uses: reference and confirm it is a full 40-character SHA with the original ref in a trailing comment.
2. Confirm repository workflows and composite actions load successfully in GitHub Actions.
3. Confirm the post-change SHA-pin scan reports zero findings.