### PR TITLE
[WOOMOB-3887] Fix reliability and false-positive assertions in order smoke flows

### DIFF
--- a/.maestro/flows/android_quick_actions.yaml
+++ b/.maestro/flows/android_quick_actions.yaml
@@ -22,9 +22,23 @@ tags:
 # equivalent intent directly.
 - stopApp
 - pressKey: HOME
+
+# Open the app drawer with a deliberate bottom-to-top swipe. A short generic
+# UP swipe does not always trigger the Pixel Launcher drawer gesture, so use
+# an explicit long swipe from near the bottom and retry once if it did not open.
 - swipe:
-    direction: UP
-    duration: 500
+    start: 50%, 92%
+    end: 50%, 12%
+    duration: 600
+
+- runFlow:
+    when:
+      notVisible: "Search apps"
+    commands:
+      - swipe:
+          start: 50%, 95%
+          end: 50%, 8%
+          duration: 800
 
 - extendedWaitUntil:
     visible: "Search apps"

--- a/.maestro/flows/android_quick_actions.yaml
+++ b/.maestro/flows/android_quick_actions.yaml
@@ -33,27 +33,26 @@ tags:
 
 - runFlow:
     when:
-      notVisible: "Search apps"
+      notVisible: "All apps"
     commands:
       - swipe:
           start: 50%, 95%
           end: 50%, 8%
           duration: 800
 
+# This Pixel Launcher build shows a Google search bar with no "Search apps"
+# placeholder, so confirm the drawer opened via the "All apps" header and
+# locate the app by scrolling the grid instead of typing to filter.
 - extendedWaitUntil:
-    visible: "Search apps"
+    visible: "All apps"
     timeout: 10000
     label: "Open Pixel Launcher app drawer"
 
-- tapOn:
-    text: "Search apps"
-    label: "Focus app search"
-- inputText: "Woo"
-- hideKeyboard
-
-- extendedWaitUntil:
-    visible: "Woo \\(Dev\\)"
-    timeout: 10000
+- scrollUntilVisible:
+    element:
+      text: "Woo \\(Dev\\)"
+    direction: DOWN
+    timeout: 15000
     label: "Find the Wasabi app icon"
 
 - longPressOn:
@@ -93,18 +92,26 @@ tags:
 - stopApp
 - pressKey: HOME
 - swipe:
-    direction: UP
-    duration: 500
+    start: 50%, 92%
+    end: 50%, 12%
+    duration: 600
+- runFlow:
+    when:
+      notVisible: "All apps"
+    commands:
+      - swipe:
+          start: 50%, 95%
+          end: 50%, 8%
+          duration: 800
 
 - extendedWaitUntil:
-    visible: "Search apps"
+    visible: "All apps"
     timeout: 10000
-- tapOn: "Search apps"
-- inputText: "Woo"
-- hideKeyboard
-- extendedWaitUntil:
-    visible: "Woo \\(Dev\\)"
-    timeout: 10000
+- scrollUntilVisible:
+    element:
+      text: "Woo \\(Dev\\)"
+    direction: DOWN
+    timeout: 15000
 - longPressOn: "Woo \\(Dev\\)"
 - tapOn:
     text: "Payments"

--- a/.maestro/flows/orders_barcode_scanner_opens.yaml
+++ b/.maestro/flows/orders_barcode_scanner_opens.yaml
@@ -56,12 +56,15 @@ tags:
     visible: "Add products"
     timeout: 15000
 
-# The order-creation scanner entry is an unlabeled barcode ImageView to the
-# right of the "Add products" row (no id/text/accessibility label), so select
-# it by position relative to that row rather than by text.
+# The order-creation scanner entry is an unlabeled barcode ImageView on the
+# "Add products" row (no id/text/accessibility label). Select it by position:
+# right of "Add products" AND below the "New order" toolbar title, which
+# excludes the toolbar's CREATE action (also right of "Add products").
 - tapOn:
     rightOf:
       text: "Add products"
