### PR TITLE
[WOOMOB-3888] Harden order-creation and POS Maestro smoke flows

### DIFF
--- a/.maestro/flows/orders_create.yaml
+++ b/.maestro/flows/orders_create.yaml
@@ -263,17 +263,26 @@ tags:
     label: "Use percentage discount"
 - eraseText: 100
 - inputText: "10"
-- hideKeyboard
 
 - assertVisible:
     text: "Calculated Amount"
     label: "Percentage discount is calculated"
 - assertNotVisible: "Discount cannot be greater than the price"
 
+# Confirm. After typing, the IME holds focus and can swallow the first tap on a
+# top-toolbar button (dropping focus instead of confirming) — a swallowed tap
+# leaves the app hierarchy unchanged, so tap again if we did not return to the
+# order. This is device-agnostic: no keyboard to detect, no destructive BACK.
 - tapOn:
     text: "Done"
-    retryTapIfNoChange: true
     label: "Save product discount"
+- runFlow:
+    when:
+      notVisible: "New order"
+    commands:
+      - tapOn:
+          text: "Done"
+          label: "Re-confirm discount after IME swallowed the first tap"
 
 - extendedWaitUntil:
     visible: "New order"
@@ -349,28 +358,26 @@ tags:
 
 - takeScreenshot: order_create_custom_amount_dialog
 
-# "Add Custom Amount" (buttonDone) is the confirm button at the bottom of the
-# sheet. hideKeyboard issues a BACK press, so calling it unconditionally pops
-# the whole sheet — discarding the entry — on AVDs where the keyboard is already
-# down (e.g. those showing only a floating IME toolbar, no full keyboard). Only
-# hide the keyboard when the button is actually occluded; if it is not visible,
-# a keyboard is covering it, so the BACK press is guaranteed to dismiss the
-# keyboard rather than the sheet.
-- runFlow:
-    when:
-      notVisible:
-        id: "buttonDone"
-    commands:
-      - hideKeyboard
+# Confirm. "Add Custom Amount" (buttonDone) submits the sheet. A blind
+# hideKeyboard here is a BACK press that pops the whole sheet — discarding the
+# entry — when there is no on-screen keyboard to dismiss. Instead just tap the
+# button; if the IME swallowed the first tap the app hierarchy is unchanged, so
+# tap again when we have not returned to the order.
 - extendedWaitUntil:
     visible:
       id: "buttonDone"
     timeout: 8000
     label: "Wait for Add Custom Amount button"
-
 - tapOn:
     id: "buttonDone"
     label: "Save custom amount"
+- runFlow:
+    when:
+      notVisible: "New order"
+    commands:
+      - tapOn:
+          id: "buttonDone"
+          label: "Re-confirm custom amount after IME swallowed the first tap"
 
 # Back on order creation — verify custom amount was added
 - extendedWaitUntil:
@@ -404,17 +411,24 @@ tags:
 - tapOn:
     id: "order_shipping_amount_input"
 - inputText: "500"
-- hideKeyboard
 
 - tapOn:
     id: "order_shipping_name_input"
+    retryTapIfNoChange: true
 - inputText: Maestro shipping ${SUITE_RUN_ID}
-- hideKeyboard
 
+# Confirm; re-tap Save if the IME swallowed the first tap (see the discount /
+# custom-amount notes above — no keyboard to detect, no destructive BACK).
 - tapOn:
     id: "order_shipping_save_button"
-    retryTapIfNoChange: true
     label: "Save shipping line"
+- runFlow:
+    when:
+      notVisible: "New order"
+    commands:
+      - tapOn:
+          id: "order_shipping_save_button"
+          label: "Re-save shipping after IME swallowed the first tap"
 
 - extendedWaitUntil:
     visible: "New order"
@@ -467,14 +481,21 @@ tags:
 - tapOn:
     id: "customerOrderNote_editor"
 - inputText: "Maestro smoke test note - please gift wrap."
-- hideKeyboard
 
 - takeScreenshot: order_create_customer_note_typed
 
-# Save via toolbar DONE
+# Save via toolbar DONE; re-tap if the IME swallowed the first tap (see the
+# discount / custom-amount notes above).
 - tapOn:
     id: "menu_done"
     label: "Save customer note"
