### PR TITLE
ci: add job-level timeout-minutes to workflow jobs

### DIFF
--- a/.github/workflows/dependabot-constraintlayout-check.yml
+++ b/.github/workflows/dependabot-constraintlayout-check.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   add-pos-reminder:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: github.actor == 'dependabot[bot]'
 
     steps:

--- a/.github/workflows/dependabot-constraintlayout-check.yml
+++ b/.github/workflows/dependabot-constraintlayout-check.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   add-pos-reminder:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     if: github.actor == 'dependabot[bot]'
 
     steps:

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v4

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -9,6 +9,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v4

--- a/.github/workflows/dependabot_automerge.yml
+++ b/.github/workflows/dependabot_automerge.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'woocommerce/woocommerce-android'
     env:
       PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/dependabot_automerge.yml
+++ b/.github/workflows/dependabot_automerge.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'woocommerce/woocommerce-android'
     env:
       PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -5,7 +5,7 @@ jobs:
   validation:
     name: "Validation"
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - uses: gradle/actions/wrapper-validation@ed408507eac070d1f99cc633dbcf757c94c7933a # v4

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -5,6 +5,7 @@ jobs:
   validation:
     name: "Validation"
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - uses: gradle/actions/wrapper-validation@ed408507eac070d1f99cc633dbcf757c94c7933a # v4


### PR DESCRIPTION
Add job timeouts. A hung job now stops in minutes, not after GitHub's default limit of 360 minutes.

| Job | Median (30d) | Max (30d) | `timeout-minutes` |
| -- | -- | -- | -- |
| `dependabot_automerge.yml` / `auto-merge` | 0.2 min | 0.4 min | 10 |
| `dependabot-constraintlayout-check.yml` / `add-pos-reminder` | 0.1 min | 0.1 min | 10 |
| `dependabot.yml` / `build` | 1.0 min | 2.1 min | 10 |
| `gradle-wrapper-validation.yml` / `validation` | 0.2 min | 0.3 min | 10 |

Part of TESTOPS-272