### PR TITLE
[WOOMOB-3885] Improve Maestro login recovery and release preflight

### DIFF
--- a/.buildkite/commands/run-maestro-tests.sh
+++ b/.buildkite/commands/run-maestro-tests.sh
@@ -39,13 +39,9 @@ if [[ -n "${MAESTRO_EXCLUDE_TAGS:-}" ]]; then
   EXCLUDE_TAGS_ARGS+=(--exclude-tags "$MAESTRO_EXCLUDE_TAGS")
 fi
 
-if [[ -n "${MAESTRO_APK_PATH:-}" ]]; then
-  APK_PATH="$MAESTRO_APK_PATH"
-else
-  echo "--- Building and installing wasabi debug APK"
-  "$(dirname "${BASH_SOURCE[0]}")/restore-cache.sh"
-  ./gradlew :WooCommerce:installWasabiDebug
-  APK_PATH=""
+APK_PATH="${MAESTRO_APK_PATH:-}"
+if [[ -z "$APK_PATH" ]]; then
+  echo "--- No candidate APK supplied; the runner will ensure the latest production release is installed"
 fi
 
 echo "--- Running Maestro smoke tests"

--- a/.maestro/README.md
+++ b/.maestro/README.md
@@ -127,7 +127,8 @@ The runner:
 - writes created entity IDs to `run-manifest.json` when seeding;
 - deletes exactly those manifest IDs during cleanup when seeding;
 - performs a guarded stale-orphan sweep for `SUITE-<date>-<hash>` entities older than 48h when seeding;
-- retries each failed non-destructive flow once and records pass-on-retry as flaky;
+- retries each failed non-destructive flow once and records pass-on-retry as a passing flaky result;
+- preserves flaky status in HTML/JUnit reports and `--rerun-failed` selection without failing the runner;
 - never blindly retries a failed destructive mutation; cleanup runs first and the failure remains visible;
 - redacts `MAESTRO_WOO_*` values from logs;
 - stores artifacts outside the repo under `$HOME/woocommerce-maestro-output/<timestamp>/`;

--- a/.maestro/README.md
+++ b/.maestro/README.md
@@ -101,8 +101,8 @@ Common variants:
 
 Profiles are copy/paste-safe presets:
 
-- `core`: lab store, `smoke_core`, quarantine and Android system surfaces excluded.
-- `phone-full`: lab store, `smoke_core,smoke_extended`, tablet POS and Android system surfaces excluded. This includes quarantined phone flows.
+- `core`: lab store, all login flows plus the other `smoke_core` paths, with quarantine and Android system surfaces excluded.
+- `phone-full`: lab store, `smoke_core,smoke_extended`, tablet POS and Android system surfaces excluded. This includes quarantined non-login phone flows.
 - `release`: shared store, `smoke_core,smoke_extended,destructive`, quarantine, tablet POS, and Android system surfaces excluded.
 - `burst`: same as `release`, repeated 3 times.
 - `pos-tablet`: lab store, `pos_tablet`, quarantine included.
@@ -145,7 +145,8 @@ The runner:
 - `destructive`: mutates store data.
 - `flaky_quarantine`: provisional or unstable flows excluded from real runs.
 
-The imported PR #15413 flows outside the four core paths are intentionally tagged `flaky_quarantine` until they graduate through the burst-based promotion policy.
+All login flows are required `smoke_core` coverage. Other provisional imported flows remain tagged `flaky_quarantine`
+until they graduate through the burst-based promotion policy.
 
 ## Coverage
 

--- a/.maestro/README.md
+++ b/.maestro/README.md
@@ -62,6 +62,9 @@ selected device, the doctor downloads the universal APK from the latest stable G
 SHA-256 digest, and installs it. The runner enforces the same check before starting any flow. When multiple devices are
 connected, pass `--device` so installation cannot target the wrong device.
 
+The selected device's primary system locale must use English (`en`, with any region). The doctor and runner fail before
+APK setup or Maestro execution when another language is primary; they do not change the device language automatically.
+
 ### Store data prerequisites
 
 `orders_create` selects an existing live-store customer and edits only the customer copy attached to the order draft.

--- a/.maestro/README.md
+++ b/.maestro/README.md
@@ -14,8 +14,8 @@ The suite has two store targets:
 
 The no-Jetpack login scenario uses its own `MAESTRO_WOO_NO_JETPACK_*` variables. Do not reuse those Jurassic Ninja
 site credentials as the `lab` store block when running the broader suite. The runner removes a trailing
-`/wp-admin` or `/wp-admin/` from this flow's site URL. WordPress.com-hosted not-Woo fixtures require the dedicated
-`MAESTRO_WOO_NOT_A_WOO_STORE_WPCOM_EMAIL/PASSWORD` pair.
+`/wp-admin` or `/wp-admin/` from this flow's site URL. The not-Woo fixture always uses its dedicated
+`MAESTRO_WOO_NOT_A_WOO_STORE_SITE_ADMIN_USERNAME/PASSWORD` pair, including through WP.com-style screens.
 
 Destructive flows against the shared store are refused outside CI. In CI, they require `--seed`, the complete
 `MAESTRO_WOO_SHARED_*` login and REST credential block, and the exact `inpersonpayments.wpcomstaging.com` host. The