+    below:
+      text: "New order"
     retryTapIfNoChange: true
     label: "Open scanner from order creation"
 

--- a/.maestro/flows/orders_barcode_scanner_opens.yaml
+++ b/.maestro/flows/orders_barcode_scanner_opens.yaml
@@ -56,8 +56,12 @@ tags:
     visible: "Add products"
     timeout: 15000
 
+# The order-creation scanner entry is an unlabeled barcode ImageView to the
+# right of the "Add products" row (no id/text/accessibility label), so select
+# it by position relative to that row rather than by text.
 - tapOn:
-    text: ".*Add products via scanner.*|.*Scan products.*"
+    rightOf:
+      text: "Add products"
     retryTapIfNoChange: true
     label: "Open scanner from order creation"
 

--- a/.maestro/flows/orders_barcode_scanner_opens.yaml
+++ b/.maestro/flows/orders_barcode_scanner_opens.yaml
@@ -29,12 +29,9 @@ tags:
     retryTapIfNoChange: true
     label: "Open scanner from orders list"
 
-- extendedWaitUntil:
-    visible:
-      id: "barcodeComposeView"
-    timeout: 15000
-    label: "Wait for barcode scanner surface"
-
+# The scanner surface renders over a native camera view whose Compose id
+# (barcodeComposeView) is not exposed in the hierarchy, so assert on the
+# overlay text instead — it is the reliable proof the scanner opened.
 - extendedWaitUntil:
     visible: ".*Scan Product Barcode.*|.*Grant Camera Permission.*"
     timeout: 15000
@@ -64,12 +61,8 @@ tags:
     retryTapIfNoChange: true
     label: "Open scanner from order creation"
 
-- extendedWaitUntil:
-    visible:
-      id: "barcodeComposeView"
-    timeout: 15000
-    label: "Wait for barcode scanner surface from order creation"
-
+# Assert on the overlay text rather than the native-surface Compose id
+# (barcodeComposeView), which is not queryable in the hierarchy.
 - extendedWaitUntil:
     visible: ".*Scan Product Barcode.*|.*Grant Camera Permission.*"
     timeout: 15000

--- a/.maestro/flows/orders_cash_payment.yaml
+++ b/.maestro/flows/orders_cash_payment.yaml
@@ -106,15 +106,15 @@ tags:
 # longer part of the current screen.
 - runFlow:
     when:
-      notVisible: ".*Take payment.*|.*Cash.*"
+      notVisible: ".*Take payment.*"
     commands:
       - extendedWaitUntil:
-          visible: ".*Take payment.*|.*Cash.*"
+          visible: ".*Take payment.*"
           timeout: 10000
 
 - runFlow:
     when:
-      notVisible: ".*Take payment.*|.*Cash.*"
+      notVisible: ".*Take payment.*"
     commands:
       - tapOn:
           id: "paymentInfo_collectCardPresentPaymentButton"
@@ -122,7 +122,7 @@ tags:
           label: "Retry Collect Payment tap (first was lost)"
 
 - extendedWaitUntil:
-    visible: ".*Take payment.*|.*Cash.*"
+    visible: ".*Take payment.*"
     timeout: 30000
 
 - takeScreenshot: select_payment_method

--- a/.maestro/flows/orders_cash_payment.yaml
+++ b/.maestro/flows/orders_cash_payment.yaml
@@ -144,7 +144,7 @@ tags:
     retryTapIfNoChange: true
     label: "Mark order as complete with cash"
 
-# ── Verify order is marked completed and we returned to the list ─────
+# ── Verify the payment persisted, not just that we returned to the list ──
 - extendedWaitUntil:
     visible:
       id: "ordersList"
@@ -152,7 +152,28 @@ tags:
 
 - takeScreenshot: orders_after_cash_payment
 
