### PR TITLE
[WOOMOB-3890] Fix assertions and cleanup in the product creation smoke flow

### DIFF
--- a/.maestro/flows/products_create.yaml
+++ b/.maestro/flows/products_create.yaml
@@ -11,7 +11,7 @@
 #   4. Configure Inventory with a unique SKU and managed stock quantity
 #   5. Add Shipping dimensions and prove the draft is a physical Simple product
 #   6. Create and attach a unique tag
-#   7. Add an Upsell from Linked products
+#   7. Add the seeded run-owned product as an Upsell from Linked products
 #   8. Add a downloadable file by URL
 #   9. Tap "Add more details" (productDetail_addMoreButton) — on a
 #      freshly-created simple product the Short description and
@@ -526,10 +526,39 @@ tags:
     timeout: 20000
     label: "Wait for product selection list"
 
+# Search for the seeded run-owned product instead of taking whichever
+# row renders first. An arbitrary product would satisfy the count check
+# below just as well, so the count would not prove anything.
 - tapOn:
-    id: "productName"
-    index: 0
-    label: "Select first existing product as Upsell"
+    id: "menu_search"
+    label: "Open product search"
+
+- extendedWaitUntil:
+    visible:
+      id: "search_src_text"
+    timeout: 10000
+
+- tapOn:
+    id: "search_src_text"
+- inputText: ${MAESTRO_FIXTURE_SIMPLE_PRODUCT}
+- hideKeyboard
+
+# Scope both to the result list: the search field holds the same text,
+# and an unscoped match lands on the toolbar instead of the row.
+- extendedWaitUntil:
+    visible:
+      text: ".*${MAESTRO_FIXTURE_SIMPLE_PRODUCT}.*"
+      childOf:
+        id: "productsRecycler"
+    timeout: 20000
+    label: "Wait for the seeded product in search results"
+
+- tapOn:
+    text: ".*${MAESTRO_FIXTURE_SIMPLE_PRODUCT}.*"
+    childOf:
+      id: "productsRecycler"
+    retryTapIfNoChange: true
+    label: "Select the seeded product as Upsell"
 
 - extendedWaitUntil:
     visible:
@@ -542,10 +571,9 @@ tags:
     label: "Confirm Upsell product"
 
 - extendedWaitUntil:
-    visible:
-      id: "productName"
+    visible: ".*${MAESTRO_FIXTURE_SIMPLE_PRODUCT}.*"
     timeout: 15000
-    label: "Upsell product appears in the linked list"
+    label: "The seeded product is the attached Upsell"
 
 - tapOn:
     point: "7%,6%"
@@ -1001,7 +1029,24 @@ tags:
     if (!maestro.copiedText || !maestro.copiedText.trim().startsWith('1')) {
         throw new Error('Published product did not retain its Upsell');
     }
+
+# A count of one says an Upsell survived, not which one. Open the list
+# and check the seeded run-owned product is the one that is attached.
+- tapOn:
+    id: "add_upsell_products"
+    retryTapIfNoChange: true
+    label: "Open the persisted Upsell list"
+- extendedWaitUntil:
+    visible: ".*${MAESTRO_FIXTURE_SIMPLE_PRODUCT}.*"
+    timeout: 15000
+    label: "Published product retains the seeded product as its Upsell"
 - takeScreenshot: product_persisted_linked_product
+- back
+- extendedWaitUntil:
+    visible:
+      id: "upsells_count"
+    timeout: 10000
+    label: "Return to Linked products"
 - back
 
 - extendedWaitUntil:

--- a/.maestro/flows/products_create.yaml
+++ b/.maestro/flows/products_create.yaml
@@ -23,7 +23,8 @@
 #  12. Tap PUBLISH in the toolbar
 #  13. Search by run ID, reopen the exact product, and verify Description,
 #      Price, Inventory, Shipping, type, category, tag, Short description,
-#      Upsell, and Downloadable file values persisted in their editors
+#      Upsell, and Downloadable file values persisted in their editors,
+#      and open the product type settings sheet without changing the type
 #
 # ⚠️  STAGING-STORE MUTATION: this flow publishes a REAL product on the
 # staging store and creates a real tag every run. The runner's cleanup
@@ -1098,6 +1099,47 @@ tags:
     label: "Published product retains its Simple downloadable type"
 - assertVisible:
     text: "Downloadable product"
+
+# Product type settings. The row only becomes tappable once the product
+# is saved (remoteId != 0), so this is the first point in the flow where
+# the type editor can be opened. Confirm it offers the types and leave
+# without changing anything: switching type rewrites product data and
+# would invalidate the checks around it.
+- tapOn:
+    text: "Product type"
+    retryTapIfNoChange: true
+    label: "Open product type settings"
+
+- extendedWaitUntil:
+    visible:
+      id: "productDetailInfo_optionsList"
+    timeout: 15000
+    label: "Wait for the product type sheet"
+
+- assertVisible:
+    text: "Select a product type"
+    label: "Type sheet is open"
+
+# The sheet leaves out the type the product already has, so a Simple
+# physical product is offered every type except its own.
+- assertVisible:
+    text: "Variable product"
+    label: "Type sheet offers Variable product"
+- assertVisible:
+    text: "Grouped product"
+    label: "Type sheet offers Grouped product"
+- assertNotVisible:
+    text: "Simple physical product"
+    label: "Type sheet leaves out the product's current type"
+
+- takeScreenshot: product_type_settings_sheet
+
+- back
+
+- extendedWaitUntil:
+    visible: "Downloadable product"
+    timeout: 10000
+    label: "Type is unchanged after leaving the sheet"
 
 # Categories persistence. Everything else the flow sets is verified
 # after publishing, and the category was the one value it changed

