### PR TITLE
Show attribute labels on order detail product rows

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 
 25.6
 -----
+- [*] Order detail: product line items now show each attribute with its label on its own line, so Product Add-Ons text values are readable instead of running together [https://github.com/woocommerce/woocommerce-android/pull/16476]
 - [Internal] Woo POS refunds: refund events now report whether totals were calculated locally or by the server, a new event records when a store falls back for lack of the server route, and refunds abandoned before submission are now reported instead of leaving the funnel open [https://github.com/woocommerce/woocommerce-android/pull/16419]
 - [*] The app name on the launcher is no longer translated - Brazilian Portuguese showed "Eba!" instead of "Woo"[https://github.com/woocommerce/woocommerce-android/pull/16452]
 - [*] Order creation: the discount screen now formats the product line and totals like the rest of the app, and "Price after discount" shows the full price until a discount is entered [https://github.com/woocommerce/woocommerce-android/pull/16453]

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
@@ -137,17 +137,25 @@ data class Order(
         @IgnoredOnParcel
         var containsAddons = false
 
+        val displayableAttributes: List<Attribute>
+            get() = attributesList.filter {
+                it.value.isNotEmpty() && it.key.isNotEmpty()
+            }.map { attribute ->
+                Attribute(
+                    key = attribute.key.fastStripHtml(),
+                    value = attribute.value
+                        .fastStripHtml()
+                        .replaceFirstChar {
+                            if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString()
+                        }
+                )
+            }
+
         /**
          * @return a comma-separated list of attribute values for display
          */
         val attributesDescription
-            get() = attributesList.filter {
-                it.value.isNotEmpty() && it.key.isNotEmpty()
-            }.joinToString { attribute ->
-                attribute.value
-                    .fastStripHtml()
-                    .replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() }
-            }
+            get() = displayableAttributes.joinToString { it.value }
 
         companion object {
             val EMPTY by lazy {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailProductItemView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailProductItemView.kt
@@ -14,7 +14,6 @@ import com.woocommerce.android.databinding.OrderDetailProductItemBinding
 import com.woocommerce.android.extensions.formatToString
 import com.woocommerce.android.extensions.loadPhotonUrlWithFallback
 import com.woocommerce.android.model.Order
-import com.woocommerce.android.util.StringUtils
 import java.math.BigDecimal
 
 typealias ViewAddonClickListener = (Order.Item) -> Unit
@@ -38,13 +37,16 @@ class OrderDetailProductItemView @JvmOverloads constructor(
         binding.productInfoTotal.text = orderTotal
 
         val productPrice = formatCurrencyForDisplay(item.price)
-        val attributes = item.attributesDescription
-            .takeIf { it.isNotEmpty() }
-            ?.let { "$it \u2981 " }
-            ?: StringUtils.EMPTY
-        binding.productInfoAttributes.text = context.getString(
-            R.string.orderdetail_product_lineitem_attributes,
-            attributes, item.quantity.formatToString(), productPrice
+        with(binding.productInfoAttributes) {
+            val attributes = item.displayableAttributes
+            isVisible = attributes.isNotEmpty()
+            text = attributes.joinToString(separator = "\n") {
+                context.getString(R.string.orderdetail_product_lineitem_attribute, it.key, it.value)
+            }
+        }
+        binding.productInfoQuantityAndPrice.text = context.getString(
+            R.string.orderdetail_product_lineitem_quantity_and_price,
+            item.quantity.formatToString(), productPrice
         )
 
         with(binding.productInfoSKU) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailProductChildItemListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailProductChildItemListAdapter.kt
@@ -15,7 +15,6 @@ import com.woocommerce.android.extensions.loadPhotonUrlWithFallback
 import com.woocommerce.android.tools.ProductImageMap
 import com.woocommerce.android.ui.orders.OrderProductActionListener
 import com.woocommerce.android.ui.orders.details.OrderProduct
-import com.woocommerce.android.util.StringUtils
 import java.math.BigDecimal
 
 class OrderDetailProductChildItemListAdapter(
@@ -76,13 +75,20 @@ class OrderDetailProductChildItemListAdapter(
             }
 
             val productPrice = formatCurrencyForDisplay(item.price)
-            val attributes = item.attributesDescription
-                .takeIf { it.isNotEmpty() }
-                ?.let { "$it \u2981 " }
-                ?: StringUtils.EMPTY
-            binding.productInfoAttributes.text = itemView.resources.getString(
-                R.string.orderdetail_product_lineitem_attributes,
-                attributes, item.quantity.formatToString(), productPrice
+            with(binding.productInfoAttributes) {
+                val attributes = item.displayableAttributes
+                isVisible = attributes.isNotEmpty()
+                text = attributes.joinToString(separator = "\n") {
+                    itemView.resources.getString(
+                        R.string.orderdetail_product_lineitem_attribute,
+                        it.key,
+                        it.value
+                    )
+                }
+            }
+            binding.productInfoQuantityAndPrice.text = itemView.resources.getString(
+                R.string.orderdetail_product_lineitem_quantity_and_price,
+                item.quantity.formatToString(), productPrice
             )
 
             productImage?.let {

--- a/WooCommerce/src/main/res/layout/order_detail_product_child_item.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_product_child_item.xml
@@ -62,7 +62,17 @@
         app:layout_constraintEnd_toStartOf="@+id/productInfo_total"
         app:layout_constraintStart_toEndOf="@+id/productInfo_iconFrame"
         app:layout_constraintTop_toBottomOf="@+id/productInfo_name"
-        tools:text="Red, Medium • $15.00 x 2" />
+        tools:text="Color: Red\nSize: Medium" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/productInfo_quantityAndPrice"
+        style="@style/Woo.ListItem.Body"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toStartOf="@+id/productInfo_total"
+        app:layout_constraintStart_toEndOf="@+id/productInfo_iconFrame"
+        app:layout_constraintTop_toBottomOf="@+id/productInfo_attributes"
+        tools:text="2 x $15.00" />
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/productInfo_SKU"
@@ -71,12 +81,10 @@
         android:layout_height="wrap_content"
         android:text="@string/orderdetail_product_lineitem_sku_value"
         app:layout_constraintStart_toEndOf="@+id/productInfo_iconFrame"
-        app:layout_constraintTop_toBottomOf="@+id/productInfo_attributes"
+        app:layout_constraintTop_toBottomOf="@+id/productInfo_quantityAndPrice"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@+id/productInfo_total"
         tools:visibility="visible"
-        android:lines="1"
-        android:ellipsize="end"
         android:paddingBottom="@dimen/minor_100"/>
 
 

--- a/WooCommerce/src/main/res/layout/order_detail_product_item.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_product_item.xml
@@ -60,7 +60,17 @@
         app:layout_constraintEnd_toStartOf="@+id/productInfo_total"
         app:layout_constraintStart_toEndOf="@+id/productInfo_iconFrame"
         app:layout_constraintTop_toBottomOf="@+id/productInfo_name"
-        tools:text="Red, Medium • $15.00 x 2" />
+        tools:text="Color: Red\nSize: Medium" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/productInfo_quantityAndPrice"
+        style="@style/Woo.ListItem.Body"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toStartOf="@+id/productInfo_total"
+        app:layout_constraintStart_toEndOf="@+id/productInfo_iconFrame"
+        app:layout_constraintTop_toBottomOf="@+id/productInfo_attributes"
+        tools:text="2 x $15.00" />
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/productInfo_SKU"
@@ -69,10 +79,8 @@
         android:layout_height="wrap_content"
         android:text="@string/orderdetail_product_lineitem_sku_value"
         app:layout_constraintEnd_toStartOf="@+id/productInfo_total"
-        android:lines="1"
-        android:ellipsize="end"
         app:layout_constraintStart_toEndOf="@+id/productInfo_iconFrame"
-        app:layout_constraintTop_toBottomOf="@+id/productInfo_attributes"
+        app:layout_constraintTop_toBottomOf="@+id/productInfo_quantityAndPrice"
         tools:visibility="visible" />
 
     <com.google.android.material.textview.MaterialTextView

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -901,7 +901,8 @@
     <string name="orderdetail_message_customer">Message</string>
     <string name="orderdetail_message_customer_using_whatsapp">Contact using WhatsApp</string>
     <string name="orderdetail_message_customer_using_telegram">Contact using Telegram</string>
-    <string name="orderdetail_product_lineitem_attributes">%1$s%2$s x %3$s</string>
+    <string name="orderdetail_product_lineitem_attribute">%1$s: %2$s</string>
+    <string name="orderdetail_product_lineitem_quantity_and_price">%1$s x %2$s</string>
     <string name="orderdetail_product_lineitem_sku_value">SKU: %1$s</string>
     <string name="orderdetail_product_lineitem_view_addons_action">View Add-ons</string>
     <string name="orderdetail_product_image_contentdesc">Product Image</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/model/OrderItemTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/model/OrderItemTest.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.model
 
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -46,5 +47,43 @@ class OrderItemTest {
             )
         )
         assertEquals("First Value, Second Value", orderItemUnderTest.attributesDescription)
+    }
+
+    @Test
+    fun `given attributes with keys, when displayableAttributes is read, then keys are kept`() {
+        // GIVEN
+        orderItemUnderTest = orderItemUnderTest.copy(
+            attributesList = listOf(
+                Order.Item.Attribute("Gift message", "<b>write this</b> on the label"),
+                Order.Item.Attribute("Color", "red")
+            )
+        )
+
+        // WHEN
+        val attributes = orderItemUnderTest.displayableAttributes
+
+        // THEN
+        assertThat(attributes).containsExactly(
+            Order.Item.Attribute("Gift message", "Write this on the label"),
+            Order.Item.Attribute("Color", "Red")
+        )
+    }
+
+    @Test
+    fun `given attributes without a key or a value, when displayableAttributes is read, then they are dropped`() {
+        // GIVEN
+        orderItemUnderTest = orderItemUnderTest.copy(
+            attributesList = listOf(
+                Order.Item.Attribute("First Key", "First Value"),
+                Order.Item.Attribute("Empty Value", ""),
+                Order.Item.Attribute("", "Orphan Value")
+            )
+        )
+
+        // WHEN
+        val attributes = orderItemUnderTest.displayableAttributes
+
+        // THEN
+        assertThat(attributes).containsExactly(Order.Item.Attribute("First Key", "First Value"))
     }
 }


### PR DESCRIPTION
Order detail showed line item attributes as a comma joined list of values, without the labels. With Product Add-Ons this becomes unreadable: several text add-ons run together into one line and you can't tell which value belongs to which add-on. Now every attribute is rendered as `Key: Value` on its own line, and quantity/price moved to a separate line. Fixes WOOMOB-3247.

| Before | After |
|---|---|
| <img width="480" alt="before" src="https://github.com/user-attachments/assets/e11dce03-4ca3-4123-ae19-cfcc8f03a1c5" /> | <img width="480" alt="after" src="https://github.com/user-attachments/assets/5fe5b193-adc5-4cfe-9f32-166744e2e083" /> |

Few things that are not visible in the diff:

- `attributesDescription` is kept and its output is byte for byte the same, so shipping label packaging, customs, order creation and POS are not touched. Only order detail uses the new `displayableAttributes`.
- The row layout is shared though, so the new look also lands on the grouped/bundle rows and on the product list inside the shipping labels card of order detail. Flat rows and grouped rows are both checked on a device. The shipping labels card I could only check by reading the code, it needs a really purchased label.
- SKU line was ellipsized before, now it wraps. Short SKU still stays on one line, and a row without attributes has no empty gap:

  <img width="480" alt="short and long SKU in one order" src="https://github.com/user-attachments/assets/88d43cf1-2a65-437c-8a35-a7b884591aa8" />

- We label every attribute, not only add-ons. iOS labels add-ons only and tells them apart by the `_pao_ids` meta, but that one needs Product Add-Ons 5.0.2+. Labelling everything covers older plugin versions too.

### Test steps

1. Open an order with a variation product. The product row should show `Color: Red` on its own line, then `1 x $10.00`, then SKU.
2. To check the add-ons case, in wp-admin create an order in `Pending payment`, add a product, click the pencil on the line item and use `Add meta` twice with names like `Gift message` and `Second local text add-on` and some long values. Save, set status to Processing, Create.
3. Open this order in the app. Every meta is on its own line with its label, long values wrap and stay readable.
4. Open an order with a product that has no attributes. No empty gap, just name, quantity/price and SKU.
5. Product with a long SKU shows the full SKU now, wrapped to a second line.
