### PR TITLE
[WOOMOB-3974] Load refund and review images asynchronously

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/IssueRefundFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/IssueRefundFragment.kt
@@ -22,7 +22,6 @@ import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.show
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.extensions.withOldValue
-import com.woocommerce.android.tools.ProductImageMap
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.common.webview.AuthenticatedWebViewLauncher
 import com.woocommerce.android.ui.main.AppBarStatus
@@ -33,6 +32,7 @@ import com.woocommerce.android.ui.payments.refunds.IssueRefundViewModel.Products
 import com.woocommerce.android.ui.payments.refunds.IssueRefundViewModel.ShippingRefundSection
 import com.woocommerce.android.ui.payments.refunds.RefundFeeListAdapter.OnFeeLineCheckedChangeListener
 import com.woocommerce.android.ui.payments.refunds.RefundShippingListAdapter.OnCheckedChangeListener
+import com.woocommerce.android.ui.products.ProductImageLoader
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.widgets.WooClickableSpan
@@ -48,7 +48,7 @@ class IssueRefundFragment :
     lateinit var currencyFormatter: CurrencyFormatter
 
     @Inject
-    lateinit var imageMap: ProductImageMap
+    lateinit var imageLoaderFactory: ProductImageLoader.Factory
 
     @Inject
     lateinit var authenticatedWebViewLauncher: AuthenticatedWebViewLauncher
