### PR TITLE
Follow-up ProGuard rule cleanups from R8 PR review

### DIFF
--- a/WooCommerce/proguard-rules.pro
+++ b/WooCommerce/proguard-rules.pro
@@ -14,17 +14,6 @@
 }
 ###### Event Bus 3 - end
 
-###### Event Bus 2 - begin
--keepclassmembers class ** {
-    public void onEvent*(**);
-}
-
-# Only required if you use AsyncExecutor
--keepclassmembers class * extends de.greenrobot.event.util.ThrowableFailureEvent {
-    ** *(java.lang.Throwable);
-}
-###### Event Bus 2 - end
-
 ##### WooCommerce - begin
 # Gson populates fields reflectively, so keep fields and enum constants of our classes
 # (we don't obfuscate, so names are stable). Methods stay eligible for R8 optimization.

--- a/WooCommerce/proguard-rules.pro
+++ b/WooCommerce/proguard-rules.pro
@@ -11,8 +11,6 @@
 -keep class com.wellsql** { *; }
 ###### FluxC - end
 
-###### Zendesk (the SDK ships its own consumer rules; Gson/Retrofit/OkHttp ship theirs too)
-
 ###### SavedStateHandleExt - begin
 ###### We use reflection so we have to keep this method
 -keepclassmembers class * extends androidx.navigation.NavArgs {
@@ -20,8 +18,8 @@
 }
 ###### SavedStateHandleExt - end
 
-###### Google Crypto Tink (still transitively present; KeysDownloader references
-###### google-http-client + joda-time which aren't on the classpath) - begin
+# Crypto Tink is still transitively present; its KeysDownloader references google-http-client
+# and joda-time, which aren't on the classpath. R8 fails to build without these.
 -dontwarn com.google.api.client.http.GenericUrl
 -dontwarn com.google.api.client.http.HttpHeaders
 -dontwarn com.google.api.client.http.HttpRequest
@@ -31,4 +29,3 @@
 -dontwarn com.google.api.client.http.javanet.NetHttpTransport$Builder
 -dontwarn com.google.api.client.http.javanet.NetHttpTransport
 -dontwarn org.joda.time.Instant
-###### Google Crypto Tink - end

--- a/WooCommerce/proguard-rules.pro
+++ b/WooCommerce/proguard-rules.pro
@@ -11,8 +11,6 @@
 -keep class com.wellsql** { *; }
 ###### FluxC - end
 
--dontwarn com.google.common.**
-
 ###### Zendesk (the SDK ships its own consumer rules; Gson/Retrofit/OkHttp ship theirs too)
 
 ###### Glide - begin

--- a/WooCommerce/proguard-rules.pro
+++ b/WooCommerce/proguard-rules.pro
@@ -21,11 +21,6 @@
 -keepclassmembers enum com.woocommerce.** { *; }
 ##### WooCommerce - end
 
-###### FluxC (Gson deserialization; model/network field keeps come from fluxc's consumer-rules.pro) - begin
--keepclassmembers class org.wordpress.android.fluxc.** { <fields>; }
--keepclassmembers enum org.wordpress.android.fluxc.** { *; }
-###### FluxC - end
-
 ###### FluxC - WellSql (needed for Addon support) - begin
 -keep class com.wellsql** { *; }
 ###### FluxC - end

--- a/WooCommerce/proguard-rules.pro
+++ b/WooCommerce/proguard-rules.pro
@@ -40,7 +40,8 @@
 }
 ###### SavedStateHandleExt - end
 
-###### Google Crypto Tink dependencies - begin
+###### Google Crypto Tink (still transitively present; KeysDownloader references
+###### google-http-client + joda-time which aren't on the classpath) - begin
 -dontwarn com.google.api.client.http.GenericUrl
 -dontwarn com.google.api.client.http.HttpHeaders
 -dontwarn com.google.api.client.http.HttpRequest
@@ -50,4 +51,4 @@
 -dontwarn com.google.api.client.http.javanet.NetHttpTransport$Builder
 -dontwarn com.google.api.client.http.javanet.NetHttpTransport
 -dontwarn org.joda.time.Instant
-###### Google Crypto Tink dependencies - end
+###### Google Crypto Tink - end

--- a/WooCommerce/proguard-rules.pro
+++ b/WooCommerce/proguard-rules.pro
@@ -1,16 +1,11 @@
 -dontobfuscate
 
-###### OkHttp (the library ships its own consumer rules) - begin
--dontwarn okio.**
--dontwarn okhttp3.**
--dontwarn com.squareup.okhttp.**
-
+###### Gson (keep generic signatures + annotations for reflective (de)serialization) - begin
 -keepattributes Signature
 -keepattributes *Annotation*
-###### OkHttp - end
+###### Gson - end
 
 ###### Event Bus 3 (the @Subscribe rule comes from the library's consumer rules)
--keepattributes *Annotation*
 -keep enum org.greenrobot.eventbus.ThreadMode { *; }
 
 # Only required if you use AsyncExecutor

--- a/WooCommerce/proguard-rules.pro
+++ b/WooCommerce/proguard-rules.pro
@@ -1,10 +1,5 @@
 -dontobfuscate
 
-###### Gson (keep generic signatures + annotations for reflective (de)serialization) - begin
--keepattributes Signature
--keepattributes *Annotation*
-###### Gson - end
-
 ###### Event Bus 3 (the @Subscribe rule comes from the library's consumer rules)
 -keep enum org.greenrobot.eventbus.ThreadMode { *; }
 

--- a/WooCommerce/proguard-rules.pro
+++ b/WooCommerce/proguard-rules.pro
@@ -13,10 +13,6 @@
 
 ###### Zendesk (the SDK ships its own consumer rules; Gson/Retrofit/OkHttp ship theirs too)
 