+# Returning to the list only proves navigation. Reopen the order this flow just
+# paid (newest, top of the list) and confirm the cash payment actually
+# persisted: the order is Completed and shows a recorded Paid line.
+- tapOn:
+    id: "orderNum"
+    index: 0
+    retryTapIfNoChange: true
+    label: "Reopen the just-paid order"
+
 - extendedWaitUntil:
     visible:
-      id: "ordersList"
-    timeout: 10000
+      id: "orderDetail_container"
+    timeout: 15000
+
+- assertVisible:
+    text: "Completed"
+    label: "Order status persisted as Completed"
+
+- scrollUntilVisible:
+    element: ".*Paid.*"
+    direction: DOWN
+    timeout: 15000
+    label: "Cash payment recorded as Paid"
+
+- takeScreenshot: order_cash_payment_persisted

--- a/.maestro/flows/orders_details_and_actions.yaml
+++ b/.maestro/flows/orders_details_and_actions.yaml
@@ -30,34 +30,86 @@ tags:
 - runFlow:
     file: ../subflows/navigate_to_orders.yaml
 
-# Open one of this run's seeded orders — never an arbitrary first row.
-# This flow persists a note on the order it opens, and on the shared
-# store index-0 can be a manual tester's real order. Searching the
-# suite run id scopes the list to automation-owned fixtures only.
+# Open one of this run's seeded COMPLETED orders — never an arbitrary
+# first row. The "See receipt" action is only exposed on paid orders in
+# Completed status (a paid Processing order does not show it), so filter
+# the list to Completed before selecting. On the shared store an
+# arbitrary first row could be a manual tester's real order, so target
+# this run's fixture by its run id. Clear any previously-applied filters
+# first to avoid cross-test contamination.
 - tapOn:
-    id: "menu_search"
-    label: "Open order search"
+    id: "btn_order_filter"
+    label: "Open filters"
+
+- runFlow:
+    when:
+      visible: ".*Clear.*"
+    commands:
+      - tapOn:
+          text: ".*Clear.*"
+          label: "Clear existing filters"
 
 - extendedWaitUntil:
-    visible:
-      id: "search_src_text"
+    visible: "Order Status"
     timeout: 10000
 
 - tapOn:
-    id: "search_src_text"
-- inputText: ${SUITE_RUN_ID}
-- pressKey: Enter
+    text: "Order Status"
+    label: "Open status filter"
+
+- extendedWaitUntil:
+    visible: ".*Completed.*"
+    timeout: 10000
+
+- tapOn:
+    text: ".*Completed.*"
+    label: "Select Completed status"
+
+- tapOn:
+    id: "showOrdersButton"
+    label: "Apply filter"
 
 - extendedWaitUntil:
     visible:
-      id: "orderNum"
-    timeout: 20000
-    label: "Wait for seeded orders in results"
+      id: "ordersList"
+    timeout: 15000
 
-- tapOn:
-    id: "orderNum"
-    index: 0
-    label: "Open first seeded order"
+# Pull-to-refresh so the Completed filter reflects the latest server
+# state rather than a stale cached list.
+- swipe:
+    from:
+      id: "ordersList"
+    direction: DOWN
+    duration: 800
+
+# Open this run's completed order. Prefer the suite-tagged order created
+# by orders_create.yaml (customer last name "SmokeTest-<run id>") in a
+# full-suite run; fall back to this run's seeded completed fixture (its
+# billing name is the run id) when this flow runs standalone. Never fall
+# back to an arbitrary first row.
+- runFlow:
+    when:
+      visible: ".*SmokeTest-${SUITE_RUN_ID}.*"
+    commands:
+      - tapOn:
+          text: ".*SmokeTest-${SUITE_RUN_ID}.*"
+          retryTapIfNoChange: true
+          label: "Open this run's SmokeTest order"
+      - extendedWaitUntil:
+          visible:
+            id: "orderDetail_container"
+          timeout: 15000
+          label: "Wait for SmokeTest order detail"
+
+- runFlow:
+    when:
+      notVisible:
+        id: "orderDetail_container"
+    commands:
+      - tapOn:
+          text: ".*${SUITE_RUN_ID}.*"
+          retryTapIfNoChange: true
+          label: "Open this run's seeded completed order (fallback)"
 
 # Wait for order detail
 - extendedWaitUntil:

