### PR TITLE
[WOOMOB-3889] Fix product Maestro flows asserting on empty-state text

### DIFF
--- a/.maestro/flows/products_detail.yaml
+++ b/.maestro/flows/products_detail.yaml
@@ -82,22 +82,16 @@ tags:
       notVisible: "Categories"
     commands:
       - scrollUntilVisible:
-          element: "Categories"
+          element:
+            id: "productDetail_addMoreButton"
           direction: DOWN
           timeout: 15000
-          optional: true
-          label: "Look for the Categories row on the detail screen"
+          label: "Scroll to the end of the detail card list"
 
 - runFlow:
     when:
       notVisible: "Categories"
     commands:
-      - scrollUntilVisible:
-          element:
-            id: "productDetail_addMoreButton"
-          direction: DOWN
-          timeout: 15000
-          label: "Scroll to Add more details"
       - tapOn:
           id: "productDetail_addMoreButton"
           retryTapIfNoChange: true

--- a/.maestro/flows/products_detail.yaml
+++ b/.maestro/flows/products_detail.yaml
@@ -55,7 +55,8 @@ tags:
 # "Write with AI" button render on every product type, so they're a
 # safer readiness signal than price-related text.
 - extendedWaitUntil:
-    visible: ".*GOT IT.*|.*Describe your product.*|.*Write with AI.*|.*PUBLISH.*"
+    visible:
+      id: "cardsRecyclerView"
     timeout: 25000
     label: "Wait for product detail to load"
 
@@ -69,7 +70,7 @@ tags:
 # Wait for the product-name field (universal).
 - extendedWaitUntil:
     visible:
-      id: "editText"
+      id: "cardsRecyclerView"
     timeout: 10000
 
 - takeScreenshot: product_detail_top

--- a/.maestro/flows/products_detail.yaml
+++ b/.maestro/flows/products_detail.yaml
@@ -14,18 +14,12 @@
 #
 # We therefore avoid asserting on type-specific labels like "Price" or
 # "Inventory" — those would fail as soon as the first product on the
-# staging store is, say, a Booking product (as happened on this run:
-# the first product was "Tourist Activity" → Booking). Instead we
-# assert on rows that render for EVERY product type:
-#
-#   - "Product type"  (always rendered; value varies)
-#   - "Reviews"       (always rendered; "no approved reviews" placeholder)
-#   - "Categories"    (always rendered; "Uncategorized" if unset)
+# staging store is, say, a Booking product.
 #
 # Verifies:
 #   - Product detail screen loads
-#   - Product name field + "Describe your product" area render
-#   - Universal ComplexProperty rows render (Product type, Reviews, Categories)
+#   - The Categories screen opens, from the detail row or from Add more details
+#   - The always-rendered "Product type" row is present
 #
 # Mutable description and product-type persistence is verified against the
 # run-owned product in products_create.yaml.
@@ -51,9 +45,7 @@ tags:
     index: 0
     label: "Tap first product"
 
-# Wait for product detail screen. The "Describe your product" hint +
-# "Write with AI" button render on every product type, so they're a
-# safer readiness signal than price-related text.
+# Wait for product detail screen.
 - extendedWaitUntil:
     visible:
       id: "cardsRecyclerView"
@@ -67,7 +59,6 @@ tags:
     commands:
       - tapOn: "GOT IT"
 
-# Wait for the product-name field (universal).
 - extendedWaitUntil:
     visible:
       id: "cardsRecyclerView"
@@ -86,8 +77,57 @@ tags:
 
 - takeScreenshot: product_detail_properties
 
-# Universal row 1: Product type (every WooCommerce product type
-# renders this — simple / variable / grouped / external / booking / …).
+- runFlow:
+    when:
+      notVisible: "Categories"
+    commands:
+      - scrollUntilVisible:
+          element: "Categories"
+          direction: DOWN
+          timeout: 15000
+          optional: true
+          label: "Look for the Categories row on the detail screen"
+
+- runFlow:
+    when:
+      notVisible: "Categories"
+    commands:
+      - scrollUntilVisible:
+          element:
+            id: "productDetail_addMoreButton"
+          direction: DOWN
+          timeout: 15000
+          label: "Scroll to Add more details"
+      - tapOn:
+          id: "productDetail_addMoreButton"
+          retryTapIfNoChange: true
+          label: "Open additional product details"
+      - extendedWaitUntil:
+          visible:
+            id: "productDetailInfo_optionsList"
+          timeout: 10000
+
+- tapOn:
+    text: "Categories"
+    retryTapIfNoChange: true
+    label: "Open product categories"
+
+- extendedWaitUntil:
+    visible:
+      id: "productCategoriesRecycler"
+    timeout: 20000
+    label: "Product categories screen is shown"
+
+- takeScreenshot: product_detail_categories
+
+- back
+
+- extendedWaitUntil:
+    visible:
+      id: "cardsRecyclerView"
+    timeout: 15000
+    label: "Back on product detail"
+
 - scrollUntilVisible:
     element: "Product type"
     direction: DOWN