+- runFlow:
+    when:
+      notVisible: "New order"
+    commands:
+      - tapOn:
+          id: "menu_done"
+          label: "Re-save note after IME swallowed the first tap"
 
 - extendedWaitUntil:
     visible: "New order"
@@ -585,13 +606,21 @@ tags:
             id: "last_name"
       - eraseText
       - inputText: "SmokeTest-${SUITE_RUN_ID}"
-- hideKeyboard
 
 - takeScreenshot: order_create_customer_re_edited
 
+# Save via toolbar DONE; re-tap if the IME swallowed the first tap (see the
+# discount / custom-amount notes above).
 - tapOn:
     id: "menu_done"
     label: "Save customer edit"
+- runFlow:
+    when:
+      notVisible: "New order"
+    commands:
+      - tapOn:
+          id: "menu_done"
+          label: "Re-save customer edit after IME swallowed the first tap"
 
 - extendedWaitUntil:
     visible: "New order"

--- a/.maestro/flows/orders_create.yaml
+++ b/.maestro/flows/orders_create.yaml
@@ -572,6 +572,19 @@ tags:
       id: "last_name"
 - eraseText
 - inputText: "SmokeTest-${SUITE_RUN_ID}"
+# Maestro inputText intermittently drops a character (observed "SokeTest-…"),
+# which would break the persisted-order search and orders_refund that locate
+# THIS order by the marker. Re-type once if the field did not capture it whole.
+- runFlow:
+    when:
+      notVisible: ".*SmokeTest-${SUITE_RUN_ID}.*"
+    commands:
+      - tapOn:
+          id: "edit_text"
+          childOf:
+            id: "last_name"
+      - eraseText
+      - inputText: "SmokeTest-${SUITE_RUN_ID}"
 - hideKeyboard
 
 - takeScreenshot: order_create_customer_re_edited

--- a/.maestro/flows/orders_create.yaml
+++ b/.maestro/flows/orders_create.yaml
@@ -342,18 +342,35 @@ tags:
 - eraseText
 # Emulator locale uses comma as decimal separator — entering "1000" yields 10,00
 - inputText: "1000"
-- hideKeyboard
 
 - tapOn:
     id: "customAmountNameText"
 - inputText: "Gift wrap"
-- hideKeyboard
 
 - takeScreenshot: order_create_custom_amount_dialog
 
+# "Add Custom Amount" (buttonDone) is the confirm button at the bottom of the
+# sheet. hideKeyboard issues a BACK press, so calling it unconditionally pops
+# the whole sheet — discarding the entry — on AVDs where the keyboard is already
+# down (e.g. those showing only a floating IME toolbar, no full keyboard). Only
+# hide the keyboard when the button is actually occluded; if it is not visible,
+# a keyboard is covering it, so the BACK press is guaranteed to dismiss the
+# keyboard rather than the sheet.
+- runFlow:
+    when:
+      notVisible:
+        id: "buttonDone"
+    commands:
+      - hideKeyboard
+- extendedWaitUntil:
+    visible:
+      id: "buttonDone"
+    timeout: 8000
+    label: "Wait for Add Custom Amount button"
+
 - tapOn:
     id: "buttonDone"
-    label: "Tap Done on custom amount"
+    label: "Save custom amount"
 
 # Back on order creation — verify custom amount was added
 - extendedWaitUntil:

--- a/.maestro/flows/orders_create.yaml
+++ b/.maestro/flows/orders_create.yaml
@@ -485,8 +485,14 @@ tags:
     label: "Customer note visible in creation screen"
 
 # ── Add a customer ────────────────────────────────────────────────────
-# Select an existing customer from the live store. Manual customer entry does
-# not satisfy the P2 existing-customer check.
+# Select the deterministic seeded customer (created by --seed) by its unique
+# email. An arbitrary live customer is unreliable here: the lab store has many
+# customers sharing a single email, and submitting the order surfaces an
+# order-derived entry for that email — so a post-order "was the account renamed?"
+# check races backend indexing. The seeded email (MAESTRO_FIXTURE_CUSTOMER_EMAIL)
+# is unique, so the search resolves the one seeded account whose original name
+# (MAESTRO_FIXTURE_CUSTOMER_NAME) the integrity check later asserts is intact.
+# Selecting a real store customer still satisfies the P2 existing-customer check.
 - scrollUntilVisible:
     element: "Add customer details"
     direction: DOWN
@@ -502,29 +508,24 @@ tags:
     visible: "Search for customers"
     timeout: 15000
 
