### PR TITLE
[WOOMOB-4003] Collect Maestro screenshots into the report and document which APK to run against

### DIFF
--- a/.maestro/README.md
+++ b/.maestro/README.md
@@ -65,6 +65,24 @@ connected, pass `--device` so installation cannot target the wrong device.
 The selected device's primary system locale must use English (`en`, with any region). The doctor and runner fail before
 APK setup or Maestro execution when another language is primary; they do not change the device language automatically.
 
+### Which APK to run against
+
+To run the flows against the current checkout instead of the release the
+doctor installs, for example while a branch adds test tags that the last
+release does not have yet, build it and pass it in with `--apk`:
+
+```bash
+./gradlew :WooCommerce:assembleVanillaRelease
+.maestro/scripts/run-smoke-tests.sh --apk WooCommerce/build/outputs/apk/vanilla/release/WooCommerce-vanilla-release.apk
+```
+
+Only the Vanilla release variant passes the package and debuggable checks
+described above.
+
+Whenever the runner installs an APK, downloaded or passed in, it validates it
+with `aapt` first, so `aapt` has to be on `PATH` or under `build-tools` in
+`ANDROID_HOME` or `ANDROID_SDK_ROOT`.
+
 ### Store data prerequisites
 
 `orders_create` selects an existing live-store customer and edits only the customer copy attached to the order draft.