@@ -95,38 +135,6 @@ tags:
     label: "Scroll to Product type row"
 
 - assertVisible: "Product type"
-
-- takeScreenshot: product_detail_type
-
-# Universal row 2: Reviews (renders with "no approved reviews"
-# placeholder when the product has none).
-- scrollUntilVisible:
-    element: "Reviews"
-    direction: DOWN
-    timeout: 15000
-    label: "Scroll to Reviews row"
-
-- assertVisible:
-    text: "Reviews"
-
-# Universal row 3: Categories (falls back to "Uncategorized" when
-# unset).
-- scrollUntilVisible:
-    element: "Categories"
-    direction: DOWN
-    timeout: 15000
-    label: "Scroll to Categories row"
-
-- assertVisible:
-    text: "Categories"
-
-# Type-specific rows. This provisional flow should target seeded/queryable
-# products before promotion so these assertions are not store-order dependent.
-- scrollUntilVisible:
-    element: ".*Price.*|.*Inventory.*|.*Shipping.*|.*Short description.*"
-    direction: DOWN
-    timeout: 10000
-    label: "Scroll to Price / Inventory / Shipping / Short description"
 
 - takeScreenshot: product_detail_bottom
 

--- a/.maestro/flows/products_list_and_sort.yaml
+++ b/.maestro/flows/products_list_and_sort.yaml
@@ -41,8 +41,6 @@ tags:
     if (!name || name.trim() === '') {
         throw new Error('Product name is empty — list may not have loaded properly');
     }
-- evalScript: ${output.productSearchText = maestro.copiedText.trim()}
-
 - takeScreenshot: products_list
 
 # Test sorting with two explicit, opposing choices. Requiring different first
@@ -96,10 +94,12 @@ tags:
     if (!descending || descending === output.firstProductAscending) {
         throw new Error('Opposing product sorts returned the same first product');
     }
+    output.firstProductDescending = descending;
 
 - takeScreenshot: products_sorted
 
-# Test search against the first visible product from the loaded list.
+# Test search against the A-to-Z first product, and require the Z-to-A
+# first product to be filtered out.
 - tapOn:
     id: "menu_search"
     label: "Open product search"
@@ -111,7 +111,7 @@ tags:
 
 - tapOn:
     id: "search_src_text"
-- inputText: ${output.productSearchText}
+- inputText: ${output.firstProductAscending}
 - pressKey: Enter
 
 # Wait for search results
@@ -121,8 +121,13 @@ tags:
     timeout: 15000
 
 - assertVisible:
-    text: "${output.productSearchText}"
-    label: "Captured product appears in search results"
+    id: "productName"
+    text: "${output.firstProductAscending}"
+    label: "Searched product appears as a result row, not only in the search field"
+
+- assertNotVisible:
+    text: "${output.firstProductDescending}"
+    label: "A product that does not match the query was filtered out"
 
 - takeScreenshot: products_search_results
 

--- a/.maestro/flows/products_list_and_sort.yaml
+++ b/.maestro/flows/products_list_and_sort.yaml
@@ -94,12 +94,10 @@ tags:
     if (!descending || descending === output.firstProductAscending) {
         throw new Error('Opposing product sorts returned the same first product');
     }
-    output.firstProductDescending = descending;
 
 - takeScreenshot: products_sorted
 
-# Test search against the A-to-Z first product, and require the Z-to-A
-# first product to be filtered out.
+# Test search against the A-to-Z first product.
 - tapOn:
     id: "menu_search"
     label: "Open product search"
@@ -124,10 +122,6 @@ tags:
     id: "productName"
     text: "${output.firstProductAscending}"
     label: "Searched product appears as a result row, not only in the search field"