+- tapOn: "Search for customers"
+- inputText: ${MAESTRO_FIXTURE_CUSTOMER_EMAIL}
+
 - extendedWaitUntil:
     visible:
       id: "customer_list_item"
     timeout: 20000
-    label: "Require at least one existing customer"
+    label: "Require the seeded customer to be searchable"
 
-# Capture and tap the second visible email. Some stores expose an address-only
-# first customer whose list summary has an email but whose full customer fetch
-# does not; requiring another live row keeps the draft identity assertion real.
-- copyTextFrom:
-    text: ".*@.*"
-    index: 1
-- evalScript: ${output.selectedCustomerEmail = maestro.copiedText.trim()}
-- evalScript: |
-    if (!output.selectedCustomerEmail || output.selectedCustomerEmail.indexOf('@') < 1) {
-        throw new Error('Existing customer prerequisite requires at least two customers with email addresses');
-    }
+- extendedWaitUntil:
+    visible: ".*${MAESTRO_FIXTURE_CUSTOMER_NAME}.*"
+    timeout: 20000
+    label: "Resolve the seeded customer by its unique identity"
 
 - tapOn:
-    text: ".*@.*"
-    index: 1
+    text: ".*${MAESTRO_FIXTURE_CUSTOMER_NAME}.*"
     retryTapIfNoChange: true
-    label: "Select existing customer"
+    label: "Select the seeded customer"
 
 - extendedWaitUntil:
     visible: "New order"
@@ -556,8 +557,8 @@ tags:
     timeout: 15000
 
 - assertVisible:
-    text: "${output.selectedCustomerEmail}"
-    label: "Customer editor shows the selected live identity"
+    text: "${MAESTRO_FIXTURE_CUSTOMER_EMAIL}"
+    label: "Customer editor shows the seeded customer identity"
 
 # Rewrite the last name with a per-suite-run-unique marker so
 # orders_refund.yaml can find THIS exact order and won't pick up an
@@ -600,7 +601,7 @@ tags:
     timeout: 15000
     label: "Edited customer marker is retained by the draft"
 - assertVisible:
-    text: "${output.selectedCustomerEmail}"
+    text: "${MAESTRO_FIXTURE_CUSTOMER_EMAIL}"
     label: "Selected customer identity is retained by the draft"
 - back
 - extendedWaitUntil:
@@ -735,23 +736,41 @@ tags:
     visible: "Search for customers"
     timeout: 15000
 - tapOn: "Search for customers"
-- inputText: ${output.selectedCustomerEmail}
-- hideKeyboard
+- inputText: ${MAESTRO_FIXTURE_CUSTOMER_EMAIL}
 - extendedWaitUntil:
-    visible: "${output.selectedCustomerEmail}"
+    visible:
+      id: "customer_list_item"
     timeout: 20000
-    label: "Find the original customer after order creation"
-- copyTextFrom:
-    text: "${output.selectedCustomerEmail}"
-- evalScript: |
-    if (maestro.copiedText.trim() !== output.selectedCustomerEmail) {
-        throw new Error('Store customer email changed after editing the order-local copy');
-    }
-- assertNotVisible:
-    text: ".*SmokeTest-${SUITE_RUN_ID}.*"
-    label: "Order-local marker was not persisted to the store customer"
-- back
-- back
+    label: "Find the seeded customer after order creation"
+# The seeded account must still carry its ORIGINAL name. Editing the order-local
+# customer copy (last name → SmokeTest-<run>) must not rename the underlying
+# store account. Submitting the order can surface a separate order-derived entry
+# with the edited name for the same email, so asserting the original name is
+# still present — rather than the marker's absence — is what proves the source
+# account was untouched.
+- assertVisible:
+    text: ".*${MAESTRO_FIXTURE_CUSTOMER_NAME}.*"
+    label: "Seeded customer account retains its original name (not renamed)"
+# Return to the orders list. The customer search keyboard may absorb the first
+# back press, so press back until the list is reached rather than a fixed count.
+- runFlow:
+    when:
+      notVisible:
+        id: "ordersList"
+    commands:
+      - back
+- runFlow:
+    when:
+      notVisible:
+        id: "ordersList"
+    commands:
+      - back
+- runFlow:
+    when:
+      notVisible:
+        id: "ordersList"
+    commands:
+      - back
 - extendedWaitUntil:
     visible:
       id: "ordersList"

