### PR TITLE
[WOOMOB-3734] Fix SelectedSiteResetException and ClassCastException on application-password logout

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,8 @@
 
 25.7
 -----
+- [*] Logging out of a store-credentials login no longer restarts the app or leaves account data behind when the selected site is reset mid-logout [https://github.com/woocommerce/woocommerce-android/pull/16483]
+- [*] Logging in with site credentials no longer crashes when the store lists an application password without a UUID [https://github.com/woocommerce/woocommerce-android/pull/16483]
 - [*] Order detail: the "Need a shipping label?" banner dismiss button is now announced as "Dismiss" by TalkBack instead of a refund message [https://github.com/woocommerce/woocommerce-android/pull/16538]
 - [*****] Updated the Stripe Terminal SDK to 5.8.0; card readers now use coarse location on Android 12+ so the app no longer requests precise location for in-person payments except on older devices [https://github.com/woocommerce/woocommerce-android/pull/16507]
 - [*] Stores configured with an HTTP address now connect securely over HTTPS, with guidance to update their WordPress address [https://github.com/woocommerce/woocommerce-android/pull/16470]
@@ -25,8 +27,6 @@
 - [*] Product attributes and tags no longer silently discard an option or tag you typed but didn't add before leaving the screen — you're now warned before discarding [https://github.com/woocommerce/woocommerce-android/pull/16449]
 - [*] Editing a product attribute's options no longer wipes the product's other local attributes and their variations [https://github.com/woocommerce/woocommerce-android/pull/16449]
 - [*] Login loading dialogs now use the correct background in dark mode
-- [*] Logging out of a store-credentials login no longer restarts the app or leaves account data behind when the selected site is reset mid-logout [https://github.com/woocommerce/woocommerce-android/pull/16483]
-- [*] Logging in with site credentials no longer crashes when the store lists an application password without a UUID [https://github.com/woocommerce/woocommerce-android/pull/16483]
 - [Internal] Woo POS refunds: refund events now report whether totals were calculated locally or by the server, a new event records when a store falls back for lack of the server route, and refunds abandoned before submission are now reported instead of leaving the funnel open [https://github.com/woocommerce/woocommerce-android/pull/16419]
 - [*] The app name on the launcher is no longer translated - Brazilian Portuguese showed "Eba!" instead of "Woo"[https://github.com/woocommerce/woocommerce-android/pull/16452]
 - [*] Order creation: the discount screen now formats the product line and totals like the rest of the app, and "Price after discount" shows the full price until a discount is entered [https://github.com/woocommerce/woocommerce-android/pull/16453]

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -25,6 +25,8 @@
 - [*] Product attributes and tags no longer silently discard an option or tag you typed but didn't add before leaving the screen — you're now warned before discarding [https://github.com/woocommerce/woocommerce-android/pull/16449]
 - [*] Editing a product attribute's options no longer wipes the product's other local attributes and their variations [https://github.com/woocommerce/woocommerce-android/pull/16449]
 - [*] Login loading dialogs now use the correct background in dark mode
+- [*] Logging out of a store-credentials login no longer restarts the app or leaves account data behind when the selected site is reset mid-logout [https://github.com/woocommerce/woocommerce-android/pull/16483]
+- [*] Logging in with site credentials no longer crashes when the store lists an application password without a UUID [https://github.com/woocommerce/woocommerce-android/pull/16483]
 - [Internal] Woo POS refunds: refund events now report whether totals were calculated locally or by the server, a new event records when a store falls back for lack of the server route, and refunds abandoned before submission are now reported instead of leaving the funnel open [https://github.com/woocommerce/woocommerce-android/pull/16419]
 - [*] The app name on the launcher is no longer translated - Brazilian Portuguese showed "Eba!" instead of "Woo"[https://github.com/woocommerce/woocommerce-android/pull/16452]
 - [*] Order creation: the discount screen now formats the product line and totals like the rest of the app, and "Price after discount" shows the full price until a discount is entered [https://github.com/woocommerce/woocommerce-android/pull/16453]

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/AccountRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/AccountRepository.kt
@@ -67,9 +67,16 @@ class AccountRepository @Inject constructor(
     suspend fun logout(): Boolean {
         if (!isUserLoggedIn()) return true
 
+        // Capture the site before the suspension point below, it may be reset while we are suspended.
+        val applicationPasswordSite = selectedSite.getOrNull()
+
         pushNotificationRepository.unregisterDeviceFromPushNotifications()
 
-        return if (accountStore.hasAccessToken()) logoutWpComAccount() else logoutApplicationPasswordAccount()
+        return if (accountStore.hasAccessToken()) {
+            logoutWpComAccount()
+        } else {
+            logoutApplicationPasswordAccount(applicationPasswordSite)
+        }
     }
 
     suspend fun closeAccount(): CloseAccountResult {
@@ -126,8 +133,12 @@ class AccountRepository @Inject constructor(
         return true
     }
 
-    private fun logoutApplicationPasswordAccount(): Boolean {
-        deleteApplicationPassword(selectedSite.get())
+    private fun logoutApplicationPasswordAccount(site: SiteModel?): Boolean {
+        if (site != null) {
+            deleteApplicationPassword(site)
+        } else {
+            WooLog.w(LOGIN, "Skipping application password deletion, the selected site is not available")
+        }
         completeLogout()
         return true
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/AccountRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/AccountRepositoryTest.kt
@@ -19,10 +19,14 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.yield
 import org.assertj.core.api.Assertions.assertThat
+import org.mockito.Mockito.lenient
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doSuspendableAnswer
+import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.given
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.action.AccountAction
@@ -111,7 +115,7 @@ class AccountRepositoryTest : BaseUnitTest() {
             given(accountStore.hasAccessToken()).willReturn(false)
             given(selectedSite.connectionType).willReturn(SiteConnectionType.ApplicationPasswords)
             val selectedSiteModel = SiteModel()
-            given(selectedSite.get()).willReturn(selectedSiteModel)
+            given(selectedSite.getOrNull()).willReturn(selectedSiteModel)
             given(siteStore.deleteApplicationPassword(selectedSiteModel))
                 .willReturn(OnApplicationPasswordDeleted(selectedSiteModel))
 
@@ -130,7 +134,7 @@ class AccountRepositoryTest : BaseUnitTest() {
             given(accountStore.hasAccessToken()).willReturn(false)
             given(selectedSite.connectionType).willReturn(SiteConnectionType.ApplicationPasswords)
             val selectedSiteModel = SiteModel()
-            given(selectedSite.get()).willReturn(selectedSiteModel)
+            given(selectedSite.getOrNull()).willReturn(selectedSiteModel)
             given(siteStore.deleteApplicationPassword(selectedSiteModel))
                 .willReturn(OnApplicationPasswordDeleted(selectedSiteModel))
             val cleanupGate = CompletableDeferred<Unit>()
@@ -149,5 +153,56 @@ class AccountRepositoryTest : BaseUnitTest() {
             result.await()
             advanceUntilIdle()
             assertThat(result.isCompleted).isTrue()
+        }
+
+    @Test
+    fun `given app password login, when the site is reset during push cleanup, then the captured site password is deleted`() =
+        testBlocking {
+            // GIVEN
+            given(accountStore.hasAccessToken()).willReturn(false)
+            given(selectedSite.connectionType).willReturn(SiteConnectionType.ApplicationPasswords)
+            val selectedSiteModel = SiteModel()
+            given(selectedSite.getOrNull()).willReturn(selectedSiteModel)
+            given(siteStore.deleteApplicationPassword(selectedSiteModel))
+                .willReturn(OnApplicationPasswordDeleted(selectedSiteModel))
+            val cleanupGate = CompletableDeferred<Unit>()
+            whenever(pushNotificationRepository.unregisterDeviceFromPushNotifications()).doSuspendableAnswer {
+                cleanupGate.await()
+            }
+
+            // WHEN
+            val result = async { repository.logout() }
+            runCurrent()
+            assertThat(result.isCompleted).isFalse()
+            // A concurrent flow resets the selected site while the push cleanup is still in flight.
+            // Stubbed leniently: the fix must not touch the selected site again after resuming.
+            lenient().doReturn(null).whenever(selectedSite).getOrNull()
+            lenient().doThrow(SelectedSite.SelectedSiteResetException()).whenever(selectedSite).get()
+            cleanupGate.complete(Unit)
+
+            // THEN
+            assertThat(result.await()).isTrue()
+            advanceUntilIdle()
+            verify(siteStore).deleteApplicationPassword(selectedSiteModel)
+            verify(selectedSite, never()).get()
+            verify(selectedSite).reset()
+        }
+
+    @Test
+    fun `given app password login and no selected site, when logout is called, then no password is deleted`() =
+        testBlocking {
+            // GIVEN
+            given(accountStore.hasAccessToken()).willReturn(false)
+            given(selectedSite.connectionType).willReturn(SiteConnectionType.ApplicationPasswords)
+            given(selectedSite.getOrNull()).willReturn(null)
+
+            // WHEN
+            val result = repository.logout()
+            advanceUntilIdle()
+
+            // THEN
+            assertThat(result).isTrue()
+            verify(selectedSite).reset()
+            verify(siteStore, never()).deleteApplicationPassword(any())
         }
 }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsApiResponses.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsApiResponses.kt
@@ -9,7 +9,7 @@ internal data class ApplicationPasswordCreationResponse(
 )
 
 internal data class ApplicationPasswordsFetchResponse(
-    @SerializedName("uuid") val uuid: ApplicationPasswordUUID,
+    @SerializedName("uuid") val uuid: ApplicationPasswordUUID?,
     @SerializedName("name") val name: String
 )
 

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/WPApiApplicationPasswordsRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/WPApiApplicationPasswordsRestClient.kt
@@ -14,7 +14,6 @@ import org.wordpress.android.fluxc.network.rest.wpapi.BaseWPAPIRestClient
 import org.wordpress.android.fluxc.network.rest.wpapi.CookieNonceAuthenticator
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIGsonRequest
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIGsonRequestBuilder
-import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetworkError
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
 import org.wordpress.android.fluxc.utils.HttpsUrlNormalizer
 import org.wordpress.android.fluxc.utils.extensions.slashJoin
@@ -86,12 +85,17 @@ internal class WPApiApplicationPasswordsRestClient @Inject constructor(
 
         return when (response) {
             is WPAPIResponse.Success -> {
-                response.data?.firstOrNull { it.name == applicationName }?.let {
-                    ApplicationPasswordUUIDFetchPayload(it.uuid)
+                val listedPassword = response.data?.firstOrNull { it.name == applicationName }
+                listedPassword?.uuid?.let {
+                    ApplicationPasswordUUIDFetchPayload(it)
                 } ?: ApplicationPasswordUUIDFetchPayload(
                     BaseNetworkError(
                         GenericErrorType.UNKNOWN,
-                        "UUID for application password $applicationName was not found"
+                        if (listedPassword == null) {
+                            "UUID for application password $applicationName was not found"
+                        } else {
+                            "UUID missing from response"
+                        }
                     )
                 )
             }
@@ -126,11 +130,8 @@ internal class WPApiApplicationPasswordsRestClient @Inject constructor(
         AppLog.d(T.MAIN, "Delete application password using Basic Authentication")
 
         val uuid = credentials.uuid ?: fetchApplicationPasswordUsingBasicAuth(site, credentials).let {
-            if (it is WPAPIResponse.Success && it.data != null) {
-                it.data
-            } else {
-                return ApplicationPasswordDeletionPayload((it as WPAPIResponse.Error).error)
-            }
+            if (it.isError) return ApplicationPasswordDeletionPayload(it.error)
+            it.uuid
         }
 
         return deleteApplicationPasswordUsingBasicAuth(site, credentials, uuid).toPayload()
@@ -139,7 +140,7 @@ internal class WPApiApplicationPasswordsRestClient @Inject constructor(
     private suspend fun fetchApplicationPasswordUsingBasicAuth(
         site: SiteModel,
         applicationPasswordCredentials: ApplicationPasswordCredentials
-    ): WPAPIResponse<ApplicationPasswordUUID> {
+    ): ApplicationPasswordUUIDFetchPayload {
         AppLog.d(T.MAIN, "Fetching application password UUID using the /introspect endpoint")
 
         val path = WPAPI.users.me.application_passwords.introspect.urlV2
@@ -151,20 +152,17 @@ internal class WPApiApplicationPasswordsRestClient @Inject constructor(
             method = Request.Method.GET,
         )
 
-        @Suppress("UNCHECKED_CAST")
         return when (response) {
-            is WPAPIResponse.Success -> response.data?.let {
-                WPAPIResponse.Success(it.uuid, response.headers)
-            } ?: WPAPIResponse.Error(
-                WPAPINetworkError(
-                    BaseNetworkError(
-                        GenericErrorType.UNKNOWN,
-                        "Response is empty"
-                    )
+            is WPAPIResponse.Success -> response.data?.uuid?.let {
+                ApplicationPasswordUUIDFetchPayload(it)
+            } ?: ApplicationPasswordUUIDFetchPayload(
+                BaseNetworkError(
+                    GenericErrorType.UNKNOWN,
+                    if (response.data == null) "Response is empty" else "UUID missing from response"
                 )
             )
 
-            is WPAPIResponse.Error -> response as WPAPIResponse.Error<ApplicationPasswordUUID>
+            is WPAPIResponse.Error -> ApplicationPasswordUUIDFetchPayload(response.error)
         }
     }
 

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/WPApiApplicationPasswordsRestClientTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/WPApiApplicationPasswordsRestClientTest.kt
@@ -1,0 +1,242 @@
+package org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords
+
+import com.android.volley.NetworkResponse
+import com.android.volley.Request
+import com.android.volley.RequestQueue
+import com.android.volley.VolleyError
+import com.google.gson.Gson
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
+import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.rest.ResponseWithHeaders
+import org.wordpress.android.fluxc.network.rest.wpapi.CookieNonceAuthenticator
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIGsonRequest
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetworkError
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@ExperimentalCoroutinesApi
+@RunWith(RobolectricTestRunner::class)
+class WPApiApplicationPasswordsRestClientTest {
+    private val testSite = SiteModel().apply {
+        url = "http://test-site.com"
+    }
+    private val credentialsWithoutUuid = ApplicationPasswordCredentials(
+        userName = "username",
+        password = "password",
+        uuid = null
+    )
+
+    private val noCookieRequestQueue: RequestQueue = mock()
+    private val cookieNonceAuthenticator: CookieNonceAuthenticator = mock()
+    private val restClient = WPApiApplicationPasswordsRestClient(
+        wpApiGsonRequestBuilder = mock(),
+        cookieNonceAuthenticator = cookieNonceAuthenticator,
+        noCookieRequestQueue = noCookieRequestQueue,
+        requestQueue = mock(),
+        dispatcher = mock<Dispatcher>(),
+        userAgent = mock<UserAgent>()
+    )
+
+    @Test
+    fun `given the introspect response has no uuid, when deleting a password, then return an error payload`() =
+        runTest {
+            // GIVEN the server answers 200 but omits the uuid field, so Gson leaves it null
+            givenSuccessResponse(
+                Gson().fromJson("""{"name":"woo-app"}""", ApplicationPasswordsFetchResponse::class.java)
+            )
+
+            // WHEN
+            val payload = restClient.deleteApplicationPassword(testSite, credentialsWithoutUuid)
+
+            // THEN
+            assertTrue(payload.isError)
+            assertFalse(payload.isDeleted)
+            assertEquals("UUID missing from response", payload.error.message)
+        }
+
+    @Test
+    fun `given the introspect response is empty, when deleting a password, then return an error payload`() =
+        runTest {
+            // GIVEN the server answers 200 with no body at all
+            givenSuccessResponse(null)
+
+            // WHEN
+            val payload = restClient.deleteApplicationPassword(testSite, credentialsWithoutUuid)
+
+            // THEN
+            assertTrue(payload.isError)
+            assertEquals("Response is empty", payload.error.message)
+        }
+
+    @Test
+    fun `given the introspect response has a uuid, when deleting a password, then the password is deleted`() =
+        runTest {
+            val introspectResponse = Gson().fromJson(
+                """{"uuid":"the-uuid","name":"woo-app"}""",
+                ApplicationPasswordsFetchResponse::class.java
+            )
+            givenSuccessResponses(introspectResponse, ApplicationPasswordDeleteResponse(deleted = true))
+
+            val payload = restClient.deleteApplicationPassword(testSite, credentialsWithoutUuid)
+
+            assertFalse(payload.isError)
+            assertTrue(payload.isDeleted)
+        }
+
+    @Test
+    fun `given the listed password has no uuid, when fetching its uuid, then return an error payload`() =
+        runTest {
+            // GIVEN the server lists the password but omits the uuid field
+            val listedPassword = Gson().fromJson(
+                """{"name":"woo-app"}""",
+                ApplicationPasswordsFetchResponse::class.java
+            )
+            whenever(
+                cookieNonceAuthenticator.makeAuthenticatedWPAPIRequest<Array<ApplicationPasswordsFetchResponse>>(
+                    eq(testSite),
+                    any()
+                )
+            ).thenReturn(WPAPIResponse.Success(arrayOf(listedPassword), emptyList()))
+
+            // WHEN
+            val payload = restClient.fetchApplicationPasswordUUID(testSite, "woo-app")
+
+            // THEN
+            assertTrue(payload.isError)
+            assertEquals("UUID missing from response", payload.error.message)
+        }
+
+    @Test
+    fun `given the password is listed with a uuid, when fetching its uuid, then return it`() =
+        runTest {
+            // GIVEN
+            val listedPassword = Gson().fromJson(
+                """{"uuid":"the-uuid","name":"woo-app"}""",
+                ApplicationPasswordsFetchResponse::class.java
+            )
+            givenCookieAuthReturns(WPAPIResponse.Success(arrayOf(listedPassword), emptyList()))
+
+            // WHEN
+            val payload = restClient.fetchApplicationPasswordUUID(testSite, "woo-app")
+
+            // THEN
+            assertFalse(payload.isError)
+            assertEquals("the-uuid", payload.uuid)
+        }
+
+    @Test
+    fun `given no password matches the app name, when fetching its uuid, then say it was not found`() =
+        runTest {
+            // GIVEN a list that does not contain our application name
+            val other = Gson().fromJson(
+                """{"uuid":"other-uuid","name":"some-other-app"}""",
+                ApplicationPasswordsFetchResponse::class.java
+            )
+            givenCookieAuthReturns(WPAPIResponse.Success(arrayOf(other), emptyList()))
+
+            // WHEN
+            val payload = restClient.fetchApplicationPasswordUUID(testSite, "woo-app")
+
+            // THEN
+            assertTrue(payload.isError)
+            assertEquals("UUID for application password woo-app was not found", payload.error.message)
+        }
+
+    @Test
+    fun `given the list request fails, when fetching a uuid, then the network error is propagated`() =
+        runTest {
+            // GIVEN
+            val networkError = WPAPINetworkError(
+                BaseNetworkError(VolleyError(NetworkResponse(500, byteArrayOf(), true, 0, emptyList())))
+            )
+            givenCookieAuthReturns(WPAPIResponse.Error(networkError))
+
+            // WHEN
+            val payload = restClient.fetchApplicationPasswordUUID(testSite, "woo-app")
+
+            // THEN
+            assertTrue(payload.isError)
+            assertEquals(networkError, payload.error)
+        }
+
+    @Test
+    fun `given the introspect request fails, when deleting a password, then the network error is propagated`() =
+        runTest {
+            // GIVEN
+            val networkError = VolleyError(NetworkResponse(500, byteArrayOf(), true, 0, emptyList()))
+            givenErrorResponse(networkError)
+
+            // WHEN
+            val payload = restClient.deleteApplicationPassword(testSite, credentialsWithoutUuid)
+
+            // THEN the original network error surfaces, not a synthesised "missing uuid" one
+            assertTrue(payload.isError)
+            assertFalse(payload.isDeleted)
+            assertEquals(networkError, payload.error.volleyError)
+        }
+
+    @Test
+    fun `given the credentials already hold a uuid, when deleting a password, then the introspect call is skipped`() =
+        runTest {
+            // GIVEN
+            givenSuccessResponse(ApplicationPasswordDeleteResponse(deleted = true))
+
+            // WHEN
+            val payload = restClient.deleteApplicationPassword(
+                testSite,
+                credentialsWithoutUuid.copy(uuid = "the-uuid")
+            )
+
+            // THEN only the DELETE is issued
+            assertFalse(payload.isError)
+            assertTrue(payload.isDeleted)
+            verify(noCookieRequestQueue, times(1)).add(any<WPAPIGsonRequest<Any>>())
+        }
+
+    private fun givenSuccessResponse(response: Any?) = givenSuccessResponses(response)
+
+    @Suppress("UNCHECKED_CAST", "SpreadOperator")
+    private fun givenSuccessResponses(vararg responses: Any?) {
+        val remaining = responses.toMutableList()
+        whenever(noCookieRequestQueue.add(any<WPAPIGsonRequest<Any>>())).thenAnswer { invocation ->
+            val request = invocation.arguments.first() as WPAPIGsonRequest<Any>
+            val deliverMethod = Request::class.java.getDeclaredMethod("deliverResponse", Any::class.java)
+            deliverMethod.isAccessible = true
+            deliverMethod.invoke(request, ResponseWithHeaders(remaining.removeAt(0), emptyList()))
+            return@thenAnswer request
+        }
+    }
+
+    private suspend fun givenCookieAuthReturns(response: WPAPIResponse<Array<ApplicationPasswordsFetchResponse>>) {
+        whenever(
+            cookieNonceAuthenticator.makeAuthenticatedWPAPIRequest<Array<ApplicationPasswordsFetchResponse>>(
+                eq(testSite),
+                any()
+            )
+        ).thenReturn(response)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun givenErrorResponse(error: VolleyError) {
+        whenever(noCookieRequestQueue.add(any<WPAPIGsonRequest<Any>>())).thenAnswer { invocation ->
+            val request = invocation.arguments.first() as WPAPIGsonRequest<Any>
+            request.deliverError(error)
+            return@thenAnswer request
+        }
+    }
+}

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/WPApiApplicationPasswordsRestClientTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/WPApiApplicationPasswordsRestClientTest.kt
@@ -25,6 +25,7 @@ import org.wordpress.android.fluxc.network.rest.wpapi.CookieNonceAuthenticator
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIGsonRequest
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetworkError
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
+import org.wordpress.android.fluxc.utils.HttpsUrlNormalizer
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -46,6 +47,7 @@ class WPApiApplicationPasswordsRestClientTest {
     private val restClient = WPApiApplicationPasswordsRestClient(
         wpApiGsonRequestBuilder = mock(),
         cookieNonceAuthenticator = cookieNonceAuthenticator,
+        httpsUrlNormalizer = HttpsUrlNormalizer(),
         noCookieRequestQueue = noCookieRequestQueue,
         requestQueue = mock(),
         dispatcher = mock<Dispatcher>(),

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/WPApiApplicationPasswordsRestClientTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/WPApiApplicationPasswordsRestClientTest.kt
@@ -108,12 +108,7 @@ class WPApiApplicationPasswordsRestClientTest {
                 """{"name":"woo-app"}""",
                 ApplicationPasswordsFetchResponse::class.java
             )
-            whenever(
-                cookieNonceAuthenticator.makeAuthenticatedWPAPIRequest<Array<ApplicationPasswordsFetchResponse>>(
-                    eq(testSite),
-                    any()
-                )
-            ).thenReturn(WPAPIResponse.Success(arrayOf(listedPassword), emptyList()))
+            givenCookieAuthReturns(WPAPIResponse.Success(arrayOf(listedPassword), emptyList()))
 
             // WHEN
             val payload = restClient.fetchApplicationPasswordUUID(testSite, "woo-app")
@@ -212,7 +207,7 @@ class WPApiApplicationPasswordsRestClientTest {
 
     private fun givenSuccessResponse(response: Any?) = givenSuccessResponses(response)
 
-    @Suppress("UNCHECKED_CAST", "SpreadOperator")
+    @Suppress("UNCHECKED_CAST")
     private fun givenSuccessResponses(vararg responses: Any?) {
         val remaining = responses.toMutableList()
         whenever(noCookieRequestQueue.add(any<WPAPIGsonRequest<Any>>())).thenAnswer { invocation ->


### PR DESCRIPTION
### Description

Fixes WOOMOB-3734

Sentry: [WOOCOMMERCE-ANDROID-VB4](https://a8c.sentry.io/issues/WOOCOMMERCE-ANDROID-VB4) (the `SelectedSiteResetException`) and [WOOCOMMERCE-ANDROID-WDM](https://a8c.sentry.io/issues/WOOCOMMERCE-ANDROID-WDM) (the `ClassCastException`).

`AccountRepository.logout()` read `selectedSite.get()` after awaiting push-notification cleanup. That cleanup is a network round-trip, and `SelectedSite.reset()` sets a sticky flag, so anything that resets the site during that window — usually a second, concurrent logout — makes `get()` throw `SelectedSiteResetException` on resume. It became likely in 24.7, when #15667 hoisted push cleanup out of the two logout branches so it runs before them. The fix captures the site with the non-throwing `getOrNull()` before the suspension point.

The second commit fixes [WOOCOMMERCE-ANDROID-WDM](https://a8c.sentry.io/issues/WOOCOMMERCE-ANDROID-WDM), the fatal `ClassCastException` linked from the same Linear issue. `ApplicationPasswordsFetchResponse.uuid` was declared non-null, but Gson leaves it null when the server omits the field, so a `WPAPIResponse.Success` could carry a null payload and the old `if/else` cast that `Success` to `Error`. Making the field nullable also surfaced an NPE on the cookie-auth path. Both are guarded and covered by tests.


### Test Steps

**Sanity check — neither fix broke normal logout (no setup)**

This exercises the happy paths the two fixes touch, not the bugs themselves; both bug repros need a harness and are below.

1. Log in with store credentials: **Log In** → **No computer? Log in with site address** → enter a store address → **Log in with your site credentials**.
2. **Menu** → **Settings** → **Log out** → confirm.
3. Logout completes, the app lands on the login screen, and the app does not restart. `adb logcat | grep WooCommerce-LOGIN` shows `Application password deleted`.

For the first fix that confirms the captured site is still the one whose password gets deleted and that `cleanup()` runs. For the second it confirms the `credentials.uuid != null` short-circuit still skips the introspect call — the crash lives behind that call, so a normal logout never reaches it.

**WOOMOB-3734 — the race itself**

The window is one network round-trip wide and needs a second concurrent logout, so it isn't reproducible by hand. The attached patch stands in for a slow push cleanup and fires a second, unguarded logout; the first caller stays suspended long enough for the second to finish and reset the selected site. It touches only `PushNotificationRepository` and `AppSettingsPresenter`, so it applies to this branch **and** to `trunk`.

[woomob-3734-repro.patch](https://github.com/user-attachments/files/31788111/woomob-3734-repro.patch)


1. `git apply woomob-3734-repro.patch`, then `./gradlew :WooCommerce:installWasabiDebug`.
2. Log in with store credentials, then **Settings** → **Log out**.
3. Watch `adb logcat -v time | grep -aE "REPRO|SelectedSiteResetException|System.exit"`.
4. On this branch: `push cleanup started (call #1)` / `(call #2)`, then `second logout completed without throwing` — no exception, no exit, and two `account_logout` events, i.e. both logouts ran `cleanup()`.
5. On `trunk` (same patch): `SelectedSiteResetException` at `SelectedSite.kt:89` ← `AccountRepository.logoutApplicationPasswordAccount(AccountRepository.kt:130)`, followed by `System.exit called, status: 0` — the app disappears and restarts.

**WOOCOMMERCE-ANDROID-WDM**

A real server won't return a password list without a `uuid`, so this one is driven with the app's built-in ApiFaker (debug builds only, so use `installWasabiDebug`). Two mocks are needed: password creation returns `409`, which sends the app into `deleteConflictedApplicationPassword()`, and the password list returns `200` with a matching name but no `uuid`.

**Setup**

The faked entry's `name` has to match `WooApplicationPasswordsConfiguration.applicationName`, which is device-specific, so derive it first:

```bash
PKG=com.woocommerce.android.dev
RECEIVER="$PKG/com.woocommerce.android.apifaker.adb.ApiFakerBroadcastReceiver"

MAN=$(adb shell getprop ro.product.manufacturer | tr -d '\r')
MOD=$(adb shell getprop ro.product.model | tr -d '\r')
case "$MOD" in "$MAN"*) DEV="$MOD";; *) DEV="$MAN $MOD";; esac
APPNAME="$PKG.app-client.$(echo "$DEV" | tr ' /\\' '---')"
echo "$APPNAME"   # e.g. com.woocommerce.android.dev.app-client.Google-sdk_gphone16k_arm64
```

Then arm ApiFaker:

```bash
adb shell am broadcast -a com.woocommerce.android.apifaker.CLEAR_ENDPOINTS -n "$RECEIVER"
adb shell am broadcast -a com.woocommerce.android.apifaker.SET_STATUS --ez enabled true -n "$RECEIVER"

# 1) application password creation -> 409 CONFLICT
adb shell am broadcast -a com.woocommerce.android.apifaker.ADD_ENDPOINT \
  --es api_type wp-api \
  --es path /wp/v2/users/me/application-passwords \
  --es http_method POST \
  --ei response_status_code 409 \
  --es response_body "'{\"code\":\"application_password_exists\"}'" \
  -n "$RECEIVER"

# 2) application password list -> 200, matching name, no uuid
adb shell am broadcast -a com.woocommerce.android.apifaker.ADD_ENDPOINT \
  --es api_type wp-api \
  --es path /wp/v2/users/me/application-passwords \
  --es http_method GET \
  --ei response_status_code 200 \
  --es response_body "'[{\"name\":\"$APPNAME\"}]'" \
  -n "$RECEIVER"
```

A red "ApiFaker Enabled" banner appears at the bottom of the app once it's on.

**Steps**

1. Log in with site credentials (site address → **Log in with your site credentials** → username/password).
2. Watch `adb logcat -v time | grep -aE "WCApiFaker|Application Password already exists|FATAL EXCEPTION"`.
3. On this branch: two `WCApiFaker: Matched request` lines, `Application Password already exists`, then login fails gracefully with an application-password error and the app stays up.
4. On `trunk` with the same mocks: same two lines, then `FATAL EXCEPTION: main` — `NullPointerException: Parameter specified as non-null is null` in `ApplicationPasswordUUIDFetchPayload.<init>` — and the process is killed.

**Cleanup**

```bash
adb shell am broadcast -a com.woocommerce.android.apifaker.SET_STATUS --ez enabled false -n "$RECEIVER"
adb shell am broadcast -a com.woocommerce.android.apifaker.CLEAR_ENDPOINTS -n "$RECEIVER"
```

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.