-###### Glide - begin
--keep class com.bumptech.glide.GeneratedAppGlideModuleImpl { *; }
-###### Glide - end
-
 ###### SavedStateHandleExt - begin
 ###### We use reflection so we have to keep this method
 -keepclassmembers class * extends androidx.navigation.NavArgs {

--- a/WooCommerce/proguard-rules.pro
+++ b/WooCommerce/proguard-rules.pro
@@ -25,10 +25,6 @@
 -keep class com.wellsql** { *; }
 ###### FluxC - end
 
-###### Dagger - begin
--dontwarn com.google.errorprone.annotations.*
-###### Dagger - end
-
 -dontwarn com.google.common.**
 
 ###### Zendesk (the SDK ships its own consumer rules; Gson/Retrofit/OkHttp ship theirs too)

--- a/WooCommerce/proguard-rules.pro
+++ b/WooCommerce/proguard-rules.pro
@@ -1,14 +1,5 @@
 -dontobfuscate
 
-###### Event Bus 3 (the @Subscribe rule comes from the library's consumer rules)
--keep enum org.greenrobot.eventbus.ThreadMode { *; }
-
-# Only required if you use AsyncExecutor
--keepclassmembers class * extends org.greenrobot.eventbus.util.ThrowableFailureEvent {
-    <init>(java.lang.Throwable);
-}
-###### Event Bus 3 - end
-
 ##### WooCommerce - begin
 # Gson populates fields reflectively, so keep fields and enum constants of our classes
 # (we don't obfuscate, so names are stable). Methods stay eligible for R8 optimization.

--- a/WooCommerce/proguard-rules.pro
+++ b/WooCommerce/proguard-rules.pro
@@ -51,9 +51,3 @@
 -dontwarn com.google.api.client.http.javanet.NetHttpTransport
 -dontwarn org.joda.time.Instant
 ###### Google Crypto Tink dependencies - end
-
-# This is generated automatically by the Android Gradle plugin.
--dontwarn java.beans.ConstructorProperties
--dontwarn java.beans.Transient
--dontwarn org.slf4j.impl.StaticLoggerBinder
--dontwarn org.slf4j.impl.StaticMDCBinder

--- a/libs/fluxc/consumer-rules.pro
+++ b/libs/fluxc/consumer-rules.pro
@@ -31,6 +31,8 @@
 # Application classes that will be serialized/deserialized over Gson
 -keep class org.wordpress.android.fluxc.model.** { <fields>; }
 -keep class org.wordpress.android.fluxc.network.** { <fields>; }
+-keepclassmembers class org.wordpress.android.fluxc.** { <fields>; }
+-keepclassmembers enum org.wordpress.android.fluxc.** { *; }
 
 # Prevent proguard from stripping interface information from TypeAdapter, TypeAdapterFactory,
 # JsonSerializer, JsonDeserializer instances (so they can be used in @JsonAdapter)


### PR DESCRIPTION
WOOMOB-3903

Follow-up to the review on #16308 — going through the ProGuard cleanup suggestions one by one. 

Original review comments:

- **OkHttp** ([comment](https://github.com/woocommerce/woocommerce-android/pull/16308#discussion_r3841471573)) — removed. OkHttp ships its own rules and `com.squareup.okhttp.**` is dead v2.
- **Event Bus 2** ([comment](https://github.com/woocommerce/woocommerce-android/pull/16308#discussion_r3841506814), [comment](https://github.com/woocommerce/woocommerce-android/pull/16308#discussion_r3841501420)) — gone. We only use Event Bus 3, there's no `de.greenrobot.event` anywhere.
- **FluxC** ([comment](https://github.com/woocommerce/woocommerce-android/pull/16308#discussion_r3841469204)) — moved into `libs/fluxc/consumer-rules.pro` where it belongs. Same rules, so the merged config doesn't change.
- **Dagger errorprone** ([comment](https://github.com/woocommerce/woocommerce-android/pull/16308#discussion_r3841527435)) — removed, library rules already cover it.
- **Crypto Tink** ([comment](https://github.com/woocommerce/woocommerce-android/pull/16308#discussion_r3841544372)) — kept. Turns out we still pull it in transitively and R8 fails without these 9 lines (`KeysDownloader` references classes that aren't on the classpath). Added a comment explaining why.
- **AGP auto-generated** ([comment](https://github.com/woocommerce/woocommerce-android/pull/16308#discussion_r3841552686)) — removed, no longer needed.

While in here I also cleaned up a few more rules that turned out to be redundant or dead:

- **`-keepattributes Signature` / `*Annotation*`** — removed. Gson's own `gson.pro` ships `Signature` and EventBus/coordinatorlayout/FluxC ship `*Annotation*`; `-keepattributes` is global, so the merged config keeps both without ours.
- **Event Bus 3 keeps** (`ThreadMode`, `ThrowableFailureEvent` ctor) — removed. EventBus's own consumer rules already ship both, and the `* extends ThrowableFailureEvent` variant only matters with AsyncExecutor, which we don't use.
- **guava `-dontwarn com.google.common.**`** — removed, R8 builds clean without it.
- **Glide `GeneratedAppGlideModuleImpl` keep** — removed. The generated class is never actually in the release build (not in R8 seeds, on trunk either), so the rule matched nothing.

The file goes from 85 lines to ~24.

### Test Steps

Build-config only, nothing user-facing. `assembleWasabiRelease` and `lintWasabiRelease` are green, and I smoke-tested the logged-in release build — dashboard/stats, orders + detail, products + detail all load real data with no crashes or stripped-class errors.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes. — N/A, internal.