--- a/.maestro/flows/pos_search_and_coupons.yaml
+++ b/.maestro/flows/pos_search_and_coupons.yaml
@@ -64,6 +64,21 @@ tags:
 - runFlow:
     file: ../subflows/pos_add_discovered_variable_product.yaml
 
+# Adding a variation leaves POS on the product search + variation list, which
+# hides the Products/Coupons tab bar. Returning to the grid can be one or two
+# back presses deep (search results, then the search field). Press back until
+# the tab bar reappears; each press is guarded on "Coupons" still being hidden,
+# so this stops as soon as the grid is reached and never backs off it.
+- runFlow:
+    when:
+      notVisible: "Coupons"
+    commands:
+      - back
+- runFlow:
+    when:
+      notVisible: "Coupons"
+    commands:
+      - back
 - runFlow:
     when:
       notVisible: "Coupons"

--- a/.maestro/subflows/hide_keyboard.yaml
+++ b/.maestro/subflows/hide_keyboard.yaml
@@ -1,0 +1,30 @@
+# Device-agnostic keyboard dismissal.
+#
+# Maestro's built-in hideKeyboard is a BACK press, which is not safe across
+# devices: when there is no on-screen keyboard to dismiss — a hardware keyboard,
+# or an IME that only shows a floating toolbar — the BACK either navigates the
+# screen back (popping dialogs and login steps) or throws "Couldn't hide the
+# keyboard" on some Compose screens. Only a real soft keyboard needs dismissing.
+#
+# The one reliable, device-independent signal is whether the element the caller
+# needs next is actually reachable. So this subflow dismisses the keyboard ONLY
+# when that element is not currently visible (i.e. a soft keyboard is covering
+# it). Pass the element's resource id as KEYBOARD_TARGET_ID:
+#
+#   - runFlow:
+#       file: ../subflows/hide_keyboard.yaml   # or hide_keyboard.yaml from subflows/
+#       env:
+#         KEYBOARD_TARGET_ID: "bottom_button"
+#
+# When the target is already visible (no keyboard, hardware keyboard, or a
+# floating toolbar that doesn't cover it) the hide is skipped — no stray back
+# press, no throw. When it is hidden, a real soft keyboard is up and hideKeyboard
+# dismisses it so the caller can tap the target.
+appId: com.woocommerce.android.dev
+---
+- runFlow:
+    when:
+      notVisible:
+        id: ${KEYBOARD_TARGET_ID}
+    commands:
+      - hideKeyboard

--- a/.maestro/subflows/login.yaml
+++ b/.maestro/subflows/login.yaml
@@ -27,7 +27,16 @@ appId: com.woocommerce.android.dev
 - tapOn:
     id: "input"
 - inputText: ${MAESTRO_WOO_JETPACK_STORE_URL}
-- hideKeyboard
+# hideKeyboard issues a BACK press. On AVDs that emulate a hardware keyboard the
+# soft keyboard never shows (only a floating IME toolbar), so an unconditional
+# hideKeyboard navigates back off the login step. Only hide the keyboard when
+# the continue button is actually covered by it.
+- runFlow:
+    when:
+      notVisible:
+        id: "bottom_button"
+    commands:
+      - hideKeyboard
 - tapOn:
     id: "bottom_button"
     retryTapIfNoChange: true
@@ -51,7 +60,12 @@ appId: com.woocommerce.android.dev
 - tapOn:
     id: "input"
 - inputText: ${MAESTRO_WOO_WPCOM_EMAIL}
-- hideKeyboard
+- runFlow:
+    when:
+      notVisible:
+        id: "login_continue_button"
+    commands:
+      - hideKeyboard
 - tapOn:
     id: "login_continue_button"
     retryTapIfNoChange: true
@@ -87,7 +101,12 @@ appId: com.woocommerce.android.dev
 - tapOn:
     id: "input"
 - inputText: ${MAESTRO_WOO_WPCOM_PASSWORD}
-- hideKeyboard
+- runFlow:
+    when:
+      notVisible:
+        id: "bottom_button"
+    commands:
+      - hideKeyboard
 - tapOn:
     id: "bottom_button"
     retryTapIfNoChange: true

