### PR TITLE
[WOOMOB-3928] Keep the refund reason when the refundable items reload

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundViewModel.kt
@@ -130,14 +130,13 @@ class WooPosRefundViewModel @AssistedInject constructor(
     }
 
     private fun refreshRefundableItems() {
-        val preservedSelection = (_state.value as? WooPosRefundState.Content)?.selectedItemIds
-            ?: contentStateBeforeRefund?.selectedItemIds
+        val draft = (_state.value as? WooPosRefundState.Content) ?: contentStateBeforeRefund
         cancelPreview()
         cancelRefundSubmission()
-        loadContent(preservedSelection = preservedSelection, isFlowStart = false)
+        loadContent(draft?.selectedItemIds, isFlowStart = false, preservedReason = draft?.refundReason.orEmpty())
     }
 
-    private fun loadContent(preservedSelection: Set<String>?, isFlowStart: Boolean) {
+    private fun loadContent(preservedSelection: Set<String>?, isFlowStart: Boolean, preservedReason: String = "") {
         loadingJob?.cancel()
         loadingJob = viewModelScope.launch {
             _state.value = WooPosRefundState.Loading
@@ -182,6 +181,7 @@ class WooPosRefundViewModel @AssistedInject constructor(
                 refundableItems = refundableItems,
                 paymentMethod = paymentMethodResult.getOrThrow(),
                 preservedSelection = preservedSelection,
+                preservedReason = preservedReason,
                 isFlowStart = isFlowStart,
             )
         }
@@ -192,6 +192,7 @@ class WooPosRefundViewModel @AssistedInject constructor(
         refundableItems: List<WooPosRefundableItem>,
         paymentMethod: String,
         preservedSelection: Set<String>? = null,
+        preservedReason: String = "",
         isFlowStart: Boolean = true,
     ) {
         _state.value = buildRefundContent(
@@ -199,7 +200,7 @@ class WooPosRefundViewModel @AssistedInject constructor(
             refundableItems = refundableItems,
             paymentMethod = paymentMethod,
             preservedSelection = preservedSelection,
-        )
+        ).copy(refundReason = preservedReason)
 
         if (isFlowStart) {
             viewModelScope.launch {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundViewModelTest.kt
@@ -2896,6 +2896,91 @@ class WooPosRefundViewModelTest {
         }
 
     @Test
+    fun `given a create rejection offering a reload, when items are refreshed, then the refund reason is kept`() =
+        runTest {
+            // GIVEN
+            val testReason = "Damaged box"
+            val firstUnit = testRefundableItem.copy(rowIndex = 0)
+            val secondUnit = testRefundableItem.copy(rowIndex = 1)
+            val groupedItems = listOf(
+                RefundRequestItem(
+                    itemId = 1L,
+                    quantity = 2,
+                    refundTotal = BigDecimal("40.00"),
+                    refundTax = emptyList()
+                )
+            )
+
+            whenever(ordersDataSource.refreshOrderById(testOrderId)).thenReturn(Result.success(testOrder))
+            whenever(retrieveOrderRefunds.invoke(eq(testOrder), any())).thenReturn(Result.success(emptyList()))
+            // The store refunded one of the two units, so the reload returns a shorter list.
+            whenever(getRefundableItems.invoke(any(), any()))
+                .thenReturn(listOf(firstUnit, secondUnit), listOf(firstUnit))
+            whenever(groupRefundItems.invoke(any(), eq(testOrder), any())).thenReturn(groupedItems)
+            whenever(refundSubmissionProcessor.submit(any())).thenReturn(
+                flowOf(
+                    WooPosRefundSubmissionState.Failure(
+                        message = "The selected quantity is more than what's left to refund.",
+                        apiErrorCode = "woocommerce_rest_quantity_exceeds_refundable",
+                    )
+                )
+            )
+
+            viewModel = createViewModel()
+            viewModel.onUIEvent(WooPosRefundUIEvent.RefundFlowOpened)
+            advanceUntilIdle()
+            viewModel.onUIEvent(WooPosRefundUIEvent.OnRefundReasonChanged(testReason))
+            viewModel.onUIEvent(WooPosRefundUIEvent.OnRefundConfirmed)
+            advanceUntilIdle()
+
+            // WHEN
+            viewModel.onUIEvent(WooPosRefundUIEvent.RefreshRefundableItems)
+            advanceUntilIdle()
+
+            // THEN
+            val content = viewModel.state.value as WooPosRefundState.Content
+            assertThat(content.refundReason).isEqualTo(testReason)
+
+            // The reason also reaches the store on the refund that follows the reload.
+            viewModel.onUIEvent(WooPosRefundUIEvent.OnRefundConfirmed)
+            advanceUntilIdle()
+            verify(refundSubmissionProcessor, times(2)).submit(argThat { refundReason == testReason })
+        }
+
+    @Test
+    fun `given a preview rejection offering a reload, when items are refreshed, then the refund reason is kept`() =
+        runTest {
+            // GIVEN
+            val testReason = "Damaged box"
+            val firstUnit = testRefundableItem.copy(rowIndex = 0)
+            val secondUnit = testRefundableItem.copy(rowIndex = 1)
+
+            whenever(ordersDataSource.refreshOrderById(testOrderId)).thenReturn(Result.success(testOrder))
+            whenever(retrieveOrderRefunds.invoke(eq(testOrder), any())).thenReturn(Result.success(emptyList()))
+            whenever(getRefundableItems.invoke(any(), any()))
+                .thenReturn(listOf(firstUnit, secondUnit), listOf(firstUnit))
+            whenever(refundPreview.invoke(any(), any())).thenReturn(
+                WooPosRefundPreview.Result.Error(WooPosRefundApiError.QuantityExceedsRefundable)
+            )
+
+            viewModel = createViewModel()
+            viewModel.onUIEvent(WooPosRefundUIEvent.RefundFlowOpened)
+            advanceUntilIdle()
+            viewModel.onUIEvent(WooPosRefundUIEvent.OnRefundReasonChanged(testReason))
+            viewModel.onUIEvent(WooPosRefundUIEvent.ContinueToReviewClicked)
+            advanceUntilIdle()
+
+            // WHEN
+            viewModel.onUIEvent(WooPosRefundUIEvent.RefreshRefundableItems)
+            advanceUntilIdle()
+
+            // THEN
+            val content = viewModel.state.value as WooPosRefundState.Content
+            assertThat(content.step).isEqualTo(WooPosRefundState.Content.RefundStep.SelectItems)
+            assertThat(content.refundReason).isEqualTo(testReason)
+        }
+
+    @Test
     fun `given at select items step, when dialog dismissed, then refund flow aborted event tracked with select items step`() =
         runTest {
             val refundableItems = listOf(testRefundableItem)


### PR DESCRIPTION
### Description

Fixes WOOMOB-3928

A cashier types a refund reason at Review. The store rejects the refund because the order changed. The cashier taps **Review remaining items**, and the reason is gone. The refund is created with an empty `reason`.

`refreshRefundableItems()` preserved only `selectedItemIds`. `WooPosBuildRefundContent` builds a new `Content`, which takes the `refundReason = ""` default. That `Content` is the only place the reason is held: the ViewModel has no `SavedStateHandle` and the navigation result key is consumed once.

This passes `preservedReason` through `loadContent` -> `showRefundableItems` -> `.copy(refundReason = ...)`. `loadRefundableItems()` keeps the `""` default, so the first load is unchanged.

### Test Steps

Two clients on the same store. The second can be a phone running the main app, refunding from order detail. In POS, create and pay for an order with one product at quantity 3. Pay with cash.

**Scenario 1 — the create is rejected. Fails on `trunk`.**

1. On the register, open the order, tap **Issue refund**. All 3 units are selected.
2. Tap **Continue**, open the Refund reason row, type `Damaged box`, tap **Save**.
3. On the second client, refund 1 unit. 2 units are left.
4. On the register, tap **Continue**, then refund on the Confirm step. The store rejects it and offers **Review remaining items**.
5. Tap it, then **Continue** to reach Review.
6. Expected: the reason row still shows `Damaged box`. On `trunk` it is empty.
7. Complete the refund and open it in wp-admin. Expected: the reason is on the refund. On `trunk` it is not.

**Scenario 2 — the preview is rejected. Fails on `trunk`.**

Needs WooCommerce 11.1.0 or later, which is the default path now.

8. On a new order, start a refund, tap **Continue**, save a reason, then tap the back arrow to return to item selection.
9. On the second client, refund 1 unit.
10. Tap **Continue**. The preview is rejected and **Review remaining items** appears above it.
11. Tap it, then **Continue**. Expected: the reason is still there. On `trunk` it is gone.

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