--- a/.maestro/scripts/run-smoke-tests.sh
+++ b/.maestro/scripts/run-smoke-tests.sh
@@ -1089,6 +1089,7 @@ run_one_attempt() {
   local log_file="$LOGS_DIR/${repeat_index}_${base}_attempt${attempt}.log"
   local attempt_screenshots_dir="$SCREENSHOTS_DIR/${repeat_index}_${base}_attempt${attempt}"
   local attempt_screenshots_rel="screenshots/${repeat_index}_${base}_attempt${attempt}/"
+  local attempt_debug_dir="$TMP_DIR/maestro-debug/${repeat_index}_${base}_attempt${attempt}"
   local media_rel=""
   local device_recording=""
   local host_recording=""
@@ -1114,27 +1115,21 @@ run_one_attempt() {
   local started ended exit_code
   started=$(date +%s)
   set +e
-  "${MAESTRO_PROCESS_ENV_ARGS[@]}" maestro test "${MAESTRO_DEVICE_ARGS[@]}" "${MAESTRO_ENV_ARGS[@]}" "$flow" >"$log_file" 2>&1
+  mkdir -p "$attempt_debug_dir"
+  "${MAESTRO_PROCESS_ENV_ARGS[@]}" maestro test "${MAESTRO_DEVICE_ARGS[@]}" "${MAESTRO_ENV_ARGS[@]}" \
+    --debug-output "$attempt_debug_dir" --flatten-debug-output "$flow" >"$log_file" 2>&1
   exit_code=$?
   set -e
   ended=$(date +%s)
 
+  # Maestro 2.9.0 writes named screenshots under its debug output as
+  # <debug dir>/<flow name>/takeScreenshot/<name>.png. Each attempt gets its
+  # own directory, so nothing here can pick up a screenshot left by an earlier
+  # attempt or run.
   mkdir -p "$attempt_screenshots_dir"
-  while IFS= read -r screenshot_name; do
-    [[ -z "$screenshot_name" ]] && continue
-    screenshot_name="${screenshot_name%.png}"
-    if [[ -f "$REPO_ROOT/$screenshot_name.png" ]]; then
-      mv "$REPO_ROOT/$screenshot_name.png" "$attempt_screenshots_dir/"
-    fi
-  done < <(
-    awk -F'takeScreenshot:[[:space:]]*' '
-      /takeScreenshot:/ {
-        name = $2
-        gsub(/^[[:space:]"'\''"]+|[[:space:]"'\''"]+$/, "", name)
-        if (name != "") print name
-      }
-    ' "$flow"
-  )
+  while IFS= read -r screenshot_path; do
+    [[ -f "$screenshot_path" ]] && mv "$screenshot_path" "$attempt_screenshots_dir/"
+  done < <(find "$attempt_debug_dir" -type f -path '*/takeScreenshot/*.png' 2>/dev/null)
   if compgen -G "$attempt_screenshots_dir/*.png" >/dev/null; then
     media_rel="$attempt_screenshots_rel"
   else
@@ -1149,7 +1144,7 @@ run_one_attempt() {
       adb -s "$DEVICE_SERIAL" pull "$device_recording" "$host_recording" >/dev/null 2>&1 || true
       adb -s "$DEVICE_SERIAL" shell "rm -f $device_recording" >/dev/null 2>&1 || true
       if [[ -f "$host_recording" ]]; then
-        media_rel="recordings/$(basename "$host_recording")"
+        media_rel="${media_rel:+$media_rel,}recordings/$(basename "$host_recording")"
       fi
     fi
   elif [[ "$exit_code" -ne 0 ]]; then
@@ -1159,7 +1154,7 @@ run_one_attempt() {
     adb -s "$DEVICE_SERIAL" pull "$device_screenshot" "$screenshot_file" >/dev/null 2>&1 || true
     adb -s "$DEVICE_SERIAL" shell "rm -f $device_screenshot" >/dev/null 2>&1 || true
     if [[ -f "$screenshot_file" ]]; then
-      media_rel="screenshots/$(basename "$screenshot_file")"
+      media_rel="${media_rel:+$media_rel,}screenshots/$(basename "$screenshot_file")"
     fi
   fi
 
@@ -1326,7 +1321,15 @@ HTML_HEAD
     IFS='|' read -r status repeat_index name duration media log_rel error recovery <<< "$result"
     artifact=""
     if [[ -n "$media" ]]; then
-      artifact="<a href=\"$media\">media</a>"
+      IFS=',' read -r -a media_items <<< "$media"
+      for media_item in "${media_items[@]}"; do
+        case "$media_item" in
+          recordings/*) media_label="recording" ;;
+          screenshots/*) media_label="screenshots" ;;
+          *) media_label="media" ;;
+        esac
+        artifact="$artifact${artifact:+ | }<a href=\"$media_item\">$media_label</a>"
+      done
     fi
     if [[ -n "$log_rel" && -f "$OUTPUT_DIR/$log_rel" ]]; then
       artifact="$artifact ${artifact:+| }<a href=\"$log_rel\">log</a>"

--- a/.maestro/scripts/run-smoke-tests.sh
+++ b/.maestro/scripts/run-smoke-tests.sh
@@ -1211,7 +1211,19 @@ for repeat_index in $(seq 1 "$REPEAT"); do
     else
       PASSED=$((PASSED + 1))
       [[ -n "$first_log" ]] && rm -f "$OUTPUT_DIR/$first_log" 2>/dev/null || true
-      [[ -n "$first_media" ]] && rm -f "$OUTPUT_DIR/$first_media" 2>/dev/null || true
+      # A clean pass drops its recording but keeps the named screenshots, and
+      # the report only links what is left.
+      kept_media=""
+      if [[ -n "$first_media" ]]; then
+        IFS=',' read -r -a media_entries <<< "$first_media"
+        for media_entry in "${media_entries[@]}"; do
+          case "$media_entry" in
+            recordings/*) rm -f "$OUTPUT_DIR/$media_entry" 2>/dev/null || true ;;
+            *) kept_media="${kept_media:+$kept_media,}$media_entry" ;;
+          esac
+        done
+      fi
+      media="$kept_media"
     fi
 
     RESULTS+=("$status|$repeat_index|$base|$duration|$media|$log_rel|$error|$recovery")

--- a/.maestro/scripts/tests/test_smoke_cli.py
+++ b/.maestro/scripts/tests/test_smoke_cli.py
@@ -235,6 +235,7 @@ class SmokeCliContractTest(unittest.TestCase):
         env_overrides: dict[str, str],
         fail_first_attempt: bool = False,
         device_locale: str = "en-US",
+        screenshot_names: tuple[str, ...] = (),
     ) -> tuple[subprocess.CompletedProcess[str], str, Path]:
         temporary_directory = tempfile.TemporaryDirectory()
         self.addCleanup(temporary_directory.cleanup)
@@ -250,6 +251,24 @@ class SmokeCliContractTest(unittest.TestCase):
             "if [ \"${1:-}\" = --version ]; then printf '%s\\n' '2.9.0'; exit 0; fi\n"
             f"printf 'ARGS:%s\\n' \"$*\" >> '{maestro_args}'\n"
             f"env | grep -E '^(MAESTRO_)?WOO_' | sort >> '{maestro_args}'\n"
+            # Maestro 2.9.0 writes named screenshots under --debug-output, in a
+            # directory named after the flow, never into the working directory.
+            + (
+                "debug_out=\nprev=\n"
+                "for arg in \"$@\"; do\n"
+                "  if [ \"$prev\" = --debug-output ]; then debug_out=$arg; fi\n"
+                "  prev=$arg\n"
+                "done\n"
+                "if [ -n \"$debug_out\" ]; then\n"
+                "  mkdir -p \"$debug_out/Flow name with spaces/takeScreenshot\"\n"
+                + "".join(
+                    f"  : > \"$debug_out/Flow name with spaces/takeScreenshot/{name}.png\"\n"
+                    for name in screenshot_names
+                )
+                + "fi\n"
+                if screenshot_names
+                else ""
+            )
             + (
                 f"if [ ! -f '{first_attempt_marker}' ]; then\n"
                 f"  : > '{first_attempt_marker}'\n"
@@ -680,6 +699,34 @@ class SmokeCliContractTest(unittest.TestCase):
         self.assertIn("MAESTRO_WOO_NO_JETPACK_SITE_URL=https://shop.example.com/subdir/", args)
         self.assertNotIn("/wp-admin/", args)
         self.assertNotIn("source=jn", args)
+
+    def test_named_screenshots_are_collected_from_the_maestro_debug_output(self) -> None:
+        result, args, output_root = self.run_with_recorded_maestro_args(
+            "--device",
+            "emulator-5554",
+            ".maestro/flows/login_successful.yaml",
+            env_overrides={
+                "MAESTRO_WOO_LAB_JETPACK_STORE_URL": "https://lab.example.com/",
+                "MAESTRO_WOO_LAB_WPCOM_EMAIL": "lab@example.com",
+                "MAESTRO_WOO_LAB_WPCOM_PASSWORD": "selected-password",
+            },
+            screenshot_names=("login_done", "login_store_ready"),
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("--debug-output", args)
+        self.assertIn("--flatten-debug-output", args)
+
+        run_directory = next(path for path in output_root.iterdir() if path.is_dir())
+        collected = sorted(run_directory.glob("screenshots/*/*.png"))
+        self.assertEqual(
+            ["login_done.png", "login_store_ready.png"],
+            sorted(path.name for path in collected),
+        )
+        self.assertIn(
+            f"screenshots/{collected[0].parent.name}/",
+            (run_directory / "report.html").read_text(encoding="utf-8"),
+        )
 
 
 if __name__ == "__main__":

--- a/.maestro/scripts/tests/test_smoke_cli.py
+++ b/.maestro/scripts/tests/test_smoke_cli.py
@@ -295,6 +295,9 @@ class SmokeCliContractTest(unittest.TestCase):
             "  printf '  versionName=25.4\\n  flags=[ HAS_CODE ]\\n'\n"
             "elif printf '%s\\n' \"$*\" | grep -q 'settings get global'; then\n"
             "  printf '1\\n'\n"
+            # A pull lands the recording on the host, like the real adb does.
+            "elif printf '%s\\n' \"$*\" | grep -q ' pull '; then\n"
+            "  : > \"$(printf '%s\\n' \"$*\" | awk '{print $NF}')\"\n"
             "fi\n"
         )
         adb.chmod(0o755)
@@ -723,10 +726,13 @@ class SmokeCliContractTest(unittest.TestCase):
             ["login_done.png", "login_store_ready.png"],
             sorted(path.name for path in collected),
         )
-        self.assertIn(
-            f"screenshots/{collected[0].parent.name}/",
-            (run_directory / "report.html").read_text(encoding="utf-8"),
-        )
+        report = (run_directory / "report.html").read_text(encoding="utf-8")
+        self.assertIn(f"screenshots/{collected[0].parent.name}/", report)
+
+        # A clean pass keeps the screenshots as evidence but drops the recording,
+        # and the report must not link the file it just removed.
+        self.assertEqual([], list(run_directory.glob("recordings/*.mp4")))
+        self.assertNotIn("recordings/", report)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description

Fixes WOOMOB-4003

The runner was looking for the `takeScreenshot` PNGs in the repo root. Maestro 2.9.0 puts them under its own debug output, so nothing was found and the reports had no screenshots. Each attempt now runs with its own `--debug-output` folder and the PNGs get copied into the report from there. The report also only had room for one link and the recording was taking it, so screenshots and recording are now linked separately.

The APK compatibility check from the issue isn't in here, I explained why on the issue. What was missing was the guide saying how to run against the current checkout, why it has to be the Vanilla release variant, and that the preflight needs `aapt`. Added that.

### Test Steps

1. `python3 -m unittest discover -s .maestro/scripts/tests`, 66 tests, all green
2. `./gradlew :WooCommerce:assembleVanillaRelease`
3. `.maestro/scripts/run-smoke-tests.sh --apk WooCommerce/build/outputs/apk/vanilla/release/WooCommerce-vanilla-release.apk --store lab .maestro/flows/hub_menu_admin_and_store.yaml`
4. Open the report, the flow's row links `screenshots` and `recording` separately
5. `screenshots/1_hub_menu_admin_and_store_attempt1/` holds the flow's three PNGs

Verified on a Pixel_10_Pro_XL emulator running Android 17. Before this change the same run left `screenshots/` empty.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
