### PR TITLE
Switch AI code review model to Fable 5.1

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -12,6 +12,8 @@ concurrency:
 jobs:
   review:
     uses: woocommerce/.github/.github/workflows/ai-code-review.yml@trunk
+    with:
+      model: claude-fable-5-1
     secrets:
       AI_CODE_REVIEW_ANTHROPIC_API_KEY: ${{ secrets.AI_CODE_REVIEW_ANTHROPIC_API_KEY }}
       AI_REVIEW_TELEMETRY_TOKEN: ${{ secrets.AI_REVIEW_TELEMETRY_TOKEN }}


### PR DESCRIPTION
Closes: [AINFRA-3133: Update Woo Android reviews model to Fable 5.1](https://linear.app/a8c/issue/AINFRA-3133/update-woo-android-reviews-model-to-fable-51)

Update internal review tooling to use `Fable 5.1` model. 

Source of the shared workflow is: https://github.com/woocommerce/.github/blob/3786a2e0ab7995ec3c753075e55cab3b0e32c8e5/.github/workflows/ai-code-review.yml