### PR TITLE
[WOOMOB-3248] Localize compact currency labels

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 
 25.7
 -----
+- [*] Dashboard chart amounts now use abbreviations in the app's language.
 - [*] Order details now shows refunded shipping lines, including refunds that only contain shipping [https://github.com/woocommerce/woocommerce-android/pull/16552]
 - [*] Product thumbnails in orders, refunds, and reviews now load without blocking the screen.
 - [*] Changing the country on an order address now clears the previous region from the form [https://github.com/woocommerce/woocommerce-android/pull/16527]

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,7 +4,7 @@
 
 25.7
 -----
-- [*] Dashboard chart amounts now use abbreviations in the app's language.
+- [*] Rounded currency amounts on charts, Blaze campaigns, payment screens, and widgets now follow the app's language.
 - [*] Order details now shows refunded shipping lines, including refunds that only contain shipping [https://github.com/woocommerce/woocommerce-android/pull/16552]
 - [*] Product thumbnails in orders, refunds, and reviews now load without blocking the screen.
 - [*] Changing the country on an order address now clears the previous region from the form [https://github.com/woocommerce/woocommerce-android/pull/16527]

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsView.kt
@@ -660,8 +660,8 @@ class DashboardStatsView @JvmOverloads constructor(
                     setDrawZeroLine(true)
                     zeroLineColor = ContextCompat.getColor(context, R.color.divider_color)
                 }
-                axisMinimum = minRevenue.roundToTheNextPowerOfTen()
-                axisMaximum = maxRevenue.roundToTheNextPowerOfTen()
+                axisMinimum = minRevenue.coerceAtMost(0f).roundToTheNextPowerOfTen()
+                axisMaximum = maxRevenue.coerceAtLeast(0f).roundToTheNextPowerOfTen()
             }
             data = LineData(dataSet)
             if (wasEmpty) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsView.kt
@@ -829,7 +829,7 @@ class DashboardStatsView @JvmOverloads constructor(
                 currencyFormatter.formatCurrencyRounded(
                     value.toDouble(),
                     revenueStatsModel?.currencyCode.orEmpty()
-                ).replace(".0", "")
+                )
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsView.kt
@@ -651,10 +651,6 @@ class DashboardStatsView @JvmOverloads constructor(
         val maxRevenue = dataSet.values.maxOf { it.y }
         val duration = context.resources.getInteger(android.R.integer.config_shortAnimTime)
         with(binding.chart) {
-            data = LineData(dataSet)
-            if (wasEmpty) {
-                animateY(duration)
-            }
             with(xAxis) {
                 labelCount = getChartXAxisLabelCount()
                 valueFormatter = StartEndDateAxisFormatter()
@@ -666,6 +662,10 @@ class DashboardStatsView @JvmOverloads constructor(
                 }
                 axisMinimum = minRevenue.roundToTheNextPowerOfTen()
                 axisMaximum = maxRevenue.roundToTheNextPowerOfTen()
+            }
+            data = LineData(dataSet)
+            if (wasEmpty) {
+                animateY(duration)
             }
             val dot = MarkerImage(context, R.drawable.chart_highlight_dot)
             val offset = DisplayUtils.dpToPx(context, LINE_CHART_DOT_OFFSET).toFloat()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/CurrencyFormatter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/CurrencyFormatter.kt
@@ -104,6 +104,13 @@ class CurrencyFormatter @Inject constructor(
         return formatCurrency(value, currencyCode, applyDecimalFormatting)
     }
 
+    /**
+     * Formats a raw amount for display based on the WooCommerce site settings, rounding the values to the nearest int.
+     *
+     * @param rawValue the value to be formatted
+     * @param currencyCode the ISO 4217 currency code to use for formatting
+     * @return the formatted value for display
+     */
     fun formatCurrencyRounded(rawValue: Double, currencyCode: String = defaultCurrencyCode): String {
         val locale = localeProvider.provideLocale() ?: Locale.getDefault()
         val displayFormatted = numberExtensionsWrapper.compactNumberCompat(rawValue.roundToLong(), locale)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/CurrencyFormatter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/CurrencyFormatter.kt
@@ -1,7 +1,9 @@
 package com.woocommerce.android.util
 
 import com.woocommerce.android.di.AppCoroutineScope
+import com.woocommerce.android.extensions.NumberExtensionsWrapper
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.util.locale.LocaleProvider
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.combine
@@ -12,12 +14,11 @@ import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import java.math.BigDecimal
-import java.text.DecimalFormat
 import java.util.Currency
+import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
-import kotlin.math.absoluteValue
-import kotlin.math.roundToInt
+import kotlin.math.roundToLong
 
 @Singleton
 class CurrencyFormatter @Inject constructor(
@@ -25,37 +26,10 @@ class CurrencyFormatter @Inject constructor(
     private val selectedSite: SelectedSite,
     private val siteIndependentCurrencyFormatter: SiteIndependentCurrencyFormatter,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
-    private val dispatchers: CoroutineDispatchers
+    private val dispatchers: CoroutineDispatchers,
+    private val numberExtensionsWrapper: NumberExtensionsWrapper,
+    private val localeProvider: LocaleProvider
 ) {
-    companion object {
-        private const val ONE_THOUSAND = 1000
-        private const val ONE_MILLION = 1000000
-
-        private const val BACKOFF_DELAY = 1_000L
-        private const val BACKOFF_INTENTS = 3
-
-        // Formats the value to two decimal places
-        private val currencyFormatter: DecimalFormat by lazy {
-            DecimalFormat("0.00")
-        }
-
-        // Formats the value to one decimal place
-        private val currencyFormatterRounded: DecimalFormat by lazy {
-            DecimalFormat("0.0")
-        }
-
-        private fun currencyStringRounded(rawValue: Double): String {
-            val roundedValue = rawValue.roundToInt().toDouble()
-            return if (roundedValue.absoluteValue >= ONE_MILLION) {
-                currencyFormatterRounded.format(roundedValue / ONE_MILLION) + "m"
-            } else if (roundedValue.absoluteValue >= ONE_THOUSAND) {
-                currencyFormatterRounded.format(roundedValue / ONE_THOUSAND) + "k"
-            } else {
-                currencyFormatter.format(roundedValue).toString().removeSuffix(".00")
-            }
-        }
-    }
-
     private var defaultCurrencyCode = ""
 
     init {
@@ -130,23 +104,10 @@ class CurrencyFormatter @Inject constructor(
         return formatCurrency(value, currencyCode, applyDecimalFormatting)
     }
 
-    /**
-     * Formats a raw amount for display based on the WooCommerce site settings, rounding the values to the nearest int.
-     *
-     * Additionally, if the value is a thousand or more, we return it rounded to the nearest tenth
-     * and suffixed with "k" (2500 -> 2.5k).
-     *
-     * Similarly, we add "m" for values a million or higher.
-     *
-     * @param rawValue the value to be formatted
-     * @param currencyCode the ISO 4217 currency code to use for formatting
-     * @return the formatted value for display
-     */
     fun formatCurrencyRounded(rawValue: Double, currencyCode: String = defaultCurrencyCode): String {
-        val displayFormatted = currencyStringRounded(rawValue)
-        return displayFormatted.takeIf { it.isNotEmpty() }?.let {
-            return wcStore.formatCurrencyForDisplay(it, selectedSite.get(), currencyCode, false)
-        }.orEmpty()
+        val locale = localeProvider.provideLocale() ?: Locale.getDefault()
+        val displayFormatted = numberExtensionsWrapper.compactNumberCompat(rawValue.roundToLong(), locale)
+        return wcStore.formatCurrencyForDisplay(displayFormatted, selectedSite.get(), currencyCode, false)
     }
 
     /**
@@ -177,4 +138,9 @@ class CurrencyFormatter @Inject constructor(
         } else {
             formatCurrency(revenue.toBigDecimal(), currencyCode)
         }
+
+    private companion object {
+        const val BACKOFF_DELAY = 1_000L
+        const val BACKOFF_INTENTS = 3
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/DefaultCurrencyFormatterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/DefaultCurrencyFormatterTest.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.util
 
 import com.automattic.android.tracks.crashlogging.CrashLogging
+import com.woocommerce.android.extensions.NumberExtensionsWrapper
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.locale.LocaleProvider
 import com.woocommerce.android.viewmodel.BaseUnitTest
@@ -14,7 +15,9 @@ import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
@@ -32,11 +35,64 @@ import java.util.Locale
 class DefaultCurrencyFormatterTest : BaseUnitTest() {
     private lateinit var formatter: CurrencyFormatter
     private val localeProvider: LocaleProvider = mock()
+    private val numberExtensionsWrapper: NumberExtensionsWrapper = mock()
     private val wcStore: WooCommerceStore = mock()
     private val selectedSite: SelectedSite = mock()
     private val crashLogging: CrashLogging = mock()
     private val siteIndependentCurrencyFormatter: SiteIndependentCurrencyFormatter =
         SiteIndependentCurrencyFormatter(localeProvider, crashLogging)
+
+    @Test
+    fun `when formatting rounded currency then use the current app locale`() = runTest {
+        // GIVEN
+        setupSitesFlow()
+        val site = SiteModel()
+        whenever(selectedSite.get()).thenReturn(site)
+        whenever(wcStore.formatCurrencyForDisplay(any<String>(), eq(site), eq("TRY"), eq(false)))
+            .thenAnswer { "₺${it.getArgument<String>(0)}" }
+        val amountsByLocale = mapOf(
+            Locale.forLanguageTag("tr-TR") to "4 B",
+            Locale.US to "4K",
+            Locale.GERMANY to "4.000"
+        )
+
+        amountsByLocale.forEach { (locale, amount) ->
+            whenever(localeProvider.provideLocale()).thenReturn(locale)
+            whenever(numberExtensionsWrapper.compactNumberCompat(4000L, locale)).thenReturn(amount)
+
+            // WHEN
+            val result = formatter.formatCurrencyRounded(4000.4, "TRY")
+
+            // THEN
+            assertThat(result).isEqualTo("₺$amount")
+        }
+    }
+
+    @Test
+    fun `when formatting rounded currency then preserve zero negative and large amounts`() = runTest {
+        // GIVEN
+        setupSitesFlow()
+        val site = SiteModel()
+        whenever(selectedSite.get()).thenReturn(site)
+        whenever(wcStore.formatCurrencyForDisplay(any<String>(), eq(site), eq("USD"), eq(false)))
+            .thenAnswer { it.getArgument<String>(0) }
+        val amounts = listOf(
+            Triple(0.0, 0L, "0"),
+            Triple(249.6, 250L, "250"),
+            Triple(-4000.4, -4000L, "-4K"),
+            Triple(4000000000.0, 4000000000L, "4B")
+        )
+
+        amounts.forEach { (rawAmount, roundedAmount, compactAmount) ->
+            whenever(numberExtensionsWrapper.compactNumberCompat(roundedAmount, Locale.US)).thenReturn(compactAmount)
+
+            // WHEN
+            val result = formatter.formatCurrencyRounded(rawAmount, "USD")
+
+            // THEN
+            assertThat(result).isEqualTo(compactAmount)
+        }
+    }
 
     @Test
     fun `when the selected site changes the default currency code updates`() =
@@ -79,7 +135,9 @@ class DefaultCurrencyFormatterTest : BaseUnitTest() {
                 selectedSite = selectedSite,
                 siteIndependentCurrencyFormatter = siteIndependentCurrencyFormatter,
                 appCoroutineScope = TestScope(coroutinesTestRule.testDispatcher),
-                dispatchers = coroutinesTestRule.testDispatchers
+                dispatchers = coroutinesTestRule.testDispatchers,
+                numberExtensionsWrapper = numberExtensionsWrapper,
+                localeProvider = localeProvider
             )
 
             advanceTimeBy(5_000)
@@ -151,7 +209,9 @@ class DefaultCurrencyFormatterTest : BaseUnitTest() {
                 selectedSite = selectedSite,
                 siteIndependentCurrencyFormatter = siteIndependentCurrencyFormatter,
                 appCoroutineScope = TestScope(coroutinesTestRule.testDispatcher),
-                dispatchers = coroutinesTestRule.testDispatchers
+                dispatchers = coroutinesTestRule.testDispatchers,
+                numberExtensionsWrapper = numberExtensionsWrapper,
+                localeProvider = localeProvider
             )
 
             advanceTimeBy(100)
@@ -194,7 +254,9 @@ class DefaultCurrencyFormatterTest : BaseUnitTest() {
             selectedSite = selectedSite,
             siteIndependentCurrencyFormatter = siteIndependentCurrencyFormatter,
             appCoroutineScope = TestScope(coroutinesTestRule.testDispatcher),
-            dispatchers = coroutinesTestRule.testDispatchers
+            dispatchers = coroutinesTestRule.testDispatchers,
+            numberExtensionsWrapper = numberExtensionsWrapper,
+            localeProvider = localeProvider
         )
     }
 
@@ -224,7 +286,9 @@ class DefaultCurrencyFormatterTest : BaseUnitTest() {
             selectedSite = selectedSite,
             siteIndependentCurrencyFormatter = siteIndependentCurrencyFormatter,
             appCoroutineScope = TestScope(coroutinesTestRule.testDispatcher),
-            dispatchers = coroutinesTestRule.testDispatchers
+            dispatchers = coroutinesTestRule.testDispatchers,
+            numberExtensionsWrapper = numberExtensionsWrapper,
+            localeProvider = localeProvider
         )
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/DefaultCurrencyFormatterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/DefaultCurrencyFormatterTest.kt
@@ -53,7 +53,7 @@ class DefaultCurrencyFormatterTest : BaseUnitTest() {
         val amountsByLocale = mapOf(
             Locale.forLanguageTag("tr-TR") to "4 B",
             Locale.US to "4K",
-            Locale.GERMANY to "4.000"
+            Locale.GERMANY to "4000"
         )
 
         amountsByLocale.forEach { (locale, amount) ->
@@ -69,7 +69,7 @@ class DefaultCurrencyFormatterTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when formatting rounded currency then preserve zero negative and large amounts`() = runTest {
+    fun `when formatting rounded currency then round the amount without narrowing to Int`() = runTest {
         // GIVEN
         setupSitesFlow()
         val site = SiteModel()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/DefaultCurrencyFormatterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/DefaultCurrencyFormatterTest.kt
@@ -43,7 +43,7 @@ class DefaultCurrencyFormatterTest : BaseUnitTest() {
         SiteIndependentCurrencyFormatter(localeProvider, crashLogging)
 
     @Test
-    fun `when formatting rounded currency then use the current app locale`() = runTest {
+    fun `when formatting rounded currency, then use the current app locale`() = runTest {
         // GIVEN
         setupSitesFlow()
         val site = SiteModel()
@@ -69,7 +69,7 @@ class DefaultCurrencyFormatterTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when formatting rounded currency then round the amount without narrowing to Int`() = runTest {
+    fun `when formatting rounded currency, then round the amount without narrowing to Int`() = runTest {
         // GIVEN
         setupSitesFlow()
         val site = SiteModel()


### PR DESCRIPTION
### Description

Fixes WOOMOB-3248

Dashboard chart labels use hardcoded `k` and `m` suffixes in Turkish. This uses the existing compact-number formatter with the app's language, so thousands display as `B`, while keeping the store's currency symbol and placement. It also preserves German grouping separators and keeps labels visible when the date range changes. Chart bounds include zero so an all-positive or all-negative series keeps its labels and curve. The shared formatter also updates rounded amounts in Blaze, payment screens, and widgets.

Review is incomplete: the final synthesis step hit a session limit. Keeping this as a draft.

### Test Steps

1. Set the app language to Turkish and open a TRY store with revenue above 1,000 in the selected period.
2. Open My Store and check the Performance **chart**. Thousands should use `B`, with the currency symbol and values displayed correctly.
3. Switch to English and check that thousands use `K`.
4. Switch to German. Change from a period with revenue in the thousands to one in the tens of thousands. Check that labels such as `TRY40.000` keep their grouping separator and remain fully visible.
5. Check a period where every bucket has positive revenue, then one with only negative revenue. The curve and axis labels should remain visible, with zero at the bottom or top.

### Images/gif

Same local ApiFaker revenue fixture on an Android 13 emulator.

| Before | After |
| --- | --- |
| ![Turkish chart before the fix](https://github.com/user-attachments/assets/aabf06a4-9f4d-4d35-afb2-9c87808489fe) | ![Turkish chart after the fix](https://github.com/user-attachments/assets/f826c3cb-a68f-49b3-aa65-753d424c0aae) |

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
