### PR TITLE
[DO NOT MERGE] Validate build lane for #16464

### DIFF
--- a/.buildkite/commands/validate-build-lane.sh
+++ b/.buildkite/commands/validate-build-lane.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+"$(dirname "${BASH_SOURCE[0]}")/restore-cache.sh"
+
+echo "--- :rubygems: Setting up Gems"
+install_gems
+
+echo "--- :closed_lock_with_key: Installing Secrets"
+bundle exec fastlane run configure_apply
+
+echo "--- :hammer_and_wrench: Running build_and_upload_beta (stop before Play Store upload)"
+LOG="$(mktemp)"
+bundle exec fastlane build_and_upload_beta app:WooCommerce skip_confirm:true | tee "${LOG}"
+
+if ! grep -F 'VALIDATION: bundle built' "${LOG}"; then
+  echo "VALIDATION: lane did not print the bundle marker; refusing to treat this as a pass"
+  exit 1
+fi

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,134 +1,15 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 ---
 
-# Nodes with values to reuse in the pipeline.
-common_params:
-  # Common plugin settings to use with the `plugins` key.
-  - &test_collector_common_params
-      files: "WooCommerce/build/buildkite-test-analytics/*.xml"
-      format: "junit"
+# Validation-only for woocommerce/woocommerce-android#16464. Close; do not merge.
 
 agents:
   queue: "android"
 
 steps:
-  - label: Gradle Wrapper Validation
-    command: validate_gradle_wrapper
-    agents:
-      queue: linter
-
-  # Wait for Gradle Wrapper to be validated before running any other jobs
-  - wait
-
-  ########################################
-  - group: "🕵️ Linters"
-    steps:
-
-      - label: ":danger: Danger - PR Check"
-        command: danger
-        key: danger
-        if: "build.pull_request.id != null"
-        retry:
-          manual:
-            permit_on_passed: true
-        agents:
-          queue: "linter"
-
-      - label: "detekt"
-        command: |
-          if .buildkite/commands/should-skip-job.sh --job-type validation; then
-            exit 0
-          fi
-          ./gradlew detektAll
-        plugins: [$CI_TOOLKIT]
-        artifact_paths:
-          - "**/build/reports/detekt/detekt.html"
-
-      - label: "lint"
-        command: .buildkite/commands/lint.sh
-        plugins: [$CI_TOOLKIT]
-        artifact_paths:
-          - "**/build/reports/lint-results*.*"
-
-      - label: "Dependency Tree Diff"
-        command: comment_with_dependency_diff 'woocommerce' 'vanillaReleaseRuntimeClasspath'
-        if: build.pull_request.id != null
-        plugins: [$CI_TOOLKIT]
-        artifact_paths:
-          - "**/build/reports/diff/*"
-
-      - label: "Merged Manifest Diff"
-        command: ".buildkite/commands/diff-merged-manifest.sh vanillaRelease"
-        if: build.pull_request.id != null
-        plugins: [$CI_TOOLKIT]
-        artifact_paths:
-          - "**/build/reports/diff_manifest/**/**/*"
-
-  ########################################
-  - group: "🚀 Prototype Build"
-    # Mobile Prototype Builds are on-demand on `trunk`, but always built on PRs
-    # WearOS Prototype Builds are on-demand both on `trunk` and PRs
-    steps:
-      - input: Create a Mobile Prototype Build?
-        prompt: Share a Mobile Prototype Build via Firebase App Distribution?
-        key: mobile_prototype_build_triggered
-        if: build.branch == "trunk"
-      - label: ":firebase: Mobile Prototype Build"
-        # Buildkite considers this implicitly satisfied if `depends_on` step is skipped due to `if:` condition, so this will run unconditionally on PRs
-        # https://buildkite.com/docs/pipelines/configure/dependencies#how-skipped-steps-affect-dependencies
-        depends_on: mobile_prototype_build_triggered
-        command: .buildkite/commands/prototype-build.sh WooCommerce
-        plugins: [$CI_TOOLKIT]
-        artifact_paths:
-          - "WooCommerce/build/outputs/apk/**/*"
-
-      - input: Create a Wear Prototype Build?
-        prompt: Share a Wear Prototype Build? (it will be uploaded to AWS S3)
-        key: wear_prototype_build_triggered
-      - label: ":amazon-s3: Wear Prototype Build"
-        depends_on: wear_prototype_build_triggered
-        command: .buildkite/commands/prototype-build.sh WooCommerce-Wear
-        plugins: [$CI_TOOLKIT]
-        artifact_paths:
-          - "WooCommerce-Wear/build/outputs/apk/**/*"
-
-  ########################################
-  - group: "🔬 Tests"
-    steps:
-
-      - label: "Unit tests"
-        key: unit-tests
-        command: .buildkite/commands/run-unit-tests.sh
-        plugins:
-          - $CI_TOOLKIT
-          - $TEST_COLLECTOR :
-              <<: *test_collector_common_params
-              api-token-env-name: "BUILDKITE_ANALYTICS_TOKEN_UNIT_TESTS"
-        artifact_paths:
-          - "**/build/test-results/merged-test-results.xml"
-
-      - label: "Instrumented tests"
-        command: .buildkite/commands/run-instrumented-tests.sh
-        plugins:
-          - $CI_TOOLKIT
-          - $TEST_COLLECTOR :
-              <<: *test_collector_common_params
-              api-token-env-name: "BUILDKITE_ANALYTICS_TOKEN_INSTRUMENTED_TESTS"
-        artifact_paths:
-          - "**/build/instrumented-tests/**/*"
-
-
-  - label: "🐘 Populate Gradle build cache"
-    command: .buildkite/commands/gradle-cache-build.sh
+  - label: ":android: Validate build_and_upload_beta (no Play Store upload)"
+    key: validate_build_lane
+    command: ".buildkite/commands/validate-build-lane.sh"
     plugins: [$CI_TOOLKIT]