-
-- assertNotVisible:
-    text: "${output.firstProductDescending}"
-    label: "A product that does not match the query was filtered out"
 
 - takeScreenshot: products_search_results
 

--- a/.maestro/flows/products_list_and_sort.yaml
+++ b/.maestro/flows/products_list_and_sort.yaml
@@ -50,6 +50,7 @@ tags:
     label: "Require product sorting control"
 - tapOn:
     id: "btn_product_sorting"
+    retryTapIfNoChange: true
     label: "Open product sorting"
 - extendedWaitUntil:
     visible: "Title: A to Z"
@@ -72,6 +73,7 @@ tags:
 
 - tapOn:
     id: "btn_product_sorting"
+    retryTapIfNoChange: true
     label: "Reopen product sorting"
 - extendedWaitUntil:
     visible: "Title: Z to A"
@@ -100,6 +102,7 @@ tags:
 # Test search against the A-to-Z first product.
 - tapOn:
     id: "menu_search"
+    retryTapIfNoChange: true
     label: "Open product search"
 
 - extendedWaitUntil:

--- a/.maestro/flows/products_media_upload.yaml
+++ b/.maestro/flows/products_media_upload.yaml
@@ -116,7 +116,8 @@ tags:
     label: "Open this run's product"
 
 - extendedWaitUntil:
-    visible: ".*GOT IT.*|.*Describe your product.*|.*Write with AI.*|.*PUBLISH.*|.*SAVE.*"
+    visible:
+      id: "cardsRecyclerView"
     timeout: 25000
     label: "Wait for product detail to load"
 
@@ -369,14 +370,10 @@ tags:
     retryTapIfNoChange: true
     label: "Tap Save/Publish to persist the image"
 
-# A few outcomes are possible depending on app version + network:
-#   1. The button label flips back to the non-dirty state and we
-#      stay on the detail screen.
-#   2. A success snackbar appears.
-#   3. The detail screen closes automatically.
-# We accept any of those signals as "save worked".
+# Require the success snackbar. The earlier alternatives included text that
+# is already on screen before saving, so they could not prove the save.
 - extendedWaitUntil:
-    visible: ".*updated.*|.*saved.*|.*productsRecycler.*|.*Describe your product.*"
+    visible: "Product saved|Product published"
     timeout: 30000
     label: "Wait for save confirmation"
 

--- a/.maestro/flows/products_media_upload.yaml
+++ b/.maestro/flows/products_media_upload.yaml
@@ -370,8 +370,7 @@ tags:
     retryTapIfNoChange: true
     label: "Tap Save/Publish to persist the image"
 
-# Require the success snackbar. The earlier alternatives included text that
-# is already on screen before saving, so they could not prove the save.
+# Require the success snackbar.
 - extendedWaitUntil:
     visible: "Product saved|Product published"
     timeout: 30000

--- a/.maestro/flows/products_media_upload.yaml
+++ b/.maestro/flows/products_media_upload.yaml
@@ -16,9 +16,13 @@
 #        └─ tap "Choose from device"
 #           (mediaPickerHelper.showMediaPicker(DEVICE))
 #              ▼
-#   MediaPickerActivity (external org.wordpress:mediapicker lib)
+#   WP media library → MediaPickerActivity (org.wordpress:mediapicker)
 #     └─ tap first image_thumbnail in the recycler
 #     └─ tap mnu_confirm_selection ("Add N") in the toolbar
+#   Device media → system photo picker (AndroidX
+#   PickMultipleVisualMedia, backed by the MediaProvider module)
+#     └─ tap first icon_thumbnail in picker_tab_recyclerview
+#     └─ tap button_add ("Add N")
 #        └─ result returned to ProductImagesFragment
 #           ▼
 #   ProductImagesFragment — gallery now shows the image
@@ -34,12 +38,19 @@
 #   - image_source_wp_media_library → "WordPress media library"
 #   - product_add_tool_bar_menu_button_done → "Publish"
 #
-# External lib resource IDs (from
+# WP media library resource IDs (from
 # org.wordpress:mediapicker:0.3.5 AAR):
 #   - recycler                 — media thumbnail list
 #   - image_thumbnail          — per-tile ImageView
 #   - mnu_confirm_selection    — "Add N" action-mode menu item
 #   - soft_ask_view            — storage-permission prompt (guarded)