--- a/.maestro/subflows/login.yaml
+++ b/.maestro/subflows/login.yaml
@@ -27,16 +27,13 @@ appId: com.woocommerce.android.dev
 - tapOn:
     id: "input"
 - inputText: ${MAESTRO_WOO_JETPACK_STORE_URL}
-# hideKeyboard issues a BACK press. On AVDs that emulate a hardware keyboard the
-# soft keyboard never shows (only a floating IME toolbar), so an unconditional
-# hideKeyboard navigates back off the login step. Only hide the keyboard when
-# the continue button is actually covered by it.
+# Dismiss the keyboard only if it is covering the continue button — see
+# hide_keyboard.yaml. A blind hideKeyboard is a BACK press that navigates off
+# the login step on devices with no on-screen keyboard.
 - runFlow:
-    when:
-      notVisible:
-        id: "bottom_button"
-    commands:
-      - hideKeyboard
+    file: hide_keyboard.yaml
+    env:
+      KEYBOARD_TARGET_ID: "bottom_button"
 - tapOn:
     id: "bottom_button"
     retryTapIfNoChange: true
@@ -61,11 +58,9 @@ appId: com.woocommerce.android.dev
     id: "input"
 - inputText: ${MAESTRO_WOO_WPCOM_EMAIL}
 - runFlow:
-    when:
-      notVisible:
-        id: "login_continue_button"
-    commands:
-      - hideKeyboard
+    file: hide_keyboard.yaml
+    env:
+      KEYBOARD_TARGET_ID: "login_continue_button"
 - tapOn:
     id: "login_continue_button"
     retryTapIfNoChange: true
@@ -102,11 +97,9 @@ appId: com.woocommerce.android.dev
     id: "input"
 - inputText: ${MAESTRO_WOO_WPCOM_PASSWORD}
 - runFlow:
-    when:
-      notVisible:
-        id: "bottom_button"
-    commands:
-      - hideKeyboard
+    file: hide_keyboard.yaml
+    env:
+      KEYBOARD_TARGET_ID: "bottom_button"
 - tapOn:
     id: "bottom_button"
     retryTapIfNoChange: true

--- a/.maestro/subflows/pos_add_discovered_variable_product.yaml
+++ b/.maestro/subflows/pos_add_discovered_variable_product.yaml
@@ -28,12 +28,19 @@ appId: com.woocommerce.android.dev
     id: "woo_pos_search_input"
     label: "Focus product search"
 - inputText: ${output.posVariableProductName}
-- hideKeyboard
 
 - extendedWaitUntil:
     visible: "Variable Product .*"
     timeout: 20000
     label: "Search resolves a Variable product"
+
+# Dismiss the keyboard only if it is covering the first result (see
+# hide_keyboard.yaml). On this Compose search screen a blind hideKeyboard throws
+# "Couldn't hide the keyboard" when there is no soft keyboard to dismiss.
+- runFlow:
+    file: hide_keyboard.yaml
+    env:
+      KEYBOARD_TARGET_ID: "woo_pos_product_item"
 
 - tapOn:
     id: "woo_pos_product_item"


### PR DESCRIPTION
### Description
Fixes WOOMOB-3888

Test-quality review of the order-creation and POS smoke flows; all now pass first-attempt on their lanes (phone `orders_create`; POS-tablet `pos_search_and_coupons`, `pos_cash_payment`). Fixes:

- **Keyboard back-press** — Maestro's `hideKeyboard` is a BACK press, so on AVDs with no soft keyboard (only a floating IME toolbar) it navigated away and discarded input. Made it conditional in the `orders_create` custom-amount step and in shared `login.yaml` (URL/email/password) — only hide when the target button is actually occluded. `login_successful` re-verified on phone and tablet.
- **POS tab bar** — after adding a variation the search/variation view hides the Products/Coupons tabs; replaced the single `back` with bounded guarded back-presses to the grid.
- **Customer integrity** — the lab store has many customers sharing one email and order submission surfaces an order-derived `SmokeTest-<run>` entry, so the old `assertNotVisible marker` raced backend indexing. Now selects the unique seeded customer and asserts its original name stays intact.
- **inputText char-drop** — the last-name marker occasionally lost a character (`SokeTest`), breaking the persisted-order search and `orders_refund`; re-type once if it didn't land whole.

Targets the feature branch, not trunk. All three flows stay `flaky_quarantine`-tagged.

### Test Steps
No need to run tests

### Images/gif
N/A

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