-
-  ########################################
-  # Claude Build Analysis - dynamically uploaded so Build result conditions evaluate at runtime after the wait
-  ########################################
-  - wait: ~
-    continue_on_failure: true
-
-  - label: ":claude: 🕵️ Build Analysis"
-    command: .buildkite/commands/upload-claude-analysis.sh
-    agents:
-      queue: upload
+    artifact_paths:
+      - "artifacts/*.aab"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -759,23 +759,10 @@ platform :android do
     version = version_name_current
     aab_file_path = build_bundle(app: app, version: version, flavor: 'Vanilla')
 
-    UI.error("Unable to find a build artifact at #{aab_file_path}") unless File.exist? aab_file_path
-
-    upload_to_play_store(
-      package_name: APP_PACKAGE_NAME,
-      aab: aab_file_path,
-      track: track(app: app, track_name: 'beta'),
-      release_status: 'completed',
-      rollout: '1.0', # Rollout to 100% of testers on the beta track
-      metadata_path: METADATA_DIR_PATH[app],
-      skip_upload_metadata: true,
-      skip_upload_changelogs: true,
-      skip_upload_images: true,
-      skip_upload_screenshots: true,
-      json_key: UPLOAD_TO_PLAY_STORE_JSON_KEY
-    )
-
-    create_gh_release(app: app, version: version, beta_release: true) if options[:create_release]
+    # THROW AWAY: assert the bundle and stop. The Play Store upload and GitHub release are deleted on this branch.
+    UI.user_error!("VALIDATION: expected AAB at #{aab_file_path}") unless File.exist?(aab_file_path)
+    UI.user_error!("VALIDATION: AAB at #{aab_file_path} is empty") if File.empty?(aab_file_path)
+    UI.success("VALIDATION: bundle built (#{File.size(aab_file_path)} bytes at #{aab_file_path}); stopping before Play Store upload")
   end
 
   # This lane triggers a stable release build on CI. If the lane is run locally, it will trigger a build on Buildkite CI.


### PR DESCRIPTION
## Validation only — do not merge

Stacked on #16464 ([AINFRA-2964](https://linear.app/a8c/issue/AINFRA-2964)).
Close this PR once the job has answered; never merge it.

## Why the ordinary pipeline misses this

#16464 removes `android_build_preflight` from `build_and_upload_release` and `build_and_upload_beta`.
Neither lane runs on a PR: `prototype-build.sh` calls `build_and_upload_prototype_build`, and the two edited lanes are only reached from `release-build.sh` → `build_and_upload_google_play`, which the release pipeline triggers.

## Which job to read

**Validate build_and_upload_beta (no Play Store upload)** is expected to **pass**.
Red means #16464 actually broke the lane — do not "fix" this PR.

Assertions:

- The lane prints `VALIDATION: bundle built` with a non-zero size — a signed Release AAB came out of `build_bundle`, so nothing in the lane depended on the `configure_apply` that `android_build_preflight` used to run before it.

The AAB is attached as a build artifact.

## What CI still cannot answer

Whether the Play Store would accept the bundle. `upload_to_play_store` and `create_gh_release` are deleted on this branch rather than exercised.
