### PR TITLE
[WOOMOB-4004] Show Offline Mode message when push notification setup dead-ends

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 
 25.7
 -----
+- [*] Push notifications setup now explains when a store's Jetpack is in Offline Mode instead of wrongly telling administrators to "ask your store administrator" [https://github.com/woocommerce/woocommerce-android/pull/16551]
 - [*] Logging out of a store-credentials login no longer restarts the app or leaves account data behind when the selected site is reset mid-logout [https://github.com/woocommerce/woocommerce-android/pull/16483]
 - [*] Logging in with site credentials no longer crashes when the store lists an application password without a UUID [https://github.com/woocommerce/woocommerce-android/pull/16483]
 - [Internal] The age restriction dialog now offers a Contact Support action that opens Help & Support while keeping the restriction enforced [https://github.com/woocommerce/woocommerce-android/pull/16523]

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/IsJetpackInOfflineMode.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/IsJetpackInOfflineMode.kt
@@ -1,0 +1,29 @@
+package com.woocommerce.android.ui.jetpack
+
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.JetpackStore
+import javax.inject.Inject
+
+/**
+ * Checks whether the site's Jetpack connection is in Offline Mode via the public
+ * `/jetpack/v4/connection` endpoint.
+ *
+ * Offline Mode is commonly left behind by `define( 'WP_ENVIRONMENT_TYPE', 'local' )` in `wp-config.php`
+ * when a site is cloned from a local or staging environment. While it's active, Jetpack revokes the
+ * connection capabilities for every user, so `/connection/data` returns 403 for administrators too. The
+ * bare `/connection` endpoint is not gated by that capability and still reports the Offline Mode state.
+ */
+class IsJetpackInOfflineMode @Inject constructor(
+    private val jetpackStore: JetpackStore
+) {
+    suspend operator fun invoke(
+        site: SiteModel,
+        useApplicationPasswords: Boolean
+    ): Boolean {
+        val result = jetpackStore.fetchJetpackConnection(
+            site = site,
+            useApplicationPasswords = useApplicationPasswords
+        )
+        return result.data?.offlineMode?.isActive == true
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionScreen.kt
@@ -104,6 +104,15 @@ fun WooPushNotificationsIntroductionScreen(
                     modifier = Modifier.fillMaxWidth()
                 )
 
+                ViewState.OfflineModeError -> ErrorContent(
+                    bodyText = stringResource(
+                        id = R.string.woo_push_notifications_introduction_error_offline_mode_body
+                    ),
+                    onContactSupportClick = onContactSupportClick,
+                    onNotNowClick = onNotNowClick,
+                    modifier = Modifier.fillMaxWidth()
+                )
+
                 ViewState.GenericError -> ErrorContent(
                     bodyText = stringResource(
                         id = R.string.woo_push_notifications_introduction_error_body
@@ -465,6 +474,21 @@ private fun WooPushNotificationsIntroductionErrorPreview() {
     WooThemeWithBackground {
         WooPushNotificationsIntroductionScreen(
             viewState = ViewState.GenericError,
+            onContinueClick = {},
+            onCloseClick = {},
+            onNotNowClick = {},
+            onWhatIsWPComClick = {},
+            onContactSupportClick = {}
+        )
+    }
+}
+
+@Composable
+@Preview
+private fun WooPushNotificationsIntroductionOfflineModeErrorPreview() {
+    WooThemeWithBackground {
+        WooPushNotificationsIntroductionScreen(
+            viewState = ViewState.OfflineModeError,
             onContinueClick = {},
             onCloseClick = {},
             onNotNowClick = {},

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionViewModel.kt
@@ -13,6 +13,7 @@ import com.woocommerce.android.tools.SiteConnectionType
 import com.woocommerce.android.tools.connectionType
 import com.woocommerce.android.ui.jetpack.FetchJetpackStatus
 import com.woocommerce.android.ui.jetpack.FetchJetpackStatus.JetpackStatusFetchResponse
+import com.woocommerce.android.ui.jetpack.IsJetpackInOfflineMode
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.ScopedViewModel
@@ -26,6 +27,7 @@ import javax.inject.Inject
 class WooPushNotificationsIntroductionViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val fetchJetpackStatus: FetchJetpackStatus,
+    private val isJetpackInOfflineMode: IsJetpackInOfflineMode,
     private val checkWCPluginSupport: CheckWooPluginPushNotificationsSupport,
     private val selectedSite: SelectedSite,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper
@@ -39,6 +41,7 @@ class WooPushNotificationsIntroductionViewModel @Inject constructor(
         private const val STATE_UPDATE_REQUIRED = "update_required"
         private const val STATE_CONNECTED = "connected"
         private const val ERROR_TYPE_NO_PERMISSION = "no_permission"
+        private const val ERROR_TYPE_OFFLINE_MODE = "offline_mode"
         private const val ERROR_TYPE_GENERIC = "generic"
     }
 
@@ -69,13 +72,7 @@ class WooPushNotificationsIntroductionViewModel @Inject constructor(
                         CheckWooPluginPushNotificationsSupport.Result.Error -> ViewState.GenericError
                     }
                 }
-                .getOrElse { exception ->
-                    if (exception is JetpackForbiddenException) {
-                        ViewState.ForbiddenError
-                    } else {
-                        ViewState.GenericError
-                    }
-                }
+                .getOrElse { exception -> mapErrorToViewState(exception, site) }
 
             _viewState.value = viewState
 
@@ -84,9 +81,18 @@ class WooPushNotificationsIntroductionViewModel @Inject constructor(
                 is ViewState.UpdateRequired -> trackIntroductionView(STATE_UPDATE_REQUIRED)
                 is ViewState.Connected -> trackIntroductionView(STATE_CONNECTED)
                 is ViewState.ForbiddenError -> trackIntroductionError(ERROR_TYPE_NO_PERMISSION)
+                is ViewState.OfflineModeError -> trackIntroductionError(ERROR_TYPE_OFFLINE_MODE)
                 is ViewState.GenericError -> trackIntroductionError(ERROR_TYPE_GENERIC)
                 is ViewState.Loading -> {}
             }
+        }
+    }
+
+    private suspend fun mapErrorToViewState(exception: Throwable, site: SiteModel): ViewState {
+        return when {
+            exception !is JetpackForbiddenException -> ViewState.GenericError
+            isJetpackInOfflineMode(site, useApplicationPasswords = true) -> ViewState.OfflineModeError
+            else -> ViewState.ForbiddenError
         }
     }
 
@@ -174,6 +180,7 @@ class WooPushNotificationsIntroductionViewModel @Inject constructor(
         data object Connected : ViewState
         data object UpdateRequired : ViewState
         data object ForbiddenError : ViewState
+        data object OfflineModeError : ViewState
         data object GenericError : ViewState
     }
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2899,6 +2899,7 @@
     <string name="woo_push_notifications_introduction_error_title">Something went wrong</string>
     <string name="woo_push_notifications_introduction_error_body">We could not complete the push notifications setup. Please contact support for assistance.</string>
     <string name="woo_push_notifications_introduction_error_forbidden_body">Your account does not have permission to complete push notifications setup. Please ask your store administrator to handle this.</string>
+    <string name="woo_push_notifications_introduction_error_offline_mode_body">Push notifications can\'t be set up because your store is in Offline Mode. If you still need help, please contact support.</string>
     <string name="woo_push_notifications_introduction_connected_title">Get push notifications for your store</string>
     <string name="woo_push_notifications_introduction_connected_body">You\'re one step away from getting notifications for new orders, reviews and more.</string>
     <string name="woo_push_notifications_introduction_update_required_title">Get push notifications for your store</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/jetpack/IsJetpackInOfflineModeTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/jetpack/IsJetpackInOfflineModeTest.kt
@@ -1,0 +1,76 @@
+package com.woocommerce.android.ui.jetpack
+
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpapi.jetpack.JetpackConnectionStatusResponse
+import org.wordpress.android.fluxc.network.rest.wpapi.jetpack.OfflineMode
+import org.wordpress.android.fluxc.store.JetpackStore
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class IsJetpackInOfflineModeTest : BaseUnitTest() {
+    private val jetpackStore: JetpackStore = mock()
+    private val site: SiteModel = SiteModel()
+
+    private val sut = IsJetpackInOfflineMode(jetpackStore)
+
+    @Test
+    fun `given offline mode is active, when invoked, then returns true`() = testBlocking {
+        stubConnection(OfflineMode(isActive = true))
+
+        val result = sut(site, useApplicationPasswords = true)
+
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `given offline mode is inactive, when invoked, then returns false`() = testBlocking {
+        stubConnection(OfflineMode(isActive = false))
+
+        val result = sut(site, useApplicationPasswords = true)
+
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `given offline mode isActive is null, when invoked, then returns false`() = testBlocking {
+        stubConnection(OfflineMode(isActive = null))
+
+        val result = sut(site, useApplicationPasswords = true)
+
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `given offline mode is missing, when invoked, then returns false`() = testBlocking {
+        stubConnection(offlineMode = null)
+
+        val result = sut(site, useApplicationPasswords = true)
+
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `given the connection fetch fails, when invoked, then returns false`() = testBlocking {
+        whenever(jetpackStore.fetchJetpackConnection(any(), any()))
+            .thenReturn(JetpackStore.JetpackResult(JetpackStore.JetpackError()))
+
+        val result = sut(site, useApplicationPasswords = true)
+
+        assertThat(result).isFalse()
+    }
+
+    private suspend fun stubConnection(offlineMode: OfflineMode?) {
+        whenever(jetpackStore.fetchJetpackConnection(any(), any()))
+            .thenReturn(
+                JetpackStore.JetpackResult(
+                    JetpackConnectionStatusResponse(isActive = false, offlineMode = offlineMode)
+                )
+            )
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionViewModelTest.kt
@@ -14,6 +14,7 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.tools.SiteConnectionType
 import com.woocommerce.android.ui.jetpack.FetchJetpackStatus
 import com.woocommerce.android.ui.jetpack.FetchJetpackStatus.JetpackStatusFetchResponse
+import com.woocommerce.android.ui.jetpack.IsJetpackInOfflineMode
 import com.woocommerce.android.ui.pushnotifications.introduction.WooPushNotificationsIntroductionViewModel.ViewState
 import com.woocommerce.android.util.getOrAwaitValue
 import com.woocommerce.android.viewmodel.BaseUnitTest
@@ -49,6 +50,7 @@ class WooPushNotificationsIntroductionViewModelTest : BaseUnitTest() {
             )
         )
     }
+    private val isJetpackInOfflineMode: IsJetpackInOfflineMode = mock()
     private val checkWCPluginSupport: CheckWooPluginPushNotificationsSupport = mock()
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper = mock()
 
@@ -82,6 +84,7 @@ class WooPushNotificationsIntroductionViewModelTest : BaseUnitTest() {
         viewModel = WooPushNotificationsIntroductionViewModel(
             savedStateHandle = SavedStateHandle(),
             fetchJetpackStatus = fetchJetpackStatus,
+            isJetpackInOfflineMode = isJetpackInOfflineMode,
             checkWCPluginSupport = checkWCPluginSupport,
             selectedSite = selectedSite,
             analyticsTrackerWrapper = analyticsTrackerWrapper
@@ -255,10 +258,11 @@ class WooPushNotificationsIntroductionViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given connection is forbidden, when screen opens, then ForbiddenError state is shown`() =
+    fun `given connection is forbidden and not in offline mode, when screen opens, then ForbiddenError state is shown`() =
         testBlocking {
             whenever(fetchJetpackStatus(any(), any(), anyOrNull()))
                 .thenReturn(Result.success(JetpackStatusFetchResponse.ConnectionForbidden))
+            whenever(isJetpackInOfflineMode(any(), any())).thenReturn(false)
 
             setup()
 
@@ -268,6 +272,56 @@ class WooPushNotificationsIntroductionViewModelTest : BaseUnitTest() {
                 eq(AnalyticsEvent.PUSH_NOTIFICATIONS_SETUP_INTRODUCTION_ERROR),
                 eq(mapOf(AnalyticsTracker.KEY_ERROR_TYPE to "no_permission"))
             )
+        }
+
+    @Test
+    fun `given connection is forbidden and site is in offline mode, when screen opens, then OfflineModeError state is shown`() =
+        testBlocking {
+            whenever(fetchJetpackStatus(any(), any(), anyOrNull()))
+                .thenReturn(Result.success(JetpackStatusFetchResponse.ConnectionForbidden))
+            whenever(isJetpackInOfflineMode(any(), any())).thenReturn(true)
+
+            setup()
+
+            val viewState = viewModel.viewState.getOrAwaitValue()
+            assertThat(viewState).isEqualTo(ViewState.OfflineModeError)
+            verify(analyticsTrackerWrapper).track(
+                eq(AnalyticsEvent.PUSH_NOTIFICATIONS_SETUP_INTRODUCTION_ERROR),
+                eq(mapOf(AnalyticsTracker.KEY_ERROR_TYPE to "offline_mode"))
+            )
+        }
+
+    @Test
+    fun `given site is not connected, when screen opens, then offline mode is not checked`() =
+        testBlocking {
+            val jetpackStatus = JetpackStatus(
+                isJetpackInstalled = false,
+                jetpackConnectionStatus = JetpackConnectionStatus.AccountNotConnected(
+                    siteRegistrationStatus = JetpackSiteRegistrationStatus.NOT_REGISTERED,
+                    blogId = null
+                )
+            )
+            whenever(fetchJetpackStatus(any(), any(), anyOrNull()))
+                .thenReturn(Result.success(JetpackStatusFetchResponse.Success(jetpackStatus)))
+
+            setup()
+
+            val viewState = viewModel.viewState.getOrAwaitValue()
+            assertThat(viewState).isEqualTo(ViewState.NotConnected)
+            verify(isJetpackInOfflineMode, never()).invoke(any(), any())
+        }
+
+    @Test
+    fun `given fetching jetpack status fails, when screen opens, then offline mode is not checked`() =
+        testBlocking {
+            whenever(fetchJetpackStatus(any(), any(), anyOrNull()))
+                .thenReturn(Result.failure(Exception("Network error")))
+
+            setup()
+
+            val viewState = viewModel.viewState.getOrAwaitValue()
+            assertThat(viewState).isEqualTo(ViewState.GenericError)
+            verify(isJetpackInOfflineMode, never()).invoke(any(), any())
         }
 
     @Test

--- a/libs/fluxc-processor/src/main/resources/jp-api-endpoints.txt
+++ b/libs/fluxc-processor/src/main/resources/jp-api-endpoints.txt
@@ -1,4 +1,5 @@
 /module/stats/active
+/connection
 /connection/url
 /connection/data
 /connection/register

--- a/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/store/JetpackStoreTest.kt
+++ b/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/store/JetpackStoreTest.kt
@@ -8,8 +8,11 @@ import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.BaseRequest
 import org.wordpress.android.fluxc.network.rest.wpapi.jetpack.JetpackConnectionProvisionResponse
+import org.wordpress.android.fluxc.network.rest.wpapi.jetpack.JetpackConnectionStatusResponse
 import org.wordpress.android.fluxc.network.rest.wpapi.jetpack.JetpackWPAPIRestClient
+import org.wordpress.android.fluxc.network.rest.wpapi.jetpack.OfflineMode
 import org.wordpress.android.fluxc.tools.initCoroutineEngine
 import kotlin.test.Test
 
@@ -33,6 +36,38 @@ class JetpackStoreTest {
 
             verify(jetpackWPAPIRestClient).registerSite(site, useApplicationPasswords = true)
             assertThat(result).isEqualTo(JetpackStore.JetpackResult(1L))
+        }
+    }
+
+    @Test
+    fun `when fetchJetpackConnection is called, then call jetpackWPAPIRestClient and return the response`() {
+        runBlocking {
+            val response = JetpackConnectionStatusResponse(
+                isActive = false,
+                offlineMode = OfflineMode(isActive = true)
+            )
+            whenever(jetpackWPAPIRestClient.fetchJetpackConnection(site, useApplicationPasswords = true))
+                .thenReturn(JetpackWPAPIRestClient.JetpackWPAPIPayload(response))
+
+            val result = jetpackStore.fetchJetpackConnection(site, useApplicationPasswords = true)
+
+            verify(jetpackWPAPIRestClient).fetchJetpackConnection(site, useApplicationPasswords = true)
+            assertThat(result).isEqualTo(JetpackStore.JetpackResult(response))
+        }
+    }
+
+    @Test
+    fun `given the client returns an error, when fetchJetpackConnection is called, then return a JetpackError`() {
+        runBlocking {
+            val error = BaseRequest.BaseNetworkError(BaseRequest.GenericErrorType.SERVER_ERROR, "boom")
+            whenever(jetpackWPAPIRestClient.fetchJetpackConnection(site, useApplicationPasswords = true))
+                .thenReturn(JetpackWPAPIRestClient.JetpackWPAPIPayload(error))
+
+            val result = jetpackStore.fetchJetpackConnection(site, useApplicationPasswords = true)
+
+            assertThat(result.isError).isTrue()
+            assertThat(result.data).isNull()
+            assertThat(result.error?.message).isEqualTo("boom")
         }
     }
 

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/jetpack/JetpackConnectionApiResponses.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/jetpack/JetpackConnectionApiResponses.kt
@@ -30,6 +30,15 @@ data class WpcomUser(
     @SerializedName("avatar") val avatar: String?
 )
 
+data class JetpackConnectionStatusResponse(
+    @SerializedName("isActive") val isActive: Boolean?,
+    @SerializedName("offlineMode") val offlineMode: OfflineMode?
+)
+
+data class OfflineMode(
+    @SerializedName("isActive") val isActive: Boolean?
+)
+
 data class JetpackConnectionRegisterResponse(
     val authorizeUrl: String
 )

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/jetpack/JetpackWPAPIRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/jetpack/JetpackWPAPIRestClient.kt
@@ -92,6 +92,22 @@ class JetpackWPAPIRestClient @Inject constructor(
         }
     }
 
+    suspend fun fetchJetpackConnection(
+        site: SiteModel,
+        useApplicationPasswords: Boolean = false
+    ): JetpackWPAPIPayload<JetpackConnectionStatusResponse> {
+        val response = makeGetWPAPIRequest<JetpackConnectionStatusResponse>(
+            site = site,
+            path = JPAPI.connection.pathV4,
+            useApplicationPasswords = useApplicationPasswords
+        )
+
+        return when (response) {
+            is Success<JetpackConnectionStatusResponse> -> JetpackWPAPIPayload(response.data)
+            is Error -> JetpackWPAPIPayload(response.error)
+        }
+    }
+
     suspend fun fetchJetpackConnectionData(
         site: SiteModel,
         useApplicationPasswords: Boolean = false

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/JetpackStore.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/JetpackStore.kt
@@ -4,6 +4,7 @@ import com.android.volley.VolleyError
 import org.wordpress.android.fluxc.Payload
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.jetpack.JetpackConnectionData
+import org.wordpress.android.fluxc.network.rest.wpapi.jetpack.JetpackConnectionStatusResponse
 import org.wordpress.android.fluxc.network.rest.wpapi.jetpack.JetpackWPAPIRestClient
 import org.wordpress.android.fluxc.store.Store.OnChangedError
 import org.wordpress.android.fluxc.tools.CoroutineEngine
@@ -49,6 +50,20 @@ class JetpackStore @Inject constructor(
                         }
                     )
                 }
+            }
+        }
+    }
+
+    suspend fun fetchJetpackConnection(
+        site: SiteModel,
+        useApplicationPasswords: Boolean
+    ): JetpackResult<JetpackConnectionStatusResponse> {
+        if (site.isUsingWpComRestApi) error("This function is not implemented yet for Jetpack tunnel")
+        return coroutineEngine.withDefaultContext(T.API, this, "fetchJetpackConnection") {
+            val result = jetpackWPAPIRestClient.fetchJetpackConnection(site, useApplicationPasswords)
+
+            result.toJetpackResult { result ->
+                JetpackResult(result)
             }
         }
     }


### PR DESCRIPTION
### Description

Fixes WOOMOB-4004

When a merchant signed in with **site credentials** taps *Enable push notifications*, and the store's Jetpack is in **Offline Mode**, the setup intro screen dead-ended on *"Your account does not have permission… please ask your store administrator."* That message is wrong and unactionable: the user already **is** the administrator, and in Offline Mode Jetpack revokes the connection capabilities for **every** user, so nobody can complete the step.

Root cause: the intro screen calls `GET /jetpack/v4/connection/data`, which returns **403** in Offline Mode (its permission callback checks the `jetpack_connect_user` cap that Offline Mode revokes). The app mapped that 403 straight to the "ask your administrator" state.

This change detects Offline Mode and shows an accurate, actionable message instead. On the 403/forbidden path only, it queries the bare `GET /jetpack/v4/connection` endpoint — which is **not** gated by the revoked capability and still reports `offlineMode.isActive` — via a new `IsJetpackInOfflineMode` use case, and renders a new `OfflineModeError` state when Offline Mode is active. If Offline Mode is not active, the previous `ForbiddenError` behaviour is unchanged.

Notes for review:
- The Offline Mode check runs **only** when the forbidden (403) path is hit, which structurally implies Jetpack is installed. A site without Jetpack returns 404 → `NotConnected` and never reaches this branch, so non-Jetpack sites are unaffected and make no extra network call.

### Test Steps

Set up a store that reproduces Offline Mode (a Jurassic Ninja rig works well):

1. Provision a WordPress site with **WooCommerce** and **Jetpack** installed and **active but not connected** to WordPress.com.
2. Add one line to `wp-config.php`: `define( 'WP_ENVIRONMENT_TYPE', 'local' );` (via wp-cli: `wp config set WP_ENVIRONMENT_TYPE local --type=constant`). Only `'local'` triggers Offline Mode — not `'development'`/`'staging'`.
3. Confirm the store condition (no app needed): `GET https://<site>/wp-json/jetpack/v4/connection` returns `"offlineMode":{"isActive":true,…}`, and `/wp-json/jetpack/v4/connection/data` returns 403 when authenticated.

Then in the app:

4. Log in to that store with **site credentials**.
5. Grant the OS notification permission when prompted (so device permission is ruled out).
6. On **My store**, tap the **"Never miss a new order / Enable push notifications"** card.
7. **Expected:** the setup screen shows the new Offline Mode message (naming Offline Mode and the `wp-config.php` change) instead of *"…ask your store administrator."*

Regression checks:

8. Remove the `wp-config.php` line (`wp config delete WP_ENVIRONMENT_TYPE`) and connect Jetpack; repeat step 6 — the flow should proceed normally (no Offline Mode message).
9. On a site with **no Jetpack** installed, the intro should still show the normal *connect to WordPress.com* screen (not the Offline Mode message).

### Images/gif

| Before | After |
|---|---|
| <img width="960" height="2142" alt="Screenshot_20260910_123914" src="https://github.com/user-attachments/assets/c0975077-b27a-4fb7-b259-f02f366f0f52" /> | <img width="960" height="2142" alt="Screenshot_20260910_124026" src="https://github.com/user-attachments/assets/4408791b-2f89-40c8-9683-e28583d3317a" /> |

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.