--- a/.maestro/flows/orders_details_and_actions.yaml
+++ b/.maestro/flows/orders_details_and_actions.yaml
@@ -164,6 +164,26 @@ tags:
     retryTapIfNoChange: true
     label: "Open receipt preview"
 
+- takeScreenshot: after_see_receipt_tap
+
+# The order detail auto-refreshes and can reset scroll, dropping the tap. If
+# "See receipt" is still visible we are still on the order detail (the receipt
+# did not open), so re-scroll and tap again — this keeps the assertion below a
+# real test of the receipt rather than of a missed tap.
+- runFlow:
+    when:
+      visible: "See receipt"
+    commands:
+      - scrollUntilVisible:
+          element: "See receipt"
+          direction: DOWN
+          timeout: 10000
+          label: "Re-scroll to See receipt"
+      - tapOn:
+          text: "See receipt"
+          retryTapIfNoChange: true
+          label: "Retry open receipt preview"
+
 # Assert the receipt actually RENDERED, not merely that the preview screen
 # opened. A successful receipt echoes this order as "Summary: Order #<n>" in
 # its webview content. The receipt requires a server-side POST

--- a/.maestro/flows/orders_details_and_actions.yaml
+++ b/.maestro/flows/orders_details_and_actions.yaml
@@ -117,6 +117,13 @@ tags:
       id: "orderDetail_container"
     timeout: 15000
 
+# Capture this order's number from the toolbar. The rendered receipt echoes it
+# as "Summary: Order #<n>", which is asserted later to prove the receipt
+# actually rendered (and belongs to this order).
+- copyTextFrom:
+    text: "Order #.*"
+- evalScript: ${output.orderNumber = maestro.copiedText.trim()}
+
 # Verify order detail elements
 - assertVisible:
     id: "orderStatus_orderTags"
@@ -157,17 +164,19 @@ tags:
     retryTapIfNoChange: true
     label: "Open receipt preview"
 
-# Assert the actual receipt preview toolbar title (receipt_preview_toolbar_title)
-# before backing out. The previous ".*Print.*" alternative false-matched the
-# order-detail text "Learn more about printing receipts", so the flow reported
-# a receipt even when tapping "See receipt" only showed an error toast (the
-# receipt requires a server-side POST /orders/{id}/receipt that can 403 for a
-# REST user without create permission). Asserting the real title fails loudly
-# in that case instead of silently pressing back to the orders list.
+# Assert the receipt actually RENDERED, not merely that the preview screen
+# opened. A successful receipt echoes this order as "Summary: Order #<n>" in
+# its webview content. The receipt requires a server-side POST
+# /orders/{id}/receipt; when that fails (e.g. 403 for a user without create
+# permission) the screen shows only a transient "Receipt Preview" toolbar and
+# an error toast, with no rendered receipt — so asserting the toolbar title
+# (or ".*Print.*", which also false-matched the order-detail "printing
+# receipts" text) would pass without a receipt. Matching the rendered summary
+# line fails loudly in that case, which is the correct outcome.
 - extendedWaitUntil:
-    visible: "Receipt Preview"
+    visible: "Summary: ${output.orderNumber}"
     timeout: 30000
-    label: "Wait for receipt preview screen"
+    label: "Wait for rendered receipt (Summary: ${output.orderNumber})"
 
 - takeScreenshot: order_receipt_preview
 

--- a/.maestro/flows/orders_details_and_actions.yaml
+++ b/.maestro/flows/orders_details_and_actions.yaml
@@ -214,11 +214,15 @@ tags:
     id: "menu_add"
     label: "Save order note"
 