--- a/.maestro/README.md
+++ b/.maestro/README.md
@@ -57,6 +57,11 @@ Run the pre-flight doctor when setting up a machine, changing credentials, or pr
 .maestro/scripts/doctor.sh --profile phone-full --store lab --device emulator-5554
 ```
 
+The doctor requires the non-debuggable production package (`com.woocommerce.android`). If it is missing from the
+selected device, the doctor downloads the universal APK from the latest stable GitHub release, verifies its published
+SHA-256 digest, and installs it. The runner enforces the same check before starting any flow. When multiple devices are
+connected, pass `--device` so installation cannot target the wrong device.
+
 ### Store data prerequisites
 
 `orders_create` selects an existing live-store customer and edits only the customer copy attached to the order draft.
@@ -86,7 +91,7 @@ Common variants:
 .maestro/scripts/run-smoke-tests.sh --profile android-system --device Pixel_8_API_35
 .maestro/scripts/doctor.sh --profile phone-full --store lab
 .maestro/scripts/run-smoke-tests.sh --device emulator-5554
-.maestro/scripts/run-smoke-tests.sh --apk WooCommerce/build/outputs/apk/wasabi/debug/WooCommerce-wasabi-debug.apk
+.maestro/scripts/run-smoke-tests.sh --apk /path/to/WooCommerce-production-release.apk
 .maestro/scripts/run-smoke-tests.sh --include-tags smoke_extended --include-quarantine --store lab
 .maestro/scripts/run-smoke-tests.sh --include-tags flaky_quarantine .maestro/flows/orders_create.yaml
 .maestro/scripts/run-smoke-tests.sh --store shared --include-tags smoke_core
@@ -102,7 +107,7 @@ Profiles are copy/paste-safe presets:
 - `burst`: same as `release`, repeated 3 times.
 - `pos-tablet`: lab store, `pos_tablet`, quarantine included.
 - `android-system`: lab store, `android_system`, quarantine included. Requires an English Pixel Launcher AVD with the
-  Wasabi app discoverable as `Woo (Dev)` in the app drawer.
+  production app discoverable as `Woo` in the app drawer.
 
 Use `--plan` with a profile or tag selection to print the exact store, repeat count, filters, and ordered flow list.
 Planning is side-effect-free: it does not load credentials, create output directories, call Maestro/ADB, or acquire a
@@ -114,6 +119,8 @@ store, device, APK, repeat, and profile options.
 
 The runner:
 
+- targets the production package (`com.woocommerce.android`) and rejects dev or debuggable APKs;
+- downloads and installs the latest stable GitHub release when no production app or candidate APK is installed;
 - selects one connected device automatically, or prompts when several are attached;
 - captures and restores animation settings;
 - can seed deterministic fixtures through the WooCommerce REST API when `--seed` is used;

--- a/.maestro/config.yaml
+++ b/.maestro/config.yaml
@@ -27,9 +27,7 @@
 # P2 reference:
 #   WooMobile P2: Smoke testing page
 
-appId: ${APP_ID}
-env:
-  APP_ID: com.woocommerce.android
+appId: com.woocommerce.android
 
 flows:
   - "flows/*"

--- a/.maestro/config.yaml
+++ b/.maestro/config.yaml
@@ -27,7 +27,9 @@
 # P2 reference:
 #   WooMobile P2: Smoke testing page
 
-appId: com.woocommerce.android.dev
+appId: ${APP_ID}
+env:
+  APP_ID: com.woocommerce.android
 
 flows:
   - "flows/*"

--- a/.maestro/env.example
+++ b/.maestro/env.example
@@ -62,15 +62,10 @@ MAESTRO_WOO_SHARED_CONSUMER_SECRET=
 # stay aligned. Leave commented-out until the matching flow is added.
 
 # ── P2: Login > Not a Woo store (login_not_woo_store.yaml) ──────────────
-# Requires a WordPress site without WooCommerce and its site-admin
-# credentials. WordPress.com-hosted fixtures also require the WP.com pair.
+# Requires a WordPress site without WooCommerce and its site-admin credentials.
 MAESTRO_WOO_NOT_A_WOO_STORE_URL=https://notawoostore.wordpress.com/
 MAESTRO_WOO_NOT_A_WOO_STORE_SITE_ADMIN_USERNAME=
 MAESTRO_WOO_NOT_A_WOO_STORE_SITE_ADMIN_PASSWORD=
-# Required for the default wordpress.com fixture; optional for self-hosted sites.
-# Set both values or leave both blank.
-MAESTRO_WOO_NOT_A_WOO_STORE_WPCOM_EMAIL=
-MAESTRO_WOO_NOT_A_WOO_STORE_WPCOM_PASSWORD=
 
 # ── P2: Login > Wrong account for the store (login_wrong_account.yaml) ──
 # Reuses the selected *_WPCOM_EMAIL + *_WPCOM_PASSWORD — only the

--- a/.maestro/flows/android_quick_actions.yaml
+++ b/.maestro/flows/android_quick_actions.yaml
@@ -3,12 +3,12 @@
 # P2 ref: Other > Quick Actions (long press on app icon)
 #
 # Verifies on the real launcher surface:
-#   - Long-pressing Woo (Dev) exposes Create order and Payments
+#   - Long-pressing the production Woo app exposes Create order and Payments
 #   - Create order opens a fresh order draft
 #   - Payments opens the Payments hub
 #
 # Run only through the android-system profile on an English Pixel Launcher AVD.
-appId: com.woocommerce.android.dev
+appId: ${APP_ID}
 name: "Android system - App shortcuts"
 tags:
   - android_system
@@ -38,12 +38,12 @@ tags:
 - hideKeyboard
 
 - extendedWaitUntil:
-    visible: "Woo \\(Dev\\)"
+    visible: "^Woo$"
     timeout: 10000
-    label: "Find the Wasabi app icon"
+    label: "Find the production Woo app icon"
 
 - longPressOn:
-    text: "Woo \\(Dev\\)"
+    text: "^Woo$"
     label: "Open Woo app shortcuts"
 
 - assertVisible:
@@ -89,9 +89,9 @@ tags:
 - inputText: "Woo"
 - hideKeyboard
 - extendedWaitUntil:
-    visible: "Woo \\(Dev\\)"
+    visible: "^Woo$"
     timeout: 10000
-- longPressOn: "Woo \\(Dev\\)"
+- longPressOn: "^Woo$"
 - tapOn:
     text: "Payments"
     label: "Launch Payments shortcut"

--- a/.maestro/flows/android_quick_actions.yaml
+++ b/.maestro/flows/android_quick_actions.yaml
@@ -8,7 +8,7 @@
 #   - Payments opens the Payments hub
 #
 # Run only through the android-system profile on an English Pixel Launcher AVD.
-appId: ${APP_ID}
+appId: com.woocommerce.android
 name: "Android system - App shortcuts"
 tags:
   - android_system

--- a/.maestro/flows/blaze_campaign.yaml
+++ b/.maestro/flows/blaze_campaign.yaml
@@ -19,7 +19,7 @@
 # above. Some lab stores do not expose Blaze in the More Menu at all;
 # in that case the flow records the unavailable state instead of
 # failing on a feature-gated menu item.
-appId: com.woocommerce.android.dev
+appId: ${APP_ID}
 name: "Blaze - Campaign creation"
 tags:
   - smoke_extended

--- a/.maestro/flows/blaze_campaign.yaml
+++ b/.maestro/flows/blaze_campaign.yaml
@@ -19,7 +19,7 @@
 # above. Some lab stores do not expose Blaze in the More Menu at all;
 # in that case the flow records the unavailable state instead of
 # failing on a feature-gated menu item.
-appId: ${APP_ID}
+appId: com.woocommerce.android
 name: "Blaze - Campaign creation"
 tags:
   - smoke_extended

--- a/.maestro/flows/dashboard_customize.yaml
+++ b/.maestro/flows/dashboard_customize.yaml
@@ -9,7 +9,7 @@
 #   - Selection and a first-pair reorder persist across an app relaunch.
 #   - The exact original selection and order are restored and verified after
 #     a second relaunch, so this flow does not leave shared dashboard state.
-appId: com.woocommerce.android.dev
+appId: ${APP_ID}
 name: "Dashboard - Customize all cards"
 tags:
   - smoke_extended

--- a/.maestro/flows/dashboard_customize.yaml
+++ b/.maestro/flows/dashboard_customize.yaml
@@ -9,7 +9,7 @@
 #   - Selection and a first-pair reorder persist across an app relaunch.
 #   - The exact original selection and order are restored and verified after
 #     a second relaunch, so this flow does not leave shared dashboard state.
-appId: ${APP_ID}
+appId: com.woocommerce.android
 name: "Dashboard - Customize all cards"
 tags:
   - smoke_extended

--- a/.maestro/flows/dashboard_stats.yaml
+++ b/.maestro/flows/dashboard_stats.yaml
@@ -8,7 +8,7 @@
 #   - Date range switching works (Today, This Week, This Month, This Year)
 #   - Top performers card is visible
 #   - "View All" store analytics navigation
-appId: com.woocommerce.android.dev
+appId: ${APP_ID}
 name: "Dashboard - Stats and analytics"
 tags:
   - smoke_core

--- a/.maestro/flows/dashboard_stats.yaml
+++ b/.maestro/flows/dashboard_stats.yaml
@@ -8,7 +8,7 @@
 #   - Date range switching works (Today, This Week, This Month, This Year)
 #   - Top performers card is visible
 #   - "View All" store analytics navigation
-appId: ${APP_ID}
+appId: com.woocommerce.android
 name: "Dashboard - Stats and analytics"
 tags:
   - smoke_core

--- a/.maestro/flows/dashboard_view_all_analytics.yaml
+++ b/.maestro/flows/dashboard_view_all_analytics.yaml
@@ -7,7 +7,7 @@
 #     opens the Analytics Hub screen
 #   - The hub renders its date selector and at least one analytics card
 #     (Revenue, Orders, etc.)
-appId: ${APP_ID}
+appId: com.woocommerce.android
 name: "Dashboard - View All store analytics"
 tags:
   - smoke_extended

--- a/.maestro/flows/dashboard_view_all_analytics.yaml
+++ b/.maestro/flows/dashboard_view_all_analytics.yaml
@@ -7,7 +7,7 @@
 #     opens the Analytics Hub screen
 #   - The hub renders its date selector and at least one analytics card
 #     (Revenue, Orders, etc.)
-appId: com.woocommerce.android.dev
+appId: ${APP_ID}
 name: "Dashboard - View All store analytics"
 tags:
   - smoke_extended

--- a/.maestro/flows/google_for_woo.yaml
+++ b/.maestro/flows/google_for_woo.yaml
@@ -19,7 +19,7 @@
 # scroll to it first to guarantee the whole menu has been traversed —
 # after that, any conditional item above it that was going to render
 # must already be in the view hierarchy.
-appId: com.woocommerce.android.dev
+appId: ${APP_ID}
 name: "Google for Woo - Campaign creation webview"
 tags:
   - smoke_extended

--- a/.maestro/flows/google_for_woo.yaml
+++ b/.maestro/flows/google_for_woo.yaml
@@ -19,7 +19,7 @@
 # scroll to it first to guarantee the whole menu has been traversed —
 # after that, any conditional item above it that was going to render
 # must already be in the view hierarchy.
-appId: ${APP_ID}
+appId: com.woocommerce.android
 name: "Google for Woo - Campaign creation webview"
 tags:
   - smoke_extended

--- a/.maestro/flows/hub_menu_admin_and_store.yaml
+++ b/.maestro/flows/hub_menu_admin_and_store.yaml
@@ -16,7 +16,7 @@
 # page depends on the staging site's current state. Asserting "we
 # left the More Menu" + toolbar title is the highest-signal smoke
 # check available.
-appId: ${APP_ID}
+appId: com.woocommerce.android
 name: "Hub Menu - WC Admin, View Store, Change store"
 tags:
   - smoke_extended

--- a/.maestro/flows/hub_menu_admin_and_store.yaml
+++ b/.maestro/flows/hub_menu_admin_and_store.yaml
@@ -16,7 +16,7 @@
 # page depends on the staging site's current state. Asserting "we
 # left the More Menu" + toolbar title is the highest-signal smoke
 # check available.
-appId: com.woocommerce.android.dev
+appId: ${APP_ID}
 name: "Hub Menu - WC Admin, View Store, Change store"
 tags:
   - smoke_extended

--- a/.maestro/flows/hub_menu_coupons.yaml
+++ b/.maestro/flows/hub_menu_coupons.yaml
@@ -11,7 +11,7 @@
 #   - Pick Percentage Discount and confirm the edit-coupon screen
 #     opens
 #   - Create a run-scoped coupon and verify it appears in the list
-appId: ${APP_ID}
+appId: com.woocommerce.android
 name: "Hub Menu - Coupons"
 tags:
   - smoke_extended

--- a/.maestro/flows/hub_menu_coupons.yaml
+++ b/.maestro/flows/hub_menu_coupons.yaml
@@ -11,7 +11,7 @@
 #   - Pick Percentage Discount and confirm the edit-coupon screen
 #     opens
 #   - Create a run-scoped coupon and verify it appears in the list
-appId: com.woocommerce.android.dev
+appId: ${APP_ID}
 name: "Hub Menu - Coupons"
 tags:
   - smoke_extended

--- a/.maestro/flows/hub_menu_customers_inbox.yaml
+++ b/.maestro/flows/hub_menu_customers_inbox.yaml
@@ -7,7 +7,7 @@
 #     screen renders with the "Search for customers" search hint
 #   - Inbox section opens from the More Menu, the Inbox screen
 #     renders (empty-state message OR an inbox note timestamp)
-appId: ${APP_ID}
+appId: com.woocommerce.android
 name: "Hub Menu - Customers and Inbox"
 tags:
   - smoke_extended

--- a/.maestro/flows/hub_menu_customers_inbox.yaml
+++ b/.maestro/flows/hub_menu_customers_inbox.yaml
@@ -7,7 +7,7 @@
 #     screen renders with the "Search for customers" search hint
 #   - Inbox section opens from the More Menu, the Inbox screen
 #     renders (empty-state message OR an inbox note timestamp)
-appId: com.woocommerce.android.dev
+appId: ${APP_ID}
 name: "Hub Menu - Customers and Inbox"
 tags:
   - smoke_extended

--- a/.maestro/flows/hub_menu_payments.yaml
+++ b/.maestro/flows/hub_menu_payments.yaml
@@ -16,7 +16,7 @@
 # setting change (noise on staging), and Order-a-card-reader exits to
 # Stripe's webview which isn't a Maestro-friendly check. Presence of
 # the items is the smoke-level guarantee P2 cares about.
-appId: ${APP_ID}
+appId: com.woocommerce.android
 name: "Hub Menu - Payments"
 tags:
   - smoke_extended

--- a/.maestro/flows/hub_menu_payments.yaml
+++ b/.maestro/flows/hub_menu_payments.yaml
@@ -16,7 +16,7 @@
 # setting change (noise on staging), and Order-a-card-reader exits to
 # Stripe's webview which isn't a Maestro-friendly check. Presence of
 # the items is the smoke-level guarantee P2 cares about.
-appId: com.woocommerce.android.dev
+appId: ${APP_ID}
 name: "Hub Menu - Payments"
 tags:
   - smoke_extended

--- a/.maestro/flows/hub_menu_settings.yaml
+++ b/.maestro/flows/hub_menu_settings.yaml
@@ -7,7 +7,7 @@
 #   - Settings screen opens from the More Menu
 #   - Every first-level Settings item is rendered (P2: smoke-test all items)
 #   - Log Out button is visible at the bottom of the screen
-appId: ${APP_ID}
+appId: com.woocommerce.android
 name: "Hub Menu - Settings"
 tags:
   - smoke_extended

--- a/.maestro/flows/hub_menu_settings.yaml
+++ b/.maestro/flows/hub_menu_settings.yaml
@@ -7,7 +7,7 @@
 #   - Settings screen opens from the More Menu
 #   - Every first-level Settings item is rendered (P2: smoke-test all items)
 #   - Log Out button is visible at the bottom of the screen
-appId: com.woocommerce.android.dev
+appId: ${APP_ID}
 name: "Hub Menu - Settings"
 tags:
   - smoke_extended

--- a/.maestro/flows/login_google.yaml
+++ b/.maestro/flows/login_google.yaml
@@ -23,7 +23,7 @@
 #
 # Required env vars:
 #   MAESTRO_WOO_JETPACK_STORE_URL   (any Jetpack-connected store the linked account accesses)
-appId: com.woocommerce.android.dev
+appId: ${APP_ID}
 name: "Login - Social login (Google)"
 tags:
   - smoke_extended

--- a/.maestro/flows/login_google.yaml
+++ b/.maestro/flows/login_google.yaml
@@ -33,15 +33,8 @@ tags:
 - launchApp:
     clearState: true
 
-- extendedWaitUntil:
-    visible: ".*Skip.*|.*Enter your store address.*|.*Log in.*"
-    timeout: 30000
-
 - runFlow:
-    when:
-      visible: "Skip"
-    commands:
-      - tapOn: "Skip"
+    file: ../subflows/dismiss_login_carousel.yaml
 
 # Continue through the QR prologue when present, then enter the store URL to
 # reach the email screen (the Google button lives there).

--- a/.maestro/flows/login_google.yaml
+++ b/.maestro/flows/login_google.yaml
@@ -26,8 +26,7 @@
 appId: com.woocommerce.android
 name: "Login - Social login (Google)"
 tags:
-  - smoke_extended
-  - flaky_quarantine
+  - smoke_core
   - login
 ---
 - launchApp:

--- a/.maestro/flows/login_google.yaml
+++ b/.maestro/flows/login_google.yaml
@@ -23,7 +23,7 @@
 #
 # Required env vars:
 #   MAESTRO_WOO_JETPACK_STORE_URL   (any Jetpack-connected store the linked account accesses)
-appId: ${APP_ID}
+appId: com.woocommerce.android
 name: "Login - Social login (Google)"
 tags:
   - smoke_extended

--- a/.maestro/flows/login_help.yaml
+++ b/.maestro/flows/login_help.yaml
@@ -9,7 +9,7 @@
 # the site-address screen — the prologue itself has no toolbar.
 #
 # No credentials required.
-appId: com.woocommerce.android.dev
+appId: ${APP_ID}
 name: "Login - Help section"
 tags:
   - smoke_extended

--- a/.maestro/flows/login_help.yaml
+++ b/.maestro/flows/login_help.yaml
@@ -12,8 +12,7 @@
 appId: com.woocommerce.android
 name: "Login - Help section"
 tags:
-  - smoke_extended
-  - flaky_quarantine
+  - smoke_core
   - login
 ---
 - launchApp:

--- a/.maestro/flows/login_help.yaml
+++ b/.maestro/flows/login_help.yaml
@@ -19,15 +19,8 @@ tags:
 - launchApp:
     clearState: true
 
-- extendedWaitUntil:
-    visible: ".*Skip.*|.*Enter your store address.*|.*Log in.*"
-    timeout: 30000
-
 - runFlow:
-    when:
-      visible: "Skip"
-    commands:
-      - tapOn: "Skip"
+    file: ../subflows/dismiss_login_carousel.yaml
 
 # Continue through the QR prologue when present and wait for the
 # site-address screen's toolbar to settle.

--- a/.maestro/flows/login_help.yaml
+++ b/.maestro/flows/login_help.yaml
@@ -9,7 +9,7 @@
 # the site-address screen — the prologue itself has no toolbar.
 #
 # No credentials required.
-appId: ${APP_ID}
+appId: com.woocommerce.android
 name: "Login - Help section"
 tags:
   - smoke_extended

--- a/.maestro/flows/login_no_jetpack.yaml
+++ b/.maestro/flows/login_no_jetpack.yaml
@@ -10,7 +10,7 @@
 #   MAESTRO_WOO_NO_JETPACK_SITE_URL             (any non-Jetpack WP site with WC)
 #   MAESTRO_WOO_NO_JETPACK_SITE_ADMIN_USERNAME  (site admin credentials — not WP.com)
 #   MAESTRO_WOO_NO_JETPACK_SITE_ADMIN_PASSWORD
-appId: ${APP_ID}
+appId: com.woocommerce.android
 name: "Login - No Jetpack via site credentials"
 tags:
   - smoke_extended

--- a/.maestro/flows/login_no_jetpack.yaml
+++ b/.maestro/flows/login_no_jetpack.yaml
@@ -13,8 +13,7 @@
 appId: com.woocommerce.android
 name: "Login - No Jetpack via site credentials"
 tags:
-  - smoke_extended
-  - flaky_quarantine
+  - smoke_core
   - login
 ---
 - launchApp:

--- a/.maestro/flows/login_no_jetpack.yaml
+++ b/.maestro/flows/login_no_jetpack.yaml
@@ -20,15 +20,8 @@ tags:
 - launchApp:
     clearState: true
 
-- extendedWaitUntil:
-    visible: ".*Skip.*|.*Enter your store address.*|.*Log in.*"
-    timeout: 30000
-
 - runFlow:
-    when:
-      visible: "Skip"
-    commands:
-      - tapOn: "Skip"
+    file: ../subflows/dismiss_login_carousel.yaml
 
 # Enter no-Jetpack store URL
 - runFlow:

--- a/.maestro/flows/login_no_jetpack.yaml
+++ b/.maestro/flows/login_no_jetpack.yaml
@@ -10,7 +10,7 @@
 #   MAESTRO_WOO_NO_JETPACK_SITE_URL             (any non-Jetpack WP site with WC)
 #   MAESTRO_WOO_NO_JETPACK_SITE_ADMIN_USERNAME  (site admin credentials — not WP.com)
 #   MAESTRO_WOO_NO_JETPACK_SITE_ADMIN_PASSWORD
-appId: com.woocommerce.android.dev
+appId: ${APP_ID}
 name: "Login - No Jetpack via site credentials"
 tags:
   - smoke_extended

--- a/.maestro/flows/login_not_woo_store.yaml
+++ b/.maestro/flows/login_not_woo_store.yaml
@@ -17,8 +17,7 @@
 appId: com.woocommerce.android
 name: "Login - Not a WooCommerce store error"
 tags:
-  - smoke_extended
-  - flaky_quarantine
+  - smoke_core
   - login
 ---
 - launchApp:

--- a/.maestro/flows/login_not_woo_store.yaml
+++ b/.maestro/flows/login_not_woo_store.yaml
@@ -78,10 +78,7 @@ tags:
           id: "login_continue_button"
           retryTapIfNoChange: true
       - runFlow:
-          when:
-            visible: "No thanks"
-          commands:
-            - tapOn: "No thanks"
+          file: ../subflows/dismiss_google_password_manager.yaml
       - runFlow:
           when:
             visible:
@@ -90,10 +87,7 @@ tags:
             - tapOn:
                 id: "login_enter_password"
       - runFlow:
-          when:
-            visible: "No thanks"
-          commands:
-            - tapOn: "No thanks"
+          file: ../subflows/dismiss_google_password_manager.yaml
       - extendedWaitUntil:
           visible:
             id: "input"

--- a/.maestro/flows/login_not_woo_store.yaml
+++ b/.maestro/flows/login_not_woo_store.yaml
@@ -14,7 +14,7 @@
 # on wordpress.com; optional for self-hosted sites that expose site credentials:
 #   MAESTRO_WOO_NOT_A_WOO_STORE_WPCOM_EMAIL
 #   MAESTRO_WOO_NOT_A_WOO_STORE_WPCOM_PASSWORD
-appId: ${APP_ID}
+appId: com.woocommerce.android
 name: "Login - Not a WooCommerce store error"
 tags:
   - smoke_extended

--- a/.maestro/flows/login_not_woo_store.yaml
+++ b/.maestro/flows/login_not_woo_store.yaml
@@ -113,4 +113,8 @@ tags:
     visible: ".*not a WooCommerce site.*"
     timeout: 30000
 
+- assertVisible:
+    text: ${STRING_LOGIN_OPEN_INSTALLATION_PAGE}
+    label: "Open installation page CTA is visible"
+
 - takeScreenshot: login_not_woo_store

--- a/.maestro/flows/login_not_woo_store.yaml
+++ b/.maestro/flows/login_not_woo_store.yaml
@@ -14,7 +14,7 @@
 # on wordpress.com; optional for self-hosted sites that expose site credentials:
 #   MAESTRO_WOO_NOT_A_WOO_STORE_WPCOM_EMAIL
 #   MAESTRO_WOO_NOT_A_WOO_STORE_WPCOM_PASSWORD
-appId: com.woocommerce.android.dev
+appId: ${APP_ID}
 name: "Login - Not a WooCommerce store error"
 tags:
   - smoke_extended

--- a/.maestro/flows/login_not_woo_store.yaml
+++ b/.maestro/flows/login_not_woo_store.yaml
@@ -2,18 +2,13 @@
 # p2: login.not-woo-store
 # P2 ref: Login > Not a Woo store (notawoostore.wordpress.com)
 #
-# Logs into a WordPress site that does NOT have WooCommerce installed.
-# Site-admin credentials are preferred, with WP.com credentials used when
-# the site routes through WordPress.com authentication instead.
+# Logs into a WordPress site that does NOT have WooCommerce installed using
+# the configured site-admin credentials through either authentication route.
 #
 # Required env vars:
 #   MAESTRO_WOO_NOT_A_WOO_STORE_URL
 #   MAESTRO_WOO_NOT_A_WOO_STORE_SITE_ADMIN_USERNAME
 #   MAESTRO_WOO_NOT_A_WOO_STORE_SITE_ADMIN_PASSWORD
-# WP.com env vars (set both or neither). Required when the fixture is hosted
-# on wordpress.com; optional for self-hosted sites that expose site credentials:
-#   MAESTRO_WOO_NOT_A_WOO_STORE_WPCOM_EMAIL
-#   MAESTRO_WOO_NOT_A_WOO_STORE_WPCOM_PASSWORD
 appId: com.woocommerce.android
 name: "Login - Not a WooCommerce store error"
 tags:
@@ -68,7 +63,8 @@ tags:
       - inputText: ${MAESTRO_WOO_NOT_A_WOO_STORE_SITE_ADMIN_PASSWORD}
       - tapOn: "Continue"
 
-# Use the resolved WP.com credentials when no site-admin route is available.
+# Use the same site-admin credentials when the fixture presents the
+# WP.com-style email and password screens.
 - runFlow:
     when:
       visible:
@@ -76,7 +72,7 @@ tags:
     commands:
       - tapOn:
           id: "input"
-      - inputText: ${MAESTRO_WOO_NOT_A_WOO_STORE_WPCOM_EMAIL}
+      - inputText: ${MAESTRO_WOO_NOT_A_WOO_STORE_SITE_ADMIN_USERNAME}
       - hideKeyboard
       - tapOn:
           id: "login_continue_button"
@@ -104,7 +100,7 @@ tags:
           timeout: 10000
       - tapOn:
           id: "input"
-      - inputText: ${MAESTRO_WOO_NOT_A_WOO_STORE_WPCOM_PASSWORD}
+      - inputText: ${MAESTRO_WOO_NOT_A_WOO_STORE_SITE_ADMIN_PASSWORD}
       - hideKeyboard
       - tapOn:
           id: "bottom_button"

--- a/.maestro/flows/login_not_woo_store.yaml
+++ b/.maestro/flows/login_not_woo_store.yaml
@@ -24,15 +24,8 @@ tags:
 - launchApp:
     clearState: true
 
-- extendedWaitUntil:
-    visible: ".*Skip.*|.*Enter your store address.*|.*Log in.*"
-    timeout: 30000
-
 - runFlow:
-    when:
-      visible: "Skip"
-    commands:
-      - tapOn: "Skip"
+    file: ../subflows/dismiss_login_carousel.yaml
 
 # Enter store address
 - runFlow:

--- a/.maestro/flows/login_not_wp_site.yaml
+++ b/.maestro/flows/login_not_wp_site.yaml
@@ -45,4 +45,20 @@ tags:
 # Verify the recovery buttons are present
 - assertVisible: "Try another store"
 
+- tapOn:
+    text: "Try another store"
+    retryTapIfNoChange: true
+
+# Verify recovery returns to the site-address step without discarding the
+# address that produced the error.
+- extendedWaitUntil:
+    visible:
+      id: "input"
+    timeout: 15000
+
+- assertVisible:
+    id: "input"
+    text: "google.com"
+    label: "Verify the last entered site address is preserved"
+
 - takeScreenshot: login_not_wp_site

--- a/.maestro/flows/login_not_wp_site.yaml
+++ b/.maestro/flows/login_not_wp_site.yaml
@@ -7,8 +7,7 @@
 appId: com.woocommerce.android
 name: "Login - Not a WordPress site error"
 tags:
-  - smoke_extended
-  - flaky_quarantine
+  - smoke_core
   - login
 ---
 - launchApp:

--- a/.maestro/flows/login_not_wp_site.yaml
+++ b/.maestro/flows/login_not_wp_site.yaml
@@ -14,17 +14,8 @@ tags:
 - launchApp:
     clearState: true
 
-# Wait for app to finish loading after clearState
-- extendedWaitUntil:
-    visible: ".*Skip.*|.*Enter your store address.*|.*Log in.*"
-    timeout: 30000
-
-# Skip carousel if shown
 - runFlow:
-    when:
-      visible: "Skip"
-    commands:
-      - tapOn: "Skip"
+    file: ../subflows/dismiss_login_carousel.yaml
 
 # Continue through the QR prologue when present, then enter a non-WordPress URL.
 - runFlow:

--- a/.maestro/flows/login_not_wp_site.yaml
+++ b/.maestro/flows/login_not_wp_site.yaml
@@ -4,7 +4,7 @@
 #
 # Manages its own login flow (does not call the login subflow) because
 # we're validating the pre-login error path. Starts from a fresh state.
-appId: ${APP_ID}
+appId: com.woocommerce.android
 name: "Login - Not a WordPress site error"
 tags:
   - smoke_extended

--- a/.maestro/flows/login_not_wp_site.yaml
+++ b/.maestro/flows/login_not_wp_site.yaml
@@ -4,7 +4,7 @@
 #
 # Manages its own login flow (does not call the login subflow) because
 # we're validating the pre-login error path. Starts from a fresh state.
-appId: com.woocommerce.android.dev
+appId: ${APP_ID}
 name: "Login - Not a WordPress site error"
 tags:
   - smoke_extended

--- a/.maestro/flows/login_successful.yaml
+++ b/.maestro/flows/login_successful.yaml
@@ -8,7 +8,7 @@
 #
 # Run:
 #   .maestro/scripts/run-smoke-tests.sh .maestro/flows/login_successful.yaml
-appId: com.woocommerce.android.dev
+appId: ${APP_ID}
 name: "Login - Successful store login"
 tags:
   - smoke_core

--- a/.maestro/flows/login_successful.yaml
+++ b/.maestro/flows/login_successful.yaml
@@ -8,7 +8,7 @@
 #
 # Run:
 #   .maestro/scripts/run-smoke-tests.sh .maestro/flows/login_successful.yaml
-appId: ${APP_ID}
+appId: com.woocommerce.android
 name: "Login - Successful store login"
 tags:
   - smoke_core

--- a/.maestro/flows/login_wrong_account.yaml
+++ b/.maestro/flows/login_wrong_account.yaml
@@ -45,10 +45,7 @@ tags:
     retryTapIfNoChange: true
 
 - runFlow:
-    when:
-      visible: "No thanks"
-    commands:
-      - tapOn: "No thanks"
+    file: ../subflows/dismiss_google_password_manager.yaml
 
 - runFlow:
     when:
@@ -59,10 +56,7 @@ tags:
           id: "login_enter_password"
 
 - runFlow:
-    when:
-      visible: "No thanks"
-    commands:
-      - tapOn: "No thanks"
+    file: ../subflows/dismiss_google_password_manager.yaml
 
 - extendedWaitUntil:
     visible:

--- a/.maestro/flows/login_wrong_account.yaml
+++ b/.maestro/flows/login_wrong_account.yaml
@@ -12,8 +12,7 @@
 appId: com.woocommerce.android
 name: "Login - Wrong account for the store"
 tags:
-  - smoke_extended
-  - flaky_quarantine
+  - smoke_core
   - login
 ---
 - launchApp:

--- a/.maestro/flows/login_wrong_account.yaml
+++ b/.maestro/flows/login_wrong_account.yaml
@@ -9,7 +9,7 @@
 #   MAESTRO_WOO_WPCOM_EMAIL, MAESTRO_WOO_WPCOM_PASSWORD
 #                                      (selected WP.com account)
 #   MAESTRO_WOO_WRONG_ACCOUNT_STORE_URL  (site the primary account can't access)
-appId: ${APP_ID}
+appId: com.woocommerce.android
 name: "Login - Wrong account for the store"
 tags:
   - smoke_extended

--- a/.maestro/flows/login_wrong_account.yaml
+++ b/.maestro/flows/login_wrong_account.yaml
@@ -9,7 +9,7 @@
 #   MAESTRO_WOO_WPCOM_EMAIL, MAESTRO_WOO_WPCOM_PASSWORD
 #                                      (selected WP.com account)
 #   MAESTRO_WOO_WRONG_ACCOUNT_STORE_URL  (site the primary account can't access)
-appId: com.woocommerce.android.dev
+appId: ${APP_ID}
 name: "Login - Wrong account for the store"
 tags:
   - smoke_extended

--- a/.maestro/flows/login_wrong_account.yaml
+++ b/.maestro/flows/login_wrong_account.yaml
@@ -19,15 +19,8 @@ tags:
 - launchApp:
     clearState: true
 
-- extendedWaitUntil:
-    visible: ".*Skip.*|.*Enter your store address.*|.*Log in.*"
-    timeout: 30000
-
 - runFlow:
-    when:
-      visible: "Skip"
-    commands:
-      - tapOn: "Skip"
+    file: ../subflows/dismiss_login_carousel.yaml
 
 - runFlow:
     file: ../subflows/open_site_address_login.yaml

--- a/.maestro/flows/login_wrong_credentials.yaml
+++ b/.maestro/flows/login_wrong_credentials.yaml
@@ -43,10 +43,7 @@ tags:
 
 # Dismiss Google Password Manager if it appears
 - runFlow:
-    when:
-      visible: "No thanks"
-    commands:
-      - tapOn: "No thanks"
+    file: ../subflows/dismiss_google_password_manager.yaml
 
 # Handle Magic Link screen
 - runFlow:
@@ -59,10 +56,7 @@ tags:
 
 # Dismiss Google Password Manager again if it appears on password screen
 - runFlow:
-    when:
-      visible: "No thanks"
-    commands:
-      - tapOn: "No thanks"
+    file: ../subflows/dismiss_google_password_manager.yaml
 
 # Enter wrong password
 - extendedWaitUntil:

--- a/.maestro/flows/login_wrong_credentials.yaml
+++ b/.maestro/flows/login_wrong_credentials.yaml
@@ -9,8 +9,7 @@
 appId: com.woocommerce.android
 name: "Login - Wrong credentials error"
 tags:
-  - smoke_extended
-  - flaky_quarantine
+  - smoke_core
   - login
 ---
 - launchApp:

--- a/.maestro/flows/login_wrong_credentials.yaml
+++ b/.maestro/flows/login_wrong_credentials.yaml
@@ -6,7 +6,7 @@
 # we're validating the wrong-password error path. Uses a real email
 # so the account lookup succeeds and the password screen is reached.
 # Credentials are available via MAESTRO_ prefix env vars automatically.
-appId: ${APP_ID}
+appId: com.woocommerce.android
 name: "Login - Wrong credentials error"
 tags:
   - smoke_extended

--- a/.maestro/flows/login_wrong_credentials.yaml
+++ b/.maestro/flows/login_wrong_credentials.yaml
@@ -16,17 +16,8 @@ tags:
 - launchApp:
     clearState: true
 
-# Wait for app to finish loading after clearState
-- extendedWaitUntil:
-    visible: ".*Skip.*|.*Enter your store address.*|.*Log in.*"
-    timeout: 30000
-
-# Skip carousel if shown
 - runFlow:
-    when:
-      visible: "Skip"
-    commands:
-      - tapOn: "Skip"
+    file: ../subflows/dismiss_login_carousel.yaml
 
 # Enter store address
 - runFlow:

--- a/.maestro/flows/login_wrong_credentials.yaml
+++ b/.maestro/flows/login_wrong_credentials.yaml
@@ -6,7 +6,7 @@
 # we're validating the wrong-password error path. Uses a real email
 # so the account lookup succeeds and the password screen is reached.
 # Credentials are available via MAESTRO_ prefix env vars automatically.
-appId: com.woocommerce.android.dev
+appId: ${APP_ID}
 name: "Login - Wrong credentials error"
 tags:
   - smoke_extended

--- a/.maestro/flows/orders_barcode_scanner_opens.yaml
+++ b/.maestro/flows/orders_barcode_scanner_opens.yaml
@@ -9,7 +9,7 @@
 #
 # This flow does not claim barcode product injection or order creation. Those
 # still require a camera feed or a guided physical barcode scan.
-appId: com.woocommerce.android.dev
+appId: ${APP_ID}
 name: "Orders - Barcode scanner opens"
 tags:
   - smoke_extended

--- a/.maestro/flows/orders_barcode_scanner_opens.yaml
+++ b/.maestro/flows/orders_barcode_scanner_opens.yaml
@@ -9,7 +9,7 @@
 #
 # This flow does not claim barcode product injection or order creation. Those
 # still require a camera feed or a guided physical barcode scan.
-appId: ${APP_ID}
+appId: com.woocommerce.android
 name: "Orders - Barcode scanner opens"
 tags:
   - smoke_extended

--- a/.maestro/flows/orders_cash_payment.yaml
+++ b/.maestro/flows/orders_cash_payment.yaml
@@ -14,7 +14,7 @@
 # with a "Cash on Delivery" gateway recorded. It therefore creates its
 # own pending-payment order first instead of consuming an arbitrary row
 # from the shared store.
-appId: ${APP_ID}
+appId: com.woocommerce.android
 name: "Orders - Collect cash payment"
 tags:
   - smoke_extended

--- a/.maestro/flows/orders_cash_payment.yaml
+++ b/.maestro/flows/orders_cash_payment.yaml
@@ -14,7 +14,7 @@
 # with a "Cash on Delivery" gateway recorded. It therefore creates its
 # own pending-payment order first instead of consuming an arbitrary row
 # from the shared store.
-appId: com.woocommerce.android.dev
+appId: ${APP_ID}
 name: "Orders - Collect cash payment"
 tags:
   - smoke_extended

--- a/.maestro/flows/orders_create.yaml
+++ b/.maestro/flows/orders_create.yaml
@@ -19,7 +19,7 @@
 # The order IS committed to the staging store and completed via COD.
 # Staging orders use test data (SmokeTest customer, $10 gift wrap) so
 # accumulation across runs is acceptable.
-appId: ${APP_ID}
+appId: com.woocommerce.android
 name: "Orders - Create a new order"
 tags:
   - smoke_extended

--- a/.maestro/flows/orders_create.yaml
+++ b/.maestro/flows/orders_create.yaml
@@ -19,7 +19,7 @@
 # The order IS committed to the staging store and completed via COD.
 # Staging orders use test data (SmokeTest customer, $10 gift wrap) so
 # accumulation across runs is acceptable.
-appId: com.woocommerce.android.dev
+appId: ${APP_ID}
 name: "Orders - Create a new order"
 tags:
   - smoke_extended

--- a/.maestro/flows/orders_details_and_actions.yaml
+++ b/.maestro/flows/orders_details_and_actions.yaml
@@ -12,7 +12,7 @@
 # (noteList_addNoteContainer, notesList_notes) and menu_add.xml
 # (menu_add) to avoid ambiguous text matches that can collide with the
 # "Add note" button in the order creation flow.
-appId: com.woocommerce.android.dev
+appId: ${APP_ID}
 name: "Orders - Detail view and actions"
 tags:
   - smoke_extended

--- a/.maestro/flows/orders_details_and_actions.yaml
+++ b/.maestro/flows/orders_details_and_actions.yaml
@@ -12,7 +12,7 @@
 # (noteList_addNoteContainer, notesList_notes) and menu_add.xml
 # (menu_add) to avoid ambiguous text matches that can collide with the
 # "Add note" button in the order creation flow.
-appId: ${APP_ID}
+appId: com.woocommerce.android
 name: "Orders - Detail view and actions"
 tags:
   - smoke_extended

--- a/.maestro/flows/orders_list_and_search.yaml
+++ b/.maestro/flows/orders_list_and_search.yaml
@@ -5,7 +5,7 @@
 # Verifies:
 #   - Orders list loads with order data
 #   - Search for an order by number or keyword
-appId: ${APP_ID}
+appId: com.woocommerce.android
 name: "Orders - List and search"
 tags:
   - smoke_core

--- a/.maestro/flows/orders_list_and_search.yaml
+++ b/.maestro/flows/orders_list_and_search.yaml
@@ -5,7 +5,7 @@
 # Verifies:
 #   - Orders list loads with order data
 #   - Search for an order by number or keyword
-appId: com.woocommerce.android.dev
+appId: ${APP_ID}
 name: "Orders - List and search"
 tags:
   - smoke_core

--- a/.maestro/flows/orders_mark_complete.yaml
+++ b/.maestro/flows/orders_mark_complete.yaml
@@ -12,7 +12,7 @@
 # The Mark Complete button is only exposed for paid orders whose status
 # is not Completed. This flow creates its own paid order, moves that
 # automation-owned order to Processing, then marks it Completed again.
-appId: ${APP_ID}
+appId: com.woocommerce.android
 name: "Orders - Mark order complete"
 tags:
   - smoke_extended

--- a/.maestro/flows/orders_mark_complete.yaml
+++ b/.maestro/flows/orders_mark_complete.yaml
@@ -12,7 +12,7 @@
 # The Mark Complete button is only exposed for paid orders whose status
 # is not Completed. This flow creates its own paid order, moves that
 # automation-owned order to Processing, then marks it Completed again.
-appId: com.woocommerce.android.dev
+appId: ${APP_ID}
 name: "Orders - Mark order complete"
 tags:
   - smoke_extended

--- a/.maestro/flows/orders_payment_qr_and_share.yaml
+++ b/.maestro/flows/orders_payment_qr_and_share.yaml
@@ -7,7 +7,7 @@
 #   - Scan To Pay renders its QR instructions
 #   - Share Payment Link opens the Android share sheet
 #   - The flow backs out without collecting payment
-appId: com.woocommerce.android.dev
+appId: ${APP_ID}
 name: "Orders - Payment QR and share link"
 tags:
   - smoke_extended

--- a/.maestro/flows/orders_payment_qr_and_share.yaml
+++ b/.maestro/flows/orders_payment_qr_and_share.yaml
@@ -7,7 +7,7 @@
 #   - Scan To Pay renders its QR instructions
 #   - Share Payment Link opens the Android share sheet
 #   - The flow backs out without collecting payment
-appId: ${APP_ID}
+appId: com.woocommerce.android
 name: "Orders - Payment QR and share link"
 tags:
   - smoke_extended

--- a/.maestro/flows/orders_refund.yaml
+++ b/.maestro/flows/orders_refund.yaml
@@ -22,7 +22,7 @@
 # Unlike the mark-complete flow, the refund is fully committed — the
 # staging store will accumulate refunded orders across runs. Test
 # orders on the store are priced low enough that this is acceptable.
-appId: ${APP_ID}
+appId: com.woocommerce.android
 name: "Orders - Issue refund"
 tags:
   - smoke_extended

--- a/.maestro/flows/orders_refund.yaml
+++ b/.maestro/flows/orders_refund.yaml
@@ -22,7 +22,7 @@
 # Unlike the mark-complete flow, the refund is fully committed — the
 # staging store will accumulate refunded orders across runs. Test
 # orders on the store are priced low enough that this is acceptable.
-appId: com.woocommerce.android.dev
+appId: ${APP_ID}
 name: "Orders - Issue refund"
 tags:
   - smoke_extended

--- a/.maestro/flows/pos_cash_payment.yaml
+++ b/.maestro/flows/pos_cash_payment.yaml
@@ -15,7 +15,7 @@
 #   - Cash payment can be completed
 #   - Payment success screen displays
 #   - A new order can be started after successful payment
-appId: ${APP_ID}
+appId: com.woocommerce.android
 name: "POS - Cash payment flow"
 tags:
   - pos_tablet

--- a/.maestro/flows/pos_cash_payment.yaml
+++ b/.maestro/flows/pos_cash_payment.yaml
@@ -15,7 +15,7 @@
 #   - Cash payment can be completed
 #   - Payment success screen displays
 #   - A new order can be started after successful payment
-appId: com.woocommerce.android.dev
+appId: ${APP_ID}
 name: "POS - Cash payment flow"
 tags:
   - pos_tablet

--- a/.maestro/flows/pos_search_and_coupons.yaml
+++ b/.maestro/flows/pos_search_and_coupons.yaml
@@ -18,7 +18,7 @@
 #   - Search resolves a variable product discovered from the live catalog
 #   - A real coupon is added to the cart
 #   - Switching back to Products reloads the product grid
-appId: com.woocommerce.android.dev
+appId: ${APP_ID}
 name: "POS - Search and Coupons tab"
 tags:
   - pos_tablet

--- a/.maestro/flows/pos_search_and_coupons.yaml
+++ b/.maestro/flows/pos_search_and_coupons.yaml
@@ -18,7 +18,7 @@
 #   - Search resolves a variable product discovered from the live catalog
 #   - A real coupon is added to the cart
 #   - Switching back to Products reloads the product grid
-appId: ${APP_ID}
+appId: com.woocommerce.android
 name: "POS - Search and Coupons tab"
 tags:
   - pos_tablet

--- a/.maestro/flows/products_create.yaml
+++ b/.maestro/flows/products_create.yaml
@@ -39,7 +39,7 @@
 #   - product_category_selector_title    → "Select categories"
 #   - product_category_selector_select_button_title_one → "Select 1 category"
 #   - product_add_tool_bar_menu_button_done → "Publish"
-appId: com.woocommerce.android.dev
+appId: ${APP_ID}
 name: "Products - Create and publish a full product"
 tags:
   - smoke_extended

--- a/.maestro/flows/products_create.yaml
+++ b/.maestro/flows/products_create.yaml
@@ -39,7 +39,7 @@
 #   - product_category_selector_title    → "Select categories"
 #   - product_category_selector_select_button_title_one → "Select 1 category"
 #   - product_add_tool_bar_menu_button_done → "Publish"
-appId: ${APP_ID}
+appId: com.woocommerce.android
 name: "Products - Create and publish a full product"
 tags:
   - smoke_extended

--- a/.maestro/flows/products_detail.yaml
+++ b/.maestro/flows/products_detail.yaml
@@ -29,7 +29,7 @@
 #
 # Mutable description and product-type persistence is verified against the
 # run-owned product in products_create.yaml.
-appId: ${APP_ID}
+appId: com.woocommerce.android
 name: "Products - Product detail view"
 tags:
   - smoke_extended

--- a/.maestro/flows/products_detail.yaml
+++ b/.maestro/flows/products_detail.yaml
@@ -29,7 +29,7 @@
 #
 # Mutable description and product-type persistence is verified against the
 # run-owned product in products_create.yaml.
-appId: com.woocommerce.android.dev
+appId: ${APP_ID}
 name: "Products - Product detail view"
 tags:
   - smoke_extended

--- a/.maestro/flows/products_list_and_sort.yaml
+++ b/.maestro/flows/products_list_and_sort.yaml
@@ -8,7 +8,7 @@
 #   - Sorting produces different first products for A-to-Z and Z-to-A
 #   - Search for products
 #   - Product filters
-appId: com.woocommerce.android.dev
+appId: ${APP_ID}
 name: "Products - List, sort, and search"
 tags:
   - smoke_core

--- a/.maestro/flows/products_list_and_sort.yaml
+++ b/.maestro/flows/products_list_and_sort.yaml
@@ -8,7 +8,7 @@
 #   - Sorting produces different first products for A-to-Z and Z-to-A
 #   - Search for products
 #   - Product filters
-appId: ${APP_ID}
+appId: com.woocommerce.android
 name: "Products - List, sort, and search"
 tags:
   - smoke_core

--- a/.maestro/flows/products_media_upload.yaml
+++ b/.maestro/flows/products_media_upload.yaml
@@ -40,7 +40,7 @@
 #   - image_thumbnail          — per-tile ImageView
 #   - mnu_confirm_selection    — "Add N" action-mode menu item
 #   - soft_ask_view            — storage-permission prompt (guarded)
-appId: ${APP_ID}
+appId: com.woocommerce.android
 name: "Products - Media upload via WP media library and device media"
 tags:
   - smoke_extended

--- a/.maestro/flows/products_media_upload.yaml
+++ b/.maestro/flows/products_media_upload.yaml
@@ -40,7 +40,7 @@
 #   - image_thumbnail          — per-tile ImageView
 #   - mnu_confirm_selection    — "Add N" action-mode menu item
 #   - soft_ask_view            — storage-permission prompt (guarded)
-appId: com.woocommerce.android.dev
+appId: ${APP_ID}
 name: "Products - Media upload via WP media library and device media"
 tags:
   - smoke_extended

--- a/.maestro/flows/products_variations_and_tags.yaml
+++ b/.maestro/flows/products_variations_and_tags.yaml
@@ -41,7 +41,7 @@
 #                                       results match the active filter
 #   - variationList                   — RecyclerView on VariationListFragment
 #   - cardsRecyclerView               — RecyclerView on variation detail
-appId: com.woocommerce.android.dev
+appId: ${APP_ID}
 name: "Products - Variations via Variable filter"
 tags:
   - smoke_extended

--- a/.maestro/flows/products_variations_and_tags.yaml
+++ b/.maestro/flows/products_variations_and_tags.yaml
@@ -41,7 +41,7 @@
 #                                       results match the active filter
 #   - variationList                   — RecyclerView on VariationListFragment
 #   - cardsRecyclerView               — RecyclerView on variation detail
-appId: ${APP_ID}
+appId: com.woocommerce.android
 name: "Products - Variations via Variable filter"
 tags:
   - smoke_extended

--- a/.maestro/scripts/device_locale.py
+++ b/.maestro/scripts/device_locale.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Validate that an Android device uses English as its primary locale."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import Callable
+
+
+LOCALE_RE = re.compile(r"^[A-Za-z]{2,3}(?:[-_][A-Za-z0-9]{1,8})*$")
+
+
+class DeviceLocaleError(RuntimeError):
+    """Raised when the device locale cannot be read or is not English."""
+
+
+@dataclass(frozen=True)
+class DeviceLocale:
+    primary: str
+    source: str
+
+    @property
+    def message(self) -> str:
+        return f"device primary locale {self.primary} is English ({self.source})"
+
+
+CommandRunner = Callable[[list[str]], subprocess.CompletedProcess[str]]
+
+
+def run_command(command: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(command, capture_output=True, text=True, check=False)
+
+
+def parse_primary_locale(value: str) -> str | None:
+    candidate = value.strip().split(",", maxsplit=1)[0].strip()
+    if not candidate or candidate.lower() == "null" or not LOCALE_RE.fullmatch(candidate):
+        return None
+    return candidate.replace("_", "-")
+
+
+def read_device_locale(device: str, command_runner: CommandRunner = run_command) -> DeviceLocale:
+    probes = (
+        ("cmd locale get-device-locale", ["shell", "cmd", "locale", "get-device-locale"]),
+        ("persist.sys.locale", ["shell", "getprop", "persist.sys.locale"]),
+        ("system_locales", ["shell", "settings", "get", "system", "system_locales"]),
+        ("persist.sys.language", ["shell", "getprop", "persist.sys.language"]),
+    )
+    for source, arguments in probes:
+        result = command_runner(["adb", "-s", device, *arguments])
+        if result.returncode != 0:
+            continue
+        primary = parse_primary_locale(result.stdout)
+        if primary:
+            return DeviceLocale(primary=primary, source=source)
+    raise DeviceLocaleError(f"could not determine the primary locale for adb device {device}")
+
+
+def ensure_english_device_locale(
+    device: str,
+    command_runner: CommandRunner = run_command,
+) -> DeviceLocale:
+    locale = read_device_locale(device, command_runner)
+    language = locale.primary.split("-", maxsplit=1)[0].lower()
+    if language != "en":
+        raise DeviceLocaleError(
+            f"device {device} primary locale is {locale.primary}; Maestro flows require English. "
+            "Set Settings > System > Languages > System languages to English, then rerun pre-flight"
+        )
+    return locale
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Require an English primary locale on an Android device.")
+    parser.add_argument("--device", required=True, help="adb device serial")
+    args = parser.parse_args()
+
+    try:
+        locale = ensure_english_device_locale(args.device)
+    except DeviceLocaleError as error:
+        print(f"Setup error: {error}", file=sys.stderr)
+        return 1
+    print(locale.message)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.maestro/scripts/doctor.py
+++ b/.maestro/scripts/doctor.py
@@ -12,6 +12,7 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+from ensure_release_app import ReleaseAppError, ensure_release_app
 from smoke_plan import PROFILES, flow_tags, selected_flows
 
 
@@ -254,10 +255,29 @@ def main() -> int:
             checks.append(Check("fail", "shared destructive runs are refused outside CI"))
 
     devices = adb_devices()
+    selected_device: str | None = None
     if args.device:
-        checks.append(Check("ok" if args.device in devices else "fail", f"requested adb device {args.device} {'is connected' if args.device in devices else 'is not connected'}"))
+        if args.device in devices:
+            selected_device = args.device
+            checks.append(Check("ok", f"requested adb device {args.device} is connected"))
+        else:
+            checks.append(Check("fail", f"requested adb device {args.device} is not connected"))
+    elif len(devices) == 1:
+        selected_device = devices[0]
+        checks.append(Check("ok", f"adb device {selected_device} is connected"))
+    elif len(devices) > 1:
+        checks.append(Check("fail", "multiple adb devices are connected; pass --device to select one"))
     else:
-        checks.append(Check("ok" if devices else "fail", f"{len(devices)} adb device(s) connected"))
+        checks.append(Check("fail", "no adb devices are connected"))
+
+    if selected_device and not any(check.status == "fail" for check in checks):
+        try:
+            release = ensure_release_app(selected_device)
+            checks.append(Check("ok", release.message))
+        except ReleaseAppError as error:
+            checks.append(Check("fail", str(error)))
+    else:
+        checks.append(Check("warn", "production release app check skipped because another pre-flight check failed"))
 
     print("Maestro smoke doctor")
     print(f"  profile: {args.profile}")

--- a/.maestro/scripts/doctor.py
+++ b/.maestro/scripts/doctor.py
@@ -64,10 +64,6 @@ def referenced_env(flows: list[Path], seed: bool) -> set[str]:
     for flow in flows:
         text = flow.read_text(errors="replace")
         flow_refs = set(REF_RE.findall(text))
-        if flow.name == "login_not_woo_store.yaml":
-            flow_refs.difference_update(
-                {"WOO_NOT_A_WOO_STORE_WPCOM_EMAIL", "WOO_NOT_A_WOO_STORE_WPCOM_PASSWORD"}
-            )
         refs.update(flow_refs)
         if SUBFLOW_LOGIN_RE.search(text):
             refs.update({"WOO_JETPACK_STORE_URL", "WOO_WPCOM_EMAIL", "WOO_WPCOM_PASSWORD"})
@@ -209,24 +205,6 @@ def main() -> int:
         checks.append(Check("fail", "missing required env vars: " + ", ".join("MAESTRO_" + ref for ref in missing)))
     else:
         checks.append(Check("ok", f"all {len(refs)} referenced WOO_* env value(s) are available"))
-
-    if any(flow.name == "login_not_woo_store.yaml" for flow in flows):
-        wpcom_fallback = [
-            has_value(env, candidates_for("WOO_NOT_A_WOO_STORE_WPCOM_EMAIL", store)),
-            has_value(env, candidates_for("WOO_NOT_A_WOO_STORE_WPCOM_PASSWORD", store)),
-        ]
-        not_woo_url = env.get("MAESTRO_WOO_NOT_A_WOO_STORE_URL", "")
-        not_woo_host = url_host(not_woo_url)
-        if not_woo_host == "wordpress.com" or not_woo_host.endswith(".wordpress.com"):
-            if not all(wpcom_fallback):
-                checks.append(
-                    Check(
-                        "fail",
-                        "WordPress.com-hosted not-Woo-store fixture requires WP.com email and password",
-                    )
-                )
-        elif any(wpcom_fallback) and not all(wpcom_fallback):
-            checks.append(Check("fail", "not-Woo-store WP.com fallback requires both email and password"))
 
     jetpack_candidates = candidates_for("WOO_JETPACK_STORE_URL", store)
     no_jetpack_candidates = candidates_for("WOO_NO_JETPACK_SITE_URL", store)

--- a/.maestro/scripts/doctor.py
+++ b/.maestro/scripts/doctor.py
@@ -12,6 +12,7 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+from device_locale import DeviceLocaleError, ensure_english_device_locale
 from ensure_release_app import ReleaseAppError, ensure_release_app
 from smoke_plan import PROFILES, flow_tags, selected_flows
 
@@ -247,6 +248,13 @@ def main() -> int:
         checks.append(Check("fail", "multiple adb devices are connected; pass --device to select one"))
     else:
         checks.append(Check("fail", "no adb devices are connected"))
+
+    if selected_device:
+        try:
+            locale = ensure_english_device_locale(selected_device)
+            checks.append(Check("ok", locale.message))
+        except DeviceLocaleError as error:
+            checks.append(Check("fail", str(error)))
 
     if selected_device and not any(check.status == "fail" for check in checks):
         try:

--- a/.maestro/scripts/ensure_release_app.py
+++ b/.maestro/scripts/ensure_release_app.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""Ensure a production WooCommerce release APK is installed on an Android device."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent.parent
+DEFAULT_CACHE_DIR = REPO_ROOT / "build" / "maestro-release-apk"
+LATEST_RELEASE_API = "https://api.github.com/repos/woocommerce/woocommerce-android/releases/latest"
+PRODUCTION_APP_ID = "com.woocommerce.android"
+
+
+class ReleaseAppError(RuntimeError):
+    """Raised when the production release app cannot be validated or installed."""
+
+
+@dataclass(frozen=True)
+class ReleaseAsset:
+    tag: str
+    name: str
+    download_url: str
+    size: int
+    sha256: str
+
+
+@dataclass(frozen=True)
+class ApkMetadata:
+    package_name: str
+    version_name: str
+    debuggable: bool
+
+
+@dataclass(frozen=True)
+class InstalledRelease:
+    version_name: str
+    installed_now: bool
+    source: str
+
+    @property
+    def message(self) -> str:
+        action = "installed" if self.installed_now else "already installed"
+        return f"production release app {PRODUCTION_APP_ID} {self.version_name} {action} ({self.source})"
+
+
+def run_command(command: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(command, capture_output=True, text=True, check=False)
+
+
+def adb(device: str, *args: str) -> subprocess.CompletedProcess[str]:
+    return run_command(["adb", "-s", device, *args])
+
+
+def parse_installed_package_dump(package_dump: str) -> ApkMetadata:
+    version_match = re.search(r"^\s*versionName=(\S+)", package_dump, re.MULTILINE)
+    if not version_match:
+        raise ReleaseAppError(f"could not read {PRODUCTION_APP_ID} versionName from adb")
+    debuggable = any(
+        "DEBUGGABLE" in flags
+        for flags in re.findall(r"(?:pkgFlags|flags)=\[([^]]*)]", package_dump)
+    )
+    return ApkMetadata(PRODUCTION_APP_ID, version_match.group(1), debuggable)
+
+
+def installed_release(device: str) -> ApkMetadata | None:
+    package_path = adb(device, "shell", "pm", "path", PRODUCTION_APP_ID)
+    if package_path.returncode != 0 or not any(
+        line.startswith("package:") for line in package_path.stdout.splitlines()
+    ):
+        return None
+
+    package_dump = adb(device, "shell", "dumpsys", "package", PRODUCTION_APP_ID)
+    if package_dump.returncode != 0:
+        raise ReleaseAppError(f"could not inspect installed package {PRODUCTION_APP_ID}")
+    metadata = parse_installed_package_dump(package_dump.stdout)
+    if metadata.debuggable:
+        raise ReleaseAppError(
+            f"{PRODUCTION_APP_ID} is installed but debuggable; uninstall it or replace it with a release APK"
+        )
+    return metadata
+
+
+def parse_release_asset(release: dict[str, Any]) -> ReleaseAsset:
+    tag = str(release.get("tag_name", "")).strip()
+    if not tag:
+        raise ReleaseAppError("GitHub latest release response has no tag_name")
+    if release.get("draft") or release.get("prerelease"):
+        raise ReleaseAppError(f"GitHub latest release {tag} is not a stable published release")
+
+    candidates = [
+        asset
+        for asset in release.get("assets", [])
+        if str(asset.get("name", "")).endswith("-universal.apk")
+    ]
+    if len(candidates) != 1:
+        raise ReleaseAppError(f"GitHub release {tag} must contain exactly one universal APK asset")
+
+    asset = candidates[0]
+    name = str(asset.get("name", ""))
+    if Path(name).name != name:
+        raise ReleaseAppError(f"GitHub release {tag} returned an unsafe APK asset name")
+    digest = str(asset.get("digest", ""))
+    if not re.fullmatch(r"sha256:[0-9a-fA-F]{64}", digest):
+        raise ReleaseAppError(f"GitHub release {tag} universal APK has no verifiable SHA-256 digest")
+    download_url = str(asset.get("browser_download_url", ""))
+    size = asset.get("size")
+    if not download_url.startswith("https://github.com/") or not isinstance(size, int) or size <= 0:
+        raise ReleaseAppError(f"GitHub release {tag} universal APK metadata is incomplete")
+    return ReleaseAsset(tag, name, download_url, size, digest.split(":", maxsplit=1)[1].lower())
+
+
+def github_headers() -> dict[str, str]:
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "woocommerce-android-maestro-doctor",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    token = os.environ.get("GITHUB_TOKEN", "")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def latest_release_asset() -> ReleaseAsset:
+    request = urllib.request.Request(LATEST_RELEASE_API, headers=github_headers())
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            release = json.load(response)
+    except (OSError, ValueError) as error:
+        raise ReleaseAppError(f"could not resolve the latest WooCommerce Android release: {error}") from error
+    if not isinstance(release, dict):
+        raise ReleaseAppError("GitHub latest release response is not an object")
+    return parse_release_asset(release)
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def valid_cached_asset(path: Path, asset: ReleaseAsset) -> bool:
+    return path.is_file() and path.stat().st_size == asset.size and sha256(path) == asset.sha256
+
+
+def download_release_asset(asset: ReleaseAsset, cache_dir: Path) -> Path:
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    destination = cache_dir / asset.name
+    if valid_cached_asset(destination, asset):
+        return destination
+
+    partial = destination.with_suffix(destination.suffix + ".part")
+    partial.unlink(missing_ok=True)
+    request = urllib.request.Request(
+        asset.download_url,
+        headers={"User-Agent": "woocommerce-android-maestro-doctor"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=300) as response, partial.open("wb") as output:
+            shutil.copyfileobj(response, output, length=1024 * 1024)
+        if not valid_cached_asset(partial, asset):
+            raise ReleaseAppError(f"downloaded {asset.name} does not match GitHub's size and SHA-256 digest")
+        partial.replace(destination)
+    except (OSError, ReleaseAppError) as error:
+        partial.unlink(missing_ok=True)
+        if isinstance(error, ReleaseAppError):
+            raise
+        raise ReleaseAppError(f"could not download {asset.name}: {error}") from error
+    return destination
+
+
+def build_tools_sort_key(path: Path) -> tuple[int, ...]:
+    return tuple(int(part) for part in re.findall(r"\d+", path.parent.name))
+
+
+def find_aapt() -> Path:
+    from_path = shutil.which("aapt")
+    if from_path:
+        return Path(from_path)
+    sdk_root_value = os.environ.get("ANDROID_HOME") or os.environ.get("ANDROID_SDK_ROOT")
+    if sdk_root_value:
+        candidates = list((Path(sdk_root_value) / "build-tools").glob("*/aapt"))
+        if candidates:
+            stable_candidates = [candidate for candidate in candidates if "-" not in candidate.parent.name]
+            return max(stable_candidates or candidates, key=build_tools_sort_key)
+    raise ReleaseAppError("aapt not found; set ANDROID_HOME or add Android build-tools to PATH")
+
+
+def parse_apk_badging(output: str) -> ApkMetadata:
+    package_match = re.search(r"^package: name='([^']+)'.*versionName='([^']+)'", output, re.MULTILINE)
+    if not package_match:
+        raise ReleaseAppError("could not read APK package name and version with aapt")
+    return ApkMetadata(
+        package_name=package_match.group(1),
+        version_name=package_match.group(2),
+        debuggable="application-debuggable" in output,
+    )
+
+
+def validate_release_apk(path: Path) -> ApkMetadata:
+    if not path.is_file() or path.suffix.lower() != ".apk":
+        raise ReleaseAppError(f"APK not found: {path}")
+    result = run_command([str(find_aapt()), "dump", "badging", str(path)])
+    if result.returncode != 0:
+        raise ReleaseAppError(f"aapt could not inspect APK: {path}")
+    metadata = parse_apk_badging(result.stdout)
+    if metadata.package_name != PRODUCTION_APP_ID:
+        raise ReleaseAppError(
+            f"APK package is {metadata.package_name}; expected production package {PRODUCTION_APP_ID}"
+        )
+    if metadata.debuggable:
+        raise ReleaseAppError(f"APK {path.name} is debuggable; a production release APK is required")
+    return metadata
+
+
+def install_release_apk(device: str, path: Path) -> None:
+    result = adb(device, "install", "-r", "-g", str(path))
+    if result.returncode != 0:
+        details = [line.strip() for line in (result.stderr + result.stdout).splitlines() if line.strip()]
+        raise ReleaseAppError(details[-1] if details else f"adb could not install {path.name}")
+
+
+def ensure_release_app(
+    device: str,
+    cache_dir: Path = DEFAULT_CACHE_DIR,
+    apk_path: Path | None = None,
+) -> InstalledRelease:
+    if apk_path is not None:
+        metadata = validate_release_apk(apk_path)
+        install_release_apk(device, apk_path)
+        installed = installed_release(device)
+        if installed is None or installed.version_name != metadata.version_name:
+            raise ReleaseAppError(f"installed {PRODUCTION_APP_ID} does not match supplied APK {metadata.version_name}")
+        return InstalledRelease(installed.version_name, True, f"supplied APK {apk_path.name}")
+
+    installed = installed_release(device)
+    if installed is not None:
+        return InstalledRelease(installed.version_name, False, "device")
+
+    asset = latest_release_asset()
+    print(f"Downloading WooCommerce Android {asset.tag} production APK from GitHub Releases...")
+    downloaded = download_release_asset(asset, cache_dir)
+    metadata = validate_release_apk(downloaded)
+    install_release_apk(device, downloaded)
+    installed = installed_release(device)
+    if installed is None or installed.version_name != metadata.version_name:
+        raise ReleaseAppError(f"installed {PRODUCTION_APP_ID} does not match downloaded release {asset.tag}")
+    return InstalledRelease(installed.version_name, True, f"GitHub release {asset.tag}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--device", required=True, help="adb device serial")
+    parser.add_argument("--apk", type=Path, help="production release APK to validate and install")
+    parser.add_argument("--cache-dir", type=Path, default=DEFAULT_CACHE_DIR)
+    args = parser.parse_args()
+
+    try:
+        release = ensure_release_app(args.device, args.cache_dir, args.apk)
+    except ReleaseAppError as error:
+        print(f"Production release app check failed: {error}", file=sys.stderr)
+        return 1
+    print(release.message)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.maestro/scripts/run-smoke-tests.sh
+++ b/.maestro/scripts/run-smoke-tests.sh
@@ -943,7 +943,7 @@ if [[ "$SEED" == "yes" ]]; then
   source "$RUN_ENV_FILE"
 fi
 
-MAESTRO_ENV_ARGS=(-e "APP_ID=$APP_ID" -e "SUITE_RUN_ID=$SUITE_RUN_ID")
+MAESTRO_ENV_ARGS=(-e "SUITE_RUN_ID=$SUITE_RUN_ID")
 MAESTRO_PROCESS_ENV_ARGS=(env)
 while IFS='=' read -r name _value; do
   [[ -n "$name" ]] && MAESTRO_PROCESS_ENV_ARGS+=(-u "$name")

--- a/.maestro/scripts/run-smoke-tests.sh
+++ b/.maestro/scripts/run-smoke-tests.sh
@@ -21,6 +21,7 @@ MEDIA_FIXTURE_DEVICE_PATH="/sdcard/Pictures/woocommerce-maestro-smoke-test-image
 SEED_SCRIPT="${WOO_MAESTRO_SEED_SCRIPT:-$REPO_ROOT/.maestro/scripts/seed-fixtures.py}"
 PLAN_SCRIPT="$REPO_ROOT/.maestro/scripts/smoke_plan.py"
 CHECK_TOOLCHAIN_SCRIPT="$REPO_ROOT/.maestro/scripts/check-toolchain.py"
+CHECK_DEVICE_LOCALE_SCRIPT="$REPO_ROOT/.maestro/scripts/device_locale.py"
 ENSURE_RELEASE_APP_SCRIPT="$REPO_ROOT/.maestro/scripts/ensure_release_app.py"
 SHARED_STORE_HOST="inpersonpayments.wpcomstaging.com"
 APP_ID="com.woocommerce.android"
@@ -735,6 +736,8 @@ resolve_device() {
 DEVICE_SERIAL="$(resolve_device "$DEVICE_SELECTOR")"
 MAESTRO_DEVICE_ARGS=(--device "$DEVICE_SERIAL")
 echo "Device: $DEVICE_SERIAL"
+echo "--- Checking device language"
+python3 "$CHECK_DEVICE_LOCALE_SCRIPT" --device "$DEVICE_SERIAL"
 
 ANIMATION_KEYS=(window_animation_scale transition_animation_scale animator_duration_scale)
 ORIGINAL_ANIMATION_VALUES=()

--- a/.maestro/scripts/run-smoke-tests.sh
+++ b/.maestro/scripts/run-smoke-tests.sh
@@ -484,7 +484,9 @@ except ET.ParseError as error:
 
 seen = set()
 for testcase in root.iter("testcase"):
-    if testcase.find("failure") is None and testcase.find("error") is None:
+    status = testcase.find("./properties/property[@name='maestro.status']")
+    is_flaky = status is not None and status.attrib.get("value") in {"FLAKY", "FLAKY_RECOVERY"}
+    if testcase.find("failure") is None and testcase.find("error") is None and not is_flaky:
         continue
     name = testcase.attrib.get("name", "").strip()
     if not name or name in seen:
@@ -1230,6 +1232,7 @@ for repeat_index in $(seq 1 "$REPEAT"); do
         duration=$((first_duration + retry_duration))
         if [[ "$retry_exit" -eq 0 ]]; then
           status="FLAKY"
+          PASSED=$((PASSED + 1))
           FLAKY=$((FLAKY + 1))
         else
           status="FAIL"
@@ -1242,6 +1245,7 @@ for repeat_index in $(seq 1 "$REPEAT"); do
       fi
     elif [[ "${first_recovery:-0}" -gt 0 ]]; then
       status="FLAKY_RECOVERY"
+      PASSED=$((PASSED + 1))
       FLAKY=$((FLAKY + 1))
     else
       PASSED=$((PASSED + 1))
@@ -1273,7 +1277,7 @@ elif [[ "$SEED" == "yes" ]]; then
   CLEANUP_STATUS="SKIPPED"
 fi
 REPORT_TOTAL_RUNS=$((TOTAL_RUNS + CLEANUP_FAILED))
-REPORT_FAILURES=$((FAILED + FLAKY + CLEANUP_FAILED))
+REPORT_FAILURES=$((FAILED + CLEANUP_FAILED))
 
 echo "--- Generating reports"
 {
@@ -1283,9 +1287,11 @@ echo "--- Generating reports"
   for result in "${RESULTS[@]}"; do
     IFS='|' read -r status repeat_index name duration media log_rel error recovery <<< "$result"
     printf '  <testcase classname="maestro.%s" name="%s" time="%s">' "$repeat_index" "$name" "$duration"
-    if [[ "$status" == "FAIL" || "$status" == "FLAKY" || "$status" == "FLAKY_RECOVERY" ]]; then
+    if [[ "$status" == "FAIL" ]]; then
       msg="$(printf '%s' "${error:-$status}" | xml_escape)"
       printf '<failure message="%s">%s</failure>' "$status" "$msg"
+    elif [[ "$status" == "FLAKY" || "$status" == "FLAKY_RECOVERY" ]]; then
+      printf '<properties><property name="maestro.status" value="%s"/></properties>' "$status"
     fi
     printf '</testcase>\n'
   done
@@ -1314,7 +1320,8 @@ table { width: 100%; border-collapse: collapse; }
 th, td { border-bottom: 1px solid #ddd; padding: 8px; text-align: left; vertical-align: top; }
 th { background: #f6f8fa; }
 .PASS { color: #136f2d; font-weight: 700; }
-.FAIL, .FLAKY, .FLAKY_RECOVERY { color: #9a1111; font-weight: 700; }
+.FLAKY, .FLAKY_RECOVERY { color: #9a6700; font-weight: 700; }
+.FAIL { color: #9a1111; font-weight: 700; }
 code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
 pre { background: #f6f8fa; border: 1px solid #d8dee4; border-radius: 6px; padding: 10px 12px; overflow-x: auto; }
 .commands { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; margin: 16px 0 20px; }
@@ -1326,7 +1333,7 @@ pre { background: #f6f8fa; border: 1px solid #d8dee4; border-radius: 6px; paddin
 <body>
 <h1>WooCommerce Android Maestro smoke report</h1>
 <p><strong>Run:</strong> <code>$SUITE_RUN_ID</code> | <strong>Store:</strong> $STORE | <strong>Device:</strong> <code>$DEVICE_SERIAL</code> | <strong>Duration:</strong> ${SUITE_DURATION}s</p>
-<p><strong>Result:</strong> $PASSED passed, $FLAKY flaky, $FAILED failed out of $TOTAL_RUNS flow executions. <strong>Cleanup:</strong> $CLEANUP_STATUS.</p>
+<p><strong>Result:</strong> $PASSED passed ($FLAKY flaky), $FAILED failed out of $TOTAL_RUNS flow executions. <strong>Cleanup:</strong> $CLEANUP_STATUS.</p>
 <section class="commands">
   <div class="command-card">
     <h2>Run the same selection</h2>
@@ -1377,13 +1384,13 @@ HTML_FOOT
 
 echo "Report: $REPORT_FILE"
 echo "JUnit:  $JUNIT_FILE"
-echo "Result: $PASSED passed, $FLAKY flaky, $FAILED failed out of $TOTAL_RUNS flow executions; cleanup $CLEANUP_STATUS (${SUITE_DURATION}s)"
+echo "Result: $PASSED passed ($FLAKY flaky), $FAILED failed out of $TOTAL_RUNS flow executions; cleanup $CLEANUP_STATUS (${SUITE_DURATION}s)"
 
 if [[ -f "$REPORT_FILE" && "$OPEN_REPORT" == "auto" && -z "${CI:-}" && -z "${BUILDKITE:-}" && "$(uname)" == "Darwin" ]]; then
   open "$REPORT_FILE" || true
 fi
 
-if [[ "$FAILED" -gt 0 || "$FLAKY" -gt 0 || "$CLEANUP_FAILED" -gt 0 ]]; then
+if [[ "$FAILED" -gt 0 || "$CLEANUP_FAILED" -gt 0 ]]; then
   exit 1
 fi
 exit 0

--- a/.maestro/scripts/run-smoke-tests.sh
+++ b/.maestro/scripts/run-smoke-tests.sh
@@ -21,7 +21,9 @@ MEDIA_FIXTURE_DEVICE_PATH="/sdcard/Pictures/woocommerce-maestro-smoke-test-image
 SEED_SCRIPT="${WOO_MAESTRO_SEED_SCRIPT:-$REPO_ROOT/.maestro/scripts/seed-fixtures.py}"
 PLAN_SCRIPT="$REPO_ROOT/.maestro/scripts/smoke_plan.py"
 CHECK_TOOLCHAIN_SCRIPT="$REPO_ROOT/.maestro/scripts/check-toolchain.py"
+ENSURE_RELEASE_APP_SCRIPT="$REPO_ROOT/.maestro/scripts/ensure_release_app.py"
 SHARED_STORE_HOST="inpersonpayments.wpcomstaging.com"
+APP_ID="com.woocommerce.android"
 
 RUN_STAMP="$(date +%Y%m%d%H%M%S)"
 RUN_HASH="$(printf '%s-%s-%s' "$RUN_STAMP" "$$" "${RANDOM:-0}" | cksum | awk '{print $1}')"
@@ -76,7 +78,7 @@ Options:
   --profile name              Preset: core, phone-full, release, burst, pos-tablet, android-system.
   --store lab|shared          Select fixture/credential namespace. Default: lab.
   --device serial|avd-name    Device serial or emulator AVD name.
-  --apk path                  Install APK before running.
+  --apk path                  Validate and install a production release APK before running.
   --repeat N                  Run the selected flow set N times.
   -t, --tag tag               Alias for --include-tags.
   --include-tags a,b          Include flows with any listed tag. Default: smoke_core.
@@ -845,14 +847,12 @@ trap cleanup_on_exit EXIT INT TERM
 
 capture_animation_settings
 
+echo "--- Ensuring production release app"
+release_app_args=(--device "$DEVICE_SERIAL")
 if [[ -n "$APK_PATH" ]]; then
-  if [[ ! -f "$APK_PATH" ]]; then
-    echo "APK not found at: $APK_PATH" >&2
-    exit 1
-  fi
-  echo "--- Installing APK"
-  adb -s "$DEVICE_SERIAL" install -r -g "$APK_PATH"
+  release_app_args+=(--apk "$APK_PATH")
 fi
+python3 "$ENSURE_RELEASE_APP_SCRIPT" "${release_app_args[@]}"
 
 prepare_device_media_fixture
 
@@ -866,26 +866,21 @@ validate_google_login_apk() {
   done
   [[ "$google_flow_selected" == "yes" ]] || return 0
 
-  local apk_to_check="$APK_PATH"
-  local pulled_apk="no"
-  if [[ -z "$apk_to_check" ]]; then
-    local installed_apk_path
-    installed_apk_path="$(
-      adb -s "$DEVICE_SERIAL" shell pm path com.woocommerce.android.dev 2>/dev/null |
-        tr -d '\r' |
-        sed -n '1s/^package://p'
-    )"
-    if [[ -z "$installed_apk_path" ]]; then
-      echo "Setup error: com.woocommerce.android.dev is not installed for login_google." >&2
-      exit 1
-    fi
-    apk_to_check="$TMP_DIR/login-google-installed.apk"
-    adb -s "$DEVICE_SERIAL" pull "$installed_apk_path" "$apk_to_check" >/dev/null
-    pulled_apk="yes"
+  local installed_apk_path
+  installed_apk_path="$(
+    adb -s "$DEVICE_SERIAL" shell pm path "$APP_ID" 2>/dev/null |
+      tr -d '\r' |
+      sed -n '1s/^package://p'
+  )"
+  if [[ -z "$installed_apk_path" ]]; then
+    echo "Setup error: $APP_ID is not installed for login_google." >&2
+    exit 1
   fi
+  local apk_to_check="$TMP_DIR/login-google-installed.apk"
+  adb -s "$DEVICE_SERIAL" pull "$installed_apk_path" "$apk_to_check" >/dev/null
 
   local validation_status=0
-  python3 - "$REPO_ROOT/WooCommerce/google-services.json-example" "$apk_to_check" <<'PY' || validation_status=$?
+  python3 - "$REPO_ROOT/WooCommerce/google-services.json-example" "$apk_to_check" "$APP_ID" <<'PY' || validation_status=$?
 import json
 import pathlib
 import sys
@@ -895,7 +890,7 @@ config = json.loads(pathlib.Path(sys.argv[1]).read_text())
 example_client_id = ""
 for client in config.get("client", []):
     package_name = client.get("client_info", {}).get("android_client_info", {}).get("package_name")
-    if package_name != "com.woocommerce.android.dev":
+    if package_name != sys.argv[3]:
         continue
     for oauth_client in client.get("oauth_client", []):
         if oauth_client.get("client_type") == 3:
@@ -914,17 +909,14 @@ except (KeyError, OSError, zipfile.BadZipFile):
 raise SystemExit(2 if example_client_id.encode() in resources else 0)
 PY
 
-  if [[ "$pulled_apk" == "yes" ]]; then
-    rm -f "$apk_to_check"
-  fi
+  rm -f "$apk_to_check"
 
   if [[ "$validation_status" -eq 2 ]]; then
     cat >&2 <<'EOF'
 Setup error: login_google cannot run with the example Google OAuth client.
 
-Build or obtain the APK with the private WooCommerce google-services.json,
-then install it or pass it with --apk. For a configured local checkout:
-  ./gradlew :WooCommerce:installWasabiDebug
+Install the official production release APK or pass a configured production
+release APK with --apk.
 EOF
     exit 1
   fi
@@ -949,7 +941,7 @@ if [[ "$SEED" == "yes" ]]; then
   source "$RUN_ENV_FILE"
 fi
 
-MAESTRO_ENV_ARGS=(-e "SUITE_RUN_ID=$SUITE_RUN_ID")
+MAESTRO_ENV_ARGS=(-e "APP_ID=$APP_ID" -e "SUITE_RUN_ID=$SUITE_RUN_ID")
 MAESTRO_PROCESS_ENV_ARGS=(env)
 while IFS='=' read -r name _value; do
   [[ -n "$name" ]] && MAESTRO_PROCESS_ENV_ARGS+=(-u "$name")

--- a/.maestro/scripts/run-smoke-tests.sh
+++ b/.maestro/scripts/run-smoke-tests.sh
@@ -599,21 +599,12 @@ validate_shared_destructive_config() {
 }
 validate_shared_destructive_config
 
-is_optional_flow_env_ref() {
-  local flow="$1"
-  local ref="$2"
-  [[ "$(basename "$flow")" == "login_not_woo_store.yaml" ]] &&
-    [[ "$ref" == "MAESTRO_WOO_NOT_A_WOO_STORE_WPCOM_EMAIL" ||
-      "$ref" == "MAESTRO_WOO_NOT_A_WOO_STORE_WPCOM_PASSWORD" ]]
-}
-
 validate_referenced_env() {
   local missing=()
   local flow ref var
   for flow in "${ORDERED_FLOWS[@]}"; do
     while IFS= read -r ref; do
       [[ -z "$ref" ]] && continue
-      is_optional_flow_env_ref "$flow" "$ref" && continue
       var="$ref"
       if [[ -z "${!var:-}" ]]; then
         missing+=("$var")
@@ -634,34 +625,6 @@ validate_referenced_env() {
   fi
 }
 validate_referenced_env
-
-validate_optional_not_woo_wpcom_env() {
-  local flow selected="no"
-  for flow in "${ORDERED_FLOWS[@]}"; do
-    if [[ "$(basename "$flow")" == "login_not_woo_store.yaml" ]]; then
-      selected="yes"
-      break
-    fi
-  done
-  [[ "$selected" == "yes" ]] || return 0
-
-  local email="${MAESTRO_WOO_NOT_A_WOO_STORE_WPCOM_EMAIL:-}"
-  local password="${MAESTRO_WOO_NOT_A_WOO_STORE_WPCOM_PASSWORD:-}"
-  local host
-  host="$(url_host "${MAESTRO_WOO_NOT_A_WOO_STORE_URL:-}")"
-  if [[ "$host" == "wordpress.com" || "$host" == *.wordpress.com ]]; then
-    if [[ -z "$email" || -z "$password" ]]; then
-      echo "WordPress.com-hosted not-Woo-store fixtures require both MAESTRO_WOO_NOT_A_WOO_STORE_WPCOM_EMAIL and MAESTRO_WOO_NOT_A_WOO_STORE_WPCOM_PASSWORD." >&2
-      exit 1
-    fi
-    return 0
-  fi
-  if [[ -n "$email" && -z "$password" ]] || [[ -z "$email" && -n "$password" ]]; then
-    echo "Missing optional WP.com fallback pair: set both MAESTRO_WOO_NOT_A_WOO_STORE_WPCOM_EMAIL and MAESTRO_WOO_NOT_A_WOO_STORE_WPCOM_PASSWORD, or leave both blank." >&2
-    exit 1
-  fi
-}
-validate_optional_not_woo_wpcom_env
 
 flow_is_selected() {
   local expected="$1"

--- a/.maestro/scripts/tests/golden/burst-plan.txt
+++ b/.maestro/scripts/tests/golden/burst-plan.txt
@@ -5,9 +5,16 @@ Maestro smoke plan
   include: smoke_core,smoke_extended,destructive
   exclude: flaky_quarantine,pos_tablet,android_system
   seed:    no
-  flows:   4
+  flows:   11
 
 Selected flows:
+  - .maestro/flows/login_not_wp_site.yaml
+  - .maestro/flows/login_wrong_credentials.yaml
+  - .maestro/flows/login_help.yaml
+  - .maestro/flows/login_not_woo_store.yaml
+  - .maestro/flows/login_wrong_account.yaml
+  - .maestro/flows/login_no_jetpack.yaml
+  - .maestro/flows/login_google.yaml
   - .maestro/flows/login_successful.yaml
   - .maestro/flows/dashboard_stats.yaml
   - .maestro/flows/orders_list_and_search.yaml

--- a/.maestro/scripts/tests/golden/core-plan.txt
+++ b/.maestro/scripts/tests/golden/core-plan.txt
@@ -5,9 +5,16 @@ Maestro smoke plan
   include: smoke_core
   exclude: flaky_quarantine,android_system
   seed:    no
-  flows:   4
+  flows:   11
 
 Selected flows:
+  - .maestro/flows/login_not_wp_site.yaml
+  - .maestro/flows/login_wrong_credentials.yaml
+  - .maestro/flows/login_help.yaml
+  - .maestro/flows/login_not_woo_store.yaml
+  - .maestro/flows/login_wrong_account.yaml
+  - .maestro/flows/login_no_jetpack.yaml
+  - .maestro/flows/login_google.yaml
   - .maestro/flows/login_successful.yaml
   - .maestro/flows/dashboard_stats.yaml
   - .maestro/flows/orders_list_and_search.yaml

--- a/.maestro/scripts/tests/golden/release-plan.txt
+++ b/.maestro/scripts/tests/golden/release-plan.txt
@@ -5,9 +5,16 @@ Maestro smoke plan
   include: smoke_core,smoke_extended,destructive
   exclude: flaky_quarantine,pos_tablet,android_system
   seed:    no
-  flows:   4
+  flows:   11
 
 Selected flows:
+  - .maestro/flows/login_not_wp_site.yaml
+  - .maestro/flows/login_wrong_credentials.yaml
+  - .maestro/flows/login_help.yaml
+  - .maestro/flows/login_not_woo_store.yaml
+  - .maestro/flows/login_wrong_account.yaml
+  - .maestro/flows/login_no_jetpack.yaml
+  - .maestro/flows/login_google.yaml
   - .maestro/flows/login_successful.yaml
   - .maestro/flows/dashboard_stats.yaml
   - .maestro/flows/orders_list_and_search.yaml

--- a/.maestro/scripts/tests/golden/smoke-extended-plan.txt
+++ b/.maestro/scripts/tests/golden/smoke-extended-plan.txt
@@ -5,16 +5,9 @@ Maestro smoke plan
   include: smoke_extended
   exclude: <none>
   seed:    no
-  flows:   27
+  flows:   20
 
 Selected flows:
-  - .maestro/flows/login_not_wp_site.yaml
-  - .maestro/flows/login_wrong_credentials.yaml
-  - .maestro/flows/login_help.yaml
-  - .maestro/flows/login_not_woo_store.yaml
-  - .maestro/flows/login_wrong_account.yaml
-  - .maestro/flows/login_no_jetpack.yaml
-  - .maestro/flows/login_google.yaml
   - .maestro/flows/dashboard_view_all_analytics.yaml
   - .maestro/flows/dashboard_customize.yaml
   - .maestro/flows/orders_create.yaml

--- a/.maestro/scripts/tests/test_ci_contract.py
+++ b/.maestro/scripts/tests/test_ci_contract.py
@@ -81,7 +81,7 @@ class MaestroCiContractTests(unittest.TestCase):
         )
         self.assertNotIn("installWasabiDebug", wrapper)
 
-    def test_all_flows_use_the_production_app_id_parameter(self) -> None:
+    def test_all_flows_use_the_production_app_id(self) -> None:
         yaml_files = [
             REPO_ROOT / ".maestro" / "config.yaml",
             *sorted((REPO_ROOT / ".maestro" / "flows").glob("*.yaml")),
@@ -90,10 +90,9 @@ class MaestroCiContractTests(unittest.TestCase):
 
         for path in yaml_files:
             with self.subTest(path=path):
-                self.assertIn("appId: ${APP_ID}", path.read_text(encoding="utf-8"))
-
-        config = (REPO_ROOT / ".maestro" / "config.yaml").read_text(encoding="utf-8")
-        self.assertIn("APP_ID: com.woocommerce.android", config)
+                source = path.read_text(encoding="utf-8")
+                self.assertIn("appId: com.woocommerce.android", source)
+                self.assertNotIn("com.woocommerce.android.dev", source)
 
         quick_actions = (
             REPO_ROOT / ".maestro" / "flows" / "android_quick_actions.yaml"

--- a/.maestro/scripts/tests/test_ci_contract.py
+++ b/.maestro/scripts/tests/test_ci_contract.py
@@ -137,6 +137,17 @@ class MaestroCiContractTests(unittest.TestCase):
             with self.subTest(path=path):
                 self.assertNotIn(obsolete_namespace, path.read_text(encoding="utf-8"))
 
+    def test_not_woo_store_requires_the_installation_page_cta(self) -> None:
+        flow = (
+            REPO_ROOT / ".maestro" / "flows" / "login_not_woo_store.yaml"
+        ).read_text(encoding="utf-8")
+        strings = (REPO_ROOT / ".maestro" / "strings.env").read_text(encoding="utf-8")
+
+        error_message = flow.index('visible: ".*not a WooCommerce site.*"')
+        cta = flow.index("text: ${STRING_LOGIN_OPEN_INSTALLATION_PAGE}")
+        self.assertLess(error_message, cta)
+        self.assertIn("STRING_LOGIN_OPEN_INSTALLATION_PAGE='Open installation page'", strings)
+
     def test_ci_defers_production_app_setup_to_the_runner(self) -> None:
         wrapper = (
             REPO_ROOT / ".buildkite" / "commands" / "run-maestro-tests.sh"

--- a/.maestro/scripts/tests/test_ci_contract.py
+++ b/.maestro/scripts/tests/test_ci_contract.py
@@ -70,15 +70,36 @@ class MaestroCiContractTests(unittest.TestCase):
         ).read_text(encoding="utf-8")
         self.assertIn("file: open_site_address_login.yaml", reusable_login)
 
-    def test_toolchain_is_configured_before_building_the_app(self) -> None:
+    def test_ci_defers_production_app_setup_to_the_runner(self) -> None:
         wrapper = (
             REPO_ROOT / ".buildkite" / "commands" / "run-maestro-tests.sh"
         ).read_text(encoding="utf-8")
 
         self.assertLess(
             wrapper.index("source .maestro/scripts/configure-toolchain.sh"),
-            wrapper.index("./gradlew :WooCommerce:installWasabiDebug"),
+            wrapper.index(".maestro/scripts/run-smoke-tests.sh"),
         )
+        self.assertNotIn("installWasabiDebug", wrapper)
+
+    def test_all_flows_use_the_production_app_id_parameter(self) -> None:
+        yaml_files = [
+            REPO_ROOT / ".maestro" / "config.yaml",
+            *sorted((REPO_ROOT / ".maestro" / "flows").glob("*.yaml")),
+            *sorted((REPO_ROOT / ".maestro" / "subflows").glob("*.yaml")),
+        ]
+
+        for path in yaml_files:
+            with self.subTest(path=path):
+                self.assertIn("appId: ${APP_ID}", path.read_text(encoding="utf-8"))
+
+        config = (REPO_ROOT / ".maestro" / "config.yaml").read_text(encoding="utf-8")
+        self.assertIn("APP_ID: com.woocommerce.android", config)
+
+        quick_actions = (
+            REPO_ROOT / ".maestro" / "flows" / "android_quick_actions.yaml"
+        ).read_text(encoding="utf-8")
+        self.assertIn('visible: "^Woo$"', quick_actions)
+        self.assertNotIn("Woo \\(Dev\\)", quick_actions)
 
     def test_changed_file_skip_only_applies_to_pull_requests(self) -> None:
         wrapper = (

--- a/.maestro/scripts/tests/test_ci_contract.py
+++ b/.maestro/scripts/tests/test_ci_contract.py
@@ -103,6 +103,16 @@ class MaestroCiContractTests(unittest.TestCase):
         self.assertNotIn(readiness_selector, reusable_login)
         self.assertNotIn('- tapOn: "Skip"', reusable_login)
 
+    def test_all_login_flows_are_required_core_coverage(self) -> None:
+        login_flows = sorted((REPO_ROOT / ".maestro" / "flows").glob("login_*.yaml"))
+
+        self.assertTrue(login_flows)
+        for path in login_flows:
+            with self.subTest(path=path):
+                source = path.read_text(encoding="utf-8")
+                self.assertIn("  - smoke_core\n", source)
+                self.assertNotIn("  - flaky_quarantine\n", source)
+
     def test_ci_defers_production_app_setup_to_the_runner(self) -> None:
         wrapper = (
             REPO_ROOT / ".buildkite" / "commands" / "run-maestro-tests.sh"

--- a/.maestro/scripts/tests/test_ci_contract.py
+++ b/.maestro/scripts/tests/test_ci_contract.py
@@ -70,6 +70,39 @@ class MaestroCiContractTests(unittest.TestCase):
         ).read_text(encoding="utf-8")
         self.assertIn("file: open_site_address_login.yaml", reusable_login)
 
+    def test_fresh_login_flows_share_the_carousel_dismissal(self) -> None:
+        helper = (
+            REPO_ROOT / ".maestro" / "subflows" / "dismiss_login_carousel.yaml"
+        ).read_text(encoding="utf-8")
+        readiness_selector = 'visible: ".*Skip.*|.*Enter your store address.*|.*Log in.*"'
+
+        self.assertIn("appId: com.woocommerce.android", helper)
+        self.assertIn(readiness_selector, helper)
+        self.assertIn('- tapOn: "Skip"', helper)
+
+        direct_login_flows = [
+            "login_google.yaml",
+            "login_help.yaml",
+            "login_no_jetpack.yaml",
+            "login_not_woo_store.yaml",
+            "login_not_wp_site.yaml",
+            "login_wrong_account.yaml",
+            "login_wrong_credentials.yaml",
+        ]
+        for flow_name in direct_login_flows:
+            with self.subTest(flow=flow_name):
+                flow = (REPO_ROOT / ".maestro" / "flows" / flow_name).read_text(encoding="utf-8")
+                self.assertIn("../subflows/dismiss_login_carousel.yaml", flow)
+                self.assertNotIn(readiness_selector, flow)
+                self.assertNotIn('- tapOn: "Skip"', flow)
+
+        reusable_login = (
+            REPO_ROOT / ".maestro" / "subflows" / "login.yaml"
+        ).read_text(encoding="utf-8")
+        self.assertIn("file: dismiss_login_carousel.yaml", reusable_login)
+        self.assertNotIn(readiness_selector, reusable_login)
+        self.assertNotIn('- tapOn: "Skip"', reusable_login)
+
     def test_ci_defers_production_app_setup_to_the_runner(self) -> None:
         wrapper = (
             REPO_ROOT / ".buildkite" / "commands" / "run-maestro-tests.sh"

--- a/.maestro/scripts/tests/test_ci_contract.py
+++ b/.maestro/scripts/tests/test_ci_contract.py
@@ -113,6 +113,30 @@ class MaestroCiContractTests(unittest.TestCase):
                 self.assertIn("  - smoke_core\n", source)
                 self.assertNotIn("  - flaky_quarantine\n", source)
 
+    def test_not_woo_store_uses_site_admin_credentials_for_both_auth_routes(self) -> None:
+        flow = (
+            REPO_ROOT / ".maestro" / "flows" / "login_not_woo_store.yaml"
+        ).read_text(encoding="utf-8")
+
+        self.assertEqual(
+            flow.count("${MAESTRO_WOO_NOT_A_WOO_STORE_SITE_ADMIN_USERNAME}"), 2
+        )
+        self.assertEqual(
+            flow.count("${MAESTRO_WOO_NOT_A_WOO_STORE_SITE_ADMIN_PASSWORD}"), 2
+        )
+
+        obsolete_namespace = "NOT_A_WOO_STORE_" + "WPCOM"
+        credential_sources = [
+            REPO_ROOT / ".maestro" / "env.example",
+            REPO_ROOT / ".maestro" / "README.md",
+            REPO_ROOT / ".maestro" / "scripts" / "doctor.py",
+            REPO_ROOT / ".maestro" / "scripts" / "run-smoke-tests.sh",
+            REPO_ROOT / ".maestro" / "flows" / "login_not_woo_store.yaml",
+        ]
+        for path in credential_sources:
+            with self.subTest(path=path):
+                self.assertNotIn(obsolete_namespace, path.read_text(encoding="utf-8"))
+
     def test_ci_defers_production_app_setup_to_the_runner(self) -> None:
         wrapper = (
             REPO_ROOT / ".buildkite" / "commands" / "run-maestro-tests.sh"

--- a/.maestro/scripts/tests/test_device_locale.py
+++ b/.maestro/scripts/tests/test_device_locale.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Tests for the Android device locale pre-flight check."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import device_locale  # noqa: E402
+
+
+def command_result(stdout: str = "", returncode: int = 0) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess([], returncode, stdout=stdout, stderr="")
+
+
+class DeviceLocaleTest(unittest.TestCase):
+    def test_accepts_english_locale_with_region(self) -> None:
+        result = device_locale.ensure_english_device_locale(
+            "emulator-5554",
+            lambda _command: command_result("en-US\n"),
+        )
+
+        self.assertEqual(result.primary, "en-US")
+        self.assertEqual(result.source, "cmd locale get-device-locale")
+
+    def test_accepts_english_locale_with_underscore(self) -> None:
+        result = device_locale.ensure_english_device_locale(
+            "emulator-5554",
+            lambda _command: command_result("en_GB\n"),
+        )
+
+        self.assertEqual(result.primary, "en-GB")
+
+    def test_rejects_non_english_primary_locale_even_when_english_is_secondary(self) -> None:
+        responses = iter(
+            (
+                command_result(returncode=1),
+                command_result(""),
+                command_result("es-ES,en-US\n"),
+            )
+        )
+
+        with self.assertRaisesRegex(
+            device_locale.DeviceLocaleError,
+            r"primary locale is es-ES; Maestro flows require English",
+        ):
+            device_locale.ensure_english_device_locale("emulator-5554", lambda _command: next(responses))
+
+    def test_falls_back_to_legacy_persisted_language(self) -> None:
+        responses = iter(
+            (
+                command_result("Locale manager help\n"),
+                command_result("null\n"),
+                command_result(""),
+                command_result("en\n"),
+            )
+        )
+
+        result = device_locale.ensure_english_device_locale(
+            "emulator-5554",
+            lambda _command: next(responses),
+        )
+
+        self.assertEqual(result, device_locale.DeviceLocale("en", "persist.sys.language"))
+
+    def test_fails_when_no_locale_probe_returns_a_locale(self) -> None:
+        with self.assertRaisesRegex(
+            device_locale.DeviceLocaleError,
+            r"could not determine the primary locale for adb device emulator-5554",
+        ):
+            device_locale.ensure_english_device_locale(
+                "emulator-5554",
+                lambda _command: command_result(""),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.maestro/scripts/tests/test_ensure_release_app.py
+++ b/.maestro/scripts/tests/test_ensure_release_app.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import ensure_release_app as release_app  # noqa: E402
+
+
+class EnsureReleaseAppTests(unittest.TestCase):
+    def test_latest_stable_release_selects_the_verified_universal_apk(self) -> None:
+        asset = release_app.parse_release_asset(
+            {
+                "tag_name": "25.4",
+                "draft": False,
+                "prerelease": False,
+                "assets": [
+                    {
+                        "name": "WooCommerce-25.4.aab",
+                        "browser_download_url": "https://github.com/example/app.aab",
+                        "size": 12,
+                        "digest": "sha256:" + "1" * 64,
+                    },
+                    {
+                        "name": "WooCommerce-25.4-universal.apk",
+                        "browser_download_url": "https://github.com/example/app.apk",
+                        "size": 42,
+                        "digest": "sha256:" + "a" * 64,
+                    },
+                ],
+            }
+        )
+
+        self.assertEqual(asset.tag, "25.4")
+        self.assertEqual(asset.name, "WooCommerce-25.4-universal.apk")
+        self.assertEqual(asset.sha256, "a" * 64)
+
+    def test_release_asset_without_a_sha256_digest_is_rejected(self) -> None:
+        with self.assertRaisesRegex(release_app.ReleaseAppError, "SHA-256"):
+            release_app.parse_release_asset(
+                {
+                    "tag_name": "25.4",
+                    "draft": False,
+                    "prerelease": False,
+                    "assets": [
+                        {
+                            "name": "WooCommerce-25.4-universal.apk",
+                            "browser_download_url": "https://github.com/example/app.apk",
+                            "size": 42,
+                            "digest": None,
+                        }
+                    ],
+                }
+            )
+
+    def test_production_apk_badging_must_not_be_debuggable(self) -> None:
+        metadata = release_app.parse_apk_badging(
+            "package: name='com.woocommerce.android' versionCode='778' versionName='25.4'\n"
+        )
+
+        self.assertEqual(metadata.package_name, "com.woocommerce.android")
+        self.assertEqual(metadata.version_name, "25.4")
+        self.assertFalse(metadata.debuggable)
+
+        debuggable = release_app.parse_apk_badging(
+            "package: name='com.woocommerce.android' versionCode='778' versionName='25.4'\n"
+            "application-debuggable\n"
+        )
+        self.assertTrue(debuggable.debuggable)
+
+    def test_dev_apk_is_rejected(self) -> None:
+        badging = release_app.subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=(
+                "package: name='com.woocommerce.android.dev' "
+                "versionCode='778' versionName='25.4-rc-1'\n"
+            ),
+            stderr="",
+        )
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            apk = Path(temporary_directory) / "WooCommerce-wasabi-release.apk"
+            apk.touch()
+            with patch.object(release_app, "find_aapt", return_value=Path("/fake/aapt")), patch.object(
+                release_app, "run_command", return_value=badging
+            ):
+                with self.assertRaisesRegex(release_app.ReleaseAppError, "expected production package"):
+                    release_app.validate_release_apk(apk)
+
+    def test_installed_debuggable_production_package_is_identified(self) -> None:
+        metadata = release_app.parse_installed_package_dump(
+            "  versionName=25.4\n  flags=[ DEBUGGABLE HAS_CODE ]\n"
+        )
+
+        self.assertEqual(metadata.version_name, "25.4")
+        self.assertTrue(metadata.debuggable)
+
+    def test_existing_release_app_is_reused_without_downloading(self) -> None:
+        installed = release_app.ApkMetadata("com.woocommerce.android", "25.4", False)
+
+        with patch.object(release_app, "installed_release", return_value=installed), patch.object(
+            release_app, "latest_release_asset"
+        ) as latest:
+            result = release_app.ensure_release_app("emulator-5554")
+
+        self.assertFalse(result.installed_now)
+        self.assertEqual(result.version_name, "25.4")
+        latest.assert_not_called()
+
+    def test_missing_release_app_downloads_verifies_and_installs_latest_stable_apk(self) -> None:
+        asset = release_app.ReleaseAsset(
+            "25.4",
+            "WooCommerce-25.4-universal.apk",
+            "https://github.com/example/app.apk",
+            42,
+            "a" * 64,
+        )
+        metadata = release_app.ApkMetadata("com.woocommerce.android", "25.4", False)
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            apk = Path(temporary_directory) / asset.name
+            apk.touch()
+            with patch.object(release_app, "installed_release", side_effect=[None, metadata]), patch.object(
+                release_app, "latest_release_asset", return_value=asset
+            ), patch.object(release_app, "download_release_asset", return_value=apk), patch.object(
+                release_app, "validate_release_apk", return_value=metadata
+            ), patch.object(release_app, "install_release_apk") as install:
+                result = release_app.ensure_release_app(
+                    "emulator-5554",
+                    cache_dir=Path(temporary_directory),
+                )
+
+        self.assertTrue(result.installed_now)
+        self.assertEqual(result.source, "GitHub release 25.4")
+        install.assert_called_once_with("emulator-5554", apk)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.maestro/scripts/tests/test_smoke_cli.py
+++ b/.maestro/scripts/tests/test_smoke_cli.py
@@ -15,9 +15,22 @@ REPO_ROOT = SCRIPT_DIR.parent.parent.parent
 RUNNER = REPO_ROOT / ".maestro" / "scripts" / "run-smoke-tests.sh"
 DOCTOR = REPO_ROOT / ".maestro" / "scripts" / "doctor.py"
 GOLDEN_DIR = SCRIPT_DIR / "golden"
+LOGIN_NOT_WP_SITE_FLOW = REPO_ROOT / ".maestro" / "flows" / "login_not_wp_site.yaml"
 
 
 class SmokeCliContractTest(unittest.TestCase):
+    def test_not_wp_site_flow_verifies_recovery_preserves_the_entered_address(self) -> None:
+        source = LOGIN_NOT_WP_SITE_FLOW.read_text(encoding="utf-8")
+
+        recovery = source.index('- tapOn:\n    text: "Try another store"')
+        preserved_address = source.index(
+            '- assertVisible:\n'
+            '    id: "input"\n'
+            '    text: "google.com"\n'
+            '    label: "Verify the last entered site address is preserved"'
+        )
+        self.assertLess(recovery, preserved_address)
+
     def test_device_media_fixture_is_prepared_only_for_the_media_flow(self) -> None:
         source = RUNNER.read_text(encoding="utf-8")
 

--- a/.maestro/scripts/tests/test_smoke_cli.py
+++ b/.maestro/scripts/tests/test_smoke_cli.py
@@ -202,13 +202,15 @@ class SmokeCliContractTest(unittest.TestCase):
         self,
         *args: str,
         env_overrides: dict[str, str],
-    ) -> tuple[subprocess.CompletedProcess[str], str]:
+        fail_first_attempt: bool = False,
+    ) -> tuple[subprocess.CompletedProcess[str], str, Path]:
         temporary_directory = tempfile.TemporaryDirectory()
         self.addCleanup(temporary_directory.cleanup)
         temporary_path = Path(temporary_directory.name)
         fake_bin = temporary_path / "bin"
         fake_bin.mkdir()
         maestro_args = temporary_path / "maestro-args"
+        first_attempt_marker = temporary_path / "first-attempt-failed"
 
         maestro = fake_bin / "maestro"
         maestro.write_text(
@@ -216,6 +218,14 @@ class SmokeCliContractTest(unittest.TestCase):
             "if [ \"${1:-}\" = --version ]; then printf '%s\\n' '2.9.0'; exit 0; fi\n"
             f"printf 'ARGS:%s\\n' \"$*\" >> '{maestro_args}'\n"
             f"env | grep -E '^(MAESTRO_)?WOO_' | sort >> '{maestro_args}'\n"
+            + (
+                f"if [ ! -f '{first_attempt_marker}' ]; then\n"
+                f"  : > '{first_attempt_marker}'\n"
+                "  exit 1\n"
+                "fi\n"
+                if fail_first_attempt
+                else ""
+            )
         )
         maestro.chmod(0o755)
         java = fake_bin / "java"
@@ -255,9 +265,15 @@ class SmokeCliContractTest(unittest.TestCase):
             text=True,
             check=False,
         )
-        return result, maestro_args.read_text(encoding="utf-8") if maestro_args.exists() else ""
+        return (
+            result,
+            maestro_args.read_text(encoding="utf-8") if maestro_args.exists() else "",
+            temporary_path / "output",
+        )
 
-    def run_core_with_recorded_maestro_args(self) -> tuple[subprocess.CompletedProcess[str], str]:
+    def run_core_with_recorded_maestro_args(
+        self,
+    ) -> tuple[subprocess.CompletedProcess[str], str, Path]:
         return self.run_with_recorded_maestro_args(
             "--profile",
             "core",
@@ -529,7 +545,7 @@ class SmokeCliContractTest(unittest.TestCase):
         self.assertFalse(adb_marker.exists())
 
     def test_maestro_cli_receives_only_selected_flow_values_and_no_rest_or_other_store_secrets(self) -> None:
-        result, args = self.run_core_with_recorded_maestro_args()
+        result, args, _ = self.run_core_with_recorded_maestro_args()
 
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("-e APP_ID=com.woocommerce.android", args)
@@ -541,8 +557,48 @@ class SmokeCliContractTest(unittest.TestCase):
         self.assertNotIn("selected-rest-secret", args)
         self.assertNotIn("other-store-secret", args)
 
+    def test_pass_on_retry_is_reported_as_flaky_without_failing_the_run(self) -> None:
+        env = {
+            "MAESTRO_WOO_LAB_JETPACK_STORE_URL": "https://lab.example.com/",
+            "MAESTRO_WOO_LAB_WPCOM_EMAIL": "lab@example.com",
+            "MAESTRO_WOO_LAB_WPCOM_PASSWORD": "lab-password",
+        }
+        result, _, output_root = self.run_with_recorded_maestro_args(
+            "--store",
+            "lab",
+            "--device",
+            "emulator-5554",
+            "--no-record",
+            ".maestro/flows/login_successful.yaml",
+            env_overrides=env,
+            fail_first_attempt=True,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("FLAKY", result.stdout)
+        self.assertIn("1 passed (1 flaky), 0 failed", result.stdout)
+        reports = list(output_root.glob("*/report.xml"))
+        self.assertEqual(len(reports), 1)
+        report = reports[0].read_text(encoding="utf-8")
+        self.assertIn('tests="1" failures="0"', report)
+        self.assertIn('<property name="maestro.status" value="FLAKY"/>', report)
+        self.assertNotIn("<failure", report)
+
+        rerun, rerun_args, _ = self.run_with_recorded_maestro_args(
+            "--store",
+            "lab",
+            "--device",
+            "emulator-5554",
+            "--no-record",
+            "--rerun-failed",
+            str(reports[0]),
+            env_overrides=env,
+        )
+        self.assertEqual(rerun.returncode, 0, rerun.stderr)
+        self.assertIn("login_successful.yaml", rerun_args)
+
     def test_wordpress_dot_com_not_woo_store_requires_explicit_wpcom_credentials(self) -> None:
-        result, args = self.run_with_recorded_maestro_args(
+        result, args, _ = self.run_with_recorded_maestro_args(
             "--device",
             "emulator-5554",
             ".maestro/flows/login_not_woo_store.yaml",
@@ -558,7 +614,7 @@ class SmokeCliContractTest(unittest.TestCase):
         self.assertEqual("", args)
 
     def test_not_woo_store_forwards_explicit_wpcom_credentials(self) -> None:
-        result, args = self.run_with_recorded_maestro_args(
+        result, args, _ = self.run_with_recorded_maestro_args(
             "--device",
             "emulator-5554",
             ".maestro/flows/login_not_woo_store.yaml",
@@ -576,7 +632,7 @@ class SmokeCliContractTest(unittest.TestCase):
         self.assertIn("MAESTRO_WOO_NOT_A_WOO_STORE_WPCOM_PASSWORD=wpcom-password", args)
 
     def test_no_jetpack_wp_admin_url_is_normalized_before_maestro(self) -> None:
-        result, args = self.run_with_recorded_maestro_args(
+        result, args, _ = self.run_with_recorded_maestro_args(
             "--device",
             "emulator-5554",
             ".maestro/flows/login_no_jetpack.yaml",

--- a/.maestro/scripts/tests/test_smoke_cli.py
+++ b/.maestro/scripts/tests/test_smoke_cli.py
@@ -42,6 +42,16 @@ class SmokeCliContractTest(unittest.TestCase):
             source.index("validate_google_login_apk()"),
         )
 
+    def test_device_locale_is_checked_before_release_app_setup(self) -> None:
+        runner_source = RUNNER.read_text(encoding="utf-8")
+        doctor_source = DOCTOR.read_text(encoding="utf-8")
+
+        self.assertLess(
+            runner_source.index('python3 "$CHECK_DEVICE_LOCALE_SCRIPT" --device "$DEVICE_SERIAL"'),
+            runner_source.index('echo "--- Ensuring production release app"'),
+        )
+        self.assertIn("ensure_english_device_locale(selected_device)", doctor_source)
+
     def test_cleanup_finishes_before_reports_and_participates_in_exit_status(self) -> None:
         source = RUNNER.read_text(encoding="utf-8")
 
@@ -203,6 +213,7 @@ class SmokeCliContractTest(unittest.TestCase):
         *args: str,
         env_overrides: dict[str, str],
         fail_first_attempt: bool = False,
+        device_locale: str = "en-US",
     ) -> tuple[subprocess.CompletedProcess[str], str, Path]:
         temporary_directory = tempfile.TemporaryDirectory()
         self.addCleanup(temporary_directory.cleanup)
@@ -236,6 +247,8 @@ class SmokeCliContractTest(unittest.TestCase):
             "#!/bin/sh\n"
             "if [ \"${1:-}\" = devices ]; then\n"
             "  printf 'List of devices attached\\nemulator-5554\\tdevice\\n'\n"
+            "elif printf '%s\\n' \"$*\" | grep -q 'shell cmd locale get-device-locale'; then\n"
+            f"  printf '%s\\n' '{device_locale}'\n"
             "elif printf '%s\\n' \"$*\" | grep -q 'shell pm path com.woocommerce.android'; then\n"
             "  printf 'package:/data/app/com.woocommerce.android/base.apk\\n'\n"
             "elif printf '%s\\n' \"$*\" | grep -q 'shell dumpsys package com.woocommerce.android'; then\n"
@@ -556,6 +569,23 @@ class SmokeCliContractTest(unittest.TestCase):
                 self.assertNotIn("selected-password", line)
         self.assertNotIn("selected-rest-secret", args)
         self.assertNotIn("other-store-secret", args)
+
+    def test_non_english_device_locale_fails_before_maestro_runs(self) -> None:
+        result, args, _ = self.run_with_recorded_maestro_args(
+            "--device",
+            "emulator-5554",
+            ".maestro/flows/login_successful.yaml",
+            env_overrides={
+                "MAESTRO_WOO_LAB_JETPACK_STORE_URL": "https://lab.example.com/",
+                "MAESTRO_WOO_LAB_WPCOM_EMAIL": "lab@example.com",
+                "MAESTRO_WOO_LAB_WPCOM_PASSWORD": "lab-password",
+            },
+            device_locale="es-ES",
+        )
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("primary locale is es-ES; Maestro flows require English", result.stderr)
+        self.assertEqual(args, "")
 
     def test_pass_on_retry_is_reported_as_flaky_without_failing_the_run(self) -> None:
         env = {

--- a/.maestro/scripts/tests/test_smoke_cli.py
+++ b/.maestro/scripts/tests/test_smoke_cli.py
@@ -597,7 +597,7 @@ class SmokeCliContractTest(unittest.TestCase):
         self.assertEqual(rerun.returncode, 0, rerun.stderr)
         self.assertIn("login_successful.yaml", rerun_args)
 
-    def test_wordpress_dot_com_not_woo_store_requires_explicit_wpcom_credentials(self) -> None:
+    def test_not_woo_store_forwards_site_admin_credentials(self) -> None:
         result, args, _ = self.run_with_recorded_maestro_args(
             "--device",
             "emulator-5554",
@@ -606,30 +606,12 @@ class SmokeCliContractTest(unittest.TestCase):
                 "MAESTRO_WOO_NOT_A_WOO_STORE_URL": "https://not-woo.wordpress.com/",
                 "MAESTRO_WOO_NOT_A_WOO_STORE_SITE_ADMIN_USERNAME": "site-admin",
                 "MAESTRO_WOO_NOT_A_WOO_STORE_SITE_ADMIN_PASSWORD": "site-password",
-            },
-        )
-
-        self.assertEqual(result.returncode, 1)
-        self.assertIn("WordPress.com-hosted not-Woo-store fixtures require both", result.stderr)
-        self.assertEqual("", args)
-
-    def test_not_woo_store_forwards_explicit_wpcom_credentials(self) -> None:
-        result, args, _ = self.run_with_recorded_maestro_args(
-            "--device",
-            "emulator-5554",
-            ".maestro/flows/login_not_woo_store.yaml",
-            env_overrides={
-                "MAESTRO_WOO_NOT_A_WOO_STORE_URL": "https://not-woo.wordpress.com/",
-                "MAESTRO_WOO_NOT_A_WOO_STORE_SITE_ADMIN_USERNAME": "site-admin",
-                "MAESTRO_WOO_NOT_A_WOO_STORE_SITE_ADMIN_PASSWORD": "site-password",
-                "MAESTRO_WOO_NOT_A_WOO_STORE_WPCOM_EMAIL": "wpcom-user",
-                "MAESTRO_WOO_NOT_A_WOO_STORE_WPCOM_PASSWORD": "wpcom-password",
             },
         )
 
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertIn("MAESTRO_WOO_NOT_A_WOO_STORE_WPCOM_EMAIL=wpcom-user", args)
-        self.assertIn("MAESTRO_WOO_NOT_A_WOO_STORE_WPCOM_PASSWORD=wpcom-password", args)
+        self.assertIn("MAESTRO_WOO_NOT_A_WOO_STORE_SITE_ADMIN_USERNAME=site-admin", args)
+        self.assertIn("MAESTRO_WOO_NOT_A_WOO_STORE_SITE_ADMIN_PASSWORD=site-password", args)
 
     def test_no_jetpack_wp_admin_url_is_normalized_before_maestro(self) -> None:
         result, args, _ = self.run_with_recorded_maestro_args(

--- a/.maestro/scripts/tests/test_smoke_cli.py
+++ b/.maestro/scripts/tests/test_smoke_cli.py
@@ -271,14 +271,13 @@ class SmokeCliContractTest(unittest.TestCase):
             temporary_path / "output",
         )
 
-    def run_core_with_recorded_maestro_args(
+    def run_login_successful_with_recorded_maestro_args(
         self,
     ) -> tuple[subprocess.CompletedProcess[str], str, Path]:
         return self.run_with_recorded_maestro_args(
-            "--profile",
-            "core",
             "--device",
             "emulator-5554",
+            ".maestro/flows/login_successful.yaml",
             env_overrides={
                 "MAESTRO_WOO_LAB_JETPACK_STORE_URL": "https://lab.example.com/",
                 "MAESTRO_WOO_LAB_WPCOM_EMAIL": "lab@example.com",
@@ -512,9 +511,10 @@ class SmokeCliContractTest(unittest.TestCase):
 
     def test_seed_request_does_not_create_unused_fixtures_without_destructive_flows(self) -> None:
         result, events = self.run_with_order_recording_tools(
-            "--profile",
-            "release",
+            "--store",
+            "shared",
             "--seed",
+            ".maestro/flows/login_successful.yaml",
             env_overrides={
                 "MAESTRO_WOO_SHARED_JETPACK_STORE_URL": "https://inpersonpayments.wpcomstaging.com/",
                 "MAESTRO_WOO_SHARED_WPCOM_EMAIL": "shared@example.com",
@@ -545,7 +545,7 @@ class SmokeCliContractTest(unittest.TestCase):
         self.assertFalse(adb_marker.exists())
 
     def test_maestro_cli_receives_only_selected_flow_values_and_no_rest_or_other_store_secrets(self) -> None:
-        result, args, _ = self.run_core_with_recorded_maestro_args()
+        result, args, _ = self.run_login_successful_with_recorded_maestro_args()
 
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertNotIn("-e APP_ID=", args)

--- a/.maestro/scripts/tests/test_smoke_cli.py
+++ b/.maestro/scripts/tests/test_smoke_cli.py
@@ -16,9 +16,30 @@ RUNNER = REPO_ROOT / ".maestro" / "scripts" / "run-smoke-tests.sh"
 DOCTOR = REPO_ROOT / ".maestro" / "scripts" / "doctor.py"
 GOLDEN_DIR = SCRIPT_DIR / "golden"
 LOGIN_NOT_WP_SITE_FLOW = REPO_ROOT / ".maestro" / "flows" / "login_not_wp_site.yaml"
+GOOGLE_PASSWORD_MANAGER_SUBFLOW = (
+    REPO_ROOT / ".maestro" / "subflows" / "dismiss_google_password_manager.yaml"
+)
 
 
 class SmokeCliContractTest(unittest.TestCase):
+    def test_google_password_manager_is_dismissed_by_stable_android_resource_id(self) -> None:
+        dismissal = GOOGLE_PASSWORD_MANAGER_SUBFLOW.read_text(encoding="utf-8")
+        affected_files = (
+            REPO_ROOT / ".maestro" / "flows" / "login_wrong_credentials.yaml",
+            REPO_ROOT / ".maestro" / "flows" / "login_wrong_account.yaml",
+            REPO_ROOT / ".maestro" / "flows" / "login_not_woo_store.yaml",
+            REPO_ROOT / ".maestro" / "subflows" / "login.yaml",
+        )
+
+        self.assertIn('id: "android:id/autofill_dialog_no"', dismissal)
+        self.assertNotIn("point:", dismissal)
+        references = 0
+        for path in affected_files:
+            source = path.read_text(encoding="utf-8")
+            self.assertNotIn('"No thanks"', source)
+            references += source.count("dismiss_google_password_manager.yaml")
+        self.assertEqual(references, 8)
+
     def test_not_wp_site_flow_verifies_recovery_preserves_the_entered_address(self) -> None:
         source = LOGIN_NOT_WP_SITE_FLOW.read_text(encoding="utf-8")
 

--- a/.maestro/scripts/tests/test_smoke_cli.py
+++ b/.maestro/scripts/tests/test_smoke_cli.py
@@ -548,7 +548,7 @@ class SmokeCliContractTest(unittest.TestCase):
         result, args, _ = self.run_core_with_recorded_maestro_args()
 
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertIn("-e APP_ID=com.woocommerce.android", args)
+        self.assertNotIn("-e APP_ID=", args)
         self.assertIn("MAESTRO_WOO_WPCOM_PASSWORD=selected-password", args)
         self.assertNotIn("\nWOO_WPCOM_PASSWORD=selected-password\n", args)
         for line in args.splitlines():

--- a/.maestro/scripts/tests/test_smoke_cli.py
+++ b/.maestro/scripts/tests/test_smoke_cli.py
@@ -226,6 +226,10 @@ class SmokeCliContractTest(unittest.TestCase):
             "#!/bin/sh\n"
             "if [ \"${1:-}\" = devices ]; then\n"
             "  printf 'List of devices attached\\nemulator-5554\\tdevice\\n'\n"
+            "elif printf '%s\\n' \"$*\" | grep -q 'shell pm path com.woocommerce.android'; then\n"
+            "  printf 'package:/data/app/com.woocommerce.android/base.apk\\n'\n"
+            "elif printf '%s\\n' \"$*\" | grep -q 'shell dumpsys package com.woocommerce.android'; then\n"
+            "  printf '  versionName=25.4\\n  flags=[ HAS_CODE ]\\n'\n"
             "elif printf '%s\\n' \"$*\" | grep -q 'settings get global'; then\n"
             "  printf '1\\n'\n"
             "fi\n"
@@ -528,6 +532,7 @@ class SmokeCliContractTest(unittest.TestCase):
         result, args = self.run_core_with_recorded_maestro_args()
 
         self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("-e APP_ID=com.woocommerce.android", args)
         self.assertIn("MAESTRO_WOO_WPCOM_PASSWORD=selected-password", args)
         self.assertNotIn("\nWOO_WPCOM_PASSWORD=selected-password\n", args)
         for line in args.splitlines():

--- a/.maestro/subflows/dashboard_assert_widget_restored.yaml
+++ b/.maestro/subflows/dashboard_assert_widget_restored.yaml
@@ -1,4 +1,4 @@
-appId: com.woocommerce.android.dev
+appId: ${APP_ID}
 ---
 - assertVisible:
     id: ".*__${CARD_SLUG}_${output.dashboardOriginalStates[CARD_SLUG]}__.*"

--- a/.maestro/subflows/dashboard_assert_widget_restored.yaml
+++ b/.maestro/subflows/dashboard_assert_widget_restored.yaml
@@ -1,4 +1,4 @@
-appId: ${APP_ID}
+appId: com.woocommerce.android
 ---
 - assertVisible:
     id: ".*__${CARD_SLUG}_${output.dashboardOriginalStates[CARD_SLUG]}__.*"

--- a/.maestro/subflows/dashboard_assert_widget_selected.yaml
+++ b/.maestro/subflows/dashboard_assert_widget_selected.yaml
@@ -1,4 +1,4 @@
-appId: com.woocommerce.android.dev
+appId: ${APP_ID}
 ---
 - runFlow:
     when:

--- a/.maestro/subflows/dashboard_assert_widget_selected.yaml
+++ b/.maestro/subflows/dashboard_assert_widget_selected.yaml
@@ -1,4 +1,4 @@
-appId: ${APP_ID}
+appId: com.woocommerce.android
 ---
 - runFlow:
     when:

--- a/.maestro/subflows/dashboard_exercise_selected_widget.yaml
+++ b/.maestro/subflows/dashboard_exercise_selected_widget.yaml
@@ -1,4 +1,4 @@
-appId: com.woocommerce.android.dev
+appId: ${APP_ID}
 ---
 - runFlow:
     when:

--- a/.maestro/subflows/dashboard_exercise_selected_widget.yaml
+++ b/.maestro/subflows/dashboard_exercise_selected_widget.yaml
@@ -1,4 +1,4 @@
-appId: ${APP_ID}
+appId: com.woocommerce.android
 ---
 - runFlow:
     when:

--- a/.maestro/subflows/dashboard_record_widget_order.yaml
+++ b/.maestro/subflows/dashboard_record_widget_order.yaml
@@ -1,4 +1,4 @@
-appId: com.woocommerce.android.dev
+appId: ${APP_ID}
 ---
 - runFlow:
     when:

--- a/.maestro/subflows/dashboard_record_widget_order.yaml
+++ b/.maestro/subflows/dashboard_record_widget_order.yaml
@@ -1,4 +1,4 @@
-appId: ${APP_ID}
+appId: com.woocommerce.android
 ---
 - runFlow:
     when:

--- a/.maestro/subflows/dashboard_record_widget_state.yaml
+++ b/.maestro/subflows/dashboard_record_widget_state.yaml
@@ -1,4 +1,4 @@
-appId: com.woocommerce.android.dev
+appId: ${APP_ID}
 ---
 - runFlow:
     when:

--- a/.maestro/subflows/dashboard_record_widget_state.yaml
+++ b/.maestro/subflows/dashboard_record_widget_state.yaml
@@ -1,4 +1,4 @@
-appId: ${APP_ID}
+appId: com.woocommerce.android
 ---
 - runFlow:
     when:

--- a/.maestro/subflows/dashboard_restore_widget.yaml
+++ b/.maestro/subflows/dashboard_restore_widget.yaml
@@ -1,4 +1,4 @@
-appId: com.woocommerce.android.dev
+appId: ${APP_ID}
 ---
 - runFlow:
     when:

--- a/.maestro/subflows/dashboard_restore_widget.yaml
+++ b/.maestro/subflows/dashboard_restore_widget.yaml
@@ -1,4 +1,4 @@
-appId: ${APP_ID}
+appId: com.woocommerce.android
 ---
 - runFlow:
     when:

--- a/.maestro/subflows/dashboard_select_widget.yaml
+++ b/.maestro/subflows/dashboard_select_widget.yaml
@@ -1,4 +1,4 @@
-appId: com.woocommerce.android.dev
+appId: ${APP_ID}
 ---
 - runFlow:
     when:

--- a/.maestro/subflows/dashboard_select_widget.yaml
+++ b/.maestro/subflows/dashboard_select_widget.yaml
@@ -1,4 +1,4 @@
-appId: ${APP_ID}
+appId: com.woocommerce.android
 ---
 - runFlow:
     when:

--- a/.maestro/subflows/dismiss_google_password_manager.yaml
+++ b/.maestro/subflows/dismiss_google_password_manager.yaml
@@ -1,0 +1,10 @@
+# Dismiss the Android autofill dialog without depending on localized button text.
+appId: com.woocommerce.android
+---
+- runFlow:
+    when:
+      visible:
+        id: "android:id/autofill_dialog_no"
+    commands:
+      - tapOn:
+          id: "android:id/autofill_dialog_no"

--- a/.maestro/subflows/dismiss_login_carousel.yaml
+++ b/.maestro/subflows/dismiss_login_carousel.yaml
@@ -1,0 +1,12 @@
+# Waits for the initial login surface and dismisses the welcome carousel when shown.
+appId: com.woocommerce.android
+---
+- extendedWaitUntil:
+    visible: ".*Skip.*|.*Enter your store address.*|.*Log in.*"
+    timeout: 30000
+
+- runFlow:
+    when:
+      visible: "Skip"
+    commands:
+      - tapOn: "Skip"

--- a/.maestro/subflows/ensure_configured_woo_store.yaml
+++ b/.maestro/subflows/ensure_configured_woo_store.yaml
@@ -1,4 +1,4 @@
-appId: com.woocommerce.android.dev
+appId: ${APP_ID}
 ---
 - runFlow:
     file: navigate_to_more_menu.yaml

--- a/.maestro/subflows/ensure_configured_woo_store.yaml
+++ b/.maestro/subflows/ensure_configured_woo_store.yaml
@@ -1,4 +1,4 @@
-appId: ${APP_ID}
+appId: com.woocommerce.android
 ---
 - runFlow:
     file: navigate_to_more_menu.yaml

--- a/.maestro/subflows/ensure_logged_in.yaml
+++ b/.maestro/subflows/ensure_logged_in.yaml
@@ -27,7 +27,7 @@
 # kick off a single non-login flow from a cold emulator. Now any
 # flow can be invoked in isolation and it'll self-heal into a
 # logged-in state on first run.
-appId: com.woocommerce.android.dev
+appId: ${APP_ID}
 ---
 - launchApp:
     clearState: false

--- a/.maestro/subflows/ensure_logged_in.yaml
+++ b/.maestro/subflows/ensure_logged_in.yaml
@@ -27,7 +27,7 @@
 # kick off a single non-login flow from a cold emulator. Now any
 # flow can be invoked in isolation and it'll self-heal into a
 # logged-in state on first run.
-appId: ${APP_ID}
+appId: com.woocommerce.android
 ---
 - launchApp:
     clearState: false

--- a/.maestro/subflows/login.yaml
+++ b/.maestro/subflows/login.yaml
@@ -8,17 +8,8 @@ appId: com.woocommerce.android
 - launchApp:
     clearState: true
 
-# Wait for app to finish loading after clearState (splash screen can take a while)
-- extendedWaitUntil:
-    visible: ".*Skip.*|.*Enter your store address.*|.*Log in.*"
-    timeout: 30000
-
-# Skip the carousel if it appears
 - runFlow:
-    when:
-      visible: "Skip"
-    commands:
-      - tapOn: "Skip"
+    file: dismiss_login_carousel.yaml
 
 # Continue through the QR prologue when present, then enter the store URL.
 - runFlow:

--- a/.maestro/subflows/login.yaml
+++ b/.maestro/subflows/login.yaml
@@ -3,7 +3,7 @@
 #
 # Required env vars: MAESTRO_WOO_JETPACK_STORE_URL, MAESTRO_WOO_WPCOM_EMAIL,
 # MAESTRO_WOO_WPCOM_PASSWORD
-appId: com.woocommerce.android.dev
+appId: ${APP_ID}
 ---
 - launchApp:
     clearState: true

--- a/.maestro/subflows/login.yaml
+++ b/.maestro/subflows/login.yaml
@@ -3,7 +3,7 @@
 #
 # Required env vars: MAESTRO_WOO_JETPACK_STORE_URL, MAESTRO_WOO_WPCOM_EMAIL,
 # MAESTRO_WOO_WPCOM_PASSWORD
-appId: ${APP_ID}
+appId: com.woocommerce.android
 ---
 - launchApp:
     clearState: true

--- a/.maestro/subflows/login.yaml
+++ b/.maestro/subflows/login.yaml
@@ -38,10 +38,7 @@ appId: com.woocommerce.android
 
 # Dismiss Google Password Manager if it appears
 - runFlow:
-    when:
-      visible: "No thanks"
-    commands:
-      - tapOn: "No thanks"
+    file: dismiss_google_password_manager.yaml
 
 # Handle Magic Link screen - tap "Enter your password instead"
 - runFlow:
@@ -54,10 +51,7 @@ appId: com.woocommerce.android
 
 # Dismiss Google Password Manager again if it appears on password screen
 - runFlow:
-    when:
-      visible: "No thanks"
-    commands:
-      - tapOn: "No thanks"
+    file: dismiss_google_password_manager.yaml
 
 # Enter password
 - extendedWaitUntil:

--- a/.maestro/subflows/navigate_to_more_menu.yaml
+++ b/.maestro/subflows/navigate_to_more_menu.yaml
@@ -1,5 +1,5 @@
 # Navigate to the More Menu (Hub) tab
-appId: com.woocommerce.android.dev
+appId: ${APP_ID}
 ---
 - tapOn:
     id: "moreMenu"

--- a/.maestro/subflows/navigate_to_more_menu.yaml
+++ b/.maestro/subflows/navigate_to_more_menu.yaml
@@ -1,5 +1,5 @@
 # Navigate to the More Menu (Hub) tab
-appId: ${APP_ID}
+appId: com.woocommerce.android
 ---
 - tapOn:
     id: "moreMenu"

--- a/.maestro/subflows/navigate_to_orders.yaml
+++ b/.maestro/subflows/navigate_to_orders.yaml
@@ -1,5 +1,5 @@
 # Navigate to the Orders tab
-appId: com.woocommerce.android.dev
+appId: ${APP_ID}
 ---
 - tapOn:
     id: "orders"

--- a/.maestro/subflows/navigate_to_orders.yaml
+++ b/.maestro/subflows/navigate_to_orders.yaml
@@ -1,5 +1,5 @@
 # Navigate to the Orders tab
-appId: ${APP_ID}
+appId: com.woocommerce.android
 ---
 - tapOn:
     id: "orders"

--- a/.maestro/subflows/navigate_to_products.yaml
+++ b/.maestro/subflows/navigate_to_products.yaml
@@ -1,5 +1,5 @@
 # Navigate to the Products tab
-appId: com.woocommerce.android.dev
+appId: ${APP_ID}
 ---
 - tapOn:
     id: "products"

--- a/.maestro/subflows/navigate_to_products.yaml
+++ b/.maestro/subflows/navigate_to_products.yaml
@@ -1,5 +1,5 @@
 # Navigate to the Products tab
-appId: ${APP_ID}
+appId: com.woocommerce.android
 ---
 - tapOn:
     id: "products"

--- a/.maestro/subflows/open_dashboard_widget_editor.yaml
+++ b/.maestro/subflows/open_dashboard_widget_editor.yaml
@@ -1,4 +1,4 @@
-appId: com.woocommerce.android.dev
+appId: ${APP_ID}
 ---
 - extendedWaitUntil:
     visible:

--- a/.maestro/subflows/open_dashboard_widget_editor.yaml
+++ b/.maestro/subflows/open_dashboard_widget_editor.yaml
@@ -1,4 +1,4 @@
-appId: ${APP_ID}
+appId: com.woocommerce.android
 ---
 - extendedWaitUntil:
     visible:

--- a/.maestro/subflows/open_site_address_login.yaml
+++ b/.maestro/subflows/open_site_address_login.yaml
@@ -4,7 +4,7 @@
 # devices without a camera can still navigate directly to the site-address
 # form, so each transition is conditional and this subflow is safe to call
 # when the form is already open.
-appId: com.woocommerce.android.dev
+appId: ${APP_ID}
 ---
 - extendedWaitUntil:
     visible: "^Log In$|.*Log in with site address.*|Site address"

--- a/.maestro/subflows/open_site_address_login.yaml
+++ b/.maestro/subflows/open_site_address_login.yaml
@@ -4,7 +4,7 @@
 # devices without a camera can still navigate directly to the site-address
 # form, so each transition is conditional and this subflow is safe to call
 # when the form is already open.
-appId: ${APP_ID}
+appId: com.woocommerce.android
 ---
 - extendedWaitUntil:
     visible: "^Log In$|.*Log in with site address.*|Site address"

--- a/.maestro/subflows/pos_add_discovered_variable_product.yaml
+++ b/.maestro/subflows/pos_add_discovered_variable_product.yaml
@@ -1,6 +1,6 @@
 # Discovers a variable product from the loaded POS catalog, searches for its
 # app-provided name, opens its variations, and adds the first variation.
-appId: com.woocommerce.android.dev
+appId: ${APP_ID}
 ---
 - scrollUntilVisible:
     element: "Variable Product .*"

--- a/.maestro/subflows/pos_add_discovered_variable_product.yaml
+++ b/.maestro/subflows/pos_add_discovered_variable_product.yaml
@@ -1,6 +1,6 @@
 # Discovers a variable product from the loaded POS catalog, searches for its
 # app-provided name, opens its variations, and adds the first variation.
-appId: ${APP_ID}
+appId: com.woocommerce.android
 ---
 - scrollUntilVisible:
     element: "Variable Product .*"


### PR DESCRIPTION
### Description

Fixes WOOMOB-3885

This PR makes the complete Maestro login matrix a reliable release signal:

- Strengthens the non-WordPress and non-WooCommerce recovery flows by verifying that **Try another store** preserves the entered address, using the dedicated site-admin credentials through either authentication route, and asserting the **Open installation page** CTA.
- Centralizes fresh-login carousel handling and replaces text-based Google Password Manager dismissals with the stable `android:id/autofill_dialog_no` resource ID.
- Makes all eight login flows required `smoke_core` coverage, promoting the seven previously quarantined flows into the core, release, and burst plans.
- Requires the non-debuggable production package (`com.woocommerce.android`) for every flow. When it is missing, the runner and doctor download the latest stable universal APK and validate its size, published SHA-256 digest, package ID, and debuggable flag before installation. CI no longer falls back to a Wasabi debug build.
- Requires English as the selected device's primary locale before APK setup or Maestro execution, accepting any `en` region and reporting how to correct unsupported locale configurations without changing the device automatically.
- Treats a non-destructive flow that passes on retry as a passing flaky result while preserving its diagnostics, JUnit status, and `--rerun-failed` eligibility. Genuine flow and cleanup failures still fail the run.

### Test Steps

1. Connect an Android device, source `.maestro/scripts/configure-toolchain.sh`, and load the required credentials.
2. Run `.maestro/scripts/run-smoke-tests.sh --plan --profile core` and verify all eight `login_*.yaml` flows are selected without quarantine.
3. Make a non-English language primary, run `.maestro/scripts/doctor.sh --profile core --store lab --device <serial>`, and verify it fails before APK setup. Restore English and verify the doctor accepts the locale and validates a non-debuggable `com.woocommerce.android` installation.
4. On a device without `com.woocommerce.android`, rerun the doctor and verify it downloads, validates, and installs the universal APK from the latest stable GitHub release.
5. Run `.maestro/scripts/run-smoke-tests.sh --store lab --device <serial> --repeat 3 .maestro/flows/login_not_woo_store.yaml` and verify each run reaches the not-a-WooCommerce-site error and displays **Open installation page** using only the dedicated site-admin credentials.
6. Run `.maestro/scripts/run-smoke-tests.sh --store lab --device <serial> .maestro/flows/login_not_wp_site.yaml` and verify **Try another store** returns to the site-address input with `google.com` preserved.
7. Run `login_wrong_credentials.yaml`, `login_wrong_account.yaml`, and `login_successful.yaml` individually. Verify the welcome carousel and Google Password Manager prompts are dismissed and each flow reaches its expected assertion.
8. Using a controlled non-destructive first-attempt failure followed by a successful retry, verify the runner exits successfully, reports the flow as `FLAKY`, retains it in `--rerun-failed`, and still fails for a genuine second-attempt or cleanup failure.

### Images/gif

N/A — Maestro tooling and flow assertions only.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary.