--- a/.maestro/flows/products_create.yaml
+++ b/.maestro/flows/products_create.yaml
@@ -791,11 +791,11 @@ tags:
     retryTapIfNoChange: true
     label: "Tap Publish"
 
-# After publishing the app may stay on the detail screen (with
-# action label swapping PUBLISH → SAVE) or return to the products
-# list. Either settling signal is good.
+# Publishing keeps the app on the detail screen. The toolbar action
+# becomes SHARE and a "Product published" snackbar appears. The
+# snackbar is transient, so SHARE is the signal that survives.
 - extendedWaitUntil:
-    visible: ".*productsRecycler.*|.*SAVE.*|.*updated.*|.*published.*"
+    visible: ".*SHARE.*|.*published.*"
     timeout: 45000
     label: "Wait for publish to complete"
 

--- a/.maestro/flows/products_create.yaml
+++ b/.maestro/flows/products_create.yaml
@@ -25,11 +25,10 @@
 #      Price, Inventory, Shipping, type, tag, Short description, Upsell, and
 #      Downloadable file values persisted in their editors
 #
-# ⚠️  STAGING-STORE MUTATION: this flow publishes a REAL product on
-# the staging store every run. Clean up periodically by searching
-# "Maestro Smoke" in wp-admin → Products and bulk-trashing the matches.
-# A future improvement would be to trash the product automatically at
-# the end of the flow (menu_trash_product exists).
+# ⚠️  STAGING-STORE MUTATION: this flow publishes a REAL product on the
+# staging store and creates a real tag every run. The runner's cleanup
+# step deletes both by searching the store for the run id, so run this
+# flow with --seed, which is what produces the manifest cleanup reads.
 #
 # Source strings (res/values/strings.xml):
 #   - product_price_empty                → "Add price"

--- a/.maestro/flows/products_create.yaml
+++ b/.maestro/flows/products_create.yaml
@@ -781,7 +781,11 @@ tags:
 - copyTextFrom:
     id: "categoryName"
     index: 0
-- evalScript: ${output.selectedCategory = maestro.copiedText.trim()}
+# The name goes straight into a regex below and a store is free to call
+# a category "Sale (50%)", so escape it. fromCharCode is needed for the
+# last three: an inline ${...} silently yields undefined if it contains a
+# literal $, and fails to parse on a literal brace.
+- evalScript: ${output.selectedCategory = String(maestro.copiedText).trim().split(String.fromCharCode(92)).join(String.fromCharCode(92) + String.fromCharCode(92)).split('.').join('\\.').split('*').join('\\*').split('+').join('\\+').split('?').join('\\?').split('^').join('\\^').split('(').join('\\(').split(')').join('\\)').split('|').join('\\|').split('[').join('\\[').split(']').join('\\]').split(String.fromCharCode(36)).join('\\' + String.fromCharCode(36)).split(String.fromCharCode(123)).join('\\' + String.fromCharCode(123)).split(String.fromCharCode(125)).join('\\' + String.fromCharCode(125))}
 - assertTrue:
     condition: ${output.selectedCategory.length > 0}
     label: "Captured the category being attached"

--- a/.maestro/flows/products_create.yaml
+++ b/.maestro/flows/products_create.yaml
@@ -22,8 +22,8 @@
 #      → select the first category ("Uncategorized" if present) → Done
 #  12. Tap PUBLISH in the toolbar
 #  13. Search by run ID, reopen the exact product, and verify Description,
-#      Price, Inventory, Shipping, type, tag, Short description, Upsell, and
-#      Downloadable file values persisted in their editors
+#      Price, Inventory, Shipping, type, category, tag, Short description,
+#      Upsell, and Downloadable file values persisted in their editors
 #
 # ⚠️  STAGING-STORE MUTATION: this flow publishes a REAL product on the
 # staging store and creates a real tag every run. The runner's cleanup
@@ -774,6 +774,17 @@ tags:
 
 - takeScreenshot: product_create_category_screen
 
+# Remember which category is about to be ticked. Index 0 is whichever
+# category renders at the top of this store's list, so the name has to
+# be read here to be checked after publishing.
+- copyTextFrom:
+    id: "categoryName"
+    index: 0
+- evalScript: ${output.selectedCategory = maestro.copiedText.trim()}
+- assertTrue:
+    condition: ${output.selectedCategory.length > 0}
+    label: "Captured the category being attached"
+
 # Only the checkbox itself toggles selection —
 # ProductCategoriesAdapter wires the click listener exclusively on
 # `categoryCheckbox`, NOT on the row or the category name TextView
