### PR TITLE
[WOOMOB-3764] Treat an undecodable Blaze ad image as unsupported instead of crashing

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,7 +7,7 @@
 - [*] The app name on the launcher is no longer translated - Brazilian Portuguese showed "Eba!" instead of "Woo"[https://github.com/woocommerce/woocommerce-android/pull/16452]
 - [*] Order creation: the discount screen now formats the product line and totals like the rest of the app, and "Price after discount" shows the full price until a discount is entered [https://github.com/woocommerce/woocommerce-android/pull/16453]
 - [*] Woo POS: removed the banner warning that Point of Sale would require WooCommerce 10.5.0, as that requirement is not enforced [https://github.com/woocommerce/woocommerce-android/pull/16466]
-- [*] Blaze: picking an ad image the device cannot decode now shows the "unsupported image type" message instead of crashing the app
+- [*] Blaze: picking an ad image the device cannot decode now shows the "unsupported image type" message instead of crashing the app [https://github.com/woocommerce/woocommerce-android/pull/16468]
 
 25.5
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 - [*] The app name on the launcher is no longer translated - Brazilian Portuguese showed "Eba!" instead of "Woo"[https://github.com/woocommerce/woocommerce-android/pull/16452]
 - [*] Order creation: the discount screen now formats the product line and totals like the rest of the app, and "Price after discount" shows the full price until a discount is entered [https://github.com/woocommerce/woocommerce-android/pull/16453]
 - [*] Woo POS: removed the banner warning that Point of Sale would require WooCommerce 10.5.0, as that requirement is not enforced [https://github.com/woocommerce/woocommerce-android/pull/16466]
+- [*] Blaze: picking an ad image the device cannot decode now shows the "unsupported image type" message instead of crashing the app
 
 25.5
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/MediaFilesRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/MediaFilesRepository.kt
@@ -35,7 +35,6 @@ import org.wordpress.android.fluxc.store.MediaStore.OnMediaUploaded
 import org.wordpress.android.mediapicker.MediaPickerUtils
 import org.wordpress.android.util.MediaUtils
 import java.io.File
-import java.io.FileDescriptor
 import java.io.IOException
 import java.net.URL
 import javax.inject.Inject
@@ -74,14 +73,18 @@ class MediaFilesRepository @Inject constructor(
                     BitmapFactory.decodeStream(URL(uri).openConnection().getInputStream(), null, options)
                 } else {
                     val parcelFileDescriptor = context.contentResolver.openFileDescriptor(Uri.parse(uri), "r")
-                    val fileDescriptor: FileDescriptor = parcelFileDescriptor!!.fileDescriptor
-                    BitmapFactory.decodeFileDescriptor(fileDescriptor, null, options)
-                    parcelFileDescriptor.close()
+                    if (parcelFileDescriptor == null) {
+                        WooLog.w(T.MEDIA, "MediaFilesRepository > Couldn't open a descriptor for uri: $uri")
+                        return@withContext UNDECODABLE_IMAGE_DETAILS
+                    }
+                    parcelFileDescriptor.use {
+                        BitmapFactory.decodeFileDescriptor(it.fileDescriptor, null, options)
+                    }
                 }
                 return@withContext ImageDetails(options.outWidth, options.outHeight, options.outMimeType)
             } catch (e: IOException) {
                 WooLog.e(T.MEDIA, "MediaFilesRepository > Error getting image details from uri: $uri", e)
-                return@withContext ImageDetails(width = 0, height = 0, mimeType = "")
+                return@withContext UNDECODABLE_IMAGE_DETAILS
             }
         }
     }
@@ -231,6 +234,10 @@ class MediaFilesRepository @Inject constructor(
     data class ImageDetails(
         val width: Int,
         val height: Int,
-        val mimeType: String
+        val mimeType: String?
     )
+
+    companion object {
+        private val UNDECODABLE_IMAGE_DETAILS = ImageDetails(width = 0, height = 0, mimeType = null)
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/MediaFilesRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/MediaFilesRepository.kt
@@ -85,6 +85,9 @@ class MediaFilesRepository @Inject constructor(
             } catch (e: IOException) {
                 WooLog.e(T.MEDIA, "MediaFilesRepository > Error getting image details from uri: $uri", e)
                 return@withContext UNDECODABLE_IMAGE_DETAILS
+            } catch (e: SecurityException) {
+                WooLog.e(T.MEDIA, "MediaFilesRepository > No access to uri: $uri", e)
+                return@withContext UNDECODABLE_IMAGE_DETAILS
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/MediaFilesRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/MediaFilesRepository.kt
@@ -70,7 +70,9 @@ class MediaFilesRepository @Inject constructor(
             try {
                 val options = Options().apply { inJustDecodeBounds = true }
                 if (Patterns.WEB_URL.matcher(uri).matches()) {
-                    BitmapFactory.decodeStream(URL(uri).openConnection().getInputStream(), null, options)
+                    URL(uri).openConnection().getInputStream().use {
+                        BitmapFactory.decodeStream(it, null, options)
+                    }
                 } else {
                     val parcelFileDescriptor = context.contentResolver.openFileDescriptor(Uri.parse(uri), "r")
                     if (parcelFileDescriptor == null) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
@@ -193,14 +193,15 @@ class BlazeRepository @Inject constructor(
             productId = productId,
             tagLine = product.name,
             description = description.fastStripHtml(),
-            campaignImage = product.images.firstOrNull().let {
-                val imageDetails = it?.source?.let { uri -> getImageDetails(uri) }
-                if (imageDetails?.isValidAdImage() == true) {
-                    BlazeCampaignImage.RemoteImage(it.source, imageDetails.mimeType)
-                } else {
-                    BlazeCampaignImage.None
+            campaignImage = product.images.firstOrNull()?.let { image ->
+                when (val validationResult = getImageDetails(image.source).validateAdImage()) {
+                    is AdImageValidationResult.Valid ->
+                        BlazeCampaignImage.RemoteImage(image.source, validationResult.mimeType)
+
+                    AdImageValidationResult.InvalidSize,
+                    AdImageValidationResult.UnsupportedMimeType -> BlazeCampaignImage.None
                 }
-            },
+            } ?: BlazeCampaignImage.None,
             budget = getDefaultBudget(),
             targetingParameters = TargetingParameters(),
             destinationParameters = DestinationParameters(
@@ -399,15 +400,16 @@ class BlazeRepository @Inject constructor(
 
     suspend fun getImageDetails(uri: String) = mediaFilesRepository.getImageDetails(uri)
 
-    fun MediaFilesRepository.ImageDetails.isValidAdImage() = validateAdImage() == AdImageValidationResult.Valid
-
     fun MediaFilesRepository.ImageDetails.validateAdImage(): AdImageValidationResult {
-        val normalizedMimeType = mimeType.trim().lowercase(Locale.US)
+        val normalizedMimeType = mimeType?.trim()?.lowercase(Locale.US)
         return when {
-            normalizedMimeType !in SUPPORTED_BLAZE_IMAGE_MIME_TYPES -> AdImageValidationResult.UnsupportedMimeType
+            normalizedMimeType == null ||
+                normalizedMimeType !in SUPPORTED_BLAZE_IMAGE_MIME_TYPES -> AdImageValidationResult.UnsupportedMimeType
+
             width < BLAZE_IMAGE_MINIMUM_SIZE_IN_PIXELS ||
                 height < BLAZE_IMAGE_MINIMUM_SIZE_IN_PIXELS -> AdImageValidationResult.InvalidSize
-            else -> AdImageValidationResult.Valid
+
+            else -> AdImageValidationResult.Valid(normalizedMimeType)
         }
     }
 
@@ -421,10 +423,10 @@ class BlazeRepository @Inject constructor(
         appPrefsWrapper.blazeCampaignSelectedObjective = objectiveId
     }
 
-    enum class AdImageValidationResult {
-        Valid,
-        InvalidSize,
-        UnsupportedMimeType
+    sealed interface AdImageValidationResult {
+        data class Valid(val mimeType: String) : AdImageValidationResult
+        data object InvalidSize : AdImageValidationResult
+        data object UnsupportedMimeType : AdImageValidationResult
     }
 
     @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/ad/BlazeCampaignCreationEditAdViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/ad/BlazeCampaignCreationEditAdViewModel.kt
@@ -142,10 +142,10 @@ class BlazeCampaignCreationEditAdViewModel @Inject constructor(
 
     fun onWPMediaSelected(image: Product.Image) {
         launch {
-            handleSelectedImage(image.source) { imageDetails ->
+            handleSelectedImage(image.source) { mimeType ->
                 BlazeRepository.BlazeCampaignImage.RemoteImage(
                     uri = image.source,
-                    mimeType = imageDetails.mimeType
+                    mimeType = mimeType
                 )
             }
         }
@@ -153,13 +153,13 @@ class BlazeCampaignCreationEditAdViewModel @Inject constructor(
 
     private suspend fun handleSelectedImage(
         uri: String,
-        createCampaignImage: (MediaFilesRepository.ImageDetails) -> BlazeRepository.BlazeCampaignImage
+        createCampaignImage: (mimeType: String) -> BlazeRepository.BlazeCampaignImage
     ) {
         val imageDetails = blazeRepository.getImageDetails(uri)
-        when (imageDetails.validateAdImage()) {
-            Valid -> {
+        when (val validationResult = imageDetails.validateAdImage()) {
+            is Valid -> {
                 _viewState.update {
-                    it.copy(adImage = createCampaignImage(imageDetails))
+                    it.copy(adImage = createCampaignImage(validationResult.mimeType))
                 }
             }
             InvalidSize -> showInvalidImageSizeDialog()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/BlazeRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/BlazeRepositoryTest.kt
@@ -129,7 +129,7 @@ class BlazeRepositoryTest : BaseUnitTest() {
 
             whenever(appPrefsWrapper.blazeCampaignSelectedObjective).thenReturn(objective)
             whenever(productDetailRepository.getProduct(productId)).thenReturn(product)
-            whenever(mediaFilesRepository.getImageDetails(imageUrl)).thenReturn(ImageDetails(0, 0, ""))
+            whenever(mediaFilesRepository.getImageDetails(imageUrl)).thenReturn(ImageDetails(0, 0, null))
 
             val before = Date()
             val details = repository.generateDefaultCampaignDetails(productId)
@@ -203,7 +203,7 @@ class BlazeRepositoryTest : BaseUnitTest() {
 
             whenever(appPrefsWrapper.blazeCampaignSelectedObjective).thenReturn(objective)
             whenever(productDetailRepository.getProduct(productId)).thenReturn(product)
-            whenever(mediaFilesRepository.getImageDetails(imageUrl)).thenReturn(ImageDetails(0, 0, ""))
+            whenever(mediaFilesRepository.getImageDetails(imageUrl)).thenReturn(ImageDetails(0, 0, null))
 
             val details = repository.generateDefaultCampaignDetails(productId)
 
@@ -221,7 +221,7 @@ class BlazeRepositoryTest : BaseUnitTest() {
             val validationResult = with(repository) { imageDetails.validateAdImage() }
 
             // THEN
-            assertThat(validationResult).isEqualTo(Valid)
+            assertThat(validationResult).isEqualTo(Valid(mimeType))
         }
     }
 
@@ -234,7 +234,7 @@ class BlazeRepositoryTest : BaseUnitTest() {
         val validationResult = with(repository) { imageDetails.validateAdImage() }
 
         // THEN
-        assertThat(validationResult).isEqualTo(Valid)
+        assertThat(validationResult).isEqualTo(Valid("image/jpeg"))
     }
 
     @Test
@@ -259,6 +259,18 @@ class BlazeRepositoryTest : BaseUnitTest() {
             height = VALID_IMAGE_SIZE,
             mimeType = "image/avif"
         )
+
+        // WHEN
+        val validationResult = with(repository) { imageDetails.validateAdImage() }
+
+        // THEN
+        assertThat(validationResult).isEqualTo(UnsupportedMimeType)
+    }
+
+    @Test
+    fun `given image details without a mime type, when validating ad image, then result is unsupported mime type`() {
+        // GIVEN
+        val imageDetails = ImageDetails(width = VALID_IMAGE_SIZE, height = VALID_IMAGE_SIZE, mimeType = null)
 
         // WHEN
         val validationResult = with(repository) { imageDetails.validateAdImage() }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/BlazeRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/BlazeRepositoryTest.kt
@@ -212,6 +212,32 @@ class BlazeRepositoryTest : BaseUnitTest() {
         }
 
     @Test
+    fun `given a product with valid image, when generateDefaultCampaignDetails invoked, then CampaignDetails with normalized mime type created`() =
+        testBlocking {
+            // GIVEN
+            val productId = 789L
+            val objective = "sales"
+            val imageUrl = "https://example.com/image-400.jpg"
+            val product = ProductTestUtils.generateProduct(
+                productId = productId,
+                productName = "Valid Image Product",
+                imageUrl = imageUrl
+            )
+
+            whenever(appPrefsWrapper.blazeCampaignSelectedObjective).thenReturn(objective)
+            whenever(productDetailRepository.getProduct(productId)).thenReturn(product)
+            whenever(mediaFilesRepository.getImageDetails(imageUrl))
+                .thenReturn(ImageDetails(VALID_IMAGE_SIZE, VALID_IMAGE_SIZE, "IMAGE/JPEG"))
+
+            // WHEN
+            val details = repository.generateDefaultCampaignDetails(productId)
+
+            // THEN
+            assertThat(details.campaignImage)
+                .isEqualTo(BlazeRepository.BlazeCampaignImage.RemoteImage(imageUrl, "image/jpeg"))
+        }
+
+    @Test
     fun `given supported image mime types, when validating ad image, then result is valid`() {
         SUPPORTED_IMAGE_MIME_TYPES.forEach { mimeType ->
             // GIVEN


### PR DESCRIPTION
### Description

Fixes WOOMOB-3764

`BitmapFactory` leaves `Options.outMimeType` null whenever it cannot decode an image, but it is a Java field, so Kotlin sees `String!` and `ImageDetails.mimeType` was declared non-null. Any corrupt, truncated or device-unsupported image killed the app in the middle of Blaze campaign creation. The mime type is nullable now, and an image without one falls into the existing "unsupported image type" path.

- `AdImageValidationResult.Valid` carries the mime type it just validated, so the two places that build a `RemoteImage` do not need `orEmpty()` or `!!` on a value they already know is good.
- Behaviour change: `RemoteImage` now gets the normalized mime type from `Valid`, so the API is sent the trimmed lowercased value instead of the raw `outMimeType`.
- Not fixed here: the local image path in `prepareCampaignImage` still sends an empty string when the uploaded media has no mime type. Pre-existing.
- My test store is connected with an application password, so Blaze is not eligible on it and the entry point never shows. To walk the flow on a device I stubbed `IsBlazeEnabled` to `true` locally. That stub is not in the diff, so you need a Blaze eligible store for the steps below.

### Test Steps

The image you need is [broken.jpg](https://github.com/user-attachments/assets/aa28a86b-4250-4ee6-8c72-4ac7dd5eaa01), attached to this PR. It is 20 bytes, a JPEG SOI plus a JFIF header and nothing after it. There is no SOF marker, so bounds decoding fails and `outMimeType` comes back null. MediaStore still lists it as `image/jpeg` from the extension.

1. Get it onto the device:

```bash
curl -L -o broken.jpg https://github.com/user-attachments/assets/aa28a86b-4250-4ee6-8c72-4ac7dd5eaa01
adb push broken.jpg /sdcard/Pictures/broken.jpg
adb shell am broadcast -a android.intent.action.MEDIA_SCANNER_SCAN_FILE -d file:///sdcard/Pictures/broken.jpg
```

2. Open any product, tap Promote with Blaze, then Start your campaign, wait for the preview and tap Edit ad.
3. Tap Change image, then Choose from device, and pick `broken.jpg`. It is the newest item in the picker and it has a blank grey thumbnail.
4. The "Invalid image" dialog is shown and the ad image stays as it was. On trunk the app dies here with `NullPointerException: outMimeType must not be null` at `MediaFilesRepository.kt:81`.
5. Pick a normal jpg or png instead. It is accepted, the preview shows it, and campaign creation still works.

### Images/gif

Step 4 with the fix, on a Pixel 9 emulator:

<img src="https://pressable-kidinov.mystagingwebsite.com/wp-content/uploads/2026/08/blaze-broken-image-dialog.png" width="300" />

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

