### PR TITLE
[WOOMOB-999] Make WCDataStore location functions suspendable

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/CustomerWithAnalytics.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/CustomerWithAnalytics.kt
@@ -30,7 +30,7 @@ data class CustomerWithAnalytics(
     fun getBillingAddress(): String = billingAddress.getFullAddress()
 }
 
-fun WCCustomerModel.toCustomerWithAnalytics(
+suspend fun WCCustomerModel.toCustomerWithAnalytics(
     repository: CustomerListRepository,
     mapper: CustomerListViewModelMapper,
 ): CustomerWithAnalytics {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/GetLocations.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/GetLocations.kt
@@ -1,11 +1,12 @@
 package com.woocommerce.android.model
 
 import com.woocommerce.android.ui.orders.details.editing.address.LocationCode
+import kotlinx.coroutines.runBlocking
 import org.wordpress.android.fluxc.store.WCDataStore
 import javax.inject.Inject
 
 class GetLocations @Inject constructor(private val locationStore: WCDataStore) {
-    operator fun invoke(countryCode: LocationCode, stateCode: LocationCode): Pair<Location, AmbiguousLocation> {
+    suspend operator fun invoke(countryCode: LocationCode, stateCode: LocationCode): Pair<Location, AmbiguousLocation> {
         val country = locationStore.getCountries()
             .firstOrNull { it.code == countryCode }
             ?.toAppModel()
@@ -19,4 +20,11 @@ class GetLocations @Inject constructor(private val locationStore: WCDataStore) {
 
         return country to state
     }
+
+    /**
+     * Only for the legacy shipping labels flow, which resolves locations outside of a coroutine.
+     * Delete along with that flow.
+     */
+    fun getBlocking(countryCode: LocationCode, stateCode: LocationCode): Pair<Location, AmbiguousLocation> =
+        runBlocking { invoke(countryCode, stateCode) }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/OrderMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/OrderMapper.kt
@@ -156,7 +156,7 @@ class OrderMapper @Inject constructor(
                 )
             }
 
-    private fun OrderAddress.mapAddress(): Address {
+    private suspend fun OrderAddress.mapAddress(): Address {
         val (country, state) = getLocations(this.country, stateCode = this.state)
         return Address(
             company = this.company,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ShippingLabelAddressMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ShippingLabelAddressMapper.kt
@@ -5,7 +5,7 @@ import javax.inject.Inject
 
 class ShippingLabelAddressMapper @Inject constructor(private val getLocations: GetLocations) {
     fun toAppModel(dto: WCShippingLabelModel.ShippingLabelAddress): Address {
-        val (countryLocation, stateLocation) = getLocations(dto.country.orEmpty(), dto.state.orEmpty())
+        val (countryLocation, stateLocation) = getLocations.getBlocking(dto.country.orEmpty(), dto.state.orEmpty())
         return Address(
             company = dto.company ?: "",
             firstName = dto.name ?: "",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/customer/GetCustomerWithStats.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/customer/GetCustomerWithStats.kt
@@ -30,7 +30,7 @@ class GetCustomerWithStats @Inject constructor(
         return mergeResults(customer, analyticsCustomer)
     }
 
-    private fun mergeResults(
+    private suspend fun mergeResults(
         customer: WCCustomerModel?,
         analyticsCustomer: WCCustomerFromAnalytics?
     ): Result<CustomerWithAnalytics> {
@@ -56,7 +56,7 @@ class GetCustomerWithStats @Inject constructor(
         }
     }
 
-    private fun customerWithBothValues(
+    private suspend fun customerWithBothValues(
         customer: WCCustomerModel,
         analyticsCustomer: WCCustomerFromAnalytics
     ): CustomerWithAnalytics {
@@ -112,7 +112,7 @@ class GetCustomerWithStats @Inject constructor(
         )
     }
 
-    private fun customerWithOutAnalytics(customer: WCCustomerModel): CustomerWithAnalytics {
+    private suspend fun customerWithOutAnalytics(customer: WCCustomerModel): CustomerWithAnalytics {
         val (billingCountry, billingState) = getLocations(customer.billingCountry, customer.billingState)
         val (shippingCountry, shippingState) = getLocations(customer.shippingCountry, customer.shippingState)
         return CustomerWithAnalytics(
@@ -158,7 +158,7 @@ class GetCustomerWithStats @Inject constructor(
         )
     }
 
-    private fun analyticsWithoutCustomer(analyticsCustomer: WCCustomerFromAnalytics): CustomerWithAnalytics {
+    private suspend fun analyticsWithoutCustomer(analyticsCustomer: WCCustomerFromAnalytics): CustomerWithAnalytics {
         val (country, state) = getLocations(analyticsCustomer.country, analyticsCustomer.state)
         val nameSplit = analyticsCustomer.name.split(" ")
         val firstName = nameSplit.firstOrNull().orEmpty()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/customer/MoreMenuCustomerListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/customer/MoreMenuCustomerListViewModel.kt
@@ -12,6 +12,7 @@ import com.woocommerce.android.ui.orders.creation.customerlist.CustomerListViewM
 import com.woocommerce.android.util.StringUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.model.customer.WCCustomerModel
 import javax.inject.Inject
 
@@ -34,7 +35,9 @@ class CustomerListDetailsViewModel @Inject constructor(
     stringUtils
 ) {
     override fun onCustomerSelected(customerModel: WCCustomerModel) {
-        triggerEvent(CustomerSelected(customerModel.toCustomerWithAnalytics(repository, mapper)))
+        launch {
+            triggerEvent(CustomerSelected(customerModel.toCustomerWithAnalytics(repository, mapper)))
+        }
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlist/CustomerListRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlist/CustomerListRepository.kt
@@ -37,7 +37,7 @@ class CustomerListRepository @Inject constructor(
         countries.find { it.code == countryCode }
             ?: Location.EMPTY
 
-    fun getState(countryCode: String, stateCode: String) =
+    suspend fun getState(countryCode: String, stateCode: String) =
         dataStore.getStates(countryCode)
             .find { it.code == stateCode }?.toAppModel()
             ?: Location.EMPTY

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlist/CustomerListSelectionViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlist/CustomerListSelectionViewModel.kt
@@ -46,7 +46,9 @@ open class CustomerListSelectionViewModel @Inject constructor(
             }
 
             allowGuests -> {
-                exitWithCustomer(customerModel)
+                launch {
+                    exitWithCustomer(customerModel)
+                }
             }
 
             else -> {
@@ -75,7 +77,7 @@ open class CustomerListSelectionViewModel @Inject constructor(
         }
     }
 
-    private fun exitWithCustomer(wcCustomer: WCCustomerModel) {
+    private suspend fun exitWithCustomer(wcCustomer: WCCustomerModel) {
         val billingAddress = mapper.mapFromCustomerModelToBillingAddress(wcCustomer)
         val shippingAddress = mapper.mapFromCustomerModelToShippingAddress(wcCustomer)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt
@@ -46,17 +46,17 @@ class AddressViewModel @Inject constructor(
     val viewStateData = LiveDataDelegate(savedState, defaultViewState())
     private var viewState by viewStateData
 
-    private val countries: List<Location>
-        get() = dataStore.getCountries().map { it.toAppModel() }
+    private suspend fun getCountries(): List<Location> =
+        dataStore.getCountries().map { it.toAppModel() }
 
-    private fun statesAvailableFor(type: AddressType): List<Location> {
+    private suspend fun statesAvailableFor(type: AddressType): List<Location> {
         return viewState.addressSelectionStates[type]?.address?.country?.code?.let { locationCode ->
             dataStore.getStates(locationCode)
                 .map { it.toAppModel() }
         }.orEmpty()
     }
 
-    private fun statesFor(countryCode: LocationCode): List<Location> {
+    private suspend fun statesFor(countryCode: LocationCode): List<Location> {
         return dataStore.getStates(countryCode)
             .map { it.toAppModel() }
     }
@@ -106,7 +106,7 @@ class AddressViewModel @Inject constructor(
             )
         }
         launch {
-            if (countries.isEmpty()) {
+            if (getCountries().isEmpty()) {
                 viewState = viewState.copy(isLoading = true)
                 dataStore.fetchCountriesAndStates(selectedSite.get())
                 viewState = viewState.copy(isLoading = false)
@@ -144,7 +144,7 @@ class AddressViewModel @Inject constructor(
         isBetterCustomerSearchEnabled = featureFlagRepository.isEnabled(FeatureFlag.BETTER_CUSTOMER_SEARCH_M2)
     )
 
-    private fun getStateSpinnerStatus(countryCode: String): StateSpinnerStatus {
+    private suspend fun getStateSpinnerStatus(countryCode: String): StateSpinnerStatus {
         return when {
             countryCode.isBlank() -> DISABLED
             statesFor(countryCode).isNotEmpty() -> HAVING_LOCATIONS
@@ -153,55 +153,64 @@ class AddressViewModel @Inject constructor(
     }
 
     fun onCountrySelected(type: AddressType, countryCode: LocationCode) {
-        val selectedCountry = dataStore.getCountries().firstOrNull { it.code == countryCode }?.toAppModel()
-            ?: Location(countryCode, countryCode)
+        launch {
+            val selectedCountry = dataStore.getCountries().firstOrNull { it.code == countryCode }?.toAppModel()
+                ?: Location(countryCode, countryCode)
+            val stateSpinnerStatus = getStateSpinnerStatus(countryCode)
 
-        viewState = viewState.copy(
-            addressSelectionStates = viewState.addressSelectionStates.mapValues { entry ->
-                if (entry.key == type) {
-                    entry.value.copy(
-                        address = entry.value.address.copy(
-                            country = selectedCountry,
-                            state = AmbiguousLocation.EMPTY
-                        ),
-                        stateSpinnerStatus = getStateSpinnerStatus(countryCode)
-                    )
-                } else {
-                    entry.value
-                }
-            },
-        )
+            viewState = viewState.copy(
+                addressSelectionStates = viewState.addressSelectionStates.mapValues { entry ->
+                    if (entry.key == type) {
+                        entry.value.copy(
+                            address = entry.value.address.copy(
+                                country = selectedCountry,
+                                state = AmbiguousLocation.EMPTY
+                            ),
+                            stateSpinnerStatus = stateSpinnerStatus
+                        )
+                    } else {
+                        entry.value
+                    }
+                },
+            )
+        }
     }
 
     fun onStateSelected(type: AddressType, selectedStateCode: LocationCode) {
-        val (_, selectedState) = getLocations(
-            countryCode = viewState.addressSelectionStates.getValue(type).address.country.code,
-            stateCode = selectedStateCode,
-        )
+        launch {
+            val (_, selectedState) = getLocations(
+                countryCode = viewState.addressSelectionStates.getValue(type).address.country.code,
+                stateCode = selectedStateCode,
+            )
 
-        viewState = viewState.copy(
-            addressSelectionStates = viewState.addressSelectionStates.mapValues { entry ->
-                if (entry.key == type) {
-                    entry.value.copy(
-                        address = entry.value.address.copy(
-                            state = selectedState
+            viewState = viewState.copy(
+                addressSelectionStates = viewState.addressSelectionStates.mapValues { entry ->
+                    if (entry.key == type) {
+                        entry.value.copy(
+                            address = entry.value.address.copy(
+                                state = selectedState
+                            )
                         )
-                    )
-                } else {
-                    entry.value
+                    } else {
+                        entry.value
+                    }
                 }
-            }
-        )
+            )
+        }
     }
 
     fun onCountrySpinnerClicked(type: AddressType) {
-        val event = ShowCountrySelector(type, countries)
-        triggerEvent(event)
+        launch {
+            val event = ShowCountrySelector(type, getCountries())
+            triggerEvent(event)
+        }
     }
 
     fun onStateSpinnerClicked(type: AddressType) {
-        val event = ShowStateSelector(type, statesAvailableFor(type))
-        triggerEvent(event)
+        launch {
+            val event = ShowStateSelector(type, statesAvailableFor(type))
+            triggerEvent(event)
+        }
     }
 
     fun onDeleteCustomerClicked() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt
@@ -9,7 +9,6 @@ import com.woocommerce.android.model.Address
 import com.woocommerce.android.model.AmbiguousLocation
 import com.woocommerce.android.model.GetLocations
 import com.woocommerce.android.model.Location
-import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.details.editing.address.AddressViewModel.StateSpinnerStatus.DISABLED
@@ -261,26 +260,6 @@ class AddressViewModel @Inject constructor(
                     entry.value
                 }
             }
-        )
-    }
-
-    fun onAddressesChanged(customer: Order.Customer) {
-        hasStarted = true
-        viewState = viewState.copy(
-            customerId = customer.customerId,
-            firstName = customer.firstName,
-            lastName = customer.lastName,
-            email = customer.email,
-            addressSelectionStates = mapOf(
-                AddressType.BILLING to AddressSelectionState(
-                    customer.billingAddress,
-                    getStateSpinnerStatus(customer.billingAddress.country.code)
-                ),
-                AddressType.SHIPPING to AddressSelectionState(
-                    customer.shippingAddress,
-                    getStateSpinnerStatus(customer.shippingAddress.country.code)
-                )
-            )
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
@@ -495,7 +495,7 @@ class CreateShippingLabelViewModel @Inject constructor(
         )
     }
 
-    private fun getStoreAddress(): Address {
+    private suspend fun getStoreAddress(): Address {
         val siteSettings = wooStore.getSiteSettings(site.get())
         val (country, state) = getLocations(
             countryCode = siteSettings?.countryCode.orEmpty(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModel.kt
@@ -79,7 +79,7 @@ class EditShippingLabelAddressViewModel @Inject constructor(
 
     private val countries: List<Location>
         get() {
-            val fullCountriesList = dataStore.getCountries()
+            val fullCountriesList = dataStore.getCountriesBlocking()
             val supportedCountries = if (arguments.addressType == ORIGIN) {
                 fullCountriesList.filter { ACCEPTED_USPS_ORIGIN_COUNTRIES.contains(it.code) }
             } else {
@@ -89,7 +89,7 @@ class EditShippingLabelAddressViewModel @Inject constructor(
         }
 
     private val states: List<Location>
-        get() = dataStore.getStates(viewState.countryField.location.code).map { it.toAppModel() }
+        get() = dataStore.getStatesBlocking(viewState.countryField.location.code).map { it.toAppModel() }
 
     init {
         viewState = viewState.copy(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsViewModel.kt
@@ -74,7 +74,7 @@ class ShippingCustomsViewModel @Inject constructor(
         get() = parameters.currencySymbol.orEmpty()
 
     val countries: List<Location>
-        get() = dataStore.getCountries().map { it.toAppModel() }
+        get() = dataStore.getCountriesBlocking().map { it.toAppModel() }
 
     val isEUShippingScenario
         get() = args.isEUShippingScenario

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/model/GetLocationsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/model/GetLocationsTest.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.model
 
+import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -18,7 +19,7 @@ class GetLocationsTest {
     }
 
     @Test
-    fun `should provide country and associated state if locations are in database`() {
+    fun `should provide country and associated state if locations are in database`() = runTest {
         // given
         val country = WCLocationModel(code = "US", name = "United States")
         val associatedState = WCLocationModel(parentCode = "US", code = "CA", "California")
@@ -34,7 +35,7 @@ class GetLocationsTest {
     }
 
     @Test
-    fun `should provide country and state with location code only if state is not found in database`() {
+    fun `should provide country and state with location code only if state is not found in database`() = runTest {
         // given
         val country = WCLocationModel(code = "US", name = "United States")
         val nonExistentStateLocationCode = "AABBCC"
@@ -50,7 +51,7 @@ class GetLocationsTest {
     }
 
     @Test
-    fun `should provide country and state with location codes only if data not found in database`() {
+    fun `should provide country and state with location codes only if data not found in database`() = runTest {
         // given
         val nonExistentCountryLocationCode = "ZZXXYY"
         val nonExistentStateLocationCode = "AABBCC"

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/model/OrderMapperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/model/OrderMapperTest.kt
@@ -28,9 +28,11 @@ class OrderMapperTest {
         orderMapper = OrderMapper(getLocations, dateUtils)
 
         whenever(dateUtils.getDateUsingSiteTimeZone(org.mockito.kotlin.any())).thenReturn(testDate)
-        whenever(getLocations.invoke(org.mockito.kotlin.any(), org.mockito.kotlin.any())).thenReturn(
-            Pair(Location.EMPTY, AmbiguousLocation.Raw(""))
-        )
+        runTest {
+            whenever(getLocations.invoke(org.mockito.kotlin.any(), org.mockito.kotlin.any())).thenReturn(
+                Pair(Location.EMPTY, AmbiguousLocation.Raw(""))
+            )
+        }
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModelTest.kt
@@ -43,6 +43,7 @@ class AddressViewModelTest : BaseUnitTest() {
 
     private val dataStore: WCDataStore = mock {
         on { getCountries() } doReturn listOf(newCountry, newCountryWithoutStates)
+        on { getStates(any()) } doReturn emptyList()
         on { getStates(newCountry.code) } doReturn listOf(newState)
     }
     private val featureFlagRepository: FeatureFlagRepository = mock()
@@ -71,8 +72,8 @@ class AddressViewModelTest : BaseUnitTest() {
 
     @Test
     fun `Should fetch countries and states on start if they've never been fetched`() {
-        whenever(dataStore.getCountries()).thenReturn(emptyList())
         testBlocking {
+            whenever(dataStore.getCountries()).thenReturn(emptyList())
             addressViewModel.start(
                 mapOf(SHIPPING to shippingAddress)
             )
@@ -82,8 +83,8 @@ class AddressViewModelTest : BaseUnitTest() {
 
     @Test
     fun `Should NOT execute start more than once`() {
-        whenever(dataStore.getCountries()).thenReturn(emptyList())
         testBlocking {
+            whenever(dataStore.getCountries()).thenReturn(emptyList())
             addressViewModel.start(
                 mapOf(SHIPPING to shippingAddress)
             )
@@ -96,8 +97,8 @@ class AddressViewModelTest : BaseUnitTest() {
 
     @Test
     fun `Should execute start again after onScreenDetached is called`() {
-        whenever(dataStore.getCountries()).thenReturn(emptyList())
         testBlocking {
+            whenever(dataStore.getCountries()).thenReturn(emptyList())
             addressViewModel.start(
                 mapOf(SHIPPING to shippingAddress)
             )
@@ -129,7 +130,9 @@ class AddressViewModelTest : BaseUnitTest() {
 
     @Test
     fun `Should apply country and state changes to view state safely on start if countries list is empty`() {
-        whenever(dataStore.getCountries()).thenReturn(emptyList())
+        testBlocking {
+            whenever(dataStore.getCountries()).thenReturn(emptyList())
+        }
         addressViewModel.start(
             mapOf(SHIPPING to shippingAddress)
         )
@@ -169,7 +172,9 @@ class AddressViewModelTest : BaseUnitTest() {
 
     @Test
     fun `Should update viewState with country code instead of name if country code is NOT on countries list`() {
-        whenever(dataStore.getCountries()).thenReturn(emptyList())
+        testBlocking {
+            whenever(dataStore.getCountries()).thenReturn(emptyList())
+        }
         val missingCountryCode = "countryCode"
 
         addressViewModel.start(mapOf(SHIPPING to shippingAddress))
@@ -216,7 +221,9 @@ class AddressViewModelTest : BaseUnitTest() {
 
     @Test
     fun `Should update viewState with state code instead of name if state code is NOT on states list`() {
-        whenever(dataStore.getStates(any())).thenReturn(emptyList())
+        testBlocking {
+            whenever(dataStore.getStates(any())).thenReturn(emptyList())
+        }
         val stateCode = "stateCode"
 
         addressViewModel.start(mapOf(SHIPPING to shippingAddress))

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModelTest.kt
@@ -84,9 +84,9 @@ class EditShippingLabelAddressViewModelTest : BaseUnitTest() {
 
     @Before
     fun setup() {
-        whenever(dataStore.getCountries()).thenReturn(countries)
-        whenever(dataStore.getStates("US")).thenReturn(states)
-        whenever(dataStore.getStates("VI")).thenReturn(emptyList())
+        whenever(dataStore.getCountriesBlocking()).thenReturn(countries)
+        whenever(dataStore.getStatesBlocking("US")).thenReturn(states)
+        whenever(dataStore.getStatesBlocking("VI")).thenReturn(emptyList())
         val resourceProviderAnswer = { i: InvocationOnMock -> i.arguments[0].toString() }
         whenever(resourceProvider.getString(any())).thenAnswer(resourceProviderAnswer)
         whenever(resourceProvider.getString(any(), anyVararg())).thenAnswer(resourceProviderAnswer)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsViewModelTest.kt
@@ -35,7 +35,7 @@ class ShippingCustomsViewModelTest : BaseUnitTest() {
     private val selectedSite: SelectedSite = mock()
     private val parameterRepository: ParameterRepository = mock()
     private val dataStore: WCDataStore = mock {
-        on { getCountries() } doReturn countries
+        on { getCountriesBlocking() } doReturn countries
     }
     private val resourceProvider: ResourceProvider = mock {
         on { getString(any()) } doAnswer { it.arguments[0].toString() }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WCDataStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WCDataStore.kt
@@ -24,19 +24,30 @@ class WCDataStore @Inject internal constructor(
     /**
      * Returns a list of countries
      */
-    fun getCountries(): List<WCLocationModel> =
-            runBlocking { locationsDao.getCountries() }
+    suspend fun getCountries(): List<WCLocationModel> = locationsDao.getCountries()
 
     suspend fun getCountry(countryCode: String): WCLocationModel? = locationsDao.getCountry(countryCode)
 
     /**
      * Returns a list of states
      */
-    fun getStates(country: String): List<WCLocationModel> = if (country.isEmpty()) {
+    suspend fun getStates(country: String): List<WCLocationModel> = if (country.isEmpty()) {
         emptyList()
     } else {
-        runBlocking { locationsDao.getStates(country) }
+        locationsDao.getStates(country)
     }
+
+    /**
+     * Only for the legacy shipping labels flow, which reads locations outside of a coroutine.
+     * Delete along with that flow.
+     */
+    fun getCountriesBlocking(): List<WCLocationModel> = runBlocking { getCountries() }
+
+    /**
+     * Only for the legacy shipping labels flow, which reads locations outside of a coroutine.
+     * Delete along with that flow.
+     */
+    fun getStatesBlocking(country: String): List<WCLocationModel> = runBlocking { getStates(country) }
 
     suspend fun fetchCountriesAndStates(site: SiteModel): WooResult<List<WCLocationModel>> {
         return coroutineEngine.withDefaultContext(AppLog.T.API, this, "fetchCountries") {


### PR DESCRIPTION
Fixes WOOMOB-999

### Description

`WCDataStore.getCountries` and `getStates` wrapped their Room reads in `runBlocking`. Both are read from ViewModels on the main thread, so editing an order address, picking a customer during order creation and opening a customer's details each blocked the main thread on a location read.

This PR makes both suspend and removes the `runBlocking`. `GetLocations`, `OrderMapper.mapAddress`, `GetCustomerWithStats`, `CustomerListRepository.getState` and the customer selection chain became suspend as a result. `AddressViewModel` now resolves countries and states inside coroutines, which affects country and state selection and the two location selectors.

The legacy shipping labels screens keep blocking access through `getCountriesBlocking`, `getStatesBlocking` and `GetLocations.getBlocking`. Those screens read locations from property getters and adapter constructors, so converting them would mean restructuring a flow that WooCommerce Shipping is replacing. The three wrappers are documented as deletable with that flow. Behavior there is unchanged.

There is one commit per step.

### Test Steps

#### 1. Order address country and state

1. Open an order from the **Orders** tab.
2. Tap **Edit** and open the billing address.
3. Tap the country field and pick a country that has states, for example United States.
4. Confirm the state field turns into a spinner and any previous state is cleared.
5. Tap the state field and pick a state.
6. Confirm the state field shows the state name.
7. Tap the country field again and pick a country with no states, for example Anguilla.
8. Confirm the state field turns into a free text field.
9. Tap **Done**.
10. Confirm the billing details on the order show the new country.

#### 2. Customer picker

Needs a registered customer with a billing address in a country that has states.

1. Tap the add order button on the **Orders** tab.
2. Tap **Add customer details**.
3. Pick the customer.
4. Confirm the billing and shipping addresses are filled in.
5. Tap the edit icon on the customer card.
6. Confirm the country and state fields show names and not codes.

#### 3. Customer details

1. Open the **More** menu and tap **Customers**.
2. Tap a customer that has an address.
3. Confirm the **Location** section shows the country and region names and not codes.

### Images/gif

N/A, no UI change.

- [x] I have considered if this change warrants release notes. This is an internal refactor with no behavior change, so none were added.