@@ -1087,6 +1098,17 @@ tags:
     label: "Published product retains its Simple downloadable type"
 - assertVisible:
     text: "Downloadable product"
+
+# Categories persistence. Everything else the flow sets is verified
+# after publishing, and the category was the one value it changed
+# without ever checking that it stuck.
+- scrollUntilVisible:
+    element: ".*${output.selectedCategory}.*"
+    direction: UP
+    timeout: 10000
+    label: "Published product retains the category picked during creation"
+- assertVisible:
+    text: ".*${output.selectedCategory}.*"
 
 # Tag persistence in the tags editor.
 - scrollUntilVisible:

--- a/.maestro/scripts/seed-fixtures.py
+++ b/.maestro/scripts/seed-fixtures.py
@@ -405,6 +405,7 @@ def cleanup(args: argparse.Namespace) -> None:
             ("product", "products"),
             ("order", "orders"),
             ("customer", "customers"),
+            ("product_tag", "products/tags"),
         ):
             query: dict[str, Any] = {"search": run_id}
             if entity_type in {"product", "order"}:

--- a/.maestro/scripts/tests/test_seed_fixtures.py
+++ b/.maestro/scripts/tests/test_seed_fixtures.py
@@ -48,7 +48,7 @@ class PartiallyFailingCleanupClient:
 
 
 class RunOwnedStragglerClient:
-    """Returns a coupon the flow made in the UI, so it is absent from the manifest."""
+    """Returns a coupon and a tag the flow made in the UI, absent from the manifest."""
 
     def __init__(self) -> None:
         self.deleted: list[tuple[str, int]] = []
@@ -58,6 +58,11 @@ class RunOwnedStragglerClient:
             return [
                 {"id": 900, "code": "suite-20260805-abc123-ui"},
                 {"id": 901, "code": "summer-sale"},
+            ]
+        if path == "products/tags":
+            return [
+                {"id": 910, "name": "Maestro tag SUITE-20260805-abc123"},
+                {"id": 911, "name": "Sale"},
             ]
         return []
 
@@ -166,7 +171,7 @@ class SeedFixturesTests(unittest.TestCase):
             finally:
                 seed_fixtures.WooClient = original_client
 
-        self.assertEqual([("coupons", 900)], client.deleted)
+        self.assertEqual([("coupons", 900), ("products/tags", 910)], client.deleted)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description

Fixes WOOMOB-3890

Review findings for `products_create.yaml`, the only flow in this chunk. Four checks weren't proving what they claimed, one left data on the store, and one step the smoke checklist asks for was missing.

The wait after publishing took four alternatives and three of them can't ever match. `productsRecycler` is a layout id, not text on screen. `SAVE` only shows when there are unsaved changes and publishing leaves none. And there's no "updated" message on this path, the snackbar says "Product published". So one alternative was carrying the whole wait, and that one is a snackbar that goes away. The toolbar turning into SHARE sits next to it now.

Linked products took whatever row came first in the selector, then checked the upsell count was one. Any product on the store passes that, so it proved a link exists rather than that we linked the right thing. It now searches for the seeded run-owned product by name, and after publishing it opens the upsell list and checks the same product is still attached. The seed script was already exporting `MAESTRO_FIXTURE_SIMPLE_PRODUCT` and nothing was using it.

The tag the flow creates never got deleted. Only the seeded tag goes into the run manifest, so cleanup never looked for this one and still reported PASS. Product tags now go through the same run-owned pass as coupons, products, orders and customers.

The header told you to go and trash the published product by hand in wp-admin, and called automatic cleanup a future improvement. Cleanup does find and delete both the product and the tag by run id, so the header says that now.

Creation ticks a category and the detail row shows it, but that was the one value the post-publish pass skipped, so a category that quietly failed to save wouldn't have been caught. Which category renders first depends on the store, so the name is grabbed when it's ticked and compared afterwards.

The smoke checklist has "Product type settings" under product details. We were reading the type row but never opening its editor, so the sheet itself was untested. The row only becomes tappable once the product is saved, so the check goes in the reopen pass. It checks the sheet lists the types, that the product's own type is left out of them, and leaves without switching, since changing the type rewrites product data and would break the checks around it.

iOS was already doing the linked products and product type parts. Their side of the tag leak is [woocommerce-ios#17811](https://github.com/woocommerce/woocommerce-ios/pull/17811).

### Test Steps

1. `python3 -m unittest discover -s .maestro/scripts/tests`, 65 tests, all green
2. `./gradlew :WooCommerce:assembleVanillaRelease`
3. `.maestro/scripts/run-smoke-tests.sh --apk WooCommerce/build/outputs/apk/vanilla/release/WooCommerce-vanilla-release.apk --store lab --seed .maestro/flows/products_create.yaml`
4. It passes, and the upsell, category and product type checks show up in the run log
5. Query the store for product tags matching the run id, nothing should be left

A downloaded release APK won't work here, this branch adds test tags the released build doesn't have.

The flow passes end to end in 325s with `cleanup PASS`, on a Pixel_10_Pro_XL emulator running Android 17 in en-US against the `lab` store. The store had five leftover automation tags before this and none after.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
