### PR TITLE
[WOOMOB-3902] Restore the POS refund selection by unit count, not by row id

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 - [*] The app name on the launcher is no longer translated - Brazilian Portuguese showed "Eba!" instead of "Woo"[https://github.com/woocommerce/woocommerce-android/pull/16452]
 - [*] Order creation: the discount screen now formats the product line and totals like the rest of the app, and "Price after discount" shows the full price until a discount is entered [https://github.com/woocommerce/woocommerce-android/pull/16453]
 - [*] Woo POS: removed the banner warning that Point of Sale would require WooCommerce 10.5.0, as that requirement is not enforced [https://github.com/woocommerce/woocommerce-android/pull/16466]
+- [*] Woo POS: reloading the remaining items after the store rejects a refund now keeps the number of units you had selected, instead of clearing the selection when the line got shorter
 
 25.5
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,7 +7,7 @@
 - [*] The app name on the launcher is no longer translated - Brazilian Portuguese showed "Eba!" instead of "Woo"[https://github.com/woocommerce/woocommerce-android/pull/16452]
 - [*] Order creation: the discount screen now formats the product line and totals like the rest of the app, and "Price after discount" shows the full price until a discount is entered [https://github.com/woocommerce/woocommerce-android/pull/16453]
 - [*] Woo POS: removed the banner warning that Point of Sale would require WooCommerce 10.5.0, as that requirement is not enforced [https://github.com/woocommerce/woocommerce-android/pull/16466]
-- [*] Woo POS: reloading the remaining items after the store rejects a refund now keeps the number of units you had selected, instead of clearing the selection when the line got shorter
+- [*] Woo POS: reloading the remaining items after the store rejects a refund now keeps the number of units you had selected, instead of clearing the selection when the line got shorter [https://github.com/woocommerce/woocommerce-android/pull/16472]
 
 25.5
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosBuildRefundContent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosBuildRefundContent.kt
@@ -16,6 +16,7 @@ class WooPosBuildRefundContent @Inject constructor(
         preservedSelection: WooPosRefundSelectionSnapshot? = null,
     ): WooPosRefundState.Content {
         val allItemIds = refundableItems.map { it.uniqueId }.toSet()
+        // An empty restore stays empty; only the absence of a snapshot selects everything.
         val selectedItemIds = preservedSelection
             ?.let { restoreSelection(refundableItems, it) }
             ?: allItemIds
@@ -41,19 +42,16 @@ class WooPosBuildRefundContent @Inject constructor(
     }
 
     /**
-     * Re-applies [snapshot] to the reloaded rows: the first *n* units of each line item, capped at
-     * what is left of it, plus the lump sums that were selected. Units of the same line item are
-     * interchangeable — only how many are selected reaches the server.
-     *
-     * A selection that no longer matches anything leaves the selection empty rather than falling
-     * back to every remaining item: the cashier picks again instead of confirming items they never
-     * chose.
+     * Re-applies [snapshot] to the reloaded rows: the first *n* rows of each line item in list
+     * order, capped at what is left of it, plus the lump sums that were selected. List order is
+     * [WooPosRefundableItem.rowIndex] order because [WooPosGetRefundableItems] emits the units of a
+     * line as `(0 until maxQuantity)`.
      */
     private fun restoreSelection(
         refundableItems: List<WooPosRefundableItem>,
         snapshot: WooPosRefundSelectionSnapshot,
     ): Set<String> {
-        val remainingUnits = snapshot.unitCountsByItemId.toMutableMap()
+        val remainingUnits = snapshot.unitCountsByOrderItemId.toMutableMap()
 
         return refundableItems.mapNotNullTo(mutableSetOf()) { item ->
             if (item.isLumpSum) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosBuildRefundContent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosBuildRefundContent.kt
@@ -13,14 +13,11 @@ class WooPosBuildRefundContent @Inject constructor(
         order: Order,
         refundableItems: List<WooPosRefundableItem>,
         paymentMethod: String,
-        preservedSelection: Set<String>? = null,
+        preservedSelection: WooPosRefundSelectionSnapshot? = null,
     ): WooPosRefundState.Content {
         val allItemIds = refundableItems.map { it.uniqueId }.toSet()
-        // A preserved selection that no longer matches anything leaves the selection empty rather
-        // than falling back to every remaining item: the cashier picks again instead of confirming
-        // items they never chose.
         val selectedItemIds = preservedSelection
-            ?.filterTo(mutableSetOf()) { it in allItemIds }
+            ?.let { restoreSelection(refundableItems, it) }
             ?: allItemIds
         val zero = PriceUtils.formatCurrency(BigDecimal.ZERO, order.currency, currencyFormatter)
 
@@ -41,5 +38,35 @@ class WooPosBuildRefundContent @Inject constructor(
             paymentMethod = paymentMethod,
             step = WooPosRefundState.Content.RefundStep.SelectItems
         )
+    }
+
+    /**
+     * Re-applies [snapshot] to the reloaded rows: the first *n* units of each line item, capped at
+     * what is left of it, plus the lump sums that were selected. Units of the same line item are
+     * interchangeable — only how many are selected reaches the server.
+     *
+     * A selection that no longer matches anything leaves the selection empty rather than falling
+     * back to every remaining item: the cashier picks again instead of confirming items they never
+     * chose.
+     */
+    private fun restoreSelection(
+        refundableItems: List<WooPosRefundableItem>,
+        snapshot: WooPosRefundSelectionSnapshot,
+    ): Set<String> {
+        val remainingUnits = snapshot.unitCountsByItemId.toMutableMap()
+
+        return refundableItems.mapNotNullTo(mutableSetOf()) { item ->
+            if (item.isLumpSum) {
+                item.uniqueId.takeIf { item.orderItemId in snapshot.selectedLumpSumIds }
+            } else {
+                val left = remainingUnits[item.orderItemId] ?: 0
+                if (left > 0) {
+                    remainingUnits[item.orderItemId] = left - 1
+                    item.uniqueId
+                } else {
+                    null
+                }
+            }
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSelectionSnapshot.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSelectionSnapshot.kt
@@ -9,10 +9,11 @@ package com.woocommerce.android.ui.woopos.orders.details.refund
  * submitted as a quantity per line item anyway (see [WooPosBuildRefundLineItems]), so the selection
  * is preserved as counts instead.
  *
- * Line items and lump sums are kept apart so a fee line id cannot be read as a line item id.
+ * Line items and lump sums are held separately because they restore by different rules: a count
+ * for units, whole-line presence for a lump sum.
  */
 data class WooPosRefundSelectionSnapshot(
-    val unitCountsByItemId: Map<Long, Int>,
+    val unitCountsByOrderItemId: Map<Long, Int>,
     val selectedLumpSumIds: Set<Long>,
 ) {
     companion object {
@@ -25,7 +26,7 @@ data class WooPosRefundSelectionSnapshot(
                 .partition { it.isLumpSum }
 
             return WooPosRefundSelectionSnapshot(
-                unitCountsByItemId = units.groupingBy { it.orderItemId }.eachCount(),
+                unitCountsByOrderItemId = units.groupingBy { it.orderItemId }.eachCount(),
                 selectedLumpSumIds = lumpSums.mapTo(mutableSetOf()) { it.orderItemId },
             )
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSelectionSnapshot.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSelectionSnapshot.kt
@@ -1,0 +1,33 @@
+package com.woocommerce.android.ui.woopos.orders.details.refund
+
+/**
+ * The cashier's item selection in a form that survives a reload of the refundable items.
+ *
+ * Unit rows have no stable identity: [WooPosRefundableItem.rowIndex] is the unit's position within
+ * what is still refundable, so it is renumbered whenever the line gets shorter. A reload only
+ * happens because the order changed, which is exactly when those positions move. Refunds are
+ * submitted as a quantity per line item anyway (see [WooPosBuildRefundLineItems]), so the selection
+ * is preserved as counts instead.
+ *
+ * Line items and lump sums are kept apart so a fee line id cannot be read as a line item id.
+ */
+data class WooPosRefundSelectionSnapshot(
+    val unitCountsByItemId: Map<Long, Int>,
+    val selectedLumpSumIds: Set<Long>,
+) {
+    companion object {
+        fun of(
+            refundableItems: List<WooPosRefundableItem>,
+            selectedItemIds: Set<String>,
+        ): WooPosRefundSelectionSnapshot {
+            val (lumpSums, units) = refundableItems
+                .filter { it.uniqueId in selectedItemIds }
+                .partition { it.isLumpSum }
+
+            return WooPosRefundSelectionSnapshot(
+                unitCountsByItemId = units.groupingBy { it.orderItemId }.eachCount(),
+                selectedLumpSumIds = lumpSums.mapTo(mutableSetOf()) { it.orderItemId },
+            )
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundViewModel.kt
@@ -128,14 +128,16 @@ class WooPosRefundViewModel @AssistedInject constructor(
     }
 
     private fun refreshRefundableItems() {
-        val stateToPreserve = (_state.value as? WooPosRefundState.Content) ?: contentStateBeforeRefund
-        val preservedSelection = stateToPreserve?.let {
-            WooPosRefundSelectionSnapshot.of(it.refundableItems, it.selectedItemIds)
-        }
+        val preservedSelection = ((_state.value as? WooPosRefundState.Content) ?: contentStateBeforeRefund)
+            ?.selectionSnapshot()
         cancelPreview()
         cancelRefundSubmission()
         loadContent(preservedSelection = preservedSelection, isFlowStart = false)
     }
+
+    /** Pairs the rows with the selection made against them, so the two cannot be mismatched. */
+    private fun WooPosRefundState.Content.selectionSnapshot() =
+        WooPosRefundSelectionSnapshot.of(refundableItems, selectedItemIds)
 
     private fun loadContent(preservedSelection: WooPosRefundSelectionSnapshot?, isFlowStart: Boolean) {
         loadingJob?.cancel()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundViewModel.kt
@@ -128,14 +128,16 @@ class WooPosRefundViewModel @AssistedInject constructor(
     }
 
     private fun refreshRefundableItems() {
-        val preservedSelection = (_state.value as? WooPosRefundState.Content)?.selectedItemIds
-            ?: contentStateBeforeRefund?.selectedItemIds
+        val stateToPreserve = (_state.value as? WooPosRefundState.Content) ?: contentStateBeforeRefund
+        val preservedSelection = stateToPreserve?.let {
+            WooPosRefundSelectionSnapshot.of(it.refundableItems, it.selectedItemIds)
+        }
         cancelPreview()
         cancelRefundSubmission()
         loadContent(preservedSelection = preservedSelection, isFlowStart = false)
     }
 
-    private fun loadContent(preservedSelection: Set<String>?, isFlowStart: Boolean) {
+    private fun loadContent(preservedSelection: WooPosRefundSelectionSnapshot?, isFlowStart: Boolean) {
         loadingJob?.cancel()
         loadingJob = viewModelScope.launch {
             _state.value = WooPosRefundState.Loading
@@ -189,7 +191,7 @@ class WooPosRefundViewModel @AssistedInject constructor(
         order: Order,
         refundableItems: List<WooPosRefundableItem>,
         paymentMethod: String,
-        preservedSelection: Set<String>? = null,
+        preservedSelection: WooPosRefundSelectionSnapshot? = null,
         isFlowStart: Boolean = true,
     ) {
         _state.value = buildRefundContent(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosBuildRefundContentTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosBuildRefundContentTest.kt
@@ -40,7 +40,7 @@ class WooPosBuildRefundContentTest {
         // GIVEN — the cashier kept only the last unit of a three-unit line, and the store refunded
         // one unit elsewhere, so the reload renumbers the two survivors from zero.
         val snapshot = WooPosRefundSelectionSnapshot(
-            unitCountsByItemId = mapOf(1L to 1),
+            unitCountsByOrderItemId = mapOf(1L to 1),
             selectedLumpSumIds = emptySet(),
         )
         val items = listOf(
@@ -61,7 +61,7 @@ class WooPosBuildRefundContentTest {
     fun `given more units were selected than are left, when content is built, then the count is clamped`() {
         // GIVEN
         val snapshot = WooPosRefundSelectionSnapshot(
-            unitCountsByItemId = mapOf(1L to 3),
+            unitCountsByOrderItemId = mapOf(1L to 3),
             selectedLumpSumIds = emptySet(),
         )
         val items = listOf(
@@ -82,7 +82,7 @@ class WooPosBuildRefundContentTest {
     fun `given a selection across two lines and one shrank, when content is built, then the other line is intact`() {
         // GIVEN — two of line 1 and one of line 2 were selected; line 1 lost a unit elsewhere
         val snapshot = WooPosRefundSelectionSnapshot(
-            unitCountsByItemId = mapOf(1L to 2, 2L to 1),
+            unitCountsByOrderItemId = mapOf(1L to 2, 2L to 1),
             selectedLumpSumIds = emptySet(),
         )
         val items = listOf(
@@ -103,7 +103,7 @@ class WooPosBuildRefundContentTest {
     fun `given a selected lump sum, when content is built, then only that fee row is selected`() {
         // GIVEN
         val snapshot = WooPosRefundSelectionSnapshot(
-            unitCountsByItemId = emptyMap(),
+            unitCountsByOrderItemId = emptyMap(),
             selectedLumpSumIds = setOf(99L),
         )
         val items = listOf(
@@ -124,7 +124,7 @@ class WooPosBuildRefundContentTest {
     fun `given a fee id equal to a line item id, when content is built, then only the fee row is selected`() {
         // GIVEN — the two id spaces are kept apart, so a selected fee never selects a line item
         val snapshot = WooPosRefundSelectionSnapshot(
-            unitCountsByItemId = emptyMap(),
+            unitCountsByOrderItemId = emptyMap(),
             selectedLumpSumIds = setOf(42L),
         )
         val items = listOf(
@@ -143,7 +143,7 @@ class WooPosBuildRefundContentTest {
     fun `given a line item id equal to a fee id, when content is built, then only the line item is selected`() {
         // GIVEN
         val snapshot = WooPosRefundSelectionSnapshot(
-            unitCountsByItemId = mapOf(42L to 1),
+            unitCountsByOrderItemId = mapOf(42L to 1),
             selectedLumpSumIds = emptySet(),
         )
         val items = listOf(
@@ -159,11 +159,37 @@ class WooPosBuildRefundContentTest {
     }
 
     @Test
+    fun `given a snapshot with unit counts and lump sums, when content is built, then both are restored`() {
+        // GIVEN — every other case has one half of the snapshot empty, so the two restore rules
+        // never run in the same call. A real reload always carries both.
+        val snapshot = WooPosRefundSelectionSnapshot(
+            unitCountsByOrderItemId = mapOf(1L to 1, 2L to 2),
+            selectedLumpSumIds = setOf(98L, 99L),
+        )
+        val items = listOf(
+            productRow(orderItemId = 1L, rowIndex = 0),
+            productRow(orderItemId = 1L, rowIndex = 1),
+            productRow(orderItemId = 2L, rowIndex = 0),
+            productRow(orderItemId = 3L, rowIndex = 0),
+            feeRow(orderItemId = 98L),
+        )
+
+        // WHEN — line 1 shrank to two rows, line 2 to one, line 3 was never selected, and fee 99
+        // was refunded elsewhere so its row is gone
+        val content = build(items, preservedSelection = snapshot)
+
+        // THEN
+        assertThat(content.selectedItemIds).containsExactlyInAnyOrder("1_0", "2_0", "fee_98")
+        assertThat(content.itemsCount).isEqualTo(3)
+        assertThat(content.allItemsSelected).isFalse()
+    }
+
+    @Test
     fun `given nothing of the selection is left, when content is built, then the selection is empty`() {
         // GIVEN — the selected line was fully refunded elsewhere. The cashier picks again rather
         // than being handed items they never chose.
         val snapshot = WooPosRefundSelectionSnapshot(
-            unitCountsByItemId = mapOf(1L to 2),
+            unitCountsByOrderItemId = mapOf(1L to 2),
             selectedLumpSumIds = emptySet(),
         )
         val items = listOf(productRow(orderItemId = 2L, rowIndex = 0))
@@ -175,24 +201,6 @@ class WooPosBuildRefundContentTest {
         assertThat(content.selectedItemIds).isEmpty()
         assertThat(content.itemsCount).isEqualTo(0)
         assertThat(content.allItemsSelected).isFalse()
-    }
-
-    @Test
-    fun `given a snapshot of a state, when it is taken, then it holds unit counts and lump sum ids`() {
-        // GIVEN
-        val items = listOf(
-            productRow(orderItemId = 1L, rowIndex = 0),
-            productRow(orderItemId = 1L, rowIndex = 1),
-            productRow(orderItemId = 2L, rowIndex = 0),
-            feeRow(orderItemId = 99L),
-        )
-
-        // WHEN — the cashier kept the second unit of line 1 and the fee
-        val snapshot = WooPosRefundSelectionSnapshot.of(items, setOf("1_1", "fee_99"))
-
-        // THEN
-        assertThat(snapshot.unitCountsByItemId).isEqualTo(mapOf(1L to 1))
-        assertThat(snapshot.selectedLumpSumIds).containsExactly(99L)
     }
 
     private fun build(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosBuildRefundContentTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosBuildRefundContentTest.kt
@@ -1,0 +1,233 @@
+package com.woocommerce.android.ui.woopos.orders.details.refund
+
+import com.woocommerce.android.ui.orders.OrderTestUtils
+import com.woocommerce.android.util.CurrencyFormatter
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.math.BigDecimal
+
+class WooPosBuildRefundContentTest {
+
+    private val currencyFormatter: CurrencyFormatter = mock {
+        whenever(it.formatCurrency(any<BigDecimal>(), any<String>(), any<Boolean>())).thenReturn("$0.00")
+    }
+
+    private val sut = WooPosBuildRefundContent(currencyFormatter)
+
+    @Test
+    fun `given no preserved selection, when content is built, then every row is selected`() {
+        // GIVEN
+        val items = listOf(
+            productRow(orderItemId = 1L, rowIndex = 0),
+            productRow(orderItemId = 1L, rowIndex = 1),
+            feeRow(orderItemId = 99L),
+        )
+
+        // WHEN
+        val content = build(items, preservedSelection = null)
+
+        // THEN
+        assertThat(content.selectedItemIds).isEqualTo(items.map { it.uniqueId }.toSet())
+        assertThat(content.allItemsSelected).isTrue()
+        assertThat(content.itemsCount).isEqualTo(3)
+    }
+
+    @Test
+    fun `given one unit of a shrunken line was selected, when content is built, then one unit is selected`() {
+        // GIVEN — the cashier kept only the last unit of a three-unit line, and the store refunded
+        // one unit elsewhere, so the reload renumbers the two survivors from zero.
+        val snapshot = WooPosRefundSelectionSnapshot(
+            unitCountsByItemId = mapOf(1L to 1),
+            selectedLumpSumIds = emptySet(),
+        )
+        val items = listOf(
+            productRow(orderItemId = 1L, rowIndex = 0),
+            productRow(orderItemId = 1L, rowIndex = 1),
+        )
+
+        // WHEN
+        val content = build(items, preservedSelection = snapshot)
+
+        // THEN
+        assertThat(content.selectedItemIds).containsExactly("1_0")
+        assertThat(content.itemsCount).isEqualTo(1)
+        assertThat(content.allItemsSelected).isFalse()
+    }
+
+    @Test
+    fun `given more units were selected than are left, when content is built, then the count is clamped`() {
+        // GIVEN
+        val snapshot = WooPosRefundSelectionSnapshot(
+            unitCountsByItemId = mapOf(1L to 3),
+            selectedLumpSumIds = emptySet(),
+        )
+        val items = listOf(
+            productRow(orderItemId = 1L, rowIndex = 0),
+            productRow(orderItemId = 1L, rowIndex = 1),
+        )
+
+        // WHEN
+        val content = build(items, preservedSelection = snapshot)
+
+        // THEN
+        assertThat(content.selectedItemIds).containsExactlyInAnyOrder("1_0", "1_1")
+        assertThat(content.itemsCount).isEqualTo(2)
+        assertThat(content.allItemsSelected).isTrue()
+    }
+
+    @Test
+    fun `given a selection across two lines and one shrank, when content is built, then the other line is intact`() {
+        // GIVEN — two of line 1 and one of line 2 were selected; line 1 lost a unit elsewhere
+        val snapshot = WooPosRefundSelectionSnapshot(
+            unitCountsByItemId = mapOf(1L to 2, 2L to 1),
+            selectedLumpSumIds = emptySet(),
+        )
+        val items = listOf(
+            productRow(orderItemId = 1L, rowIndex = 0),
+            productRow(orderItemId = 2L, rowIndex = 0),
+            productRow(orderItemId = 2L, rowIndex = 1),
+        )
+
+        // WHEN
+        val content = build(items, preservedSelection = snapshot)
+
+        // THEN
+        assertThat(content.selectedItemIds).containsExactlyInAnyOrder("1_0", "2_0")
+        assertThat(content.itemsCount).isEqualTo(2)
+    }
+
+    @Test
+    fun `given a selected lump sum, when content is built, then only that fee row is selected`() {
+        // GIVEN
+        val snapshot = WooPosRefundSelectionSnapshot(
+            unitCountsByItemId = emptyMap(),
+            selectedLumpSumIds = setOf(99L),
+        )
+        val items = listOf(
+            productRow(orderItemId = 1L, rowIndex = 0),
+            feeRow(orderItemId = 98L),
+            feeRow(orderItemId = 99L),
+        )
+
+        // WHEN
+        val content = build(items, preservedSelection = snapshot)
+
+        // THEN
+        assertThat(content.selectedItemIds).containsExactly("fee_99")
+        assertThat(content.itemsCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `given a fee id equal to a line item id, when content is built, then only the fee row is selected`() {
+        // GIVEN — the two id spaces are kept apart, so a selected fee never selects a line item
+        val snapshot = WooPosRefundSelectionSnapshot(
+            unitCountsByItemId = emptyMap(),
+            selectedLumpSumIds = setOf(42L),
+        )
+        val items = listOf(
+            productRow(orderItemId = 42L, rowIndex = 0),
+            feeRow(orderItemId = 42L),
+        )
+
+        // WHEN
+        val content = build(items, preservedSelection = snapshot)
+
+        // THEN
+        assertThat(content.selectedItemIds).containsExactly("fee_42")
+    }
+
+    @Test
+    fun `given a line item id equal to a fee id, when content is built, then only the line item is selected`() {
+        // GIVEN
+        val snapshot = WooPosRefundSelectionSnapshot(
+            unitCountsByItemId = mapOf(42L to 1),
+            selectedLumpSumIds = emptySet(),
+        )
+        val items = listOf(
+            productRow(orderItemId = 42L, rowIndex = 0),
+            feeRow(orderItemId = 42L),
+        )
+
+        // WHEN
+        val content = build(items, preservedSelection = snapshot)
+
+        // THEN
+        assertThat(content.selectedItemIds).containsExactly("42_0")
+    }
+
+    @Test
+    fun `given nothing of the selection is left, when content is built, then the selection is empty`() {
+        // GIVEN — the selected line was fully refunded elsewhere. The cashier picks again rather
+        // than being handed items they never chose.
+        val snapshot = WooPosRefundSelectionSnapshot(
+            unitCountsByItemId = mapOf(1L to 2),
+            selectedLumpSumIds = emptySet(),
+        )
+        val items = listOf(productRow(orderItemId = 2L, rowIndex = 0))
+
+        // WHEN
+        val content = build(items, preservedSelection = snapshot)
+
+        // THEN
+        assertThat(content.selectedItemIds).isEmpty()
+        assertThat(content.itemsCount).isEqualTo(0)
+        assertThat(content.allItemsSelected).isFalse()
+    }
+
+    @Test
+    fun `given a snapshot of a state, when it is taken, then it holds unit counts and lump sum ids`() {
+        // GIVEN
+        val items = listOf(
+            productRow(orderItemId = 1L, rowIndex = 0),
+            productRow(orderItemId = 1L, rowIndex = 1),
+            productRow(orderItemId = 2L, rowIndex = 0),
+            feeRow(orderItemId = 99L),
+        )
+
+        // WHEN — the cashier kept the second unit of line 1 and the fee
+        val snapshot = WooPosRefundSelectionSnapshot.of(items, setOf("1_1", "fee_99"))
+
+        // THEN
+        assertThat(snapshot.unitCountsByItemId).isEqualTo(mapOf(1L to 1))
+        assertThat(snapshot.selectedLumpSumIds).containsExactly(99L)
+    }
+
+    private fun build(
+        items: List<WooPosRefundableItem>,
+        preservedSelection: WooPosRefundSelectionSnapshot?,
+    ) = sut(
+        order = OrderTestUtils.generateTestOrder(),
+        refundableItems = items,
+        paymentMethod = "Card",
+        preservedSelection = preservedSelection,
+    )
+
+    private fun productRow(orderItemId: Long, rowIndex: Int) = WooPosRefundableItem(
+        orderItemId = orderItemId,
+        productId = 10L,
+        variationId = 0L,
+        name = "Product",
+        unitPrice = BigDecimal("20.00"),
+        unitTax = BigDecimal("2.00"),
+        formattedUnitPrice = "$20.00",
+        formattedUnitTax = "$2.00",
+        rowIndex = rowIndex,
+        isLumpSum = false,
+    )
+
+    private fun feeRow(orderItemId: Long) = WooPosRefundableItem(
+        orderItemId = orderItemId,
+        productId = 0L,
+        variationId = 0L,
+        name = "Fee",
+        unitPrice = BigDecimal("10.00"),
+        unitTax = BigDecimal("1.50"),
+        formattedUnitPrice = "$10.00",
+        formattedUnitTax = "$1.50",
+        rowIndex = 0,
+        isLumpSum = true,
+    )
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSelectionSnapshotTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSelectionSnapshotTest.kt
@@ -1,0 +1,93 @@
+package com.woocommerce.android.ui.woopos.orders.details.refund
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import java.math.BigDecimal
+
+class WooPosRefundSelectionSnapshotTest {
+
+    @Test
+    fun `given a selection over units and a fee, when a snapshot is taken, then counts and ids match`() {
+        // GIVEN
+        val items = listOf(
+            productRow(orderItemId = 1L, rowIndex = 0),
+            productRow(orderItemId = 1L, rowIndex = 1),
+            productRow(orderItemId = 2L, rowIndex = 0),
+            feeRow(orderItemId = 98L),
+            feeRow(orderItemId = 99L),
+        )
+
+        // WHEN — the cashier kept the second unit of line 1, all of line 2, and one of the two fees
+        val snapshot = WooPosRefundSelectionSnapshot.of(items, selectedIds(items, 1 to 1, 2 to 0, 99 to null))
+
+        // THEN
+        assertThat(snapshot.unitCountsByOrderItemId).isEqualTo(mapOf(1L to 1, 2L to 1))
+        assertThat(snapshot.selectedLumpSumIds).containsExactly(99L)
+    }
+
+    @Test
+    fun `given an empty selection, when a snapshot is taken, then it holds nothing`() {
+        // GIVEN
+        val items = listOf(productRow(orderItemId = 1L, rowIndex = 0), feeRow(orderItemId = 99L))
+
+        // WHEN
+        val snapshot = WooPosRefundSelectionSnapshot.of(items, emptySet())
+
+        // THEN
+        assertThat(snapshot.unitCountsByOrderItemId).isEmpty()
+        assertThat(snapshot.selectedLumpSumIds).isEmpty()
+    }
+
+    @Test
+    fun `given a selected id that is not among the rows, when a snapshot is taken, then it is ignored`() {
+        // GIVEN — the selection and the rows come from different loads
+        val items = listOf(productRow(orderItemId = 1L, rowIndex = 0))
+
+        // WHEN
+        val snapshot = WooPosRefundSelectionSnapshot.of(items, setOf("7_0", "fee_99"))
+
+        // THEN
+        assertThat(snapshot.unitCountsByOrderItemId).isEmpty()
+        assertThat(snapshot.selectedLumpSumIds).isEmpty()
+    }
+
+    /**
+     * Builds the id set from the rows themselves, so these tests do not restate the id format.
+     * Each pair is an `orderItemId` plus the `rowIndex` to select, or null for a lump sum.
+     */
+    private fun selectedIds(
+        items: List<WooPosRefundableItem>,
+        vararg picks: Pair<Int, Int?>,
+    ): Set<String> = picks.mapTo(mutableSetOf()) { (orderItemId, rowIndex) ->
+        items.first {
+            it.orderItemId == orderItemId.toLong() && it.isLumpSum == (rowIndex == null) &&
+                (rowIndex == null || it.rowIndex == rowIndex)
+        }.uniqueId
+    }
+
+    private fun productRow(orderItemId: Long, rowIndex: Int) = WooPosRefundableItem(
+        orderItemId = orderItemId,
+        productId = 10L,
+        variationId = 0L,
+        name = "Product",
+        unitPrice = BigDecimal("20.00"),
+        unitTax = BigDecimal("2.00"),
+        formattedUnitPrice = "$20.00",
+        formattedUnitTax = "$2.00",
+        rowIndex = rowIndex,
+        isLumpSum = false,
+    )
+
+    private fun feeRow(orderItemId: Long) = WooPosRefundableItem(
+        orderItemId = orderItemId,
+        productId = 0L,
+        variationId = 0L,
+        name = "Fee",
+        unitPrice = BigDecimal("10.00"),
+        unitTax = BigDecimal("1.50"),
+        formattedUnitPrice = "$10.00",
+        formattedUnitTax = "$1.50",
+        rowIndex = 0,
+        isLumpSum = true,
+    )
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundViewModelTest.kt
@@ -2739,6 +2739,111 @@ class WooPosRefundViewModelTest {
         }
 
     @Test
+    fun `given only the last unit of a line was selected, when items are refreshed, then one unit stays selected`() =
+        runTest {
+            // GIVEN — three units of one line, and the cashier keeps only the last one
+            val units = List(3) { testRefundableItem.copy(rowIndex = it) }
+            val remainingUnits = units.take(2)
+
+            whenever(ordersDataSource.refreshOrderById(testOrderId)).thenReturn(Result.success(testOrder))
+            whenever(retrieveOrderRefunds.invoke(eq(testOrder), any())).thenReturn(Result.success(emptyList()))
+            // The store refunded one of the three units, so the reload renumbers the survivors
+            // from zero and none of the preserved row ids matches.
+            whenever(getRefundableItems.invoke(any(), any())).thenReturn(units, remainingUnits)
+            whenever(refundPreview.invoke(any(), any())).thenReturn(
+                WooPosRefundPreview.Result.Error(WooPosRefundApiError.QuantityExceedsRefundable)
+            )
+
+            viewModel = createViewModel()
+            viewModel.onUIEvent(WooPosRefundUIEvent.RefundFlowOpened)
+            advanceUntilIdle()
+            viewModel.onUIEvent(WooPosRefundUIEvent.ItemSelectionToggled(units[0].uniqueId))
+            viewModel.onUIEvent(WooPosRefundUIEvent.ItemSelectionToggled(units[1].uniqueId))
+            advanceUntilIdle()
+            viewModel.onUIEvent(WooPosRefundUIEvent.ContinueToReviewClicked)
+            advanceUntilIdle()
+
+            // WHEN
+            viewModel.onUIEvent(WooPosRefundUIEvent.RefreshRefundableItems)
+            advanceUntilIdle()
+
+            // THEN
+            val content = viewModel.state.value as WooPosRefundState.Content
+            assertThat(content.refundableItems).isEqualTo(remainingUnits)
+            assertThat(content.selectedItemIds).containsExactly(remainingUnits[0].uniqueId)
+            assertThat(content.itemsCount).isEqualTo(1)
+            assertThat(content.allItemsSelected).isFalse()
+        }
+
+    @Test
+    fun `given a selection over two lines and one shrank, when items are refreshed, then the other line is kept`() =
+        runTest {
+            // GIVEN — one unit selected on each of two lines
+            val firstLine = List(2) { testRefundableItem.copy(orderItemId = 1L, rowIndex = it) }
+            val secondLine = List(2) { testRefundableItem.copy(orderItemId = 2L, name = "Other", rowIndex = it) }
+            val remaining = listOf(firstLine[0]) + secondLine
+
+            whenever(ordersDataSource.refreshOrderById(testOrderId)).thenReturn(Result.success(testOrder))
+            whenever(retrieveOrderRefunds.invoke(eq(testOrder), any())).thenReturn(Result.success(emptyList()))
+            whenever(getRefundableItems.invoke(any(), any())).thenReturn(firstLine + secondLine, remaining)
+            whenever(refundPreview.invoke(any(), any())).thenReturn(
+                WooPosRefundPreview.Result.Error(WooPosRefundApiError.QuantityExceedsRefundable)
+            )
+
+            viewModel = createViewModel()
+            viewModel.onUIEvent(WooPosRefundUIEvent.RefundFlowOpened)
+            advanceUntilIdle()
+            viewModel.onUIEvent(WooPosRefundUIEvent.ItemSelectionToggled(firstLine[1].uniqueId))
+            viewModel.onUIEvent(WooPosRefundUIEvent.ItemSelectionToggled(secondLine[1].uniqueId))
+            advanceUntilIdle()
+            viewModel.onUIEvent(WooPosRefundUIEvent.ContinueToReviewClicked)
+            advanceUntilIdle()
+
+            // WHEN
+            viewModel.onUIEvent(WooPosRefundUIEvent.RefreshRefundableItems)
+            advanceUntilIdle()
+
+            // THEN
+            val content = viewModel.state.value as WooPosRefundState.Content
+            assertThat(content.selectedItemIds)
+                .containsExactlyInAnyOrder(firstLine[0].uniqueId, secondLine[0].uniqueId)
+            assertThat(content.itemsCount).isEqualTo(2)
+        }
+
+    @Test
+    fun `given a selected fee, when items are refreshed, then the fee stays selected`() =
+        runTest {
+            // GIVEN — one unit of a two-unit line plus a fee are selected
+            val units = List(2) { testRefundableItem.copy(rowIndex = it) }
+            val fee = testRefundableItem.copy(orderItemId = 99L, name = "Fee", rowIndex = 0, isLumpSum = true)
+            val remaining = listOf(units[0], fee)
+
+            whenever(ordersDataSource.refreshOrderById(testOrderId)).thenReturn(Result.success(testOrder))
+            whenever(retrieveOrderRefunds.invoke(eq(testOrder), any())).thenReturn(Result.success(emptyList()))
+            whenever(getRefundableItems.invoke(any(), any())).thenReturn(units + fee, remaining)
+            whenever(refundPreview.invoke(any(), any())).thenReturn(
+                WooPosRefundPreview.Result.Error(WooPosRefundApiError.QuantityExceedsRefundable)
+            )
+
+            viewModel = createViewModel()
+            viewModel.onUIEvent(WooPosRefundUIEvent.RefundFlowOpened)
+            advanceUntilIdle()
+            viewModel.onUIEvent(WooPosRefundUIEvent.ItemSelectionToggled(units[1].uniqueId))
+            advanceUntilIdle()
+            viewModel.onUIEvent(WooPosRefundUIEvent.ContinueToReviewClicked)
+            advanceUntilIdle()
+
+            // WHEN
+            viewModel.onUIEvent(WooPosRefundUIEvent.RefreshRefundableItems)
+            advanceUntilIdle()
+
+            // THEN
+            val content = viewModel.state.value as WooPosRefundState.Content
+            assertThat(content.selectedItemIds).containsExactlyInAnyOrder(units[0].uniqueId, fee.uniqueId)
+            assertThat(content.itemsCount).isEqualTo(2)
+        }
+
+    @Test
     fun `given at select items step, when dialog dismissed, then refund flow aborted event tracked with select items step`() =
         runTest {
             val refundableItems = listOf(testRefundableItem)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundViewModelTest.kt
@@ -2778,7 +2778,8 @@ class WooPosRefundViewModelTest {
     @Test
     fun `given a selection over two lines and one shrank, when items are refreshed, then the other line is kept`() =
         runTest {
-            // GIVEN — one unit selected on each of two lines
+            // GIVEN — the trailing unit of each of two lines is kept. Trailing matters: a leading
+            // selection survives the old id intersection unchanged, so it would not catch the bug.
             val firstLine = List(2) { testRefundableItem.copy(orderItemId = 1L, rowIndex = it) }
             val secondLine = List(2) { testRefundableItem.copy(orderItemId = 2L, name = "Other", rowIndex = it) }
             val remaining = listOf(firstLine[0]) + secondLine
@@ -2793,8 +2794,8 @@ class WooPosRefundViewModelTest {
             viewModel = createViewModel()
             viewModel.onUIEvent(WooPosRefundUIEvent.RefundFlowOpened)
             advanceUntilIdle()
-            viewModel.onUIEvent(WooPosRefundUIEvent.ItemSelectionToggled(firstLine[1].uniqueId))
-            viewModel.onUIEvent(WooPosRefundUIEvent.ItemSelectionToggled(secondLine[1].uniqueId))
+            viewModel.onUIEvent(WooPosRefundUIEvent.ItemSelectionToggled(firstLine[0].uniqueId))
+            viewModel.onUIEvent(WooPosRefundUIEvent.ItemSelectionToggled(secondLine[0].uniqueId))
             advanceUntilIdle()
             viewModel.onUIEvent(WooPosRefundUIEvent.ContinueToReviewClicked)
             advanceUntilIdle()
@@ -2813,7 +2814,8 @@ class WooPosRefundViewModelTest {
     @Test
     fun `given a selected fee, when items are refreshed, then the fee stays selected`() =
         runTest {
-            // GIVEN — one unit of a two-unit line plus a fee are selected
+            // GIVEN — the trailing unit of a two-unit line plus a fee are selected. Trailing for the
+            // same reason as above; the fee guards that lump sums survive the move to counts.
             val units = List(2) { testRefundableItem.copy(rowIndex = it) }
             val fee = testRefundableItem.copy(orderItemId = 99L, name = "Fee", rowIndex = 0, isLumpSum = true)
             val remaining = listOf(units[0], fee)
@@ -2828,7 +2830,7 @@ class WooPosRefundViewModelTest {
             viewModel = createViewModel()
             viewModel.onUIEvent(WooPosRefundUIEvent.RefundFlowOpened)
             advanceUntilIdle()
-            viewModel.onUIEvent(WooPosRefundUIEvent.ItemSelectionToggled(units[1].uniqueId))
+            viewModel.onUIEvent(WooPosRefundUIEvent.ItemSelectionToggled(units[0].uniqueId))
             advanceUntilIdle()
             viewModel.onUIEvent(WooPosRefundUIEvent.ContinueToReviewClicked)
             advanceUntilIdle()
@@ -2841,6 +2843,50 @@ class WooPosRefundViewModelTest {
             val content = viewModel.state.value as WooPosRefundState.Content
             assertThat(content.selectedItemIds).containsExactlyInAnyOrder(units[0].uniqueId, fee.uniqueId)
             assertThat(content.itemsCount).isEqualTo(2)
+        }
+
+    @Test
+    fun `given only the last unit was selected, when items are refreshed after a rejected refund, then one unit stays selected`() =
+        runTest {
+            // GIVEN — the reason this differs from the tests above: the refund is submitted and
+            // rejected, so the state is Error and the snapshot has to come from
+            // contentStateBeforeRefund rather than from the current Content. refundPreview is
+            // deliberately left unstubbed so the flow cannot reach the other branch.
+            val units = List(3) { testRefundableItem.copy(rowIndex = it) }
+            val remainingUnits = units.take(1)
+
+            whenever(ordersDataSource.refreshOrderById(testOrderId)).thenReturn(Result.success(testOrder))
+            whenever(retrieveOrderRefunds.invoke(eq(testOrder), any())).thenReturn(Result.success(emptyList()))
+            whenever(getRefundableItems.invoke(any(), any())).thenReturn(units, remainingUnits)
+            whenever(refundSubmissionProcessor.submit(any())).thenReturn(
+                flowOf(
+                    WooPosRefundSubmissionState.Processing,
+                    WooPosRefundSubmissionState.Failure(
+                        message = "Rejected",
+                        apiErrorCode = "woocommerce_rest_quantity_exceeds_refundable",
+                    )
+                )
+            )
+
+            viewModel = createViewModel()
+            viewModel.onUIEvent(WooPosRefundUIEvent.RefundFlowOpened)
+            advanceUntilIdle()
+            viewModel.onUIEvent(WooPosRefundUIEvent.ItemSelectionToggled(units[0].uniqueId))
+            advanceUntilIdle()
+            viewModel.onUIEvent(WooPosRefundUIEvent.OnRefundConfirmed)
+            advanceUntilIdle()
+
+            val errorState = viewModel.state.value as WooPosRefundState.Error
+            assertThat(errorState.recovery).isEqualTo(WooPosRefundState.Recovery.RefreshItems)
+
+            // WHEN
+            viewModel.onUIEvent(WooPosRefundUIEvent.RefreshRefundableItems)
+            advanceUntilIdle()
+
+            // THEN
+            val content = viewModel.state.value as WooPosRefundState.Content
+            assertThat(content.selectedItemIds).containsExactly(remainingUnits[0].uniqueId)
+            assertThat(content.itemsCount).isEqualTo(1)
         }
 
     @Test


### PR DESCRIPTION
### Description

Fixes WOOMOB-3902

When the store rejects a refund preview or create because the order changed, the refund screen offers to reload the remaining items and tries to keep what the cashier had selected. It restored that selection by matching `WooPosRefundableItem.uniqueId`, which is `"${orderItemId}_$rowIndex"`. `rowIndex` is the unit's position within what is still refundable, so it is renumbered on every reload — and a reload only happens because the order changed, which is exactly when those positions move.

Item 42 with quantity 3 gives `42_0`, `42_1`, `42_2`. The cashier deselects `42_0` and keeps the two trailing units. Another register refunds two units. The reload yields only `42_0`, nothing matches, and the selection is emptied. The cashier has to pick again with no explanation.

The failing case is always a trailing one. The selection has to exceed what is left for the store to reject it at all, so a leading selection survives the old id intersection unchanged.

This replaces the id set with `WooPosRefundSelectionSnapshot`: a unit count per `orderItemId` plus the selected lump-sum ids. `WooPosBuildRefundContent` now selects the first *n* units of each line, capped at what is left, and selects a fee row if its id was selected. Products and fees are kept in separate fields because they restore by different rules: a count for units, whole-line presence for a lump sum.

Restoring by count rather than giving units a stable identity is deliberate: nothing downstream needs per-unit identity. `WooPosBuildRefundLineItems` (server path), `WooPosGroupRefundItems` (local path) and `WooPosCalculateRefundSubtotal` all group by `orderItemId` and use the row count, so the count is the only meaningful state.

Two notes for review:

- WOOMOB-3902 describes the no-survivor fallback as "select everything". That is no longer the code — it was changed to leave the selection empty in #16440. The live symptom is therefore a lost selection, not a widened one, and this PR keeps the empty fallback.
- Of the three `WooPosRefundViewModelTest` cases that cover the reload, only the trailing-unit one failed on `trunk` as originally written. The other two deselected the last unit, so the survivors matched the old intersection and they passed. Both have been changed to deselect the *first* unit. All three now fail on `trunk`, along with the new post-rejection case: pasting the four into `trunk`'s `WooPosRefundViewModelTest` gives 80 tests and 4 failures, the trailing-unit ones with `expected:<[["1_0"]]> but was:<[[]]>`.

Pre-existing and unchanged by this PR: if the reload itself fails, the error screen's **Retry** loads with no preserved selection, which selects every remaining unit. Worth knowing if you hit a load error while testing. Tracked as WOOMOB-3927.

### Test Steps

Needs two clients signed in to the same store. The second can be a phone running the main app, as long as it is already signed in — the store needs a WordPress.com login, so a fresh device will not do. Refunding from the main app's order detail screen is enough.

These steps assume the server-calculated refund path, so the store rejects at the preview when Continue is tapped.

Only scenario 1 fails on `trunk`. Scenarios 2 and 3 pass there too — they guard behaviour this PR must not break, so check them against the stated counts rather than reading a pass as proof of the fix.

**Scenario 1 — a shrinking line. Fails on `trunk`.**

1. On the register, open an order with a line item of quantity 3 and start a refund.
2. Deselect the **first** unit of that line. The counter reads `(2 SELECTED)`.
3. On the second client, refund **two** units of that line item. One unit is left.
4. On the register, tap **Continue**. Selected (2) exceeds what is left (1), so the store rejects with "The selected quantity is more than what's left to refund."
5. Tap **Review remaining items**.
6. Expected: one unit is listed and it is selected — `(1 SELECTED)`, Continue enabled.
   On `trunk`: `(0 SELECTED)`, Continue disabled.

**Scenario 2 — a fee alongside the units. Regression guard.**

Use a fresh order with a line item of quantity 3 plus a fee. In POS, "Custom amount" adds one.

7. Start a refund. Deselect the **first** unit, leaving the two trailing units and the fee. The counter reads `(3 SELECTED)`.
8. On the second client, refund **two** units of that line item. Leave the fee alone.
9. On the register, tap **Continue**, then **Review remaining items**.
10. Expected: two rows are listed and **both** are selected — `(2 SELECTED)`: the remaining unit and the fee.
    On `trunk`: `(1 SELECTED)`. The fee survives there because a lump sum's `uniqueId` is `fee_<id>` and carries no `rowIndex`, so only the unit is lost. Assert the count, not just the fee.

**Scenario 3 — nothing survives. Regression guard for #16440.**

Use another fresh order with a line item of quantity 3 plus a fee. Scenario 2's order will not do: it has one unit left, so step 12 cannot refund three.

11. Start a refund. Deselect the **fee**, leaving all three units. The counter reads `(3 SELECTED)`.
12. On the second client, refund **all three** units of that line item.
13. On the register, tap **Continue**, then **Review remaining items**.
14. Expected: only the fee row is listed, and it is **unselected** — `(0 SELECTED)`, Continue disabled. The cashier picks again rather than confirming an item they never chose.
    `trunk` behaves the same: this is #16440's empty fallback, which this PR keeps.

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

