### PR TITLE
[WOOMOB-3972] Make blocking ThemeStore theme lookups suspendable

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemeRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemeRepository.kt
@@ -6,8 +6,6 @@ import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.dispatchAndAwait
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.ThemeActionBuilder
 import org.wordpress.android.fluxc.model.ThemeModel
@@ -66,9 +64,8 @@ class ThemeRepository @Inject constructor(
         }
     }
 
-    suspend fun getTheme(themeId: String): Theme? = withContext(Dispatchers.IO) {
+    suspend fun getTheme(themeId: String): Theme? =
         themeStore.getWpComThemeByThemeId(themeId)?.toAppModel()
-    }
 
     suspend fun fetchCurrentTheme(): Result<Theme> {
         val currentThemResult: OnCurrentThemeFetched = dispatcher.dispatchAndAwait(

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.kt
@@ -150,9 +150,8 @@ class ThemeStore @Inject constructor(
         AppLog.d(T.API, "ThemeStore onRegister")
     }
 
-    fun getWpComThemes(themeIds: List<String>): List<ThemeModel> = runBlocking {
+    suspend fun getWpComThemes(themeIds: List<String>): List<ThemeModel> =
         database.themeDao().getWpComThemes(themeIds)
-    }
 
     fun getInstalledThemeByThemeId(siteModel: SiteModel, themeId: String): ThemeModel? {
         if (themeId.isEmpty()) {
@@ -163,13 +162,11 @@ class ThemeStore @Inject constructor(
         }
     }
 
-    fun getWpComThemeByThemeId(themeId: String): ThemeModel? {
+    suspend fun getWpComThemeByThemeId(themeId: String): ThemeModel? {
         if (themeId.isEmpty()) {
             return null
         }
-        return runBlocking {
-            database.themeDao().getWpComThemeByThemeId(themeId)
-        }
+        return database.themeDao().getWpComThemeByThemeId(themeId)
     }
 
     fun setActiveThemeForSite(site: SiteModel, theme: ThemeModel) = runBlocking {
@@ -270,7 +267,7 @@ class ThemeStore @Inject constructor(
             val activatedTheme = if (payload.site.isJetpackConnected) {
                 getInstalledThemeByThemeId(payload.site, payload.theme.themeId)
             } else {
-                getWpComThemeByThemeId(payload.theme.themeId)
+                runBlocking { getWpComThemeByThemeId(payload.theme.themeId) }
             }
             activatedTheme?.let {
                 setActiveThemeForSite(payload.site, it)


### PR DESCRIPTION
Fixes WOOMOB-3972

### Description

`ThemeStore.getWpComThemes` and `getWpComThemeByThemeId` wrapped their Room reads in `runBlocking`. `ThemePickerViewModel` loads the theme list from `viewModelScope`, so the list read ran on the main thread.

Both are suspend now. The two callers in `ThemeRepository` were already suspend, and `getTheme` no longer needs `withContext(Dispatchers.IO)` because the Room DAO dispatches on its own. Part of WOOMOB-983.

`handleThemeActivated` is reached from `Store.onAction`, which cannot be suspend, so the lookup there is wrapped in `runBlocking`. It runs on the EventBus async thread, next to two calls that already block the same way.

### Test Steps

1. Open the **Menu** tab.
2. Tap **Settings**.
3. Tap **Themes**.
4. Confirm the theme carousel loads and lists themes.
5. Tap a theme.
6. Confirm the button at the bottom reads "Use <theme name>".

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
