### PR TITLE
Fix R8 release crash from logging lambda-bearing payment states

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 - [*] The toolbar search icon on the Products and Orders lists is purple again, like the other toolbar icons, instead of black [https://github.com/woocommerce/woocommerce-android/pull/16508]
 - [*****] [Internal] Migrated Google Play Age Signals to SDK 0.0.4 with recoverable verification and privacy-bounded monitoring [https://github.com/woocommerce/woocommerce-android/pull/16377]
 - [Internal] Fixed R8 full mode stripping/abstracting reflectively-deserialized Gson DTOs in release builds, which broke several features (POS, analytics, subscriptions, shipping labels) [https://github.com/woocommerce/woocommerce-android/pull/16485]
+- [Internal] Card reader and POS payment logs no longer stringify a whole payment-state object that holds a lambda, which crashed release (R8) builds via a reflective toString()
 - [*] Remote images now load through the app's custom network stack again, fixing image loading on some stores [https://github.com/woocommerce/woocommerce-android/pull/16484]
 - [*] Order detail: product line items now show each attribute with its label on its own line, so Product Add-Ons text values are readable instead of running together [https://github.com/woocommerce/woocommerce-android/pull/16476]
 - [Internal] The product shipping screen no longer reads the shipping class from the database on the main thread [https://github.com/woocommerce/woocommerce-android/pull/16490]

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,7 +7,7 @@
 - [*] The toolbar search icon on the Products and Orders lists is purple again, like the other toolbar icons, instead of black [https://github.com/woocommerce/woocommerce-android/pull/16508]
 - [*****] [Internal] Migrated Google Play Age Signals to SDK 0.0.4 with recoverable verification and privacy-bounded monitoring [https://github.com/woocommerce/woocommerce-android/pull/16377]
 - [Internal] Fixed R8 full mode stripping/abstracting reflectively-deserialized Gson DTOs in release builds, which broke several features (POS, analytics, subscriptions, shipping labels) [https://github.com/woocommerce/woocommerce-android/pull/16485]
-- [Internal] Card reader and POS payment logs no longer stringify a whole payment-state object that holds a lambda, which crashed release (R8) builds via a reflective toString()
+- [Internal] Card reader and POS payment logs no longer stringify a whole payment-state object that holds a lambda, which crashed release (R8) builds via a reflective toString() [https://github.com/woocommerce/woocommerce-android/pull/16517]
 - [*] Remote images now load through the app's custom network stack again, fixing image loading on some stores [https://github.com/woocommerce/woocommerce-android/pull/16484]
 - [*] Order detail: product line items now show each attribute with its label on its own line, so Product Add-Ons text values are readable instead of running together [https://github.com/woocommerce/woocommerce-android/pull/16476]
 - [Internal] The product shipping screen no longer reads the shipping class from the database on the main thread [https://github.com/woocommerce/woocommerce-android/pull/16490]

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentController.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentController.kt
@@ -699,7 +699,7 @@ class CardReaderPaymentController(
 
             else -> WooLog.e(
                 WooLog.T.CARD_READER,
-                "Got SDK message when cardReaderPaymentController is in ${_paymentState.value}"
+                "Got SDK message when cardReaderPaymentController is in ${_paymentState.value::class.simpleName}"
             )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModel.kt
@@ -230,7 +230,9 @@ class WooPosCardPaymentViewModel @Inject constructor(
                     is CardReaderPaymentState.PaymentFailed.BuiltInReaderFailedPayment,
                     is CardReaderPaymentState.PrintingReceipt,
                     CardReaderPaymentState.SharingReceipt -> {
-                        throw IllegalArgumentException("Payment state: $paymentState not compatible with POS")
+                        throw IllegalArgumentException(
+                            "Payment state: ${paymentState::class.simpleName} not compatible with POS"
+                        )
                     }
                 }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionController.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionController.kt
@@ -822,7 +822,7 @@ class WooPosCardReaderConnectionController(
             is WooPosCardReaderConnectionState.UpdateAvailable -> {
                 _state.value = currentState.copy(showCancelWarning = true)
             }
-            else -> error("Invalid state $currentState for update back button clicked")
+            else -> error("Invalid state ${currentState::class.simpleName} for update back button clicked")
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
@@ -789,7 +789,9 @@ class WooPosTotalsViewModel @Inject constructor(
             is CardReaderPaymentOrRefundState.CardReaderInteracRefundState,
             is CardReaderPaymentState.PrintingReceipt,
             CardReaderPaymentState.SharingReceipt ->
-                throw IllegalArgumentException("Payment state: $paymentState not compatible with POS")
+                throw IllegalArgumentException(
+                    "Payment state: ${paymentState::class.simpleName} not compatible with POS"
+                )
         }
     }
 
@@ -815,7 +817,9 @@ class WooPosTotalsViewModel @Inject constructor(
             is CardReaderPaymentOrRefundState.CardReaderInteracRefundState,
             is CardReaderPaymentState.PrintingReceipt,
             CardReaderPaymentState.SharingReceipt ->
-                throw IllegalArgumentException("Payment state: $paymentState not compatible with POS")
+                throw IllegalArgumentException(
+                    "Payment state: ${paymentState::class.simpleName} not compatible with POS"
+                )
         }
     }
 


### PR DESCRIPTION
### Description
Card reader and POS payment code logged whole payment-state objects (e.g. `"…$paymentState"`). Under R8 full mode the generated `toString()` renders a lambda-typed property through kotlin-reflect, which can't resolve the members and crashes at runtime — release builds only. This logs `::class.simpleName` at the five sites instead.

Companion guard PR that prevents this from being reintroduced: #16518

### Test Steps
1. Build a release build
2. Connect to a card reader
3. Connect to a TTP reader when you are still connected to card reader
4. Notice the app doesn't crash

### Images/gif
N/A

### Investigation details

Why fix the code instead of R8 / build config?

Root cause. Under R8 full mode (android.enableR8.fullMode=true), R8’s Kotlin-metadata rewriter strips @kotlin.Metadata from a subset of classes (verified: the pre-R8 .class has it, the post-R8 dex doesn’t). kotlin-reflect is on the runtime classpath (pulled in and required by the Stripe Terminal SDK), so a lambda/function-reference’s toString() routes through kotlin-reflect. With the metadata gone, reflect can’t resolve the members and throws (… no members found) — but only in a minified release build, which is why debug never reproduced it.

_Alternatives tried, and why each was a dead end:_

- Global metadata keep rule (-keepattributes RuntimeVisibleAnnotations, -keep class kotlin.Metadata { *; }) — no effect. It’s the full-mode rewriter dropping metadata, not a shrinking/keep decision, so keep rules don’t govern it. Measured byte-identical output.
- Broader keep rules / { *; } “keep everything” — rejected: erases the dex/size gains from enabling R8 full mode, and still doesn’t address the rewriter.
- Disabling R8 full mode — would work, but throws away the whole optimization win; not acceptable.
- Different R8 / Kotlin compiler versions (incl. downgrading Kotlin, indy and annotations-in-metadata flags) — metadata still stripped.
- Removing kotlin-reflect — breaks Stripe Terminal at runtime (it genuinely needs reflect, verified on device), so it can’t be excluded.

Conclusion. No build-config lever reliably keeps the metadata, and kotlin-reflect can’t be removed — so the only durable fix is code-side: don’t stringify a whole object that carries a lambda. This PR does that at the five sites; the companion guard PR (#16518) adds a type-resolution detekt rule so the pattern can’t come back.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.