### PR TITLE
[WOOMOB-3976] Remove the blocking call in ProductShippingFragment

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 25.6
 -----
 - [*] Order detail: product line items now show each attribute with its label on its own line, so Product Add-Ons text values are readable instead of running together [https://github.com/woocommerce/woocommerce-android/pull/16476]
+- [Internal] The product shipping screen no longer reads the shipping class from the database on the main thread [https://github.com/woocommerce/woocommerce-android/pull/16490]
 - [*] Product attributes and tags no longer silently discard an option or tag you typed but didn't add before leaving the screen — you're now warned before discarding [https://github.com/woocommerce/woocommerce-android/pull/16449]
 - [*] Editing a product attribute's options no longer wipes the product's other local attributes and their variations [https://github.com/woocommerce/woocommerce-android/pull/16449]
 - [*] Login loading dialogs now use the correct background in dark mode

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/shipping/ProductShippingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/shipping/ProductShippingFragment.kt
@@ -21,7 +21,6 @@ import com.woocommerce.android.util.setupTabletSecondPaneToolbar
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.runBlocking
 
 /**
  * Fragment which enables updating product shipping data.
@@ -68,9 +67,8 @@ class ProductShippingFragment : BaseProductEditorFragment(R.layout.fragment_prod
             new.shippingData.height?.takeIfNotEqualTo(old?.shippingData?.height) { height ->
                 showValue(binding.productHeight, R.string.product_height, height, viewModel.parameters.dimensionUnit)
             }
-            new.shippingData.shippingClassId?.takeIfNotEqualTo(old?.shippingData?.shippingClassId) { classId ->
-                val selectedText = runBlocking { viewModel.getShippingClassByRemoteShippingClassId(classId) }
-                binding.productShippingClassSpinner.setText(selectedText)
+            new.shippingClassName?.takeIfNotEqualTo(old?.shippingClassName) { shippingClassName ->
+                binding.productShippingClassSpinner.setText(shippingClassName)
             }
             new.isOneTimeShippingSectionVisible.takeIfNotEqualTo(old?.isOneTimeShippingSectionVisible) { isVisible ->
                 binding.productOneTimeShipping.isVisible = isVisible

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/shipping/ProductShippingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/shipping/ProductShippingViewModel.kt
@@ -14,6 +14,8 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
 import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
@@ -41,7 +43,12 @@ class ProductShippingViewModel @Inject constructor(
         ViewState(
             shippingData = navArgs.shippingData,
             isShippingClassSectionVisible = navArgs.requestCode == RequestCodes.PRODUCT_DETAIL_SHIPPING
-        )
+        ),
+        onChange = { old, new ->
+            if (old?.shippingData?.shippingClassId != new.shippingData.shippingClassId) {
+                refreshShippingClassName()
+            }
+        }
     )
     private var viewState by viewStateData
 
@@ -50,6 +57,8 @@ class ProductShippingViewModel @Inject constructor(
     }
 
     private val originalShippingData = navArgs.shippingData
+
+    private var shippingClassNameJob: Job? = null
 
     val shippingData
         get() = viewState.shippingData
@@ -99,9 +108,18 @@ class ProductShippingViewModel @Inject constructor(
         }
     }
 
-    suspend fun getShippingClassByRemoteShippingClassId(remoteShippingClassId: Long) =
-        productRepository.getProductShippingClassByRemoteId(remoteShippingClassId)?.name
-            ?: shippingData.shippingClassSlug ?: ""
+    private fun refreshShippingClassName() {
+        val remoteShippingClassId = shippingData.shippingClassId ?: return
+        // The view is re-observed on every recreation, so a refresh for the previous class can still be
+        // in flight when the selected one changes. Cancel it, otherwise the stale name can land last.
+        shippingClassNameJob?.cancel()
+        shippingClassNameJob = launch {
+            viewState = viewState.copy(
+                shippingClassName = productRepository.getProductShippingClassByRemoteId(remoteShippingClassId)?.name
+                    ?: shippingData.shippingClassSlug ?: ""
+            )
+        }
+    }
 
     override fun onCleared() {
         super.onCleared()
@@ -111,7 +129,8 @@ class ProductShippingViewModel @Inject constructor(
     @Parcelize
     data class ViewState(
         val shippingData: ShippingData = ShippingData(),
-        val isShippingClassSectionVisible: Boolean? = null
+        val isShippingClassSectionVisible: Boolean? = null,
+        @IgnoredOnParcel val shippingClassName: String? = null
     ) : Parcelable {
         @IgnoredOnParcel
         val isOneTimeShippingSectionVisible = shippingData.subscriptionShippingData != null

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/shipping/ProductShippingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/shipping/ProductShippingViewModelTest.kt
@@ -4,6 +4,7 @@ import com.woocommerce.android.RequestCodes
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.model.ShippingClass
 import com.woocommerce.android.ui.products.ParameterRepository
 import com.woocommerce.android.ui.products.details.ProductDetailRepository
 import com.woocommerce.android.viewmodel.BaseUnitTest
@@ -15,6 +16,7 @@ import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.spy
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 
 @ExperimentalCoroutinesApi
 class ProductShippingViewModelTest : BaseUnitTest() {
@@ -58,6 +60,33 @@ class ProductShippingViewModelTest : BaseUnitTest() {
             )
         )
     }
+
+    @Test
+    fun `given the shipping class is in the database, when the view state is observed, then its name is shown`() =
+        testBlocking {
+            whenever(productDetailRepository.getProductShippingClassByRemoteId(1))
+                .thenReturn(ShippingClass(name = "Heavy items", slug = "heavy-items", remoteShippingClassId = 1))
+            var actual: String? = null
+
+            viewModel.viewStateData.observeForever { _, new ->
+                actual = new.shippingClassName
+            }
+
+            Assertions.assertThat(actual).isEqualTo("Heavy items")
+        }
+
+    @Test
+    fun `given the shipping class is missing, when the view state is observed, then the slug is shown`() =
+        testBlocking {
+            whenever(productDetailRepository.getProductShippingClassByRemoteId(1)).thenReturn(null)
+            var actual: String? = null
+
+            viewModel.viewStateData.observeForever { _, new ->
+                actual = new.shippingClassName
+            }
+
+            Assertions.assertThat(actual).isEqualTo(initialData.shippingClassSlug)
+        }
 
     @Test
     fun `Test that the initial data is displayed correctly`() = testBlocking {


### PR DESCRIPTION
Fixes WOOMOB-3976

`ProductShippingFragment` filled the shipping class field from inside its view state observer with `runBlocking { viewModel.getShippingClassByRemoteShippingClassId(classId) }`, so opening the product's Shipping card read the class from Room on the main thread.

`ProductShippingViewModel` now resolves the name itself when the selected class changes and exposes it as `ViewState.shippingClassName`, and the fragment just renders that. This follows the same shape as WOOMOB-992, which moved the parent category name into `AddProductCategoryViewModel`. Part of WOOMOB-983.

The refresh keeps its `Job` and cancels the previous one. `LiveDataDelegate.observe` resets its `previousValue` on every view recreation, so returning from the class picker starts a refresh for the old id just before the result starts one for the new id; without the cancel the stale name could land last.

### Test Steps

Needs a product with a shipping class assigned, and at least one other shipping class on the store.

1. Open the **Products** tab.
2. Open the product that has a shipping class.
3. Tap the **Shipping** card.
4. Check the **Shipping class** field shows the class name.
5. Tap the **Shipping class** field.
6. Select a different shipping class.
7. Check the **Shipping class** field shows the newly selected class name.

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.