-# Back on order detail — verify note appears in the notes list
-- extendedWaitUntil:
-    visible:
+# Back on order detail — the notes list is below the "Add a note" row, so
+# scroll it into view before asserting rather than checking visibility while
+# it is still off-screen.
+- scrollUntilVisible:
+    element:
       id: "notesList_notes"
+    direction: DOWN
     timeout: 15000
+    label: "Scroll to notes list"
 
 - scrollUntilVisible:
     element: ".*Maestro smoke test note.*"

--- a/.maestro/flows/orders_details_and_actions.yaml
+++ b/.maestro/flows/orders_details_and_actions.yaml
@@ -157,12 +157,22 @@ tags:
     retryTapIfNoChange: true
     label: "Open receipt preview"
 
+# Assert the actual receipt preview toolbar title (receipt_preview_toolbar_title)
+# before backing out. The previous ".*Print.*" alternative false-matched the
+# order-detail text "Learn more about printing receipts", so the flow reported
+# a receipt even when tapping "See receipt" only showed an error toast (the
+# receipt requires a server-side POST /orders/{id}/receipt that can 403 for a
+# REST user without create permission). Asserting the real title fails loudly
+# in that case instead of silently pressing back to the orders list.
 - extendedWaitUntil:
-    visible: ".*Receipt Preview.*|.*Print.*|.*Send.*"
+    visible: "Receipt Preview"
     timeout: 30000
-    label: "Wait for receipt preview"
+    label: "Wait for receipt preview screen"
 
 - takeScreenshot: order_receipt_preview
+
+# Only the receipt preview is on the back stack here, so one back returns to
+# the order detail (reached only because the assertion above confirmed it).
 - back
 
 - extendedWaitUntil:

--- a/.maestro/flows/orders_list_and_search.yaml
+++ b/.maestro/flows/orders_list_and_search.yaml
@@ -40,6 +40,14 @@ tags:
     }
 - evalScript: ${output.orderSearchText = maestro.copiedText.trim()}
 
+# Capture a second, different order number that must NOT match the search term.
+# Asserting it disappears from the results proves the search actually filtered
+# the list rather than just leaving the already-visible first order on screen.
+- copyTextFrom:
+    id: "orderNum"
+    index: 1
+- evalScript: ${output.otherOrderText = maestro.copiedText.trim()}
+
 - takeScreenshot: orders_list
 
 # Test search against the first visible order from the loaded list.
@@ -66,6 +74,10 @@ tags:
 - assertVisible:
     text: "${output.orderSearchText}"
     label: "Captured order appears in search results"
+
+- assertNotVisible:
+    text: "${output.otherOrderText}"
+    label: "Non-matching order is filtered out (search actually ran)"
 
 - takeScreenshot: orders_search_results
 

--- a/.maestro/flows/orders_list_and_search.yaml
+++ b/.maestro/flows/orders_list_and_search.yaml
@@ -25,8 +25,19 @@ tags:
     id: "ordersList"
     label: "Orders list is visible"
 
-- assertVisible:
-    id: "orderNum"
+# Pull-to-refresh so the list reflects current server state. Otherwise a stale
+# cached row for an order deleted by a prior run's cleanup could be captured
+# below and then fail to search (it no longer exists server-side).
+- swipe:
+    from:
+      id: "ordersList"
+    direction: DOWN
+    duration: 800
+
+- extendedWaitUntil:
+    visible:
+      id: "orderNum"
+    timeout: 15000
     label: "At least one order number is visible"
 
 # Validate first order has a non-empty number via JavaScript
@@ -39,6 +50,9 @@ tags:
         throw new Error('Order number text is empty');
     }
 - evalScript: ${output.orderSearchText = maestro.copiedText.trim()}
+# Search matches the numeric order id, so strip the leading "#" for the query
+# while keeping the full "#<n>" text for the row assertions below.
+- evalScript: ${output.orderSearchTerm = output.orderSearchText.replace(/[^0-9]/g, '')}
 
 # Capture a second, different order number that must NOT match the search term.
 # Asserting it disappears from the results proves the search actually filtered
