### PR TITLE
[WOOMOB-4015] Clear the Top performers error state once a reload succeeds

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 
 25.7
 -----
+- [*] The Top performers card on My Store no longer stays on "Unable to load data" after a retry or pull to refresh succeeds [https://github.com/woocommerce/woocommerce-android/pull/16542]
 - [*****] Updated the Stripe Terminal SDK to 5.8.0; card readers now use coarse location on Android 12+ so the app no longer requests precise location for in-person payments except on older devices [https://github.com/woocommerce/woocommerce-android/pull/16507]
 - [*] Stores configured with an HTTP address now connect securely over HTTPS, with guidance to update their WordPress address [https://github.com/woocommerce/woocommerce-android/pull/16470]
 - [*] The "not a WordPress site" login error screen now shows a title and a back arrow instead of an empty toolbar [https://github.com/woocommerce/woocommerce-android/pull/16515]

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topperformers/DashboardTopPerformersViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topperformers/DashboardTopPerformersViewModel.kt
@@ -223,6 +223,7 @@ class DashboardTopPerformersViewModel @AssistedInject constructor(
                         }
                         _topPerformersState.value = _topPerformersState.value?.copy(
                             isLoading = false,
+                            error = null,
                             isOutdated = result.topPerformers.isOutdated,
                             topPerformers = result.topPerformers.value.toTopPerformersUiList(),
                         )
@@ -230,7 +231,7 @@ class DashboardTopPerformersViewModel @AssistedInject constructor(
 
                     is GetTopPerformers.TopPerformerResult.Loading -> {
                         parentViewModel.hideRefreshingIndicator()
-                        _topPerformersState.value = _topPerformersState.value?.copy(isLoading = true)
+                        _topPerformersState.value = _topPerformersState.value?.copy(isLoading = true, error = null)
                     }
                 }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topperformers/DashboardTopPerformersViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topperformers/DashboardTopPerformersViewModel.kt
@@ -201,13 +201,7 @@ class DashboardTopPerformersViewModel @AssistedInject constructor(
                     is GetTopPerformers.TopPerformerResult.Error -> {
                         parentViewModel.hideRefreshingIndicator()
                         _topPerformersState.value = _topPerformersState.value?.copy(
-                            error = if (
-                                (result.exception as? WooException)?.error?.type == WooErrorType.API_NOT_FOUND
-                            ) {
-                                ErrorType.WCAnalyticsInactive
-                            } else {
-                                ErrorType.Generic
-                            },
+                            error = result.exception.toErrorType(),
                             isLoading = false
                         )
                         trackEventForTopPerformersCard(
@@ -247,6 +241,13 @@ class DashboardTopPerformersViewModel @AssistedInject constructor(
                     AnalyticData.TOP_PERFORMERS
                 ).collect { lastUpdateMillis -> _lastUpdateTopPerformers.value = lastUpdateMillis }
             }
+        }
+
+    private fun Throwable.toErrorType() =
+        if ((this as? WooException)?.error?.type == WooErrorType.API_NOT_FOUND) {
+            ErrorType.WCAnalyticsInactive
+        } else {
+            ErrorType.Generic
         }
 
     private fun List<TopPerformerProduct>.toTopPerformersUiList() = map { it.toTopPerformersUiModel() }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/topperformers/DashboardTopPerformersViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/topperformers/DashboardTopPerformersViewModelTest.kt
@@ -1,0 +1,172 @@
+package com.woocommerce.android.ui.dashboard.topperformers
+
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.AppPrefsWrapper
+import com.woocommerce.android.tools.NetworkStatus
+import com.woocommerce.android.ui.analytics.hub.sync.AnalyticsUpdateDataStore.AnalyticData
+import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType
+import com.woocommerce.android.ui.dashboard.DashboardViewModel
+import com.woocommerce.android.ui.dashboard.DashboardViewModel.RefreshEvent
+import com.woocommerce.android.ui.dashboard.data.TopPerformersCustomDateRangeDataStore
+import com.woocommerce.android.ui.dashboard.domain.GetTopPerformers
+import com.woocommerce.android.ui.dashboard.domain.GetTopPerformers.TopPerformerResult
+import com.woocommerce.android.ui.dashboard.domain.ObserveLastUpdate
+import com.woocommerce.android.ui.dashboard.topperformers.DashboardTopPerformersViewModel.ErrorType
+import com.woocommerce.android.util.CalendarHelper
+import com.woocommerce.android.util.DateUtils
+import com.woocommerce.android.util.LocalizedDatePatternsTestRule
+import com.woocommerce.android.util.ResultWithOutdatedFlag
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import com.woocommerce.android.viewmodel.ResourceProvider
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyVararg
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.util.Calendar
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DashboardTopPerformersViewModelTest : BaseUnitTest() {
+    @get:Rule
+    val localizedDatePatterns = LocalizedDatePatternsTestRule()
+
+    private val parentRefreshTrigger = MutableSharedFlow<RefreshEvent>(extraBufferCapacity = 1)
+    private val parentViewModel: DashboardViewModel = mock {
+        on { refreshTrigger } doReturn parentRefreshTrigger
+    }
+    private val networkStatus: NetworkStatus = mock {
+        on { isConnected() } doReturn true
+    }
+    private val getTopPerformers: GetTopPerformers = mock()
+    private val observeLastUpdate: ObserveLastUpdate = mock {
+        on { invoke(any(), eq(AnalyticData.TOP_PERFORMERS)) } doReturn flowOf(LAST_UPDATE)
+    }
+    private val resourceProvider: ResourceProvider = mock {
+        on { getString(any(), anyVararg()) } doReturn ""
+    }
+    private val appPrefsWrapper: AppPrefsWrapper = mock {
+        val prefsChangesFlow = MutableStateFlow(SelectionType.TODAY.name)
+        on { observePrefs() } doAnswer { prefsChangesFlow.map { } }
+        on { getActiveTopPerformersTab() } doAnswer { prefsChangesFlow.value }
+    }
+    private val customDateRangeDataStore: TopPerformersCustomDateRangeDataStore = mock {
+        on { dateRange } doReturn flowOf(null)
+    }
+    private val calendarHelper: CalendarHelper = mock {
+        on { getCalendarForSelectedSite() } doReturn Calendar.getInstance()
+    }
+    private val dateUtils: DateUtils = mock()
+
+    private lateinit var viewModel: DashboardTopPerformersViewModel
+
+    private suspend fun setup(prepareMocks: suspend () -> Unit = {}) {
+        prepareMocks()
+        viewModel = DashboardTopPerformersViewModel(
+            savedState = SavedStateHandle(),
+            parentViewModel = parentViewModel,
+            selectedSite = mock(),
+            networkStatus = networkStatus,
+            observeLastUpdate = observeLastUpdate,
+            resourceProvider = resourceProvider,
+            getTopPerformers = getTopPerformers,
+            currencyFormatter = mock(),
+            usageTracksEventEmitter = mock(),
+            analyticsTrackerWrapper = mock(),
+            wooCommerceStore = mock(),
+            dateUtils = dateUtils,
+            appPrefsWrapper = appPrefsWrapper,
+            customDateRangeDataStore = customDateRangeDataStore,
+            dateFormatter = mock(),
+            getSelectedDateRange = GetSelectedRangeForTopPerformers(
+                appPrefs = appPrefsWrapper,
+                customDateRangeDataStore = customDateRangeDataStore,
+                dateUtils = dateUtils,
+                calendarHelper = calendarHelper
+            )
+        )
+    }
+
+    @Test
+    fun `given fetching top performers fails, when the card loads, then the error is shown`() = testBlocking {
+        setup {
+            whenever(getTopPerformers.invoke(any(), any())).thenReturn(flowOf(TopPerformerResult.Error(Exception())))
+        }
+
+        val state = viewModel.topPerformersState.value
+
+        assertThat(state?.error).isEqualTo(ErrorType.Generic)
+        assertThat(state?.isLoading).isFalse()
+    }
+
+    @Test
+    fun `given the card shows an error, when a retry succeeds, then the error is cleared`() = testBlocking {
+        setup {
+            whenever(getTopPerformers.invoke(any(), any()))
+                .thenReturn(flowOf(TopPerformerResult.Error(Exception())))
+                .thenReturn(flowOf(TopPerformerResult.Success(ResultWithOutdatedFlag(TOP_PERFORMERS))))
+        }
+
+        viewModel.onRefresh()
+
+        val state = viewModel.topPerformersState.value
+        assertThat(state?.error).isNull()
+        assertThat(state?.isLoading).isFalse()
+        assertThat(state?.topPerformers?.map { it.productId }).isEqualTo(TOP_PERFORMERS.map { it.productId })
+    }
+
+    @Test
+    fun `given an offline pull to refresh showed an error, when a retry succeeds online, then the error is cleared`() =
+        testBlocking {
+            setup {
+                whenever(getTopPerformers.invoke(any(), any()))
+                    .thenReturn(flowOf(TopPerformerResult.Success(ResultWithOutdatedFlag(TOP_PERFORMERS))))
+                whenever(networkStatus.isConnected()).thenReturn(true, false, true)
+            }
+            parentRefreshTrigger.tryEmit(RefreshEvent(isForced = true))
+
+            viewModel.onRefresh()
+
+            val state = viewModel.topPerformersState.value
+            assertThat(state?.error).isNull()
+            assertThat(state?.topPerformers?.map { it.productId }).isEqualTo(TOP_PERFORMERS.map { it.productId })
+        }
+
+    @Test
+    fun `given the card shows an error, when a reload starts loading, then the error is cleared`() = testBlocking {
+        setup {
+            whenever(getTopPerformers.invoke(any(), any()))
+                .thenReturn(flowOf(TopPerformerResult.Error(Exception())))
+                .thenReturn(flowOf(TopPerformerResult.Loading))
+        }
+
+        parentRefreshTrigger.tryEmit(RefreshEvent())
+
+        val state = viewModel.topPerformersState.value
+        assertThat(state?.error).isNull()
+        assertThat(state?.isLoading).isTrue()
+    }
+
+    private companion object {
+        const val LAST_UPDATE = 1690382344865L
+        val TOP_PERFORMERS = listOf(
+            GetTopPerformers.TopPerformerProduct(
+                productId = 134,
+                name = "Shirt",
+                quantity = 4,
+                currency = "USD",
+                total = 10.50,
+                imageUrl = null
+            )
+        )
+    }
+}


### PR DESCRIPTION
Fixes WOOMOB-4015

### Description

Once the Top performers card fails to load, it stays on "Unable to load data" even after a retry or a pull to refresh brings the data back. Only killing the app cleared it.

The card updates its state with `copy`, and the success and loading branches never reset the `error` field, so the error from the previous attempt survived every later result. Both branches clear it now. The error type mapping moved into a small helper in a separate commit, only to keep the method under detekt's length limit.

### Test Steps

1. Open My Store and wait for the Top performers card to load.
2. Turn on airplane mode.
3. Pull to refresh.
4. Confirm the Top performers card shows "Unable to load data".
5. Turn airplane mode off and wait a few seconds.
6. Confirm the Top performers card shows its data again, together with the Performance card.

### Images/gif

| Before | After |
|---|---|
| <img src="https://github.com/user-attachments/assets/53a3103e-1062-4c4c-8c8d-cd0030092657" width="400" /> | <img src="https://github.com/user-attachments/assets/6998d5f0-1e27-4df6-9cd5-19b11617f2cc" width="400" /> |

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