@@ -147,7 +147,7 @@ class IssueRefundFragment :
             new.currency.takeIfNotEqualTo(old?.currency) {
                 productsBinding.issueRefundProducts.adapter = RefundProductListAdapter(
                     currencyFormatter.buildBigDecimalFormatter(new.currency),
-                    imageMap,
+                    imageLoaderFactory,
                     false,
                     { uniqueId -> viewModel.onRefundQuantityTapped(uniqueId) }
                 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundDetailFragment.kt
@@ -14,11 +14,11 @@ import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.show
 import com.woocommerce.android.extensions.takeIfNotEqualTo
-import com.woocommerce.android.tools.ProductImageMap
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.main.MainNavigationRouter
 import com.woocommerce.android.ui.payments.refunds.RefundDetailViewModel.ViewOrderedAddons
+import com.woocommerce.android.ui.products.ProductImageLoader
 import com.woocommerce.android.util.CurrencyFormatter
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -27,7 +27,7 @@ import javax.inject.Inject
 class RefundDetailFragment : BaseFragment(R.layout.fragment_refund_detail) {
     @Inject lateinit var currencyFormatter: CurrencyFormatter
 
-    @Inject lateinit var imageMap: ProductImageMap
+    @Inject lateinit var imageLoaderFactory: ProductImageLoader.Factory
 
     private val viewModel: RefundDetailViewModel by viewModels()
 
@@ -101,7 +101,7 @@ class RefundDetailFragment : BaseFragment(R.layout.fragment_refund_detail) {
             new.currency?.takeIfNotEqualTo(old?.currency) {
                 productsBinding.issueRefundProducts.adapter = RefundProductListAdapter(
                     currencyFormatter.buildBigDecimalFormatter(new.currency),
-                    imageMap,
+                    imageLoaderFactory,
                     isProductDetailList = true,
                     onItemClicked = { uniqueId ->
                         (activity as? MainNavigationRouter)?.showProductDetail(uniqueId)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundProductListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundProductListAdapter.kt
@@ -3,7 +3,6 @@ package com.woocommerce.android.ui.payments.refunds
 import android.annotation.SuppressLint
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import android.widget.ImageView
 import android.widget.TextView
 import androidx.annotation.LayoutRes
 import androidx.constraintlayout.widget.ConstraintLayout.GONE
@@ -11,26 +10,23 @@ import androidx.constraintlayout.widget.ConstraintLayout.VISIBLE
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.DiffUtil.Callback
 import androidx.recyclerview.widget.RecyclerView
-import com.bumptech.glide.Glide
-import com.bumptech.glide.load.resource.bitmap.CenterCrop
-import com.bumptech.glide.load.resource.bitmap.RoundedCorners
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.formatToString
 import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.extensions.isEqualTo
-import com.woocommerce.android.extensions.loadPhotonUrlWithFallback
 import com.woocommerce.android.extensions.show
 import com.woocommerce.android.model.Order
-import com.woocommerce.android.tools.ProductImageMap
 import com.woocommerce.android.ui.payments.refunds.RefundProductListAdapter.RefundViewHolder
+import com.woocommerce.android.ui.products.ProductImageLoader
+import com.woocommerce.android.ui.products.ProductImageViewTarget
 import java.math.BigDecimal
 
 typealias ViewAddonClickListener = (Order.Item) -> Unit
 
 class RefundProductListAdapter(
     private val formatCurrency: (BigDecimal) -> String,
-    private val imageMap: ProductImageMap,
+    private val imageLoaderFactory: ProductImageLoader.Factory,
     private val isProductDetailList: Boolean,
     private val onItemClicked: (Long) -> Unit = { },
     private val onViewAddonsClick: ViewAddonClickListener? = null
@@ -39,9 +35,9 @@ class RefundProductListAdapter(
 
     override fun onCreateViewHolder(parent: ViewGroup, itemType: Int): RefundViewHolder {
         return if (isProductDetailList) {
-            RefundDetailViewHolder(parent, formatCurrency, imageMap, onViewAddonsClick)
+            RefundDetailViewHolder(parent, formatCurrency, imageLoaderFactory, onViewAddonsClick)
         } else {
-            IssueRefundViewHolder(parent, formatCurrency, onItemClicked, imageMap)
+            IssueRefundViewHolder(parent, formatCurrency, onItemClicked, imageLoaderFactory)
         }
     }
 
@@ -57,23 +53,31 @@ class RefundProductListAdapter(
         diffResult.dispatchUpdatesTo(this)
     }
 
-    abstract class RefundViewHolder(parent: ViewGroup, @LayoutRes layout: Int) : RecyclerView.ViewHolder(
+    abstract class RefundViewHolder(
+        parent: ViewGroup,
+        @LayoutRes layout: Int,
+        imageLoaderFactory: ProductImageLoader.Factory
+    ) : RecyclerView.ViewHolder(
         LayoutInflater.from(parent.context).inflate(layout, parent, false)
     ) {
+        protected val imageTarget = ProductImageViewTarget(
+            itemView.findViewById(R.id.refundItem_icon),
+            imageLoaderFactory
+        )
+
         abstract fun bind(item: ProductRefundListItem)
     }
 
     class RefundDetailViewHolder(
         parent: ViewGroup,
         private val formatCurrency: (BigDecimal) -> String,
-        private val imageMap: ProductImageMap,
+        imageLoaderFactory: ProductImageLoader.Factory,
         private val onViewAddonsClick: ViewAddonClickListener?
-    ) : RefundViewHolder(parent, R.layout.refunds_detail_product_list_item) {
+    ) : RefundViewHolder(parent, R.layout.refunds_detail_product_list_item, imageLoaderFactory) {
         private val nameTextView: TextView = itemView.findViewById(R.id.refundItem_productName)
         private val descriptionTextView: TextView = itemView.findViewById(R.id.refundItem_description)
         private val skuTextView: TextView = itemView.findViewById(R.id.refundItem_sku)
         private val quantityTextView: TextView = itemView.findViewById(R.id.refundItem_quantity)
-        private val productImageView: ImageView = itemView.findViewById(R.id.refundItem_icon)
         private val productAddonsView: TextView = itemView.findViewById(R.id.refundItem_addons)
 
         @SuppressLint("SetTextI18n")
@@ -112,15 +116,7 @@ class RefundProductListAdapter(
                 onViewAddonsClick?.invoke(item.orderItem)
             }
 
-            imageMap.get(item.orderItem.productId)?.let {
-                val imageCornerRadius = itemView.context.resources.getDimensionPixelSize(R.dimen.corner_radius_image)
-                val imageSize = itemView.context.resources.getDimensionPixelSize(R.dimen.image_minor_100)
-                Glide.with(itemView.context)
-                    .loadPhotonUrlWithFallback(it, imageSize, imageSize)
-                    .transform(CenterCrop(), RoundedCorners(imageCornerRadius))
-                    .placeholder(R.drawable.ic_product)
-                    .into(productImageView)
-            } ?: productImageView.setImageResource(R.drawable.ic_product)
+            imageTarget.load(item.orderItem.productId)
         }
     }
 
@@ -128,12 +124,11 @@ class RefundProductListAdapter(
         parent: ViewGroup,
         private val formatCurrency: (BigDecimal) -> String,
         private val onItemClicked: (Long) -> Unit,
-        private val imageMap: ProductImageMap
-    ) : RefundViewHolder(parent, R.layout.refunds_product_list_item) {
+        imageLoaderFactory: ProductImageLoader.Factory
+    ) : RefundViewHolder(parent, R.layout.refunds_product_list_item, imageLoaderFactory) {
         private val nameTextView: TextView = itemView.findViewById(R.id.refundItem_productName)
         private val descriptionTextView: TextView = itemView.findViewById(R.id.refundItem_description)
         private val quantityTextView: TextView = itemView.findViewById(R.id.refundItem_quantity)
-        private val productImageView: ImageView = itemView.findViewById(R.id.refundItem_icon)
         private val subtotalTextView: TextView = itemView.findViewById(R.id.refundItemSubtotal)
         private val taxesTextView: TextView = itemView.findViewById(R.id.refundItemTaxes)
 
@@ -152,15 +147,7 @@ class RefundProductListAdapter(
                 onItemClicked(item.orderItem.itemId)
             }
 
-            imageMap.get(item.orderItem.productId)?.let {
-                val imageCornerRadius = itemView.context.resources.getDimensionPixelSize(R.dimen.corner_radius_image)
-                val imageSize = itemView.context.resources.getDimensionPixelSize(R.dimen.image_minor_100)
-                Glide.with(itemView.context)
-                    .loadPhotonUrlWithFallback(it, imageSize, imageSize)
-                    .transform(CenterCrop(), RoundedCorners(imageCornerRadius))
-                    .placeholder(R.drawable.ic_product)
-                    .into(productImageView)
-            } ?: productImageView.setImageResource(R.drawable.ic_product)
+            imageTarget.load(item.orderItem.productId)
 
             subtotalTextView.text = formatCurrency(item.subtotal)
             taxesTextView.text = formatCurrency(item.taxesTotal)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImageLoader.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImageLoader.kt
@@ -1,0 +1,39 @@
+package com.woocommerce.android.ui.products
+
+import com.woocommerce.android.tools.ProductImageMap
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+
+interface ProductImageTarget {
+    fun show(imageUrl: String?)
+}
+
+class ProductImageLoader @AssistedInject constructor(
+    private val imageMap: ProductImageMap,
+    @Assisted private val target: ProductImageTarget,
+    @Assisted private val scope: CoroutineScope,
+) {
+    private var imageJob: Job? = null
+
+    fun load(remoteProductId: Long) {
+        imageJob?.cancel()
+        target.show(null)
+        imageJob = scope.launch {
+            target.show(imageMap.getAsync(remoteProductId))
+        }
+    }
+
+    fun cancel() {
+        imageJob?.cancel()
+        imageJob = null
+    }
+
+    @AssistedFactory
+    interface Factory {
+        fun create(target: ProductImageTarget, scope: CoroutineScope): ProductImageLoader
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImageViewTarget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImageViewTarget.kt
@@ -33,12 +33,13 @@ class ProductImageViewTarget(
 
     override fun show(imageUrl: String?) {
         val request = Glide.with(imageView)
-            .loadPhotonUrlWithFallback(imageUrl, imageSize, imageSize)
+            .asDrawable()
             .placeholder(R.drawable.ic_product)
         when {
             cornerRadius > 0 -> request.transform(CenterCrop(), RoundedCorners(cornerRadius))
             else -> request
-        }.into(imageView)
+        }.loadPhotonUrlWithFallback(imageUrl, imageSize, imageSize)
+            .into(imageView)
     }
 
     override fun onViewAttachedToWindow(view: View) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImageViewTarget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImageViewTarget.kt
@@ -1,0 +1,60 @@
+package com.woocommerce.android.ui.products
+
+import android.view.View
+import android.widget.ImageView
+import androidx.lifecycle.findViewTreeLifecycleOwner
+import androidx.lifecycle.lifecycleScope
+import com.bumptech.glide.Glide
+import com.bumptech.glide.load.resource.bitmap.CenterCrop
+import com.bumptech.glide.load.resource.bitmap.RoundedCorners
+import com.woocommerce.android.R
+import com.woocommerce.android.extensions.loadPhotonUrlWithFallback
+
+class ProductImageViewTarget(
+    private val imageView: ImageView,
+    private val factory: ProductImageLoader.Factory,
+    private val imageSize: Int = imageView.resources.getDimensionPixelSize(R.dimen.image_minor_100),
+    private val cornerRadius: Int = imageView.resources.getDimensionPixelSize(R.dimen.corner_radius_image),
+) : ProductImageTarget, View.OnAttachStateChangeListener {
+    private var imageLoader: ProductImageLoader? = null
+    private var remoteProductId: Long? = null
+
+    init {
+        imageView.addOnAttachStateChangeListener(this)
+    }
+
+    fun load(remoteProductId: Long) {
+        this.remoteProductId = remoteProductId
+        when (imageView.isAttachedToWindow) {
+            true -> loadImage(remoteProductId)
+            false -> show(null)
+        }
+    }
+
+    override fun show(imageUrl: String?) {
+        val request = Glide.with(imageView)
+            .loadPhotonUrlWithFallback(imageUrl, imageSize, imageSize)
+            .placeholder(R.drawable.ic_product)
+        when {
+            cornerRadius > 0 -> request.transform(CenterCrop(), RoundedCorners(cornerRadius))
+            else -> request
+        }.into(imageView)
+    }
+
+    override fun onViewAttachedToWindow(view: View) {
+        remoteProductId?.let { loadImage(it) }
+    }
+
+    override fun onViewDetachedFromWindow(view: View) {
+        imageLoader?.cancel()
+        imageLoader = null
+    }
+
+    private fun loadImage(remoteProductId: Long) {
+        val loader = imageLoader ?: factory.create(
+            target = this,
+            scope = checkNotNull(imageView.findViewTreeLifecycleOwner()).lifecycleScope
+        ).also { imageLoader = it }
+        loader.load(remoteProductId)
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailFragment.kt
@@ -21,16 +21,16 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentReviewDetailBinding
 import com.woocommerce.android.extensions.fastStripHtml
 import com.woocommerce.android.extensions.handleResult
-import com.woocommerce.android.extensions.loadPhotonUrlWithFallback
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.model.ProductReview
-import com.woocommerce.android.tools.ProductImageMap
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.common.texteditor.SimpleTextEditorFragment
 import com.woocommerce.android.ui.common.texteditor.SimpleTextEditorStrategy.SEND_RESULT_ON_CONFIRMATION
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
+import com.woocommerce.android.ui.products.ProductImageLoader
+import com.woocommerce.android.ui.products.ProductImageViewTarget
 import com.woocommerce.android.ui.reviews.ProductReviewStatus.APPROVED
 import com.woocommerce.android.ui.reviews.ProductReviewStatus.HOLD
 import com.woocommerce.android.ui.reviews.ProductReviewStatus.SPAM
@@ -56,12 +56,13 @@ class ReviewDetailFragment :
     BackPressListener {
     @Inject lateinit var uiMessageResolver: UIMessageResolver
 
-    @Inject lateinit var productImageMap: ProductImageMap
+    @Inject lateinit var productImageLoaderFactory: ProductImageLoader.Factory
 
     private val viewModel: ReviewDetailViewModel by viewModels()
 
     private var runOnStartFunc: (() -> Unit)? = null
     private var productIconSize: Int = 0
+    private var productImageTarget: ProductImageViewTarget? = null
     private val skeletonView = SkeletonView()
 
     private var _binding: FragmentReviewDetailBinding? = null
@@ -136,6 +137,7 @@ class ReviewDetailFragment :
     override fun onDestroyView() {
         skeletonView.hide()
         super.onDestroyView()
+        productImageTarget = null
         _binding = null
     }
 
@@ -224,15 +226,13 @@ class ReviewDetailFragment :
     }
 
     private fun refreshProductImage(remoteProductId: Long) {
-        // Note that if productImageMap doesn't already have the image for this product then it will request
-        // it from the backend. When the request completes it will be captured by the presenter, which will
-        // call this method to show the image for the just-downloaded product model
-        productImageMap.get(remoteProductId)?.let { productImage ->
-            Glide.with(activity as Context)
-                .loadPhotonUrlWithFallback(productImage, productIconSize, productIconSize)
-                .placeholder(ContextCompat.getDrawable(requireContext(), R.drawable.ic_product))
-                .into(binding.reviewProductIcon)
-        }
+        val target = productImageTarget ?: ProductImageViewTarget(
+            imageView = binding.reviewProductIcon,
+            factory = productImageLoaderFactory,
+            imageSize = productIconSize,
+            cornerRadius = 0
+        ).also { productImageTarget = it }
+        target.load(remoteProductId)
     }
 
     private fun showSkeleton(show: Boolean) {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductImageLoaderTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductImageLoaderTest.kt
@@ -1,0 +1,64 @@
+package com.woocommerce.android.ui.products
+
+import com.woocommerce.android.tools.ProductImageMap
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.doSuspendableAnswer
+import org.mockito.kotlin.mock
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ProductImageLoaderTest {
+    private val images = mutableListOf<String?>()
+    private val target = object : ProductImageTarget {
+        override fun show(imageUrl: String?) {
+            images.add(imageUrl)
+        }
+    }
+
+    @Test
+    fun `when a row is rebound during loading, then only show the new product image`() =
+        runTest(UnconfinedTestDispatcher()) {
+            // GIVEN
+            val firstImage = CompletableDeferred<String?>()
+            val secondImage = CompletableDeferred<String?>()
+            val imageMap: ProductImageMap = mock {
+                on { getAsync(1) } doSuspendableAnswer { firstImage.await() }
+                on { getAsync(2) } doSuspendableAnswer { secondImage.await() }
+            }
+            val loader = ProductImageLoader(imageMap, target, backgroundScope)
+            loader.load(1)
+
+            // WHEN
+            loader.load(2)
+            secondImage.complete("second.png")
+            firstImage.complete("first.png")
+
+            // THEN
+            assertThat(images).containsExactly(null, null, "second.png")
+        }
+
+    @Test
+    fun `when loading is canceled, then stop updating the target until another load`() =
+        runTest(UnconfinedTestDispatcher()) {
+            // GIVEN
+            val image = CompletableDeferred<String?>()
+            val imageMap: ProductImageMap = mock {
+                on { getAsync(1) } doSuspendableAnswer { image.await() }
+            }
+            val loader = ProductImageLoader(imageMap, target, backgroundScope)
+            loader.load(1)
+
+            // WHEN
+            loader.cancel()
+            image.complete("product.png")
+
+            // THEN
+            assertThat(images).containsExactly(null)
+            loader.load(1)
+            assertThat(images).containsExactly(null, null, "product.png")
+        }
+}


### PR DESCRIPTION
### Description

Fixes WOOMOB-3974

Refund and review screens now load product images through the async cache API. A shared injected loader cancels updates when a view is rebound or detached. The view wrapper keeps image rendering and lifecycle handling outside the loader.

- **Merge order:** #16540, #16541, then #16535.
- The release note for the full change is in #16535.

### Test Steps

1. Open a product review whose product has an image. Check that its photo appears after loading.
2. Open refund selection and an existing refund. Check products with photos and products without images. Do not submit a refund.
3. Leave each screen and reopen it. Check that images still appear and the app does not crash.

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