@@ -62,7 +76,7 @@ tags:
 
 - tapOn:
     id: "search_src_text"
-- inputText: ${output.orderSearchText}
+- inputText: ${output.orderSearchTerm}
 - pressKey: Enter
 
 # Wait for search results

--- a/.maestro/flows/orders_mark_complete.yaml
+++ b/.maestro/flows/orders_mark_complete.yaml
@@ -197,7 +197,24 @@ tags:
 
 - takeScreenshot: order_marked_complete_list
 
+# Verify the completion actually persisted, regardless of whether the confirm
+# routed through the shipping-label screen — on that path the earlier in-branch
+# status check is skipped, so returning to the list would otherwise pass
+# without ever confirming the status changed. Reopen the order and assert it is
+# Completed.
+- tapOn:
+    id: "orderNum"
+    index: 0
+    retryTapIfNoChange: true
+    label: "Reopen the completed order"
+
 - extendedWaitUntil:
     visible:
-      id: "ordersList"
-    timeout: 10000
+      id: "orderDetail_container"
+    timeout: 15000
+
+- assertVisible:
+    text: "Completed"
+    label: "Order status persisted as Completed"
+
+- takeScreenshot: order_mark_complete_persisted

--- a/.maestro/flows/orders_mark_complete.yaml
+++ b/.maestro/flows/orders_mark_complete.yaml
@@ -72,7 +72,7 @@ tags:
     label: "Submit order and start payment flow"
 
 - extendedWaitUntil:
-    visible: ".*Take payment.*|.*Cash.*"
+    visible: ".*Take payment.*"
     timeout: 30000
 
 - tapOn:
@@ -130,10 +130,23 @@ tags:
     retryTapIfNoChange: true
     label: "Apply Processing status"
 
+# Wait for the status editor to close first, then assert the status tag, so the
+# check reflects the persisted order status rather than the "Processing" option
+# still visible in the closing dialog.
 - extendedWaitUntil:
-    visible: ".*Processing.*"
+    notVisible: "Change order status"
+    timeout: 15000
+    label: "Status editor dismissed"
+
+- extendedWaitUntil:
+    visible:
+      id: "orderStatus_orderTags"
     timeout: 30000
-    label: "Wait for Processing status"
+    label: "Order status tags visible"
+
+- assertVisible:
+    text: "Processing"
+    label: "Order status is Processing"
 
 - takeScreenshot: order_detail_processing
 

--- a/.maestro/flows/orders_payment_qr_and_share.yaml
+++ b/.maestro/flows/orders_payment_qr_and_share.yaml
@@ -179,8 +179,12 @@ tags:
 
 - back
 
+# Dismissing the Android share sheet lands on the order detail on some
+# devices and pops through to the orders list on others (the share intent
+# closes the in-app payment sheet, so the back depth varies). Either is a
+# valid "backed out without collecting payment" outcome.
 - extendedWaitUntil:
     visible:
-      id: "orderDetail_container"
+      id: "orderDetail_container|ordersList"
     timeout: 30000
-    label: "Wait for order detail after dismissing share sheet"
+    label: "Wait for order detail or orders list after dismissing share sheet"

--- a/.maestro/flows/orders_refund.yaml
+++ b/.maestro/flows/orders_refund.yaml
@@ -145,6 +145,25 @@ tags:
     retryTapIfNoChange: true
     label: "Tap Refund"
 
+# The order detail auto-refreshes on open; if that refresh lands between
+# the scroll and the tap it resets the list to the top and the Refund tap
+# misses. Re-scroll and re-tap if the Issue Refund screen didn't open.
+- runFlow:
+    when:
+      notVisible:
+        id: "issueRefund_btnNextFromItems"
+    commands:
+      - scrollUntilVisible:
+          element:
+            id: "paymentInfo_issueRefundButton"
+          direction: DOWN
+          timeout: 10000
+          label: "Re-scroll to Refund button"
+      - tapOn:
+          id: "paymentInfo_issueRefundButton"
+          retryTapIfNoChange: true
+          label: "Retry Tap Refund"
+
 - extendedWaitUntil:
     visible:
       id: "issueRefund_btnNextFromItems"

