### PR TITLE
[WOOMOB-4002] Add Contact Support action to the age restriction dialog

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 -----
 - [*] Logging out of a store-credentials login no longer restarts the app or leaves account data behind when the selected site is reset mid-logout [https://github.com/woocommerce/woocommerce-android/pull/16483]
 - [*] Logging in with site credentials no longer crashes when the store lists an application password without a UUID [https://github.com/woocommerce/woocommerce-android/pull/16483]
+- [Internal] The age restriction dialog now offers a Contact Support action that opens Help & Support while keeping the restriction enforced [https://github.com/woocommerce/woocommerce-android/pull/16523]
 - [*] Order detail: the "Need a shipping label?" banner dismiss button is now announced as "Dismiss" by TalkBack instead of a refund message [https://github.com/woocommerce/woocommerce-android/pull/16538]
 - [*****] Updated the Stripe Terminal SDK to 5.8.0; card readers now use coarse location on Android 12+ so the app no longer requests precise location for in-person payments except on older devices [https://github.com/woocommerce/woocommerce-android/pull/16507]
 - [*] Stores configured with an HTTP address now connect securely over HTTPS, with guidance to update their WordPress address [https://github.com/woocommerce/woocommerce-android/pull/16470]

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
@@ -1179,6 +1179,7 @@ enum class AnalyticsEvent(override val siteless: Boolean = false) : IAnalyticsEv
     // Age restriction check
     ACCOUNT_AGE_RESTRICTION_CHECKED,
     ACCOUNT_AGE_RESTRICTION_DIALOG_SHOWN,
+    ACCOUNT_AGE_RESTRICTION_CONTACT_SUPPORT_TAPPED,
     ACCOUNT_AGE_VERIFICATION_ACTION;
 
     override val isPosEvent: Boolean = false

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/help/HelpActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/help/HelpActivity.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.view.MenuItem
 import android.view.View
 import androidx.activity.viewModels
+import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
 import androidx.core.view.updatePadding
@@ -307,7 +308,8 @@ class HelpActivity : AppCompatActivity() {
     }
 
     companion object {
-        private const val ORIGIN_KEY = "ORIGIN_KEY"
+        @VisibleForTesting
+        internal const val ORIGIN_KEY = "ORIGIN_KEY"
         private const val EXTRA_TAGS_KEY = "EXTRA_TAGS_KEY"
         private const val LOGIN_FLOW_KEY = "LOGIN_FLOW_KEY"
         private const val LOGIN_STEP_KEY = "LOGIN_STEP_KEY"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/help/HelpOrigin.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/help/HelpOrigin.kt
@@ -36,7 +36,8 @@ enum class HelpOrigin(private val stringValue: String) {
     AI_TROUBLESHOOTING("origin:ai-troubleshooting"),
     APPLICATION_PASSWORD_TUTORIAL("origin:application-password-tutorial"),
     CONNECTION_ERROR("origin:connection-error"),
-    POS("origin:point-of-sale");
+    POS("origin:point-of-sale"),
+    AGE_RESTRICTION("origin:age-restriction");
 
     override fun toString(): String {
         return stringValue

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/ageeligibility/AgeRestrictionSupportLauncher.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/ageeligibility/AgeRestrictionSupportLauncher.kt
@@ -1,0 +1,14 @@
+package com.woocommerce.android.ui.ageeligibility
+
+import android.content.Context
+import com.woocommerce.android.support.help.HelpActivity
+import com.woocommerce.android.support.help.HelpOrigin
+import javax.inject.Inject
+
+class AgeRestrictionSupportLauncher @Inject constructor() {
+    fun open(context: Context) {
+        context.startActivity(
+            HelpActivity.createIntent(context, HelpOrigin.AGE_RESTRICTION, extraSupportTags = null)
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -43,6 +43,7 @@ import com.woocommerce.android.support.help.HelpOrigin
 import com.woocommerce.android.support.requests.SupportRequestFormActivity
 import com.woocommerce.android.ui.ageeligibility.AgeCheckTrigger
 import com.woocommerce.android.ui.ageeligibility.AgeEligibilityChecker
+import com.woocommerce.android.ui.ageeligibility.AgeRestrictionSupportLauncher
 import com.woocommerce.android.ui.ageeligibility.AgeEligibilityDecision
 import com.woocommerce.android.ui.ageeligibility.AgeVerificationRequiredDialogFragment
 import com.woocommerce.android.ui.ageeligibility.dismissAgeVerificationRequiredDialog
@@ -199,6 +200,9 @@ class LoginActivity :
 
     @Inject
     internal lateinit var ageEligibilityChecker: AgeEligibilityChecker
+
+    @Inject
+    internal lateinit var ageRestrictionSupportLauncher: AgeRestrictionSupportLauncher
 
     @Inject
     internal lateinit var registerDevice: RegisterDevice
@@ -1228,6 +1232,10 @@ class LoginActivity :
             .setMessage(state.ageRestrictedMessage)
             .setCancelable(false)
             .setPositiveButton(R.string.dialog_ok) { _, _ -> finishAffinity() }
+            .setNegativeButton(R.string.support_contact) { _, _ ->
+                AnalyticsTracker.track(stat = AnalyticsEvent.ACCOUNT_AGE_RESTRICTION_CONTACT_SUPPORT_TAPPED)
+                ageRestrictionSupportLauncher.open(this)
+            }
             .create()
             .also {
                 it.show()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/ageeligibility/AgeRestrictionSupportLauncherTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/ageeligibility/AgeRestrictionSupportLauncherTest.kt
@@ -1,0 +1,29 @@
+package com.woocommerce.android.ui.ageeligibility
+
+import androidx.core.content.IntentCompat
+import androidx.fragment.app.FragmentActivity
+import com.woocommerce.android.support.help.HelpActivity
+import com.woocommerce.android.support.help.HelpOrigin
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class AgeRestrictionSupportLauncherTest {
+    @Test
+    fun `when open is called, then Help and Support is started with the age restriction origin`() {
+        val activity = Robolectric.buildActivity(FragmentActivity::class.java).setup().get()
+
+        AgeRestrictionSupportLauncher().open(activity)
+
+        val startedIntent = shadowOf(activity).nextStartedActivity
+        assertThat(startedIntent.component?.className).isEqualTo(HelpActivity::class.java.name)
+        assertThat(IntentCompat.getSerializableExtra(startedIntent, HelpActivity.ORIGIN_KEY, HelpOrigin::class.java))
+            .isEqualTo(HelpOrigin.AGE_RESTRICTION)
+    }
+}


### PR DESCRIPTION
### Description

Fixes WOOMOB-4002

Related discussion - pe5sF9-5Ch-p2#comment-5806

The terminal age-restriction dialog (title "Account Access Restricted") previously offered only **OK**, which closes the app, leaving a restricted merchant with no recovery path. Support asked for an in-app support affordance for worst-case setups (e.g. an incorrect Google account configuration).

This adds a secondary **Contact Support** button to that dialog that opens the in-app Help & Support section via a new `HelpOrigin.AGE_RESTRICTION`, tracking `ACCOUNT_AGE_RESTRICTION_CONTACT_SUPPORT_TAPPED`. 

The restriction stays enforced: launching Help & Support drops `LoginActivity` below `STARTED`, and on return `keepTrackOfAgeEligibility()`'s `repeatOnLifecycle(STARTED)` collector re-emits the still-`Restricted` state and re-shows the dialog — so the support path cannot bypass the restriction. No new enforcement code was needed; this reuses the same mechanism as the existing Play Store retry flow.

Contact Support is wired as the dialog's negative button so it groups next to OK on the right (`Contact Support | OK`) rather than being pushed to the far left as a neutral button would be. 

### Test Steps

The age check binds the real Google Play client, so triggering the restricted state on a device normally needs a Play internal-testing build with an underage account. For local review, temporarily swap in a fake client:

1. Add a `FakeAgeSignalsClient : AgeSignalsClient` (in `ui/ageeligibility/`) whose `requestAgeSignals()` returns `AgeSignalsRequestResult(AgeSignalsAccessStatus.SHARED, SharedAgeSignals(ageLower = 0, ageUpper = 12, AppAgeRangeSource.UNSPECIFIED, AppSignificantChangeStatus.UNSPECIFIED))` (an under-13 → `Restricted` result). See the test-only `FakeAgeSignalsClient` in `AgeEligibilityCheckerTest.kt` for the exact shape to copy.
2. In `AgeSignalsModule.kt`, temporarily change the binding from `GoogleAgeSignalsClient` to your `FakeAgeSignalsClient`. Ensure the `age_eligibility_checks` feature flag is on (defaults on in debug; otherwise enable it in Developer Options → Feature Flags).
3. Build/run and open the app logged out (or log out). On the login screen the "Account Access Restricted" dialog appears with **OK** and **Contact Support**.
4. Tap **Contact Support** → the in-app Help & Support screen opens.
5. Press back → you return to the enforced restriction dialog; confirm no store/authenticated screens are reachable.
6. Tap **OK** → the app closes.

### Images/gif


https://github.com/user-attachments/assets/b1f906f6-ab2c-41af-8ccc-cad408c8e96d



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.