+#
+# System photo picker resource IDs. The MediaProvider package name
+# varies by OEM and Android version, so these are matched as regex
+# suffixes rather than fully qualified IDs:
+#   - picker_tab_recyclerview  — media thumbnail grid
+#   - icon_thumbnail           — per-tile ImageView
+#   - button_add               — "Add N" confirm button
 appId: com.woocommerce.android.dev
 name: "Products - Media upload via WP media library and device media"
 tags:
@@ -314,18 +325,18 @@ tags:
 
 - extendedWaitUntil:
     visible:
-      id: "recycler"
+      id: ".*picker_tab_recyclerview"
     timeout: 30000
     label: "Wait for device media grid"
 
 - tapOn:
-    id: "image_thumbnail"
+    id: ".*icon_thumbnail"
     index: 0
     retryTapIfNoChange: true
     label: "Select the deterministic device media item"
 
 - tapOn:
-    id: "mnu_confirm_selection"
+    id: ".*button_add"
     retryTapIfNoChange: true
     label: "Add the selected device media"
 

--- a/.maestro/flows/products_variations_and_tags.yaml
+++ b/.maestro/flows/products_variations_and_tags.yaml
@@ -40,7 +40,8 @@
 #   - empty_view                      — shown on products list when no
 #                                       results match the active filter
 #   - variationList                   — RecyclerView on VariationListFragment
-#   - cardsRecyclerView               — RecyclerView on variation detail
+#   - cardsRecyclerView               — RecyclerView on product and
+#                                       variation detail
 appId: com.woocommerce.android.dev
 name: "Products - Variations via Variable filter"
 tags:
@@ -163,7 +164,8 @@ tags:
     label: "Open discovered Variable product"
 
 - extendedWaitUntil:
-    visible: ".*GOT IT.*|.*Describe your product.*|.*Write with AI.*|.*PUBLISH.*|.*SAVE.*"
+    visible:
+      id: "cardsRecyclerView"
     timeout: 25000
     label: "Wait for product detail"
 
@@ -280,7 +282,7 @@ tags:
     label: "Wait for variations list"
 
 - tapOn:
-    id: "variationList"
+    id: "variationOptionName"
     index: 0
     retryTapIfNoChange: true
     label: "Open first available variation"

--- a/.maestro/flows/products_variations_and_tags.yaml
+++ b/.maestro/flows/products_variations_and_tags.yaml
@@ -175,7 +175,7 @@ tags:
 
 - extendedWaitUntil:
     visible:
-      id: "editText"
+      id: "cardsRecyclerView"
     timeout: 10000
 
 - takeScreenshot: products_variable_detail
@@ -245,7 +245,7 @@ tags:
 
 - extendedWaitUntil:
     visible:
-      id: "editText"
+      id: "cardsRecyclerView"
     timeout: 10000
 
 - scrollUntilVisible:
@@ -302,7 +302,7 @@ tags:
 
 - extendedWaitUntil:
     visible:
-      id: "editText"
+      id: "cardsRecyclerView"
     timeout: 10000
 
 # ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
### Description

Fixes WOOMOB-3889

The product flows waited for text like "Describe your product" to decide the detail screen had loaded, but the app only shows that on a product with an empty description, so they failed on a store with real products. They now wait for `cardsRecyclerView`. Same idea for the rest: `products_detail` opens the Categories screen instead of matching a row label that is not always there, `products_list_and_sort` binds the search check to a result row so it stops passing with zero results, `products_variations_and_tags` stops asserting a field that is off screen after back and taps a variation row instead of the list, and `products_media_upload` requires the save snackbar.

- `products_detail` loses the "Reviews" assert and the Price/Inventory/Shipping scroll, both depend on product data. Categories navigation replaces them.
- I could not run `products_media_upload`, it needs `products_create` and seeded REST credentials.
- The media flow still leaves its product and both images in the store. That product comes from `products_create.yaml`, so it belongs to WOOMOB-3890.

### Test Steps

1. Point `.maestro/.env.local` at a store with a few products that have descriptions, and at least one in-stock variable product.
2. Run `products_list_and_sort`, `products_detail` and `products_variations_and_tags` with `run-smoke-tests.sh`. All three should pass on the first attempt.
3. Open `product_detail_categories.png` in the report and check it shows the categories list screen.
4. Do the same on the base branch, `products_detail` and `products_variations_and_tags` should fail there.

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