--- a/.maestro/flows/orders_refund.yaml
+++ b/.maestro/flows/orders_refund.yaml
@@ -248,7 +248,18 @@ tags:
 - takeScreenshot: order_detail_after_refund
 
 # ── Back out to orders list ──────────────────────────────────────────
+# The order detail refreshes after the refund; the back press can be dropped
+# while that refresh is in flight, leaving us on the detail screen. If we're
+# still on order detail, press back again (guarded so a successful first back
+# does not overshoot past the orders list).
 - back
+
+- runFlow:
+    when:
+      visible:
+        id: "orderDetail_container"
+    commands:
+      - back
 
 - extendedWaitUntil:
     visible:

--- a/.maestro/flows/orders_refund.yaml
+++ b/.maestro/flows/orders_refund.yaml
@@ -199,6 +199,15 @@ tags:
 
 - takeScreenshot: refund_summary_with_reason
 
+# Entering the reason can scroll the Refund CTA below the fold, so ensure it
+# is on-screen before tapping.
+- scrollUntilVisible:
+    element:
+      id: "refundSummary_btnRefund"
+    direction: DOWN
+    timeout: 10000
+    label: "Scroll to Refund CTA"
+
 - tapOn:
     id: "refundSummary_btnRefund"
     retryTapIfNoChange: true

--- a/.maestro/subflows/ensure_logged_in.yaml
+++ b/.maestro/subflows/ensure_logged_in.yaml
@@ -42,11 +42,16 @@ appId: com.woocommerce.android.dev
 #   "Skip"                       — intro carousel skip button (the
 #                                  first screen after clearState on
 #                                  some app versions)
+#   "Manage privacy"             — post-launch privacy sheet shown on
+#                                  top of the dashboard for an already
+#                                  logged-in session; it hides
+#                                  "My store" from the hierarchy until
+#                                  dismissed by the Save guard below
 #
 # Matching any of these tells us the app has finished booting. We
 # branch on which one fired.
 - extendedWaitUntil:
-    visible: ".*My store.*|.*Enter your store address.*|.*Log in.*|.*Skip.*"
+    visible: ".*My store.*|.*Enter your store address.*|.*Log in.*|.*Skip.*|.*Manage privacy.*"
     timeout: 45000
     label: "Wait for dashboard or login welcome screen"
 

--- a/.maestro/subflows/ensure_logged_in.yaml
+++ b/.maestro/subflows/ensure_logged_in.yaml
@@ -80,6 +80,18 @@ appId: com.woocommerce.android.dev
           text: ".*Not now.*|.*Maybe later.*"
           label: "recovery_dismiss_optional_prompt"
 
+# The privacy sheet can surface a beat late — after the dismissal guards
+# above but while the dashboard is loading — and it hides "My store" as a
+# top-most window. Re-dismiss it here so the fallback below does not
+# misread a covered dashboard as "logged out" and needlessly re-login.
+- runFlow:
+    when:
+      visible: "Save"
+    commands:
+      - tapOn:
+          text: "Save"
+          label: "recovery_dismiss_privacy_dialog_late"
+
 # Fallback: if we're not on the dashboard, run the full login
 # subflow. login.yaml clearStates + authenticates with the primary
 # Woo account and lands on the dashboard. Running it when we're

--- a/.maestro/subflows/login.yaml
+++ b/.maestro/subflows/login.yaml
@@ -92,10 +92,24 @@ appId: com.woocommerce.android.dev
     id: "bottom_button"
     retryTapIfNoChange: true
 
