### PR TITLE
[WOOMOB-1422] Add toolbar title and back navigation to Not WordPress site error

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,9 +2,12 @@
 *** Use [*****] to indicate smoke tests of all critical flows should be run on the final APK before release (e.g. major library or targetSdk updates).
 *** For entries which are touching the Android Wear app's, start entry with `[WEAR]` too.
 
-25.6
+25.7
 -----
 - [*] The "not a WordPress site" login error screen now shows a title and a back arrow instead of an empty toolbar [https://github.com/woocommerce/woocommerce-android/pull/16515]
+
+25.6
+-----
 - [*] The toolbar search icon on the Products and Orders lists is purple again, like the other toolbar icons, instead of black [https://github.com/woocommerce/woocommerce-android/pull/16508]
 - [*****] [Internal] Migrated Google Play Age Signals to SDK 0.0.4 with recoverable verification and privacy-bounded monitoring [https://github.com/woocommerce/woocommerce-android/pull/16377]
 - [Internal] Fixed R8 full mode stripping/abstracting reflectively-deserialized Gson DTOs in release builds, which broke several features (POS, analytics, subscriptions, shipping labels) [https://github.com/woocommerce/woocommerce-android/pull/16485]

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 
 25.6
 -----
+- [*] The "not a WordPress site" login error screen now shows a title and a back arrow instead of an empty toolbar [https://github.com/woocommerce/woocommerce-android/pull/16515]
 - [*] The toolbar search icon on the Products and Orders lists is purple again, like the other toolbar icons, instead of black [https://github.com/woocommerce/woocommerce-android/pull/16508]
 - [*****] [Internal] Migrated Google Play Age Signals to SDK 0.0.4 with recoverable verification and privacy-bounded monitoring [https://github.com/woocommerce/woocommerce-android/pull/16377]
 - [Internal] Fixed R8 full mode stripping/abstracting reflectively-deserialized Gson DTOs in release builds, which broke several features (POS, analytics, subscriptions, shipping labels) [https://github.com/woocommerce/woocommerce-android/pull/16485]

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/error/LoginNotWPDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/error/LoginNotWPDialogFragment.kt
@@ -13,8 +13,14 @@ class LoginNotWPDialogFragment : LoginBaseErrorDialogFragment() {
         const val TAG = "LoginNotWPDialogFragment"
     }
 
+    override val title: String
+        get() = getString(R.string.login_not_wordpress_site_title)
+
     override val text: CharSequence
         get() = getString(R.string.login_not_wordpress_site_v2)
+
+    override val onNavigationButtonClick: () -> Unit
+        get() = { dismiss() }
 
     override val helpOrigin: HelpOrigin
         get() = HelpOrigin.LOGIN_SITE_ADDRESS

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -302,6 +302,7 @@
     <string name="login_install_woo">Install WooCommerce</string>
     <string name="login_open_installation_page">Open installation page</string>
     <string name="login_no_jetpack">To use this app for %1$s you\'ll need to have the Jetpack plugin setup and connected to a WordPress.com account</string>
+    <string name="login_not_wordpress_site_title">Not a WordPress site</string>
     <string name="login_not_wordpress_site_v2">We were not able to detect a WordPress site at the address you entered. Please make sure WordPress is installed and that you are running the latest available version.</string>
     <string name="login_site_info_fallback_dialog_title">Connection Issue</string>
     <string name="login_site_info_fallback_dialog_message">We couldn\'t verify your site details. You can try logging in with your site credentials instead.</string>


### PR DESCRIPTION
### Description
Fixes WOOMOB-1422

If you enter a non-WordPress address on the login site address screen, the error screen showed an empty toolbar with only the help icon in it. In July the error screen family was reworked so that the toolbar carries the title and a back arrow, and `LoginNoWPcomAccountFoundDialogFragment` got both. `LoginNotWPDialogFragment` was left with the old defaults (`title = null`, `onNavigationButtonClick = null`), so its bar had nothing to show. This adds the title and a back arrow that dismisses, same as the migrated sibling.

Two things which are not visible in the diff:

- The issue also mentions wrong colour. That is just `color_toolbar`, which in dark mode is a bit lighter than the page, so an empty bar looked like a stray band. With a title in it the bar reads as a normal toolbar, so I did not change the colour. Every other Compose toolbar in the app uses the same one.
- `LoginNotWooDialogFragment` and `ApplicationPasswordsDisabledDialogFragment` have the same empty toolbar. They need new title strings, so I left them out of this PR.

### Test Steps
1. Put the device in dark mode.
2. On a logged out app tap **Log In**, then **No computer? Log in with site address**.
3. Enter `google.com` and tap **Continue**.
4. The toolbar should say **Not a WordPress site** and have a back arrow next to the help icon.
5. Tap the back arrow. You should get back to the site address screen with the address still there.
6. Switch to light mode and repeat.

### Images/gif

| | Before | After |
|---|---|---|
| Dark | <img src="https://github.com/user-attachments/assets/ea3e67d3-ef81-49ce-bd4a-587ff066c780" width="400" /> | <img src="https://github.com/user-attachments/assets/1c4f131c-e48d-40b4-bfba-62c5090999f5" width="400" /> |
| Light | <img src="https://github.com/user-attachments/assets/90d95cb6-2b7f-4a94-a66c-ff5ebb812004" width="400" /> | <img src="https://github.com/user-attachments/assets/a1c3fd13-09a8-46e0-a474-d38ea93414d8" width="400" /> |

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
