### PR TITLE
[WOOMOB-4034] Keep TagSoup so R8 full mode doesn't crash the Aztec editor

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 
 25.6
 -----
+- [Internal] Fixed an IllegalAccessError crash when opening the Aztec editor (e.g. a product's description) in release builds, caused by R8 full mode inlining TagSoup's HTML parser across a package boundary [https://github.com/woocommerce/woocommerce-android/pull/16530]
 - [*] The toolbar search icon on the Products and Orders lists is purple again, like the other toolbar icons, instead of black [https://github.com/woocommerce/woocommerce-android/pull/16508]
 - [*****] [Internal] Migrated Google Play Age Signals to SDK 0.0.4 with recoverable verification and privacy-bounded monitoring [https://github.com/woocommerce/woocommerce-android/pull/16377]
 - [Internal] Fixed R8 full mode stripping/abstracting reflectively-deserialized Gson DTOs in release builds, which broke several features (POS, analytics, subscriptions, shipping labels) [https://github.com/woocommerce/woocommerce-android/pull/16485]

--- a/WooCommerce/proguard-rules.pro
+++ b/WooCommerce/proguard-rules.pro
@@ -36,6 +36,17 @@
 }
 ###### SavedStateHandleExt - end
 
+###### TagSoup (Aztec editor HTML parser) - begin
+# TagSoup is a plain JAR transitively pulled in by the Aztec editor, with no
+# consumer ProGuard rules. Parser.theContentHandler is a private field assigned
+# in Parser's constructor; Aztec's Html does `new Parser()` without subclassing,
+# so R8 full-mode optimization inlines that constructor into
+# org.wordpress.aztec.AztecParser (a different class), turning the private-field
+# write into an illegal cross-class access -> IllegalAccessError when opening the
+# Aztec editor (e.g. a product description). Keep TagSoup so it isn't inlined away.
+-keep class org.ccil.cowan.tagsoup.** { *; }
+###### TagSoup - end
+
 # Crypto Tink is still transitively present; its KeysDownloader references google-http-client
 # and joda-time, which aren't on the classpath. R8 fails to build without these.
 -dontwarn com.google.api.client.http.GenericUrl


### PR DESCRIPTION
### Description

Fixes WOOMOB-4034

Opening the Aztec editor (product description, short description, purchase note, or variation description) crashes release builds with `IllegalAccessError: Field 'org.ccil.cowan.tagsoup.Parser.theContentHandler' is inaccessible to class 'org.wordpress.aztec.AztecParser'`. TagSoup's `theContentHandler` is a private field set in `Parser`'s constructor, and since R8 full mode was enabled, R8 inlines that constructor into `AztecParser` (a different class), turning the private-field write into an illegal cross-class access. TagSoup ships no consumer ProGuard rules, so this keeps its classes to stop R8 inlining them across the package boundary.

Scoped to just `org.ccil.cowan.tagsoup.**` — the private field lives there; keeping Aztec's own package or `org.xml.sax` (a framework package R8 never shrinks) isn't needed.

### Test Steps


**Optional**
1. Build and install a minified release variant, e.g. `./gradlew :WooCommerce:installWasabiRelease` (the crash only happens in minified builds).
2. Open any product → tap **Description**. The Aztec editor should open. Before this change it crashed immediately on open.
3. Repeat for **Short description**, **Purchase note** (Product settings), a variable product's **variation Description**, and a **Custom Field** value editor — all use the same parser.

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.