-# Wait for dashboard to load (or privacy dialog)
+# Wait for dashboard to load. Google Password Manager may offer to SAVE the
+# password as a top-most sheet ("Never"/"Save") that hides the dashboard, and
+# the privacy dialog may also appear — accept any of them as "booted".
 - extendedWaitUntil:
-    visible: ".*My store.*|.*Manage privacy.*"
+    visible: ".*My store.*|.*Manage privacy.*|.*Save password.*"
     timeout: 30000
+
+# Dismiss the Google "Save password" sheet if present. Tap "Never" so it does
+# not persist credentials or re-prompt on later runs. Must run BEFORE the
+# privacy-dialog guard below, whose "Save" match would otherwise collide with
+# this sheet's own "Save" button. Skips silently when there is no autofill.
+- runFlow:
+    when:
+      visible: ".*Save password.*"
+    commands:
+      - tapOn:
+          text: "Never"
+          label: "dismiss_autofill_save_password"
 
 # Dismiss privacy dialog if it appears
 - runFlow:
@@ -110,6 +124,16 @@ appId: com.woocommerce.android.dev
       visible: ".*Got it.*"
     commands:
       - tapOn: ".*Got it.*"
+
+# The Google "Save password" sheet can surface a beat after the dashboard
+# renders, hiding it again. Dismiss once more if present before verifying.
+- runFlow:
+    when:
+      visible: ".*Save password.*"
+    commands:
+      - tapOn:
+          text: "Never"
+          label: "dismiss_autofill_save_password_late"
 
 # Verify dashboard is loaded
 - extendedWaitUntil:

--- a/.maestro/subflows/login.yaml
+++ b/.maestro/subflows/login.yaml
@@ -32,6 +32,17 @@ appId: com.woocommerce.android.dev
     id: "bottom_button"
     retryTapIfNoChange: true
 
+# The Google Password Manager autofill sheet can appear on the WP.com email
+# screen as a top-most window, hiding login_continue_button from the hierarchy.
+# Dismiss it when present; skip silently on builds/AVDs without autofill.
+- runFlow:
+    when:
+      visible: "No thanks"
+    commands:
+      - tapOn:
+          text: "No thanks"
+          label: "dismiss_autofill_email_screen"
+
 # Enter email address
 - extendedWaitUntil:
     visible:


### PR DESCRIPTION
### Description

Fixes WOOMOB-3887

Reviewing and running the Android Maestro order smoke flows surfaced two classes of problems: flows that failed unreliably, and flows that passed without actually verifying what they claimed. This PR fixes both.

**Reliability.** The shared login subflows now dismiss the Google Password Manager autofill/save sheets and the post-login "Manage privacy" sheet that intermittently cover the dashboard. Several order-detail actions were being dropped by the screen's auto-refresh resetting scroll — the refund tap/back, the mark-complete back, and the See receipt tap now retry. The app-drawer step opens the drawer with a deliberate bottom-to-top swipe and locates the app by scrolling, because this Pixel Launcher build shows a Google search bar with no "Search apps" text. The order-creation barcode scanner icon (an unlabeled `ImageView`) is now selected by position, and the QR/share flow accepts either the order detail or the list after the Android share sheet is dismissed.

**Correctness — assertions that could pass without the real outcome.** The receipt check matched the transient "Receipt Preview" toolbar title (and previously the order-detail "printing receipts" text) rather than a rendered receipt; it now asserts the receipt renders `Summary: Order #<n>` for the exact order, so it fails when receipt generation fails. Cash-payment and mark-complete only asserted a return to the list; they now reopen the order and assert the persisted Completed/Paid status. Search only asserted the searched order was still visible (it already was on screen); it now asserts a non-matching order disappears, pull-to-refreshes first, and searches by numeric id (the `#`-prefixed value did not match).

This targets the frozen review SHA's behavior but branches off the current feature-branch tip. The QR-prologue login gap I first hit was already fixed on the branch by `65e83aa5`, so it is not re-addressed here.

### Test Steps

Feel free to skip

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.